### PR TITLE
Copyrights 2018

### DIFF
--- a/benchmark/multi-source/PrimsSplit/Prims.swift
+++ b/benchmark/multi-source/PrimsSplit/Prims.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/multi-source/PrimsSplit/Prims_main.swift
+++ b/benchmark/multi-source/PrimsSplit/Prims_main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/Benchmark_DTrace.in
+++ b/benchmark/scripts/Benchmark_DTrace.in
@@ -4,7 +4,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -5,7 +5,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/Benchmark_GuardMalloc.in
+++ b/benchmark/scripts/Benchmark_GuardMalloc.in
@@ -4,7 +4,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/Benchmark_QuickCheck.in
+++ b/benchmark/scripts/Benchmark_QuickCheck.in
@@ -4,7 +4,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
+++ b/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
@@ -4,7 +4,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/bench_code_size.py
+++ b/benchmark/scripts/bench_code_size.py
@@ -5,7 +5,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -5,7 +5,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/generate_harness/generate_harness.py
+++ b/benchmark/scripts/generate_harness/generate_harness.py
@@ -4,7 +4,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -4,7 +4,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/perf_test_driver/swift_stats.d
+++ b/benchmark/scripts/perf_test_driver/swift_stats.d
@@ -2,7 +2,7 @@
  *
  * This source file is part of the Swift.org open source project
  *
- * Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ * Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
  * Licensed under Apache License v2.0 with Runtime Library Exception
  *
  * See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/run_smoke_bench.py
+++ b/benchmark/scripts/run_smoke_bench.py
@@ -5,7 +5,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -5,7 +5,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -5,7 +5,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/scripts/test_utils.py
+++ b/benchmark/scripts/test_utils.py
@@ -5,7 +5,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Ackermann.swift
+++ b/benchmark/single-source/Ackermann.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/AngryPhonebook.swift
+++ b/benchmark/single-source/AngryPhonebook.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/AnyHashableWithAClass.swift
+++ b/benchmark/single-source/AnyHashableWithAClass.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Array2D.swift
+++ b/benchmark/single-source/Array2D.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ArrayAppend.swift
+++ b/benchmark/single-source/ArrayAppend.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ArrayInClass.swift
+++ b/benchmark/single-source/ArrayInClass.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ArrayLiteral.swift
+++ b/benchmark/single-source/ArrayLiteral.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ArrayOfGenericPOD.swift
+++ b/benchmark/single-source/ArrayOfGenericPOD.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ArrayOfGenericRef.swift
+++ b/benchmark/single-source/ArrayOfGenericRef.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ArrayOfPOD.swift
+++ b/benchmark/single-source/ArrayOfPOD.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ArrayOfRef.swift
+++ b/benchmark/single-source/ArrayOfRef.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ArraySetElement.swift
+++ b/benchmark/single-source/ArraySetElement.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ArraySubscript.swift
+++ b/benchmark/single-source/ArraySubscript.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/BitCount.swift
+++ b/benchmark/single-source/BitCount.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ByteSwap.swift
+++ b/benchmark/single-source/ByteSwap.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/CString.swift
+++ b/benchmark/single-source/CString.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Calculator.swift
+++ b/benchmark/single-source/Calculator.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/CaptureProp.swift
+++ b/benchmark/single-source/CaptureProp.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/CharacterLiteralsLarge.swift
+++ b/benchmark/single-source/CharacterLiteralsLarge.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/CharacterLiteralsSmall.swift
+++ b/benchmark/single-source/CharacterLiteralsSmall.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/CharacterProperties.swift
+++ b/benchmark/single-source/CharacterProperties.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/CharacterProperties.swift.gyb
+++ b/benchmark/single-source/CharacterProperties.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Chars.swift
+++ b/benchmark/single-source/Chars.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ClassArrayGetter.swift
+++ b/benchmark/single-source/ClassArrayGetter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DataBenchmarks.swift
+++ b/benchmark/single-source/DataBenchmarks.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DeadArray.swift
+++ b/benchmark/single-source/DeadArray.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DictTest.swift
+++ b/benchmark/single-source/DictTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DictTest2.swift
+++ b/benchmark/single-source/DictTest2.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DictTest3.swift
+++ b/benchmark/single-source/DictTest3.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DictionaryBridge.swift
+++ b/benchmark/single-source/DictionaryBridge.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DictionaryGroup.swift
+++ b/benchmark/single-source/DictionaryGroup.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DictionaryLiteral.swift
+++ b/benchmark/single-source/DictionaryLiteral.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DictionaryRemove.swift
+++ b/benchmark/single-source/DictionaryRemove.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DictionarySubscriptDefault.swift
+++ b/benchmark/single-source/DictionarySubscriptDefault.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DictionarySwap.swift
+++ b/benchmark/single-source/DictionarySwap.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DropFirst.swift
+++ b/benchmark/single-source/DropFirst.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DropFirst.swift.gyb
+++ b/benchmark/single-source/DropFirst.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DropLast.swift
+++ b/benchmark/single-source/DropLast.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DropLast.swift.gyb
+++ b/benchmark/single-source/DropLast.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DropWhile.swift
+++ b/benchmark/single-source/DropWhile.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/DropWhile.swift.gyb
+++ b/benchmark/single-source/DropWhile.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ErrorHandling.swift
+++ b/benchmark/single-source/ErrorHandling.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Exclusivity.swift
+++ b/benchmark/single-source/Exclusivity.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ExistentialPerformance.swift
+++ b/benchmark/single-source/ExistentialPerformance.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Fibonacci.swift
+++ b/benchmark/single-source/Fibonacci.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Hanoi.swift
+++ b/benchmark/single-source/Hanoi.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/HashQuadratic.swift
+++ b/benchmark/single-source/HashQuadratic.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Histogram.swift
+++ b/benchmark/single-source/Histogram.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Integrate.swift
+++ b/benchmark/single-source/Integrate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/IterateData.swift
+++ b/benchmark/single-source/IterateData.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Join.swift
+++ b/benchmark/single-source/Join.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/LazyFilter.swift
+++ b/benchmark/single-source/LazyFilter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/LinkedList.swift
+++ b/benchmark/single-source/LinkedList.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/MapReduce.swift
+++ b/benchmark/single-source/MapReduce.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Memset.swift
+++ b/benchmark/single-source/Memset.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/MonteCarloE.swift
+++ b/benchmark/single-source/MonteCarloE.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/MonteCarloPi.swift
+++ b/benchmark/single-source/MonteCarloPi.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/NSDictionaryCastToSwift.swift
+++ b/benchmark/single-source/NSDictionaryCastToSwift.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/NSError.swift
+++ b/benchmark/single-source/NSError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/NSStringConversion.swift
+++ b/benchmark/single-source/NSStringConversion.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/NopDeinit.swift
+++ b/benchmark/single-source/NopDeinit.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ObjectAllocation.swift
+++ b/benchmark/single-source/ObjectAllocation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ObjectiveCBridging.swift
+++ b/benchmark/single-source/ObjectiveCBridging.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ObjectiveCBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCBridgingStubs.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ObserverClosure.swift
+++ b/benchmark/single-source/ObserverClosure.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ObserverForwarderStruct.swift
+++ b/benchmark/single-source/ObserverForwarderStruct.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ObserverPartiallyAppliedMethod.swift
+++ b/benchmark/single-source/ObserverPartiallyAppliedMethod.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ObserverUnappliedMethod.swift
+++ b/benchmark/single-source/ObserverUnappliedMethod.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/OpenClose.swift
+++ b/benchmark/single-source/OpenClose.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Phonebook.swift
+++ b/benchmark/single-source/Phonebook.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/PolymorphicCalls.swift
+++ b/benchmark/single-source/PolymorphicCalls.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/PopFront.swift
+++ b/benchmark/single-source/PopFront.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/PopFrontGeneric.swift
+++ b/benchmark/single-source/PopFrontGeneric.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Prefix.swift
+++ b/benchmark/single-source/Prefix.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Prefix.swift.gyb
+++ b/benchmark/single-source/Prefix.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/PrefixWhile.swift
+++ b/benchmark/single-source/PrefixWhile.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/PrefixWhile.swift.gyb
+++ b/benchmark/single-source/PrefixWhile.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Prims.swift
+++ b/benchmark/single-source/Prims.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ProtocolDispatch.swift
+++ b/benchmark/single-source/ProtocolDispatch.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ProtocolDispatch2.swift
+++ b/benchmark/single-source/ProtocolDispatch2.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Queue.swift
+++ b/benchmark/single-source/Queue.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/RC4.swift
+++ b/benchmark/single-source/RC4.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/RGBHistogram.swift
+++ b/benchmark/single-source/RGBHistogram.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/RangeAssignment.swift
+++ b/benchmark/single-source/RangeAssignment.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/RangeIteration.swift
+++ b/benchmark/single-source/RangeIteration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/RecursiveOwnedParameter.swift
+++ b/benchmark/single-source/RecursiveOwnedParameter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ReduceInto.swift
+++ b/benchmark/single-source/ReduceInto.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/RemoveWhere.swift
+++ b/benchmark/single-source/RemoveWhere.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/ReversedCollections.swift
+++ b/benchmark/single-source/ReversedCollections.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/SequenceAlgos.swift
+++ b/benchmark/single-source/SequenceAlgos.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/SevenBoom.swift
+++ b/benchmark/single-source/SevenBoom.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Sim2DArray.swift
+++ b/benchmark/single-source/Sim2DArray.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/SortLargeExistentials.swift
+++ b/benchmark/single-source/SortLargeExistentials.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/SortLettersInPlace.swift
+++ b/benchmark/single-source/SortLettersInPlace.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/SortStrings.swift
+++ b/benchmark/single-source/SortStrings.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StackPromo.swift
+++ b/benchmark/single-source/StackPromo.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StaticArray.swift
+++ b/benchmark/single-source/StaticArray.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StrComplexWalk.swift
+++ b/benchmark/single-source/StrComplexWalk.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StrToInt.swift
+++ b/benchmark/single-source/StrToInt.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringBuilder.swift
+++ b/benchmark/single-source/StringBuilder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringComparison.swift
+++ b/benchmark/single-source/StringComparison.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringComparison.swift.gyb
+++ b/benchmark/single-source/StringComparison.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringEdits.swift
+++ b/benchmark/single-source/StringEdits.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringEnum.swift
+++ b/benchmark/single-source/StringEnum.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringInterpolation.swift
+++ b/benchmark/single-source/StringInterpolation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringMatch.swift
+++ b/benchmark/single-source/StringMatch.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringTests.swift
+++ b/benchmark/single-source/StringTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringWalk.swift
+++ b/benchmark/single-source/StringWalk.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/StringWalk.swift.gyb
+++ b/benchmark/single-source/StringWalk.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Substring.swift
+++ b/benchmark/single-source/Substring.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Suffix.swift
+++ b/benchmark/single-source/Suffix.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Suffix.swift.gyb
+++ b/benchmark/single-source/Suffix.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/SuperChars.swift
+++ b/benchmark/single-source/SuperChars.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/TwoSum.swift
+++ b/benchmark/single-source/TwoSum.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/TypeFlood.swift
+++ b/benchmark/single-source/TypeFlood.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/UTF8Decode.swift
+++ b/benchmark/single-source/UTF8Decode.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/Walsh.swift
+++ b/benchmark/single-source/Walsh.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/single-source/XorLoop.swift
+++ b/benchmark/single-source/XorLoop.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/utils/ArgParse.swift
+++ b/benchmark/utils/ArgParse.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/utils/LibProc/LibProcIncludeSystemHeader.h
+++ b/benchmark/utils/LibProc/LibProcIncludeSystemHeader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/utils/LibProc/module.modulemap
+++ b/benchmark/utils/LibProc/module.modulemap
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/utils/ObjectiveCTests/ObjectiveCTests.h
+++ b/benchmark/utils/ObjectiveCTests/ObjectiveCTests.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/utils/ObjectiveCTests/ObjectiveCTests.m
+++ b/benchmark/utils/ObjectiveCTests/ObjectiveCTests.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/utils/ObjectiveCTests/module.map
+++ b/benchmark/utils/ObjectiveCTests/module.map
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/benchmark/utils/convertToJSON.py
+++ b/benchmark/utils/convertToJSON.py
@@ -4,7 +4,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/cmake/dummy.cpp
+++ b/cmake/dummy.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/docs/proposals/ArrayBridge.rst
+++ b/docs/proposals/ArrayBridge.rst
@@ -4,7 +4,7 @@
 ..
 .. This source file is part of the Swift.org open source project
 ..
-.. Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+.. Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 .. Licensed under Apache License v2.0 with Runtime Library Exception
 ..
 .. See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/Class.h
+++ b/include/swift/ABI/Class.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/HeapObject.h
+++ b/include/swift/ABI/HeapObject.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/KeyPath.h
+++ b/include/swift/ABI/KeyPath.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/MetadataKind.def
+++ b/include/swift/ABI/MetadataKind.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/System.h
+++ b/include/swift/ABI/System.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/TrailingObjects.h
+++ b/include/swift/ABI/TrailingObjects.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/TypeIdentity.h
+++ b/include/swift/ABI/TypeIdentity.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ABI/ValueWitness.def
+++ b/include/swift/ABI/ValueWitness.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ASTVisitor.h
+++ b/include/swift/AST/ASTVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AccessRequests.h
+++ b/include/swift/AST/AccessRequests.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AccessScopeChecker.h
+++ b/include/swift/AST/AccessScopeChecker.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AccessTypeIDZone.def
+++ b/include/swift/AST/AccessTypeIDZone.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AccessorKinds.def
+++ b/include/swift/AST/AccessorKinds.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AnyRequest.h
+++ b/include/swift/AST/AnyRequest.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/CanTypeVisitor.h
+++ b/include/swift/AST/CanTypeVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ClangNode.h
+++ b/include/swift/AST/ClangNode.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ConcreteDeclRef.h
+++ b/include/swift/AST/ConcreteDeclRef.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DebuggerClient.h
+++ b/include/swift/AST/DebuggerClient.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DeclNameLoc.h
+++ b/include/swift/AST/DeclNameLoc.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DeclNodes.def
+++ b/include/swift/AST/DeclNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DefaultArgumentKind.h
+++ b/include/swift/AST/DefaultArgumentKind.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsAll.def
+++ b/include/swift/AST/DiagnosticsAll.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsClangImporter.h
+++ b/include/swift/AST/DiagnosticsClangImporter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsCommon.h
+++ b/include/swift/AST/DiagnosticsCommon.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsDriver.h
+++ b/include/swift/AST/DiagnosticsDriver.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsFrontend.h
+++ b/include/swift/AST/DiagnosticsFrontend.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsIRGen.h
+++ b/include/swift/AST/DiagnosticsIRGen.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsModuleDiffer.def
+++ b/include/swift/AST/DiagnosticsModuleDiffer.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsModuleDiffer.h
+++ b/include/swift/AST/DiagnosticsModuleDiffer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsParse.h
+++ b/include/swift/AST/DiagnosticsParse.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsRefactoring.def
+++ b/include/swift/AST/DiagnosticsRefactoring.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsRefactoring.h
+++ b/include/swift/AST/DiagnosticsRefactoring.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsSIL.h
+++ b/include/swift/AST/DiagnosticsSIL.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/DiagnosticsSema.h
+++ b/include/swift/AST/DiagnosticsSema.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ExprNodes.def
+++ b/include/swift/AST/ExprNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ForeignErrorConvention.h
+++ b/include/swift/AST/ForeignErrorConvention.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ForeignInfo.h
+++ b/include/swift/AST/ForeignInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/FunctionRefKind.h
+++ b/include/swift/AST/FunctionRefKind.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/GenericParamKey.h
+++ b/include/swift/AST/GenericParamKey.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/IfConfigClause.h
+++ b/include/swift/AST/IfConfigClause.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/KnownFoundationEntities.def
+++ b/include/swift/AST/KnownFoundationEntities.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/KnownProtocols.h
+++ b/include/swift/AST/KnownProtocols.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/LayoutConstraint.h
+++ b/include/swift/AST/LayoutConstraint.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/LinkLibrary.h
+++ b/include/swift/AST/LinkLibrary.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Ownership.h
+++ b/include/swift/AST/Ownership.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/PatternNodes.def
+++ b/include/swift/AST/PatternNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/PlatformKinds.def
+++ b/include/swift/AST/PlatformKinds.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ProtocolAssociations.h
+++ b/include/swift/AST/ProtocolAssociations.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ReferencedNameTracker.h
+++ b/include/swift/AST/ReferencedNameTracker.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/RequirementEnvironment.h
+++ b/include/swift/AST/RequirementEnvironment.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/ResilienceExpansion.h
+++ b/include/swift/AST/ResilienceExpansion.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/SILLayout.h
+++ b/include/swift/AST/SILLayout.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/StmtNodes.def
+++ b/include/swift/AST/StmtNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/SyntaxASTMap.h
+++ b/include/swift/AST/SyntaxASTMap.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeCheckerDebugConsumer.h
+++ b/include/swift/AST/TypeCheckerDebugConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeLoc.h
+++ b/include/swift/AST/TypeLoc.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeMemberVisitor.h
+++ b/include/swift/AST/TypeMemberVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeNodes.def
+++ b/include/swift/AST/TypeNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeOrExtensionDecl.h
+++ b/include/swift/AST/TypeOrExtensionDecl.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeReprNodes.def
+++ b/include/swift/AST/TypeReprNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeVisitor.h
+++ b/include/swift/AST/TypeVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/TypeWalker.h
+++ b/include/swift/AST/TypeWalker.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/USRGeneration.h
+++ b/include/swift/AST/USRGeneration.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ASTSectionImporter/ASTSectionImporter.h
+++ b/include/swift/ASTSectionImporter/ASTSectionImporter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Algorithm.h
+++ b/include/swift/Basic/Algorithm.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/AnyValue.h
+++ b/include/swift/Basic/AnyValue.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/ArrayRefView.h
+++ b/include/swift/Basic/ArrayRefView.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/AssertImplements.h
+++ b/include/swift/Basic/AssertImplements.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/BlotMapVector.h
+++ b/include/swift/Basic/BlotMapVector.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/BlotSetVector.h
+++ b/include/swift/Basic/BlotSetVector.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/CTypeIDZone.def
+++ b/include/swift/Basic/CTypeIDZone.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Cache.h
+++ b/include/swift/Basic/Cache.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/ColorUtils.h
+++ b/include/swift/Basic/ColorUtils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/CycleDiagnosticKind.h
+++ b/include/swift/Basic/CycleDiagnosticKind.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Defer.h
+++ b/include/swift/Basic/Defer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/DefineTypeIDZone.h
+++ b/include/swift/Basic/DefineTypeIDZone.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/DiverseList.h
+++ b/include/swift/Basic/DiverseList.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/DiverseStack.h
+++ b/include/swift/Basic/DiverseStack.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Dwarf.h
+++ b/include/swift/Basic/Dwarf.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Edit.h
+++ b/include/swift/Basic/Edit.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/EditorPlaceholder.h
+++ b/include/swift/Basic/EditorPlaceholder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/EncodedSequence.h
+++ b/include/swift/Basic/EncodedSequence.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/ExternalUnion.h
+++ b/include/swift/Basic/ExternalUnion.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/FlagSet.h
+++ b/include/swift/Basic/FlagSet.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/FlaggedPointer.h
+++ b/include/swift/Basic/FlaggedPointer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/ImmutablePointerSet.h
+++ b/include/swift/Basic/ImmutablePointerSet.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/ImplementTypeIDZone.h
+++ b/include/swift/Basic/ImplementTypeIDZone.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/JSONSerialization.h
+++ b/include/swift/Basic/JSONSerialization.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/LLVMContext.h
+++ b/include/swift/Basic/LLVMContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/LLVMInitialize.h
+++ b/include/swift/Basic/LLVMInitialize.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Lazy.h
+++ b/include/swift/Basic/Lazy.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Malloc.h
+++ b/include/swift/Basic/Malloc.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/NullablePtr.h
+++ b/include/swift/Basic/NullablePtr.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/OptimizationMode.h
+++ b/include/swift/Basic/OptimizationMode.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/OptionSet.h
+++ b/include/swift/Basic/OptionSet.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/OptionalEnum.h
+++ b/include/swift/Basic/OptionalEnum.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/OwnedString.h
+++ b/include/swift/Basic/OwnedString.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/PointerIntEnum.h
+++ b/include/swift/Basic/PointerIntEnum.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/PrefixMap.h
+++ b/include/swift/Basic/PrefixMap.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/PrettyStackTrace.h
+++ b/include/swift/Basic/PrettyStackTrace.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/PrimitiveParsing.h
+++ b/include/swift/Basic/PrimitiveParsing.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/ProfileCounter.h
+++ b/include/swift/Basic/ProfileCounter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Program.h
+++ b/include/swift/Basic/Program.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/QuotedString.h
+++ b/include/swift/Basic/QuotedString.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Range.h
+++ b/include/swift/Basic/Range.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/RelativePointer.h
+++ b/include/swift/Basic/RelativePointer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Sanitizers.h
+++ b/include/swift/Basic/Sanitizers.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/SimpleDisplay.h
+++ b/include/swift/Basic/SimpleDisplay.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/SuccessorMap.h
+++ b/include/swift/Basic/SuccessorMap.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/TaskQueue.h
+++ b/include/swift/Basic/TaskQueue.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/ThreadSafeRefCounted.h
+++ b/include/swift/Basic/ThreadSafeRefCounted.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/TopCollection.h
+++ b/include/swift/Basic/TopCollection.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/TransformArrayRef.h
+++ b/include/swift/Basic/TransformArrayRef.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/TreeScopedHashTable.h
+++ b/include/swift/Basic/TreeScopedHashTable.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/TypeID.h
+++ b/include/swift/Basic/TypeID.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/UUID.h
+++ b/include/swift/Basic/UUID.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Unicode.h
+++ b/include/swift/Basic/Unicode.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/ValueEnumerator.h
+++ b/include/swift/Basic/ValueEnumerator.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Varint.h
+++ b/include/swift/Basic/Varint.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ClangImporter/BuiltinMappedTypes.def
+++ b/include/swift/ClangImporter/BuiltinMappedTypes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/ClangImporter/SIMDMappedTypes.def
+++ b/include/swift/ClangImporter/SIMDMappedTypes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Demangling/ManglingMacros.h
+++ b/include/swift/Demangling/ManglingMacros.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Demangling/ManglingUtils.h
+++ b/include/swift/Demangling/ManglingUtils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Demangling/Punycode.h
+++ b/include/swift/Demangling/Punycode.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Demangling/StandardTypesMangling.def
+++ b/include/swift/Demangling/StandardTypesMangling.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Demangling/ValueWitnessMangling.def
+++ b/include/swift/Demangling/ValueWitnessMangling.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Driver/DependencyGraph.h
+++ b/include/swift/Driver/DependencyGraph.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Driver/FrontendUtil.h
+++ b/include/swift/Driver/FrontendUtil.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Driver/ParseableOutput.h
+++ b/include/swift/Driver/ParseableOutput.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Driver/Util.h
+++ b/include/swift/Driver/Util.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Frontend/SerializedDiagnosticConsumer.h
+++ b/include/swift/Frontend/SerializedDiagnosticConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/FrontendTool/FrontendTool.h
+++ b/include/swift/FrontendTool/FrontendTool.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/CommentConversion.h
+++ b/include/swift/IDE/CommentConversion.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/Formatting.h
+++ b/include/swift/IDE/Formatting.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/ModuleInterfacePrinting.h
+++ b/include/swift/IDE/ModuleInterfacePrinting.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/REPLCodeCompletion.h
+++ b/include/swift/IDE/REPLCodeCompletion.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/Refactoring.h
+++ b/include/swift/IDE/Refactoring.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IRGen/IRGenPublic.h
+++ b/include/swift/IRGen/IRGenPublic.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IRGen/IRGenSILPasses.h
+++ b/include/swift/IRGen/IRGenSILPasses.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/IRGen/ValueWitness.h
+++ b/include/swift/IRGen/ValueWitness.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Immediate/Immediate.h
+++ b/include/swift/Immediate/Immediate.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Index/Index.h
+++ b/include/swift/Index/Index.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Index/IndexDataConsumer.h
+++ b/include/swift/Index/IndexDataConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Index/IndexRecord.h
+++ b/include/swift/Index/IndexRecord.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/include/swift/Index/IndexSymbol.h
+++ b/include/swift/Index/IndexSymbol.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Index/Utils.h
+++ b/include/swift/Index/Utils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/LLVMPasses/Passes.h
+++ b/include/swift/LLVMPasses/Passes.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/LLVMPasses/PassesFwd.h
+++ b/include/swift/LLVMPasses/PassesFwd.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Markup/AST.h
+++ b/include/swift/Markup/AST.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Markup/ASTNodes.def
+++ b/include/swift/Markup/ASTNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Markup/LineList.h
+++ b/include/swift/Markup/LineList.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Markup/Markup.h
+++ b/include/swift/Markup/Markup.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Markup/SimpleFields.def
+++ b/include/swift/Markup/SimpleFields.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Markup/SourceLoc.h
+++ b/include/swift/Markup/SourceLoc.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Markup/XMLUtils.h
+++ b/include/swift/Markup/XMLUtils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Migrator/ASTMigratorPass.h
+++ b/include/swift/Migrator/ASTMigratorPass.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Migrator/EditorAdapter.h
+++ b/include/swift/Migrator/EditorAdapter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Migrator/FixitApplyDiagnosticConsumer.h
+++ b/include/swift/Migrator/FixitApplyDiagnosticConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Migrator/MigrationState.h
+++ b/include/swift/Migrator/MigrationState.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Migrator/Migrator.h
+++ b/include/swift/Migrator/Migrator.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Migrator/MigratorOptions.h
+++ b/include/swift/Migrator/MigratorOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Migrator/Replacement.h
+++ b/include/swift/Migrator/Replacement.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Migrator/RewriteBufferEditsReceiver.h
+++ b/include/swift/Migrator/RewriteBufferEditsReceiver.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Option/SanitizerOptions.h
+++ b/include/swift/Option/SanitizerOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/Confusables.def
+++ b/include/swift/Parse/Confusables.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/Confusables.h
+++ b/include/swift/Parse/Confusables.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/DelayedParsingCallbacks.h
+++ b/include/swift/Parse/DelayedParsingCallbacks.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/LexerState.h
+++ b/include/swift/Parse/LexerState.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/LocalContext.h
+++ b/include/swift/Parse/LocalContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/ParseSILSupport.h
+++ b/include/swift/Parse/ParseSILSupport.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/ParserPosition.h
+++ b/include/swift/Parse/ParserPosition.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/ParserResult.h
+++ b/include/swift/Parse/ParserResult.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/SyntaxParserResult.h
+++ b/include/swift/Parse/SyntaxParserResult.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/PrintAsObjC/PrintAsObjC.h
+++ b/include/swift/PrintAsObjC/PrintAsObjC.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Reflection/MetadataSource.h
+++ b/include/swift/Reflection/MetadataSource.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Reflection/MetadataSourceBuilder.h
+++ b/include/swift/Reflection/MetadataSourceBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Reflection/MetadataSources.def
+++ b/include/swift/Reflection/MetadataSources.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Reflection/TypeLowering.h
+++ b/include/swift/Reflection/TypeLowering.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Reflection/TypeRefs.def
+++ b/include/swift/Reflection/TypeRefs.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Remote/CMemoryReader.h
+++ b/include/swift/Remote/CMemoryReader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Remote/Failure.h
+++ b/include/swift/Remote/Failure.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Remote/FailureKinds.def
+++ b/include/swift/Remote/FailureKinds.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Remote/InProcessMemoryReader.h
+++ b/include/swift/Remote/InProcessMemoryReader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/RemoteAST/RemoteAST.h
+++ b/include/swift/RemoteAST/RemoteAST.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Casting.h
+++ b/include/swift/Runtime/Casting.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/InstrumentsSupport.h
+++ b/include/swift/Runtime/InstrumentsSupport.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/MutexPThread.h
+++ b/include/swift/Runtime/MutexPThread.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/MutexWin32.h
+++ b/include/swift/Runtime/MutexWin32.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Once.h
+++ b/include/swift/Runtime/Once.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Portability.h
+++ b/include/swift/Runtime/Portability.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Reflection.h
+++ b/include/swift/Runtime/Reflection.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/RuntimeFnWrappersGen.h
+++ b/include/swift/Runtime/RuntimeFnWrappersGen.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Runtime/Unreachable.h
+++ b/include/swift/Runtime/Unreachable.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/BridgedTypes.def
+++ b/include/swift/SIL/BridgedTypes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/CFG.h
+++ b/include/swift/SIL/CFG.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/Consumption.h
+++ b/include/swift/SIL/Consumption.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/FormalLinkage.h
+++ b/include/swift/SIL/FormalLinkage.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/LoopInfo.h
+++ b/include/swift/SIL/LoopInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/Notifications.h
+++ b/include/swift/SIL/Notifications.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/OptimizationRemark.h
+++ b/include/swift/SIL/OptimizationRemark.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/PostOrder.h
+++ b/include/swift/SIL/PostOrder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/PrettyStackTrace.h
+++ b/include/swift/SIL/PrettyStackTrace.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILAllocated.h
+++ b/include/swift/SIL/SILAllocated.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILBuiltinVisitor.h
+++ b/include/swift/SIL/SILBuiltinVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILDebuggerClient.h
+++ b/include/swift/SIL/SILDebuggerClient.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILDefaultWitnessTable.h
+++ b/include/swift/SIL/SILDefaultWitnessTable.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILPrintContext.h
+++ b/include/swift/SIL/SILPrintContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILProfiler.h
+++ b/include/swift/SIL/SILProfiler.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILProperty.h
+++ b/include/swift/SIL/SILProperty.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILSuccessor.h
+++ b/include/swift/SIL/SILSuccessor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILUndef.h
+++ b/include/swift/SIL/SILUndef.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILVisitor.h
+++ b/include/swift/SIL/SILVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/Analysis.def
+++ b/include/swift/SILOptimizer/Analysis/Analysis.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/CFG.h
+++ b/include/swift/SILOptimizer/Analysis/CFG.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/ClosureScope.h
+++ b/include/swift/SILOptimizer/Analysis/ClosureScope.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/ColdBlockInfo.h
+++ b/include/swift/SILOptimizer/Analysis/ColdBlockInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/DominanceAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DominanceAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/FunctionOrder.h
+++ b/include/swift/SILOptimizer/Analysis/FunctionOrder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/IVAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/IVAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/LoopAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/PostOrderAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/PostOrderAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/ProgramTerminationAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ProgramTerminationAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
+++ b/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/TypeExpansionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/TypeExpansionAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Analysis/ValueTracking.h
+++ b/include/swift/SILOptimizer/Analysis/ValueTracking.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.def
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.h
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/PassManager/PrettyStackTrace.h
+++ b/include/swift/SILOptimizer/PassManager/PrettyStackTrace.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/PassManager/Transforms.h
+++ b/include/swift/SILOptimizer/PassManager/Transforms.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/CFG.h
+++ b/include/swift/SILOptimizer/Utils/CFG.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/CastOptimizer.h
+++ b/include/swift/SILOptimizer/Utils/CastOptimizer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/ConstantFolding.h
+++ b/include/swift/SILOptimizer/Utils/ConstantFolding.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/Existential.h
+++ b/include/swift/SILOptimizer/Utils/Existential.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/IndexTrie.h
+++ b/include/swift/SILOptimizer/Utils/IndexTrie.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/LoopUtils.h
+++ b/include/swift/SILOptimizer/Utils/LoopUtils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/OptimizerStatsUtils.h
+++ b/include/swift/SILOptimizer/Utils/OptimizerStatsUtils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
+++ b/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/SCCVisitor.h
+++ b/include/swift/SILOptimizer/Utils/SCCVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
+++ b/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/SpecializationMangler.h
+++ b/include/swift/SILOptimizer/Utils/SpecializationMangler.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SILOptimizer/Utils/StackNesting.h
+++ b/include/swift/SILOptimizer/Utils/StackNesting.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Serialization/BCReadingExtras.h
+++ b/include/swift/Serialization/BCReadingExtras.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Serialization/DeclTypeRecordNodes.def
+++ b/include/swift/Serialization/DeclTypeRecordNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SwiftDemangle/MangleHack.h
+++ b/include/swift/SwiftDemangle/MangleHack.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SwiftDemangle/Platform.h
+++ b/include/swift/SwiftDemangle/Platform.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SwiftDemangle/SwiftDemangle.h
+++ b/include/swift/SwiftDemangle/SwiftDemangle.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SwiftRemoteMirror/MemoryReaderInterface.h
+++ b/include/swift/SwiftRemoteMirror/MemoryReaderInterface.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SwiftRemoteMirror/Platform.h
+++ b/include/swift/SwiftRemoteMirror/Platform.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorLegacyInterop.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorLegacyInterop.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorLegacyInteropTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorLegacyInteropTypes.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/AtomicCache.h
+++ b/include/swift/Syntax/AtomicCache.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/Format.h
+++ b/include/swift/Syntax/Format.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/References.h
+++ b/include/swift/Syntax/References.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/SyntaxBuilders.h.gyb
+++ b/include/swift/Syntax/SyntaxBuilders.h.gyb
@@ -10,7 +10,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -9,7 +9,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -10,7 +10,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/SyntaxVisitor.h.gyb
+++ b/include/swift/Syntax/SyntaxVisitor.h.gyb
@@ -10,7 +10,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/TokenKinds.def.gyb
+++ b/include/swift/Syntax/TokenKinds.def.gyb
@@ -9,7 +9,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/TokenKinds.h
+++ b/include/swift/Syntax/TokenKinds.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Syntax/UnknownSyntax.h
+++ b/include/swift/Syntax/UnknownSyntax.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/AccessScopeChecker.cpp
+++ b/lib/AST/AccessScopeChecker.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/CaptureInfo.cpp
+++ b/lib/AST/CaptureInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/DeclNameLoc.cpp
+++ b/lib/AST/DeclNameLoc.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/DiagnosticList.cpp
+++ b/lib/AST/DiagnosticList.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ForeignRepresentationInfo.h
+++ b/lib/AST/ForeignRepresentationInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/LayoutConstraint.cpp
+++ b/lib/AST/LayoutConstraint.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/NameLookupImpl.h
+++ b/lib/AST/NameLookupImpl.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/SILLayout.cpp
+++ b/lib/AST/SILLayout.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/SubstitutionMapStorage.h
+++ b/lib/AST/SubstitutionMapStorage.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/SyntaxASTMap.cpp
+++ b/lib/AST/SyntaxASTMap.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ASTSectionImporter/ASTSectionImporter.cpp
+++ b/lib/ASTSectionImporter/ASTSectionImporter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/AnyValue.cpp
+++ b/lib/Basic/AnyValue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Cache.cpp
+++ b/lib/Basic/Cache.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/ClusteredBitVector.cpp
+++ b/lib/Basic/ClusteredBitVector.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Darwin/Cache-Mac.cpp
+++ b/lib/Basic/Darwin/Cache-Mac.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Default/TaskQueue.inc
+++ b/lib/Basic/Default/TaskQueue.inc
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/DiverseStack.cpp
+++ b/lib/Basic/DiverseStack.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Edit.cpp
+++ b/lib/Basic/Edit.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/EditorPlaceholder.cpp
+++ b/lib/Basic/EditorPlaceholder.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/JSONSerialization.cpp
+++ b/lib/Basic/JSONSerialization.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/LLVMContext.cpp
+++ b/lib/Basic/LLVMContext.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/PartsOfSpeech.def
+++ b/lib/Basic/PartsOfSpeech.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/PrefixMap.cpp
+++ b/lib/Basic/PrefixMap.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/PrettyStackTrace.cpp
+++ b/lib/Basic/PrettyStackTrace.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/PrimitiveParsing.cpp
+++ b/lib/Basic/PrimitiveParsing.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Program.cpp
+++ b/lib/Basic/Program.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/QuotedString.cpp
+++ b/lib/Basic/QuotedString.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/TaskQueue.cpp
+++ b/lib/Basic/TaskQueue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/ThreadSafeRefCounted.cpp
+++ b/lib/Basic/ThreadSafeRefCounted.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Timer.cpp
+++ b/lib/Basic/Timer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/UUID.cpp
+++ b/lib/Basic/UUID.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Unicode.cpp
+++ b/lib/Basic/Unicode.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/UnicodeExtendedGraphemeClusters.cpp.gyb
+++ b/lib/Basic/UnicodeExtendedGraphemeClusters.cpp.gyb
@@ -7,7 +7,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Unix/TaskQueue.inc
+++ b/lib/Basic/Unix/TaskQueue.inc
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/CFDatabase.def
+++ b/lib/ClangImporter/CFDatabase.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/CFTypeInfo.cpp
+++ b/lib/ClangImporter/CFTypeInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/CFTypeInfo.h
+++ b/lib/ClangImporter/CFTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ClangAdapter.h
+++ b/lib/ClangImporter/ClangAdapter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ClangDiagnosticConsumer.h
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/IAMInference.cpp
+++ b/lib/ClangImporter/IAMInference.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/IAMInference.h
+++ b/lib/ClangImporter/IAMInference.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ImportEnumInfo.h
+++ b/lib/ClangImporter/ImportEnumInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/InferredAttributes.def
+++ b/lib/ClangImporter/InferredAttributes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/MacroTable.def
+++ b/lib/ClangImporter/MacroTable.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/MappedTypes.def
+++ b/lib/ClangImporter/MappedTypes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/SortedCFDatabase.def.gyb
+++ b/lib/ClangImporter/SortedCFDatabase.def.gyb
@@ -6,7 +6,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/ManglingUtils.cpp
+++ b/lib/Demangling/ManglingUtils.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/NodeDumper.cpp
+++ b/lib/Demangling/NodeDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/Punycode.cpp
+++ b/lib/Demangling/Punycode.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Demangling/TypeDecoder.cpp
+++ b/lib/Demangling/TypeDecoder.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Driver/Action.cpp
+++ b/lib/Driver/Action.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Driver/CompilationRecord.h
+++ b/lib/Driver/CompilationRecord.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Driver/DependencyGraph.cpp
+++ b/lib/Driver/DependencyGraph.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Driver/ParseableOutput.cpp
+++ b/lib/Driver/ParseableOutput.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/FrontendTool/ImportedModules.h
+++ b/lib/FrontendTool/ImportedModules.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/FrontendTool/ReferenceDependencies.h
+++ b/lib/FrontendTool/ReferenceDependencies.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/FrontendTool/TBD.h
+++ b/lib/FrontendTool/TBD.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/APIDigesterData.cpp
+++ b/lib/IDE/APIDigesterData.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ClassLayout.cpp
+++ b/lib/IRGen/ClassLayout.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ClassLayout.h
+++ b/lib/IRGen/ClassLayout.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ConstantBuilder.h
+++ b/lib/IRGen/ConstantBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/DominancePoint.h
+++ b/lib/IRGen/DominancePoint.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/DominanceScope.h
+++ b/lib/IRGen/DominanceScope.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/EnumMetadataVisitor.h
+++ b/lib/IRGen/EnumMetadataVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Explosion.h
+++ b/lib/IRGen/Explosion.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ExtraInhabitants.cpp
+++ b/lib/IRGen/ExtraInhabitants.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ExtraInhabitants.h
+++ b/lib/IRGen/ExtraInhabitants.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ForeignClassMetadataVisitor.h
+++ b/lib/IRGen/ForeignClassMetadataVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Fulfillment.h
+++ b/lib/IRGen/Fulfillment.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenArchetype.h
+++ b/lib/IRGen/GenArchetype.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenBuiltin.h
+++ b/lib/IRGen/GenBuiltin.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenCast.h
+++ b/lib/IRGen/GenCast.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenConstant.h
+++ b/lib/IRGen/GenConstant.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenControl.cpp
+++ b/lib/IRGen/GenControl.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenDecl.h
+++ b/lib/IRGen/GenDecl.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenExistential.h
+++ b/lib/IRGen/GenExistential.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenOpaque.h
+++ b/lib/IRGen/GenOpaque.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenPoly.cpp
+++ b/lib/IRGen/GenPoly.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenPoly.h
+++ b/lib/IRGen/GenPoly.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenStruct.h
+++ b/lib/IRGen/GenStruct.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenTuple.h
+++ b/lib/IRGen/GenTuple.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenValueWitness.h
+++ b/lib/IRGen/GenValueWitness.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/GenericRequirement.h
+++ b/lib/IRGen/GenericRequirement.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/HeapTypeInfo.h
+++ b/lib/IRGen/HeapTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGen.h
+++ b/lib/IRGen/IRGen.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/IndirectTypeInfo.h
+++ b/lib/IRGen/IndirectTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/LoadableTypeInfo.h
+++ b/lib/IRGen/LoadableTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/LocalTypeData.h
+++ b/lib/IRGen/LocalTypeData.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/LocalTypeDataCache.h
+++ b/lib/IRGen/LocalTypeDataCache.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/LocalTypeDataKind.h
+++ b/lib/IRGen/LocalTypeDataKind.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/MemberAccessStrategy.h
+++ b/lib/IRGen/MemberAccessStrategy.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/MetadataLayout.h
+++ b/lib/IRGen/MetadataLayout.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/MetadataPath.h
+++ b/lib/IRGen/MetadataPath.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/NativeConventionSchema.h
+++ b/lib/IRGen/NativeConventionSchema.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/NecessaryBindings.h
+++ b/lib/IRGen/NecessaryBindings.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/NominalMetadataVisitor.h
+++ b/lib/IRGen/NominalMetadataVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ReferenceTypeInfo.h
+++ b/lib/IRGen/ReferenceTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ResilientTypeInfo.h
+++ b/lib/IRGen/ResilientTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/ScalarTypeInfo.h
+++ b/lib/IRGen/ScalarTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/SwiftTargetInfo.h
+++ b/lib/IRGen/SwiftTargetInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/SwitchBuilder.h
+++ b/lib/IRGen/SwitchBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/Temporary.h
+++ b/lib/IRGen/Temporary.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/TypeLayoutDumper.cpp
+++ b/lib/IRGen/TypeLayoutDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/TypeLayoutDumper.h
+++ b/lib/IRGen/TypeLayoutDumper.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/TypeLayoutVerifier.cpp
+++ b/lib/IRGen/TypeLayoutVerifier.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/TypeVisitor.h
+++ b/lib/IRGen/TypeVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/IRGen/WitnessIndex.h
+++ b/lib/IRGen/WitnessIndex.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Index/IndexDataConsumer.cpp
+++ b/lib/Index/IndexDataConsumer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/LLVMPasses/LLVMARCContract.cpp
+++ b/lib/LLVMPasses/LLVMARCContract.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/LLVMPasses/LLVMARCOpts.h
+++ b/lib/LLVMPasses/LLVMARCOpts.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/LLVMPasses/LLVMInlineTree.cpp
+++ b/lib/LLVMPasses/LLVMInlineTree.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -3,7 +3,7 @@
 // This source file is part of the Swift.org open source project
 // Licensed under Apache License v2.0 with Runtime Library Exception
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//

--- a/lib/LLVMPasses/LLVMSwift.def
+++ b/lib/LLVMPasses/LLVMSwift.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/LLVMPasses/LLVMSwiftAA.cpp
+++ b/lib/LLVMPasses/LLVMSwiftAA.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/LLVMPasses/LLVMSwiftRCIdentity.cpp
+++ b/lib/LLVMPasses/LLVMSwiftRCIdentity.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Markup/AST.cpp
+++ b/lib/Markup/AST.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Markup/LineList.cpp
+++ b/lib/Markup/LineList.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Markup/Markup.cpp
+++ b/lib/Markup/Markup.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Migrator/EditorAdapter.cpp
+++ b/lib/Migrator/EditorAdapter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
+++ b/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Migrator/MigrationState.cpp
+++ b/lib/Migrator/MigrationState.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -1,7 +1,7 @@
 //===--- Migrator.cpp -----------------------------------------------------===//
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Migrator/RewriteBufferEditsReceiver.cpp
+++ b/lib/Migrator/RewriteBufferEditsReceiver.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Option/Options.cpp
+++ b/lib/Option/Options.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/Confusables.cpp
+++ b/lib/Parse/Confusables.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/RemoteAST/InProcessMemoryReader.cpp
+++ b/lib/RemoteAST/InProcessMemoryReader.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/BasicBlockUtils.cpp
+++ b/lib/SIL/BasicBlockUtils.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/Dominance.cpp
+++ b/lib/SIL/Dominance.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/LoopInfo.cpp
+++ b/lib/SIL/LoopInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/OptimizationRemark.cpp
+++ b/lib/SIL/OptimizationRemark.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/PrettyStackTrace.cpp
+++ b/lib/SIL/PrettyStackTrace.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILCoverageMap.cpp
+++ b/lib/SIL/SILCoverageMap.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILDebugScope.cpp
+++ b/lib/SIL/SILDebugScope.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILDefaultWitnessTable.cpp
+++ b/lib/SIL/SILDefaultWitnessTable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILGlobalVariable.cpp
+++ b/lib/SIL/SILGlobalVariable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILLocation.cpp
+++ b/lib/SIL/SILLocation.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILSuccessor.cpp
+++ b/lib/SIL/SILSuccessor.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILVTable.cpp
+++ b/lib/SIL/SILVTable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/SILWitnessTable.cpp
+++ b/lib/SIL/SILWitnessTable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/UseOwnershipRequirement.h
+++ b/lib/SIL/UseOwnershipRequirement.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/ValueOwnershipKindClassifier.cpp
+++ b/lib/SIL/ValueOwnershipKindClassifier.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SIL/ValueOwnershipKindClassifier.h
+++ b/lib/SIL/ValueOwnershipKindClassifier.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/ASTVisitor.h
+++ b/lib/SILGen/ASTVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/ArgumentScope.h
+++ b/lib/SILGen/ArgumentScope.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Callee.h
+++ b/lib/SILGen/Callee.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Condition.cpp
+++ b/lib/SILGen/Condition.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Condition.h
+++ b/lib/SILGen/Condition.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/ExitableFullExpr.h
+++ b/lib/SILGen/ExitableFullExpr.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/FormalEvaluation.cpp
+++ b/lib/SILGen/FormalEvaluation.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/JumpDest.h
+++ b/lib/SILGen/JumpDest.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SGFContext.h
+++ b/lib/SILGen/SGFContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenDynamicCast.h
+++ b/lib/SILGen/SILGenDynamicCast.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Scope.cpp
+++ b/lib/SILGen/Scope.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Scope.h
+++ b/lib/SILGen/Scope.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/SpecializedEmitter.h
+++ b/lib/SILGen/SpecializedEmitter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILGen/Varargs.h
+++ b/lib/SILGen/Varargs.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/ARCBBState.cpp
+++ b/lib/SILOptimizer/ARC/ARCBBState.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/ARCBBState.h
+++ b/lib/SILOptimizer/ARC/ARCBBState.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/ARCLoopOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCLoopOpts.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/ARCMatchingSet.cpp
+++ b/lib/SILOptimizer/ARC/ARCMatchingSet.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/ARCMatchingSet.h
+++ b/lib/SILOptimizer/ARC/ARCMatchingSet.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/ARCRegionState.cpp
+++ b/lib/SILOptimizer/ARC/ARCRegionState.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/ARCRegionState.h
+++ b/lib/SILOptimizer/ARC/ARCRegionState.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.h
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/RCStateTransition.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransition.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/RCStateTransition.def
+++ b/lib/SILOptimizer/ARC/RCStateTransition.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/RCStateTransition.h
+++ b/lib/SILOptimizer/ARC/RCStateTransition.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/RCStateTransitionVisitors.h
+++ b/lib/SILOptimizer/ARC/RCStateTransitionVisitors.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/ARC/RefCountState.h
+++ b/lib/SILOptimizer/ARC/RefCountState.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/Analysis.cpp
+++ b/lib/SILOptimizer/Analysis/Analysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/CFG.cpp
+++ b/lib/SILOptimizer/Analysis/CFG.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/ClosureScope.cpp
+++ b/lib/SILOptimizer/Analysis/ClosureScope.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
+++ b/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/FunctionOrder.cpp
+++ b/lib/SILOptimizer/Analysis/FunctionOrder.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/IVAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/IVAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/LoopAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/TypeExpansionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/TypeExpansionAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/IPO/UsePrespecialized.cpp
+++ b/lib/SILOptimizer/IPO/UsePrespecialized.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
+++ b/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/PassManager/PrettyStackTrace.cpp
+++ b/lib/SILOptimizer/PassManager/PrettyStackTrace.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/AssumeSingleThreaded.cpp
+++ b/lib/SILOptimizer/Transforms/AssumeSingleThreaded.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/Devirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/Devirtualizer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
+++ b/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/MergeCondFail.cpp
+++ b/lib/SILOptimizer/Transforms/MergeCondFail.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
+++ b/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/Sink.cpp
+++ b/lib/SILOptimizer/Transforms/Sink.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Transforms/UnsafeGuaranteedPeephole.cpp
+++ b/lib/SILOptimizer/Transforms/UnsafeGuaranteedPeephole.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/AADumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AADumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/BasicCalleePrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BasicCalleePrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/BasicInstructionPropertyDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BasicInstructionPropertyDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/CFGPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/CFGPrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/CallerAnalysisPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/CallerAnalysisPrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/ComputeDominanceInfo.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ComputeDominanceInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/ComputeLoopInfo.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ComputeLoopInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/EpilogueARCMatcherDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/EpilogueARCMatcherDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/EpilogueRetainReleaseMatcherDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/EpilogueRetainReleaseMatcherDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/IVInfoPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/IVInfoPrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/InstCount.cpp
+++ b/lib/SILOptimizer/UtilityPasses/InstCount.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/LSLocationPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LSLocationPrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/LoopCanonicalizer.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LoopCanonicalizer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/LoopInfoPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LoopInfoPrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/LoopRegionPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LoopRegionPrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/MemBehaviorDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/MemBehaviorDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/RCIdentityDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/RCIdentityDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/SideEffectsDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SideEffectsDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/SimplifyUnreachableContainingBlocks.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SimplifyUnreachableContainingBlocks.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/StripDebugInfo.cpp
+++ b/lib/SILOptimizer/UtilityPasses/StripDebugInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/UtilityPasses/ValueOwnershipKindDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ValueOwnershipKindDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/LoadStoreOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoadStoreOptUtils.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/CalleeCandidateInfo.h
+++ b/lib/Sema/CalleeCandidateInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/ConstraintGraphScope.h
+++ b/lib/Sema/ConstraintGraphScope.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/ConstraintSolverStats.def
+++ b/lib/Sema/ConstraintSolverStats.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/OverloadChoice.h
+++ b/lib/Sema/OverloadChoice.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckAccess.h
+++ b/lib/Sema/TypeCheckAccess.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Sema/TypoCorrection.h
+++ b/lib/Sema/TypoCorrection.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Serialization/SerializedSILLoader.cpp
+++ b/lib/Serialization/SerializedSILLoader.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SwiftDemangle/MangleHack.cpp
+++ b/lib/SwiftDemangle/MangleHack.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/SwiftDemangle/SwiftDemangle.cpp
+++ b/lib/SwiftDemangle/SwiftDemangle.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/Syntax.cpp
+++ b/lib/Syntax/Syntax.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/SyntaxBuilders.cpp.gyb
+++ b/lib/Syntax/SyntaxBuilders.cpp.gyb
@@ -11,7 +11,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -9,7 +9,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/SyntaxKind.cpp.gyb
+++ b/lib/Syntax/SyntaxKind.cpp.gyb
@@ -9,7 +9,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -10,7 +10,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/SyntaxVisitor.cpp.gyb
+++ b/lib/Syntax/SyntaxVisitor.cpp.gyb
@@ -10,7 +10,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/Trivia.cpp.gyb
+++ b/lib/Syntax/Trivia.cpp.gyb
@@ -10,7 +10,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/Syntax/UnknownSyntax.cpp
+++ b/lib/Syntax/UnknownSyntax.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
+++ b/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/StdlibCollectionUnittest.swift
+++ b/stdlib/private/StdlibCollectionUnittest/StdlibCollectionUnittest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibCollectionUnittest/WriteBackMutableSlice.swift
+++ b/stdlib/private/StdlibCollectionUnittest/WriteBackMutableSlice.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnicodeUnittest/Collation.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/Collation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnicodeUnittest/StdlibUnicodeUnittest.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/StdlibUnicodeUnittest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/CheckStrideable.swift
+++ b/stdlib/private/StdlibUnittest/CheckStrideable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/GetOSVersion.mm
+++ b/stdlib/private/StdlibUnittest/GetOSVersion.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/InspectValue.cpp
+++ b/stdlib/private/StdlibUnittest/InspectValue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/InspectValue.swift
+++ b/stdlib/private/StdlibUnittest/InspectValue.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/InterceptTraps.cpp
+++ b/stdlib/private/StdlibUnittest/InterceptTraps.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/LifetimeTracked.swift
+++ b/stdlib/private/StdlibUnittest/LifetimeTracked.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/MinimalTypes.swift
+++ b/stdlib/private/StdlibUnittest/MinimalTypes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.cpp
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/Statistics.swift
+++ b/stdlib/private/StdlibUnittest/Statistics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/StringConvertible.swift
+++ b/stdlib/private/StdlibUnittest/StringConvertible.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/TestHelpers.swift
+++ b/stdlib/private/StdlibUnittest/TestHelpers.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittest/TypeIndexed.swift
+++ b/stdlib/private/StdlibUnittest/TypeIndexed.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
+++ b/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/StdlibUnittestFoundationExtras/UnavailableFoundationMethodThunks.mm
+++ b/stdlib/private/StdlibUnittestFoundationExtras/UnavailableFoundationMethodThunks.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
+++ b/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/SwiftPrivate/SwiftPrivate.swift
+++ b/stdlib/private/SwiftPrivate/SwiftPrivate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.c
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.c
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/Darwin.swift.gyb
+++ b/stdlib/public/Platform/Darwin.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/Glibc.swift.gyb
+++ b/stdlib/public/Platform/Glibc.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/MachError.swift
+++ b/stdlib/public/Platform/MachError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/TiocConstants.swift
+++ b/stdlib/public/Platform/TiocConstants.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/msvcrt.swift
+++ b/stdlib/public/Platform/msvcrt.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Reflection/MetadataSource.cpp
+++ b/stdlib/public/Reflection/MetadataSource.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/ARKit/ARKit.swift
+++ b/stdlib/public/SDK/ARKit/ARKit.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AVFoundation/AVCaptureDevice.swift
+++ b/stdlib/public/SDK/AVFoundation/AVCaptureDevice.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AVFoundation/AVCapturePhotoOutput.swift
+++ b/stdlib/public/SDK/AVFoundation/AVCapturePhotoOutput.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AVFoundation/AVCaptureSynchronizedDataCollection.swift
+++ b/stdlib/public/SDK/AVFoundation/AVCaptureSynchronizedDataCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AVFoundation/AVCaptureVideoDataOutput.swift
+++ b/stdlib/public/SDK/AVFoundation/AVCaptureVideoDataOutput.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AVFoundation/AVError.swift
+++ b/stdlib/public/SDK/AVFoundation/AVError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AVFoundation/AVMetadataObject.swift
+++ b/stdlib/public/SDK/AVFoundation/AVMetadataObject.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AppKit/AppKit.swift
+++ b/stdlib/public/SDK/AppKit/AppKit.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AppKit/AppKit_FoundationExtensions.swift
+++ b/stdlib/public/SDK/AppKit/AppKit_FoundationExtensions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AppKit/NSError.swift
+++ b/stdlib/public/SDK/AppKit/NSError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AppKit/NSGraphics.swift
+++ b/stdlib/public/SDK/AppKit/NSGraphics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AppKit/NSOpenGL.swift
+++ b/stdlib/public/SDK/AppKit/NSOpenGL.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/AssetsLibrary/ALAssetsLibrary.swift
+++ b/stdlib/public/SDK/AssetsLibrary/ALAssetsLibrary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CallKit/CXProviderConfiguration.swift
+++ b/stdlib/public/SDK/CallKit/CXProviderConfiguration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Contacts/CNError.swift
+++ b/stdlib/public/SDK/Contacts/CNError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreData/CocoaError.swift
+++ b/stdlib/public/SDK/CoreData/CocoaError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreData/CoreData.mm
+++ b/stdlib/public/SDK/CoreData/CoreData.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreData/NSManagedObjectContext.swift
+++ b/stdlib/public/SDK/CoreData/NSManagedObjectContext.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreFoundation/CoreFoundation.swift
+++ b/stdlib/public/SDK/CoreFoundation/CoreFoundation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreGraphics/Private.swift
+++ b/stdlib/public/SDK/CoreGraphics/Private.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreImage/CoreImage.swift
+++ b/stdlib/public/SDK/CoreImage/CoreImage.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreLocation/CLError.swift
+++ b/stdlib/public/SDK/CoreLocation/CLError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreMedia/CMTime.swift
+++ b/stdlib/public/SDK/CoreMedia/CMTime.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CoreMedia/CMTimeRange.swift
+++ b/stdlib/public/SDK/CoreMedia/CMTimeRange.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/CryptoTokenKit/TKSmartCard.swift
+++ b/stdlib/public/SDK/CryptoTokenKit/TKSmartCard.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Dispatch/Block.swift
+++ b/stdlib/public/SDK/Dispatch/Block.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Dispatch/Dispatch.mm
+++ b/stdlib/public/SDK/Dispatch/Dispatch.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Dispatch/Dispatch.swift
+++ b/stdlib/public/SDK/Dispatch/Dispatch.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Dispatch/IO.swift
+++ b/stdlib/public/SDK/Dispatch/IO.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Dispatch/Private.swift
+++ b/stdlib/public/SDK/Dispatch/Private.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Dispatch/Source.swift
+++ b/stdlib/public/SDK/Dispatch/Source.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -3,7 +3,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Boxing.swift
+++ b/stdlib/public/SDK/Foundation/Boxing.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Codable.swift
+++ b/stdlib/public/SDK/Foundation/Codable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/DataThunks.m
+++ b/stdlib/public/SDK/Foundation/DataThunks.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Date.swift
+++ b/stdlib/public/SDK/Foundation/Date.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/DateComponents.swift
+++ b/stdlib/public/SDK/Foundation/DateComponents.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/DateInterval.swift
+++ b/stdlib/public/SDK/Foundation/DateInterval.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
+++ b/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/FileManager.swift
+++ b/stdlib/public/SDK/Foundation/FileManager.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSArray.swift
+++ b/stdlib/public/SDK/Foundation/NSArray.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSCoder.swift
+++ b/stdlib/public/SDK/Foundation/NSCoder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSDate.swift
+++ b/stdlib/public/SDK/Foundation/NSDate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSDictionary.swift
+++ b/stdlib/public/SDK/Foundation/NSDictionary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSExpression.swift
+++ b/stdlib/public/SDK/Foundation/NSExpression.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSFastEnumeration.swift
+++ b/stdlib/public/SDK/Foundation/NSFastEnumeration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSGeometry.swift
+++ b/stdlib/public/SDK/Foundation/NSGeometry.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSIndexSet.swift
+++ b/stdlib/public/SDK/Foundation/NSIndexSet.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSItemProvider.swift
+++ b/stdlib/public/SDK/Foundation/NSItemProvider.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSNumber.swift
+++ b/stdlib/public/SDK/Foundation/NSNumber.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSPredicate.swift
+++ b/stdlib/public/SDK/Foundation/NSPredicate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSRange.swift
+++ b/stdlib/public/SDK/Foundation/NSRange.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSSet.swift
+++ b/stdlib/public/SDK/Foundation/NSSet.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSString.swift
+++ b/stdlib/public/SDK/Foundation/NSString.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSStringEncodings.swift
+++ b/stdlib/public/SDK/Foundation/NSStringEncodings.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSTextCheckingResult.swift
+++ b/stdlib/public/SDK/Foundation/NSTextCheckingResult.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSURL.swift
+++ b/stdlib/public/SDK/Foundation/NSURL.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSUndoManager.swift
+++ b/stdlib/public/SDK/Foundation/NSUndoManager.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/NSValue.swift.gyb
+++ b/stdlib/public/SDK/Foundation/NSValue.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Notification.swift
+++ b/stdlib/public/SDK/Foundation/Notification.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/PersonNameComponents.swift
+++ b/stdlib/public/SDK/Foundation/PersonNameComponents.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/Progress.swift
+++ b/stdlib/public/SDK/Foundation/Progress.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/ReferenceConvertible.swift
+++ b/stdlib/public/SDK/Foundation/ReferenceConvertible.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/String.swift
+++ b/stdlib/public/SDK/Foundation/String.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/TypePreservingNSNumber.mm
+++ b/stdlib/public/SDK/Foundation/TypePreservingNSNumber.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/URLComponents.swift
+++ b/stdlib/public/SDK/Foundation/URLComponents.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/URLRequest.swift
+++ b/stdlib/public/SDK/Foundation/URLRequest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/GLKit/GLKMath.swift.gyb
+++ b/stdlib/public/SDK/GLKit/GLKMath.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/GameplayKit/GameplayKit.swift
+++ b/stdlib/public/SDK/GameplayKit/GameplayKit.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/HomeKit/HomeKit.swift
+++ b/stdlib/public/SDK/HomeKit/HomeKit.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/IOKit/IOReturn.swift
+++ b/stdlib/public/SDK/IOKit/IOReturn.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INBooleanResolutionResult.swift
+++ b/stdlib/public/SDK/Intents/INBooleanResolutionResult.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INCallRecord.swift
+++ b/stdlib/public/SDK/Intents/INCallRecord.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INDoubleResolutionResult.swift
+++ b/stdlib/public/SDK/Intents/INDoubleResolutionResult.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INGetCarLockStatusIntentResponse.swift
+++ b/stdlib/public/SDK/Intents/INGetCarLockStatusIntentResponse.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INGetCarPowerLevelStatusIntentResponse.swift
+++ b/stdlib/public/SDK/Intents/INGetCarPowerLevelStatusIntentResponse.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INIntegerResolutionResult.swift
+++ b/stdlib/public/SDK/Intents/INIntegerResolutionResult.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INNotebookItemTypeResolutionResult.swift
+++ b/stdlib/public/SDK/Intents/INNotebookItemTypeResolutionResult.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INParameter.swift
+++ b/stdlib/public/SDK/Intents/INParameter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INRequestRideIntent.swift
+++ b/stdlib/public/SDK/Intents/INRequestRideIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INRideOption.swift
+++ b/stdlib/public/SDK/Intents/INRideOption.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INSaveProfileInCarIntent.swift
+++ b/stdlib/public/SDK/Intents/INSaveProfileInCarIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INSearchCallHistoryIntent.swift
+++ b/stdlib/public/SDK/Intents/INSearchCallHistoryIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INSearchForPhotosIntentResponse.swift
+++ b/stdlib/public/SDK/Intents/INSearchForPhotosIntentResponse.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INSetCarLockStatusIntent.swift
+++ b/stdlib/public/SDK/Intents/INSetCarLockStatusIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INSetClimateSettingsInCarIntent.swift
+++ b/stdlib/public/SDK/Intents/INSetClimateSettingsInCarIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INSetDefrosterSettingsInCarIntent.swift
+++ b/stdlib/public/SDK/Intents/INSetDefrosterSettingsInCarIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INSetProfileInCarIntent.swift
+++ b/stdlib/public/SDK/Intents/INSetProfileInCarIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INSetRadioStationIntent.swift
+++ b/stdlib/public/SDK/Intents/INSetRadioStationIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INSetSeatSettingsInCarIntent.swift
+++ b/stdlib/public/SDK/Intents/INSetSeatSettingsInCarIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INStartPhotoPlaybackIntentResponse.swift
+++ b/stdlib/public/SDK/Intents/INStartPhotoPlaybackIntentResponse.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/INStartWorkoutIntent.swift
+++ b/stdlib/public/SDK/Intents/INStartWorkoutIntent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Intents/NSStringIntents.swift
+++ b/stdlib/public/SDK/Intents/NSStringIntents.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Metal/Metal.swift
+++ b/stdlib/public/SDK/Metal/Metal.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/MetalKit/MetalKit.swift
+++ b/stdlib/public/SDK/MetalKit/MetalKit.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/ModelIO/ModelIO.swift
+++ b/stdlib/public/SDK/ModelIO/ModelIO.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/OpenCL/OpenCL.swift
+++ b/stdlib/public/SDK/OpenCL/OpenCL.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Photos/PHChange.swift
+++ b/stdlib/public/SDK/Photos/PHChange.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/QuartzCore/NSValue.swift.gyb
+++ b/stdlib/public/SDK/QuartzCore/NSValue.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/SafariServices/SafariServices.swift
+++ b/stdlib/public/SDK/SafariServices/SafariServices.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/SceneKit/SceneKit.swift.gyb
+++ b/stdlib/public/SDK/SceneKit/SceneKit.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/SpriteKit/SpriteKit.swift
+++ b/stdlib/public/SDK/SpriteKit/SpriteKit.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/SpriteKit/SpriteKitQuickLooks.swift.gyb
+++ b/stdlib/public/SDK/SpriteKit/SpriteKitQuickLooks.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/UIKit/DesignatedInitializers.mm
+++ b/stdlib/public/SDK/UIKit/DesignatedInitializers.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/UIKit/UIKit_FoundationExtensions.swift.gyb
+++ b/stdlib/public/SDK/UIKit/UIKit_FoundationExtensions.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/Vision/Vision.swift
+++ b/stdlib/public/SDK/Vision/Vision.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/WatchKit/WKInterfaceController.swift
+++ b/stdlib/public/SDK/WatchKit/WKInterfaceController.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/XCTest/XCTestCaseAdditions.mm
+++ b/stdlib/public/SDK/XCTest/XCTestCaseAdditions.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/XPC/XPC.swift
+++ b/stdlib/public/SDK/XPC/XPC.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/os/format.h
+++ b/stdlib/public/SDK/os/format.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/os/format.m
+++ b/stdlib/public/SDK/os/format.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/os/os.m
+++ b/stdlib/public/SDK/os/os.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/os/os_log.swift
+++ b/stdlib/public/SDK/os/os_log.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/os/os_signpost.swift
+++ b/stdlib/public/SDK/os/os_signpost.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/os/os_trace_blob.c
+++ b/stdlib/public/SDK/os/os_trace_blob.c
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/os/os_trace_blob.h
+++ b/stdlib/public/SDK/os/os_trace_blob.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/os/thunks.h
+++ b/stdlib/public/SDK/os/thunks.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/os/thunks.mm
+++ b/stdlib/public/SDK/os/thunks.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SDK/simd/simd.swift.gyb
+++ b/stdlib/public/SDK/simd/simd.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
+++ b/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/AssertionReporting.h
+++ b/stdlib/public/SwiftShims/AssertionReporting.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/CFCharacterSetShims.h
+++ b/stdlib/public/SwiftShims/CFCharacterSetShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/CFHashingShims.h
+++ b/stdlib/public/SwiftShims/CFHashingShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/CoreFoundationOverlayShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationOverlayShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/FoundationOverlayShims.h
+++ b/stdlib/public/SwiftShims/FoundationOverlayShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/FoundationShimSupport.h
+++ b/stdlib/public/SwiftShims/FoundationShimSupport.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/FoundationShims.h
+++ b/stdlib/public/SwiftShims/FoundationShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/KeyPath.h
+++ b/stdlib/public/SwiftShims/KeyPath.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSCalendarShims.h
+++ b/stdlib/public/SwiftShims/NSCalendarShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSCharacterSetShims.h
+++ b/stdlib/public/SwiftShims/NSCharacterSetShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSCoderShims.h
+++ b/stdlib/public/SwiftShims/NSCoderShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSDataShims.h
+++ b/stdlib/public/SwiftShims/NSDataShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSDictionaryShims.h
+++ b/stdlib/public/SwiftShims/NSDictionaryShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSErrorShims.h
+++ b/stdlib/public/SwiftShims/NSErrorShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSFileManagerShims.h
+++ b/stdlib/public/SwiftShims/NSFileManagerShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSIndexPathShims.h
+++ b/stdlib/public/SwiftShims/NSIndexPathShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSIndexSetShims.h
+++ b/stdlib/public/SwiftShims/NSIndexSetShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSKeyedArchiverShims.h
+++ b/stdlib/public/SwiftShims/NSKeyedArchiverShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSLocaleShims.h
+++ b/stdlib/public/SwiftShims/NSLocaleShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSTimeZoneShims.h
+++ b/stdlib/public/SwiftShims/NSTimeZoneShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/NSUndoManagerShims.h
+++ b/stdlib/public/SwiftShims/NSUndoManagerShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/OSOverlayShims.h
+++ b/stdlib/public/SwiftShims/OSOverlayShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/ObjectiveCOverlayShims.h
+++ b/stdlib/public/SwiftShims/ObjectiveCOverlayShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/RuntimeStubs.h
+++ b/stdlib/public/SwiftShims/RuntimeStubs.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/SafariServicesOverlayShims.h
+++ b/stdlib/public/SwiftShims/SafariServicesOverlayShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/SwiftStdbool.h
+++ b/stdlib/public/SwiftShims/SwiftStdbool.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/SwiftStddef.h
+++ b/stdlib/public/SwiftShims/SwiftStddef.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/SwiftStdint.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/UIKitOverlayShims.h
+++ b/stdlib/public/SwiftShims/UIKitOverlayShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/XCTestOverlayShims.h
+++ b/stdlib/public/SwiftShims/XCTestOverlayShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/SwiftShims/XPCOverlayShims.h
+++ b/stdlib/public/SwiftShims/XPCOverlayShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ASCII.swift
+++ b/stdlib/public/core/ASCII.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ArrayBody.swift
+++ b/stdlib/public/core/ArrayBody.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/BuiltinMath.swift.gyb
+++ b/stdlib/public/core/BuiltinMath.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/CharacterUnicodeScalars.swift
+++ b/stdlib/public/core/CharacterUnicodeScalars.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/DropWhile.swift
+++ b/stdlib/public/core/DropWhile.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Dump.swift
+++ b/stdlib/public/core/Dump.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/FixedArray.swift.gyb
+++ b/stdlib/public/core/FixedArray.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/HashedCollectionsAnyHashableExtensions.swift
+++ b/stdlib/public/core/HashedCollectionsAnyHashableExtensions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ICU.swift
+++ b/stdlib/public/core/ICU.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Mirrors.swift.gyb
+++ b/stdlib/public/core/Mirrors.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/NewtypeWrapper.swift
+++ b/stdlib/public/core/NewtypeWrapper.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/REPL.swift
+++ b/stdlib/public/core/REPL.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringSwitch.swift
+++ b/stdlib/public/core/StringSwitch.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringTesting.swift
+++ b/stdlib/public/core/StringTesting.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/StringVariant.swift
+++ b/stdlib/public/core/StringVariant.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ThreadLocalStorage.swift
+++ b/stdlib/public/core/ThreadLocalStorage.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Tuple.swift.gyb
+++ b/stdlib/public/core/Tuple.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UTF32.swift
+++ b/stdlib/public/core/UTF32.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UTFEncoding.swift
+++ b/stdlib/public/core/UTFEncoding.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnavailableStringAPIs.swift.gyb
+++ b/stdlib/public/core/UnavailableStringAPIs.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnfoldSequence.swift
+++ b/stdlib/public/core/UnfoldSequence.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnicodeEncoding.swift
+++ b/stdlib/public/core/UnicodeEncoding.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnmanagedOpaqueString.swift
+++ b/stdlib/public/core/UnmanagedOpaqueString.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnmanagedString.swift
+++ b/stdlib/public/core/UnmanagedString.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnsafeBitMap.swift
+++ b/stdlib/public/core/UnsafeBitMap.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/WriteBackMutableSlice.swift
+++ b/stdlib/public/core/WriteBackMutableSlice.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Array.cpp
+++ b/stdlib/public/runtime/Array.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/CygwinPort.cpp
+++ b/stdlib/public/runtime/CygwinPort.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/EnumImpl.h
+++ b/stdlib/public/runtime/EnumImpl.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ErrorDefaultImpls.cpp
+++ b/stdlib/public/runtime/ErrorDefaultImpls.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ErrorObjectConstants.cpp
+++ b/stdlib/public/runtime/ErrorObjectConstants.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ErrorObjectNative.cpp
+++ b/stdlib/public/runtime/ErrorObjectNative.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ImageInspectionCOFF.h
+++ b/stdlib/public/runtime/ImageInspectionCOFF.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ImageInspectionELF.h
+++ b/stdlib/public/runtime/ImageInspectionELF.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/LLVMSupport.cpp
+++ b/stdlib/public/runtime/LLVMSupport.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Leaks.h
+++ b/stdlib/public/runtime/Leaks.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Leaks.mm
+++ b/stdlib/public/runtime/Leaks.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/MutexPThread.cpp
+++ b/stdlib/public/runtime/MutexPThread.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/MutexWin32.cpp
+++ b/stdlib/public/runtime/MutexWin32.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Once.cpp
+++ b/stdlib/public/runtime/Once.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Portability.cpp
+++ b/stdlib/public/runtime/Portability.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/RefCount.cpp
+++ b/stdlib/public/runtime/RefCount.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.def
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/StaticBinaryELF.cpp
+++ b/stdlib/public/runtime/StaticBinaryELF.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/SwiftHashableSupport.h
+++ b/stdlib/public/runtime/SwiftHashableSupport.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/SwiftRT-COFF.cpp
+++ b/stdlib/public/runtime/SwiftRT-COFF.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/SwiftValue.h
+++ b/stdlib/public/runtime/SwiftValue.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/runtime/WeakReference.h
+++ b/stdlib/public/runtime/WeakReference.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/CommandLine.cpp
+++ b/stdlib/public/stubs/CommandLine.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/KeyPaths.cpp
+++ b/stdlib/public/stubs/KeyPaths.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/MathStubs.cpp
+++ b/stdlib/public/stubs/MathStubs.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/OptionalBridgingHelper.mm
+++ b/stdlib/public/stubs/OptionalBridgingHelper.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/Reflection.mm
+++ b/stdlib/public/stubs/Reflection.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
+++ b/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Dependencies/Inputs/touch.py
+++ b/test/Driver/Dependencies/Inputs/touch.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Dependencies/Inputs/update-dependencies.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Inputs/crash-after-generating-pch.py
+++ b/test/Driver/Inputs/crash-after-generating-pch.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Inputs/crash.py
+++ b/test/Driver/Inputs/crash.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Inputs/fail.py
+++ b/test/Driver/Inputs/fail.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Inputs/fake-toolchain/clang++
+++ b/test/Driver/Inputs/fake-toolchain/clang++
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Inputs/fake-toolchain/ld
+++ b/test/Driver/Inputs/fake-toolchain/ld
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Inputs/filelists/check-filelist-abc.py
+++ b/test/Driver/Inputs/filelists/check-filelist-abc.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Driver/Inputs/filelists/fake-ld.py
+++ b/test/Driver/Inputs/filelists/fake-ld.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/Interpreter/FunctionConversion.swift
+++ b/test/Interpreter/FunctionConversion.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Interpreter/generic_subscript.swift
+++ b/test/Interpreter/generic_subscript.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Interpreter/subclass_existentials_objc.swift
+++ b/test/Interpreter/subclass_existentials_objc.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Prototypes/Algorithms.swift
+++ b/test/Prototypes/Algorithms.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Prototypes/GenericDispatch.swift
+++ b/test/Prototypes/GenericDispatch.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Prototypes/PatternMatching.swift
+++ b/test/Prototypes/PatternMatching.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Prototypes/Result.swift
+++ b/test/Prototypes/Result.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/Unit/lit.cfg
+++ b/test/Unit/lit.cfg
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/BridgeNonVerbatim.swift
+++ b/test/stdlib/BridgeNonVerbatim.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/BridgeStorage.swift.gyb
+++ b/test/stdlib/BridgeStorage.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Builtins.swift
+++ b/test/stdlib/Builtins.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Casts.swift
+++ b/test/stdlib/Casts.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Filter.swift
+++ b/test/stdlib/Filter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/InputStream.swift.gyb
+++ b/test/stdlib/InputStream.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/ArrayBridge/ArrayBridge.h
+++ b/test/stdlib/Inputs/ArrayBridge/ArrayBridge.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/ArrayBridge/ArrayBridge.m
+++ b/test/stdlib/Inputs/ArrayBridge/ArrayBridge.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/ArrayBridge/module.map
+++ b/test/stdlib/Inputs/ArrayBridge/module.map
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.m
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/FoundationBridge/module.map
+++ b/test/stdlib/Inputs/FoundationBridge/module.map
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/Mirror/Mirror.h
+++ b/test/stdlib/Inputs/Mirror/Mirror.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/Mirror/Mirror.mm
+++ b/test/stdlib/Inputs/Mirror/Mirror.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/Mirror/module.map
+++ b/test/stdlib/Inputs/Mirror/module.map
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/SwiftNativeNSBase/SwiftNativeNSBase.m
+++ b/test/stdlib/Inputs/SwiftNativeNSBase/SwiftNativeNSBase.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
+++ b/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/IntervalTraps.swift
+++ b/test/stdlib/IntervalTraps.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/KeyValuePairs.swift
+++ b/test/stdlib/KeyValuePairs.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/ManagedBuffer.swift
+++ b/test/stdlib/ManagedBuffer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Map.swift
+++ b/test/stdlib/Map.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/NSError.swift
+++ b/test/stdlib/NSError.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/NSItemProvider.swift
+++ b/test/stdlib/NSItemProvider.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/NSKeyedArchival.swift
+++ b/test/stdlib/NSKeyedArchival.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/NSValueBridging.swift.gyb
+++ b/test/stdlib/NSValueBridging.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/NoFoundation.swift
+++ b/test/stdlib/NoFoundation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/OptionSetTest.swift
+++ b/test/stdlib/OptionSetTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/OptionalBridge.swift
+++ b/test/stdlib/OptionalBridge.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/RangeDiagnostics.swift
+++ b/test/stdlib/RangeDiagnostics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Reduce.swift
+++ b/test/stdlib/Reduce.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/RemoveElements.swift
+++ b/test/stdlib/RemoveElements.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Strideable.swift
+++ b/test/stdlib/Strideable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestAffineTransform.swift
+++ b/test/stdlib/TestAffineTransform.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestCalendar.swift
+++ b/test/stdlib/TestCalendar.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestData_Swift4.swift
+++ b/test/stdlib/TestData_Swift4.swift
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestDate.swift
+++ b/test/stdlib/TestDate.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestDateInterval.swift
+++ b/test/stdlib/TestDateInterval.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestFileManager.swift
+++ b/test/stdlib/TestFileManager.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestIndexPath.swift
+++ b/test/stdlib/TestIndexPath.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestIndexSet.swift
+++ b/test/stdlib/TestIndexSet.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestLocale.swift
+++ b/test/stdlib/TestLocale.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestMeasurement.swift
+++ b/test/stdlib/TestMeasurement.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestNSNumberBridging.swift
+++ b/test/stdlib/TestNSNumberBridging.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestNSRange.swift
+++ b/test/stdlib/TestNSRange.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestNotification.swift
+++ b/test/stdlib/TestNotification.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestPersonNameComponents.swift
+++ b/test/stdlib/TestPersonNameComponents.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestPlistEncoder.swift
+++ b/test/stdlib/TestPlistEncoder.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestProgress.swift
+++ b/test/stdlib/TestProgress.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestTimeZone.swift
+++ b/test/stdlib/TestTimeZone.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestURL.swift
+++ b/test/stdlib/TestURL.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestUUID.swift
+++ b/test/stdlib/TestUUID.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/TestUserInfo.swift
+++ b/test/stdlib/TestUserInfo.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/Unicode.swift
+++ b/test/stdlib/Unicode.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/stdlib/WeakMirror.swift
+++ b/test/stdlib/WeakMirror.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/test/swift_test.py
+++ b/test/swift_test.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/bindings/python/sourcekitd/__init__.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/bindings/python/sourcekitd/request.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/request.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Core/Context.h
+++ b/tools/SourceKit/include/SourceKit/Core/Context.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Core/LLVM.h
+++ b/tools/SourceKit/include/SourceKit/Core/LLVM.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Core/NotificationCenter.h
+++ b/tools/SourceKit/include/SourceKit/Core/NotificationCenter.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Support/Concurrency.h
+++ b/tools/SourceKit/include/SourceKit/Support/Concurrency.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Support/FuzzyStringMatcher.h
+++ b/tools/SourceKit/include/SourceKit/Support/FuzzyStringMatcher.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Support/ImmutableTextBuffer.h
+++ b/tools/SourceKit/include/SourceKit/Support/ImmutableTextBuffer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Support/Logging.h
+++ b/tools/SourceKit/include/SourceKit/Support/Logging.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Support/Statistic.h
+++ b/tools/SourceKit/include/SourceKit/Support/Statistic.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Support/ThreadSafeRefCntPtr.h
+++ b/tools/SourceKit/include/SourceKit/Support/ThreadSafeRefCntPtr.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Support/Tracing.h
+++ b/tools/SourceKit/include/SourceKit/Support/Tracing.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/Support/UIdent.h
+++ b/tools/SourceKit/include/SourceKit/Support/UIdent.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/include/SourceKit/SwiftLang/Factory.h
+++ b/tools/SourceKit/include/SourceKit/SwiftLang/Factory.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Core/Context.cpp
+++ b/tools/SourceKit/lib/Core/Context.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Core/LangSupport.cpp
+++ b/tools/SourceKit/lib/Core/LangSupport.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Core/NotificationCenter.cpp
+++ b/tools/SourceKit/lib/Core/NotificationCenter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Support/Concurrency-libdispatch.cpp
+++ b/tools/SourceKit/lib/Support/Concurrency-libdispatch.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Support/FuzzyStringMatcher.cpp
+++ b/tools/SourceKit/lib/Support/FuzzyStringMatcher.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Support/ImmutableTextBuffer.cpp
+++ b/tools/SourceKit/lib/Support/ImmutableTextBuffer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Support/Logging.cpp
+++ b/tools/SourceKit/lib/Support/Logging.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Support/ThreadSafeRefCntPtr.cpp
+++ b/tools/SourceKit/lib/Support/ThreadSafeRefCntPtr.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Support/Tracing.cpp
+++ b/tools/SourceKit/lib/Support/Tracing.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/Support/UIDRegistry.cpp
+++ b/tools/SourceKit/lib/Support/UIDRegistry.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorDiagConsumer.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorDiagConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftInvocation.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftInvocation.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/lib/SwiftLang/SwiftStatistics.def
+++ b/tools/SourceKit/lib/SwiftLang/SwiftStatistics.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/complete-test/complete-test.cpp
+++ b/tools/SourceKit/tools/complete-test/complete-test.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
+++ b/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CodeCompletionResultsArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CodeCompletionResultsArray.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CompactArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CompactArray.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocStructureArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocStructureArray.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocSupportAnnotationArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocSupportAnnotationArray.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal-XPC.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal-XPC.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Logging.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Logging.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/RequestResponsePrinterBase.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/RequestResponsePrinterBase.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/TokenAnnotationsArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/TokenAnnotationsArray.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CodeCompletionResultsArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CodeCompletionResultsArray.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DocSupportAnnotationArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DocSupportAnnotationArray.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/TokenAnnotationsArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/TokenAnnotationsArray.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/driver/api_notes.cpp
+++ b/tools/driver/api_notes.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/driver/swift_format_main.cpp
+++ b/tools/driver/swift_format_main.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
+++ b/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-api-digester/ModuleDiagsConsumer.cpp
+++ b/tools/swift-api-digester/ModuleDiagsConsumer.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-api-digester/ModuleDiagsConsumer.h
+++ b/tools/swift-api-digester/ModuleDiagsConsumer.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-ide-test/XMLValidator.cpp
+++ b/tools/swift-ide-test/XMLValidator.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-ide-test/XMLValidator.h
+++ b/tools/swift-ide-test/XMLValidator.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-llvm-opt/LLVMOpt.cpp
+++ b/tools/swift-llvm-opt/LLVMOpt.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-reflection-test/messages.h
+++ b/tools/swift-reflection-test/messages.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-remoteast-test/messages.h
+++ b/tools/swift-remoteast-test/messages.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-stdlib-tool/swift-stdlib-tool.mm
+++ b/tools/swift-stdlib-tool/swift-stdlib-tool.mm
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/AST/ArithmeticEvaluatorTypeIDZone.def
+++ b/unittests/AST/ArithmeticEvaluatorTypeIDZone.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/AST/TypeMatchTests.cpp
+++ b/unittests/AST/TypeMatchTests.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/BlotMapVectorTest.cpp
+++ b/unittests/Basic/BlotMapVectorTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/CacheTest.cpp
+++ b/unittests/Basic/CacheTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/DemangleTest.cpp
+++ b/unittests/Basic/DemangleTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/DiverseStackTest.cpp
+++ b/unittests/Basic/DiverseStackTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/EditorPlaceholderTest.cpp
+++ b/unittests/Basic/EditorPlaceholderTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/EncodedSequenceTest.cpp
+++ b/unittests/Basic/EncodedSequenceTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/FileSystemTest.cpp
+++ b/unittests/Basic/FileSystemTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/ImmutablePointerSetTest.cpp
+++ b/unittests/Basic/ImmutablePointerSetTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/OptionSetTest.cpp
+++ b/unittests/Basic/OptionSetTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/OwnedStringTest.cpp
+++ b/unittests/Basic/OwnedStringTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/PointerIntEnumTest.cpp
+++ b/unittests/Basic/PointerIntEnumTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/PrefixMapTest.cpp
+++ b/unittests/Basic/PrefixMapTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/RangeTest.cpp
+++ b/unittests/Basic/RangeTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/SourceManagerTest.cpp
+++ b/unittests/Basic/SourceManagerTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/StringExtrasTest.cpp
+++ b/unittests/Basic/StringExtrasTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/SuccessorMapTest.cpp
+++ b/unittests/Basic/SuccessorMapTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/ThreadSafeRefCntPointerTest.cpp
+++ b/unittests/Basic/ThreadSafeRefCntPointerTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/TransformArrayRefTest.cpp
+++ b/unittests/Basic/TransformArrayRefTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/TreeScopedHashTableTest.cpp
+++ b/unittests/Basic/TreeScopedHashTableTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/UnicodeGraphemeBreakTest.cpp.gyb
+++ b/unittests/Basic/UnicodeGraphemeBreakTest.cpp.gyb
@@ -7,7 +7,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/UnicodeTest.cpp
+++ b/unittests/Basic/UnicodeTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/ValueEnumeratorTest.cpp
+++ b/unittests/Basic/ValueEnumeratorTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/SourceKit/Support/FuzzyStringMatcherTest.cpp
+++ b/unittests/SourceKit/Support/FuzzyStringMatcherTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/SourceKit/Support/ImmutableTextBufferTest.cpp
+++ b/unittests/SourceKit/Support/ImmutableTextBufferTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/SwiftDemangle/DemangleTest.cpp
+++ b/unittests/SwiftDemangle/DemangleTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/Array.cpp
+++ b/unittests/runtime/Array.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/Enum.cpp
+++ b/unittests/runtime/Enum.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/Exclusivity.cpp
+++ b/unittests/runtime/Exclusivity.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/LongTests/LongRefcounting.cpp
+++ b/unittests/runtime/LongTests/LongRefcounting.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/Mutex.cpp
+++ b/unittests/runtime/Mutex.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/Refcounting.cpp
+++ b/unittests/runtime/Refcounting.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/Refcounting.mm
+++ b/unittests/runtime/Refcounting.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/unittests/runtime/weak.mm
+++ b/unittests/runtime/weak.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/SwiftFloatingPointTypes.py
+++ b/utils/SwiftFloatingPointTypes.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/android/__init__.py
+++ b/utils/android/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/android/adb/commands.py
+++ b/utils/android/adb/commands.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/android/adb_clean.py
+++ b/utils/android/adb_clean.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/android/adb_push_built_products.py
+++ b/utils/android/adb_push_built_products.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/android/adb_push_built_products/main.py
+++ b/utils/android/adb_push_built_products/main.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/android/adb_test_runner.py
+++ b/utils/android/adb_test_runner.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/android/adb_test_runner/main.py
+++ b/utils/android/adb_test_runner/main.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/android/build-toolchain
+++ b/utils/android/build-toolchain
@@ -4,7 +4,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/bug_reducer/tests/__init__.py
+++ b/utils/bug_reducer/tests/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/bug_reducer/tests/test_funcbugreducer.py
+++ b/utils/bug_reducer/tests/test_funcbugreducer.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/bug_reducer/tests/test_optbugreducer.py
+++ b/utils/bug_reducer/tests/test_optbugreducer.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2,7 +2,7 @@
 #
 ## This source file is part of the Swift.org open source project
 ##
-## Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+## Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ## Licensed under Apache License v2.0 with Runtime Library Exception
 ##
 ## See https://swift.org/LICENSE.txt for license information

--- a/utils/build-script
+++ b/utils/build-script
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3,7 +3,7 @@
 #
 ## This source file is part of the Swift.org open source project
 ##
-## Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+## Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ## Licensed under Apache License v2.0 with Runtime Library Exception
 ##
 ## See https://swift.org/LICENSE.txt for license information

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -4,7 +4,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/__init__.py
+++ b/utils/build_swift/__init__.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/argparse/__init__.py
+++ b/utils/build_swift/argparse/__init__.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/argparse/actions.py
+++ b/utils/build_swift/argparse/actions.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/argparse/parser.py
+++ b/utils/build_swift/argparse/parser.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/defaults.py
+++ b/utils/build_swift/defaults.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/migration.py
+++ b/utils/build_swift/migration.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/presets.py
+++ b/utils/build_swift/presets.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/__init__.py
+++ b/utils/build_swift/tests/__init__.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/argparse/__init__.py
+++ b/utils/build_swift/tests/argparse/__init__.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/argparse/test_actions.py
+++ b/utils/build_swift/tests/argparse/test_actions.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/argparse/test_parser.py
+++ b/utils/build_swift/tests/argparse/test_parser.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/argparse/test_types.py
+++ b/utils/build_swift/tests/argparse/test_types.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/test_driver_arguments.py
+++ b/utils/build_swift/tests/test_driver_arguments.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/test_migration.py
+++ b/utils/build_swift/tests/test_migration.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/test_presets.py
+++ b/utils/build_swift/tests/test_presets.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/build_swift/tests/utils.py
+++ b/utils/build_swift/tests/utils.py
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/cmpcodesize/cmpcodesize.py
+++ b/utils/cmpcodesize/cmpcodesize.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/cmpcodesize/cmpcodesize/__init__.py
+++ b/utils/cmpcodesize/cmpcodesize/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/cmpcodesize/setup.py
+++ b/utils/cmpcodesize/setup.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/cmpcodesize/tests/__init__.py
+++ b/utils/cmpcodesize/tests/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/cmpcodesize/tests/test_list_function_sizes.py
+++ b/utils/cmpcodesize/tests/test_list_function_sizes.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/coverage/coverage-build-db
+++ b/utils/coverage/coverage-build-db
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/coverage/coverage-generate-data
+++ b/utils/coverage/coverage-generate-data
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/coverage/coverage-query-db
+++ b/utils/coverage/coverage-query-db
@@ -4,7 +4,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/coverage/coverage-touch-tests
+++ b/utils/coverage/coverage-touch-tests
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/darwin-installer-scripts/postinstall
+++ b/utils/darwin-installer-scripts/postinstall
@@ -3,7 +3,7 @@
 #
 ## This source file is part of the Swift.org open source project
 ##
-## Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+## Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ## Licensed under Apache License v2.0 with Runtime Library Exception
 ##
 ## See https://swift.org/LICENSE.txt for license information

--- a/utils/dev-scripts/blockifyasm
+++ b/utils/dev-scripts/blockifyasm
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/dev-scripts/split-cmdline
+++ b/utils/dev-scripts/split-cmdline
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/find-overlay-dependencies-loop.sh
+++ b/utils/find-overlay-dependencies-loop.sh
@@ -3,7 +3,7 @@
 #
 ## This source file is part of the Swift.org open source project
 ##
-## Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+## Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ## Licensed under Apache License v2.0 with Runtime Library Exception
 ##
 ## See https://swift.org/LICENSE.txt for license information

--- a/utils/find-overlay-dependencies.sh
+++ b/utils/find-overlay-dependencies.sh
@@ -3,7 +3,7 @@
 #
 ## This source file is part of the Swift.org open source project
 ##
-## Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+## Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ## Licensed under Apache License v2.0 with Runtime Library Exception
 ##
 ## See https://swift.org/LICENSE.txt for license information

--- a/utils/generate_confusables.py
+++ b/utils/generate_confusables.py
@@ -4,7 +4,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -79,7 +79,7 @@ def main(args=sys.argv):
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/utils/gyb_benchmark_support.py
+++ b/utils/gyb_benchmark_support.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/gyb_stdlib_support.py
+++ b/utils/gyb_stdlib_support.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/inferior-swift-mode.el
+++ b/utils/inferior-swift-mode.el
@@ -2,7 +2,7 @@
 ;
 ; This source file is part of the Swift.org open source project
 ;
-; Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+; Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ; Licensed under Apache License v2.0 with Runtime Library Exception
 ;
 ; See https://swift.org/LICENSE.txt for license information

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -302,7 +302,7 @@ def run():
     ... //
     ... // This source file is part of the Swift.org open source project
     ... //
-    ... // Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+    ... // Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
     ... // Licensed under Apache License v2.0 with Runtime Library Exception
     ... //
     ... // See https://swift.org/LICENSE.txt for license information

--- a/utils/optimizer_counters_to_sql.py
+++ b/utils/optimizer_counters_to_sql.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/python_lint.py
+++ b/utils/python_lint.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/rth
+++ b/utils/rth
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/run-test
+++ b/utils/run-test
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -2,7 +2,7 @@
 ;;
 ;; This source file is part of the Swift.org open source project
 ;;
-;; Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+;; Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ;; Licensed under Apache License v2.0 with Runtime Library Exception
 ;;
 ;; See https://swift.org/LICENSE.txt for license information

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/sourcekit_fuzzer/sourcekit_fuzzer.swift
+++ b/utils/sourcekit_fuzzer/sourcekit_fuzzer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/utils/split_file.py
+++ b/utils/split_file.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift-mode.el
+++ b/utils/swift-mode.el
@@ -2,7 +2,7 @@
 ;
 ; This source file is part of the Swift.org open source project
 ;
-; Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+; Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ; Licensed under Apache License v2.0 with Runtime Library Exception
 ;
 ; See https://swift.org/LICENSE.txt for license information

--- a/utils/swift-project-settings.el
+++ b/utils/swift-project-settings.el
@@ -2,7 +2,7 @@
 ;
 ; This source file is part of the Swift.org open source project
 ;
-; Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+; Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ; Licensed under Apache License v2.0 with Runtime Library Exception
 ;
 ; See https://swift.org/LICENSE.txt for license information
@@ -165,7 +165,7 @@ Swift header should look like.
 "//
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/__init__.py
+++ b/utils/swift_build_support/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/SwiftBuildSupport.py
+++ b/utils/swift_build_support/swift_build_support/SwiftBuildSupport.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/__init__.py
+++ b/utils/swift_build_support/swift_build_support/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/arguments.py
+++ b/utils/swift_build_support/swift_build_support/arguments.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/cache_util.py
+++ b/utils/swift_build_support/swift_build_support/cache_util.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/debug.py
+++ b/utils/swift_build_support/swift_build_support/debug.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/diagnostics.py
+++ b/utils/swift_build_support/swift_build_support/diagnostics.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/host.py
+++ b/utils/swift_build_support/swift_build_support/host.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/migration.py
+++ b/utils/swift_build_support/swift_build_support/migration.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/foundation.py
+++ b/utils/swift_build_support/swift_build_support/products/foundation.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/libdispatch.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/libicu.py
+++ b/utils/swift_build_support/swift_build_support/products/libicu.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/llbuild.py
+++ b/utils/swift_build_support/swift_build_support/products/llbuild.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/lldb.py
+++ b/utils/swift_build_support/swift_build_support/products/lldb.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/products/xctest.py
+++ b/utils/swift_build_support/swift_build_support/products/xctest.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/tar.py
+++ b/utils/swift_build_support/swift_build_support/tar.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/which.py
+++ b/utils/swift_build_support/swift_build_support/which.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/workspace.py
+++ b/utils/swift_build_support/swift_build_support/workspace.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/swift_build_support/xcrun.py
+++ b/utils/swift_build_support/swift_build_support/xcrun.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/__init__.py
+++ b/utils/swift_build_support/tests/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/mock-distcc
+++ b/utils/swift_build_support/tests/mock-distcc
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/products/__init__.py
+++ b/utils/swift_build_support/tests/products/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/products/test_llvm.py
+++ b/utils/swift_build_support/tests/products/test_llvm.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the LLVM.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the LLVM project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the LLVM project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_arguments.py
+++ b/utils/swift_build_support/tests/test_arguments.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_cache_util.py
+++ b/utils/swift_build_support/tests/test_cache_util.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_debug.py
+++ b/utils/swift_build_support/tests/test_debug.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_host.py
+++ b/utils/swift_build_support/tests/test_host.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_migration.py
+++ b/utils/swift_build_support/tests/test_migration.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_tar.py
+++ b/utils/swift_build_support/tests/test_tar.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_targets.py
+++ b/utils/swift_build_support/tests/test_targets.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_toolchain.py
+++ b/utils/swift_build_support/tests/test_toolchain.py
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_which.py
+++ b/utils/swift_build_support/tests/test_which.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_workspace.py
+++ b/utils/swift_build_support/tests/test_workspace.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/swift_build_support/tests/test_xcrun.py
+++ b/utils/swift_build_support/tests/test_xcrun.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/toolchain-codesign
+++ b/utils/toolchain-codesign
@@ -3,7 +3,7 @@
 #
 ## This source file is part of the Swift.org open source project
 ##
-## Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+## Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ## Licensed under Apache License v2.0 with Runtime Library Exception
 ##
 ## See https://swift.org/LICENSE.txt for license information

--- a/utils/toolchain-installer
+++ b/utils/toolchain-installer
@@ -3,7 +3,7 @@
 #
 ## This source file is part of the Swift.org open source project
 ##
-## Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+## Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 ## Licensed under Apache License v2.0 with Runtime Library Exception
 ##
 ## See https://swift.org/LICENSE.txt for license information

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28510-size-t-llvm-sys-locale-columnwidth-i-gettext-i-gettext-size.swift
+++ b/validation-test/compiler_crashers/28510-size-t-llvm-sys-locale-columnwidth-i-gettext-i-gettext-size.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
+++ b/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28682-swift-lowering-silgenfunction-emitopenexistential.swift
+++ b/validation-test/compiler_crashers/28682-swift-lowering-silgenfunction-emitopenexistential.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28689-swift-lowering-silgenfunction-emitopenexistential.swift
+++ b/validation-test/compiler_crashers/28689-swift-lowering-silgenfunction-emitopenexistential.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28782-superclass-superclass-isequal-t-should-have-diagnosed-multiple-superclasses-by-n.swift
+++ b/validation-test/compiler_crashers/28782-superclass-superclass-isequal-t-should-have-diagnosed-multiple-superclasses-by-n.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28806-swift-silmodule-get-or-create-function.swift
+++ b/validation-test/compiler_crashers/28806-swift-silmodule-get-or-create-function.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28809-isdigit-ident-pos-first-char-of-sub-string-may-not-be-a-digit.swift
+++ b/validation-test/compiler_crashers/28809-isdigit-ident-pos-first-char-of-sub-string-may-not-be-a-digit.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28818-hastype-e-expected-type-to-have-been-set.swift
+++ b/validation-test/compiler_crashers/28818-hastype-e-expected-type-to-have-been-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28859-resolver-unable-to-resolve-type-witness.swift
+++ b/validation-test/compiler_crashers/28859-resolver-unable-to-resolve-type-witness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28861-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers/28861-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/28870-swift-associatedtypedecl-getoverriddendecls-const.swift
+++ b/validation-test/compiler_crashers/28870-swift-associatedtypedecl-getoverriddendecls-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_2_fixed/0019-rdar21511651.swift
+++ b/validation-test/compiler_crashers_2_fixed/0019-rdar21511651.swift
@@ -145,7 +145,7 @@ public extension Sequence
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
+++ b/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
@@ -158,7 +158,7 @@ public class TypeIndexed<Value> : Resettable {
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_2_fixed/0027-rdar21514140.swift
+++ b/validation-test/compiler_crashers_2_fixed/0027-rdar21514140.swift
@@ -147,7 +147,7 @@ public extension Sequence
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_2_fixed/0070-sr3515.swift
+++ b/validation-test/compiler_crashers_2_fixed/0070-sr3515.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_2_fixed/0123-rdar31164540.swift
+++ b/validation-test/compiler_crashers_2_fixed/0123-rdar31164540.swift
@@ -5,7 +5,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00006-swift-mangle-mangler-manglecontext.swift
+++ b/validation-test/compiler_crashers_fixed/00006-swift-mangle-mangler-manglecontext.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00007-convenience-init-in-extension.swift
+++ b/validation-test/compiler_crashers_fixed/00007-convenience-init-in-extension.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00012-emitdirecttypemetadataref.swift
+++ b/validation-test/compiler_crashers_fixed/00012-emitdirecttypemetadataref.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00018-swift-irgen-emitpolymorphicarguments.swift
+++ b/validation-test/compiler_crashers_fixed/00018-swift-irgen-emitpolymorphicarguments.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00020-swift-typechecker-conformstoprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/00020-swift-typechecker-conformstoprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00023-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/00023-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00024-emitdirecttypemetadataref.swift
+++ b/validation-test/compiler_crashers_fixed/00024-emitdirecttypemetadataref.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00025-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00025-no-stacktrace.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00027-void-map-over-sequence.swift
+++ b/validation-test/compiler_crashers_fixed/00027-void-map-over-sequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00029-class-with-anyobject-type-constraint.swift
+++ b/validation-test/compiler_crashers_fixed/00029-class-with-anyobject-type-constraint.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00036-szone-malloc-should-clear.swift
+++ b/validation-test/compiler_crashers_fixed/00036-szone-malloc-should-clear.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00037-no-stacktrace.script.swift
+++ b/validation-test/compiler_crashers_fixed/00037-no-stacktrace.script.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00039-string-join.script.swift
+++ b/validation-test/compiler_crashers_fixed/00039-string-join.script.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00040-std-function-func-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00040-std-function-func-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00043-substdependenttypes.swift
+++ b/validation-test/compiler_crashers_fixed/00043-substdependenttypes.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00046-swift-archetypebuilder-potentialarchetype-getnestedtype.timeout.swift
+++ b/validation-test/compiler_crashers_fixed/00046-swift-archetypebuilder-potentialarchetype-getnestedtype.timeout.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00047-emitdirecttypemetadataref.swift
+++ b/validation-test/compiler_crashers_fixed/00047-emitdirecttypemetadataref.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00049-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/00049-swift-nominaltypedecl-getmembers.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00051-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00051-resolvetypedecl.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00052-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00052-no-stacktrace.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00053-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00053-std-function-func-swift-type-subst.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00056-addminimumprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/00056-addminimumprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00057-get-type-of-member-reference.swift
+++ b/validation-test/compiler_crashers_fixed/00057-get-type-of-member-reference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
+++ b/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00059-fold-sequence.swift
+++ b/validation-test/compiler_crashers_fixed/00059-fold-sequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00060-adjust-function-type.swift
+++ b/validation-test/compiler_crashers_fixed/00060-adjust-function-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00062-ioctl.swift
+++ b/validation-test/compiler_crashers_fixed/00062-ioctl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00063-tiny-malloc-from-free-list.swift
+++ b/validation-test/compiler_crashers_fixed/00063-tiny-malloc-from-free-list.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00064-bool.swift
+++ b/validation-test/compiler_crashers_fixed/00064-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00065-cerror.swift
+++ b/validation-test/compiler_crashers_fixed/00065-cerror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00066-diagnoseunknowntype.swift
+++ b/validation-test/compiler_crashers_fixed/00066-diagnoseunknowntype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00067-szone-malloc-should-clear.swift
+++ b/validation-test/compiler_crashers_fixed/00067-szone-malloc-should-clear.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00068-foldsequence.swift
+++ b/validation-test/compiler_crashers_fixed/00068-foldsequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00069-swift-typevisitor.swift
+++ b/validation-test/compiler_crashers_fixed/00069-swift-typevisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00070-getgenericparam.swift
+++ b/validation-test/compiler_crashers_fixed/00070-getgenericparam.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00071-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00071-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00072-llvm-bitstreamcursor-readrecord.swift
+++ b/validation-test/compiler_crashers_fixed/00072-llvm-bitstreamcursor-readrecord.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00073-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/00073-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00074-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/00074-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00075-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00075-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00076-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00076-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00077-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00077-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00078-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00078-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00079-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/00079-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00080-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00080-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00081-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00081-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00082-std-function-func-containsprotocolself.swift
+++ b/validation-test/compiler_crashers_fixed/00082-std-function-func-containsprotocolself.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00083-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/00083-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00084-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/00084-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00085-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/00085-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00086-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00086-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00087-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/00087-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00088-swift-archetypetype-getnestedtype.swift
+++ b/validation-test/compiler_crashers_fixed/00088-swift-archetypetype-getnestedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00089-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00089-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00090-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00090-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00091-swift-astprinter-printname.swift
+++ b/validation-test/compiler_crashers_fixed/00091-swift-astprinter-printname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00092-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/00092-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00093-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00093-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00094-swift-bracestmt-create.swift
+++ b/validation-test/compiler_crashers_fixed/00094-swift-bracestmt-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00095-swift-clangimporter-implementation-mergepropinfointoaccessor.swift
+++ b/validation-test/compiler_crashers_fixed/00095-swift-clangimporter-implementation-mergepropinfointoaccessor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00096-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00096-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00097-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/00097-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00098-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00098-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00099-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/00099-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00100-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/00100-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00101-swift-constraints-constraintsystem-applysolution.swift
+++ b/validation-test/compiler_crashers_fixed/00101-swift-constraints-constraintsystem-applysolution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00102-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/00102-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00103-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/00103-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00104-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/00104-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00105-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/00105-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00106-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00106-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00107-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00107-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00108-swift-constraints-constraintsystem-lookthroughimplicitlyunwrappedoptionaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00108-swift-constraints-constraintsystem-lookthroughimplicitlyunwrappedoptionaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00109-swift-constraints-constraintsystem-matchfunctiontypes.swift
+++ b/validation-test/compiler_crashers_fixed/00109-swift-constraints-constraintsystem-matchfunctiontypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00110-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00110-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00111-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00111-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00112-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/00112-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00113-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/00113-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00114-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00114-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00115-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00115-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00116-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/00116-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00117-swift-declrefexpr-setgenericargs.swift
+++ b/validation-test/compiler_crashers_fixed/00117-swift-declrefexpr-setgenericargs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00118-swift-dependentgenerictyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/00118-swift-dependentgenerictyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00119-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00119-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00120-swift-derivedconformance-deriveequatable.swift
+++ b/validation-test/compiler_crashers_fixed/00120-swift-derivedconformance-deriveequatable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00121-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/00121-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00122-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/00122-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00123-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00123-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00124-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00124-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00125-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/00125-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00126-swift-generictypetoarchetyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/00126-swift-generictypetoarchetyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00127-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00127-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00128-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/00128-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00129-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00129-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00130-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/00130-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00131-swift-lexer-lexnumber.swift
+++ b/validation-test/compiler_crashers_fixed/00131-swift-lexer-lexnumber.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00132-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00132-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00133-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00133-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00134-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00134-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00135-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00135-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00136-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/00136-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00137-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/00137-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00138-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/00138-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00139-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/00139-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00140-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/00140-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00141-swift-nominaltypedecl-getextensions.swift
+++ b/validation-test/compiler_crashers_fixed/00141-swift-nominaltypedecl-getextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00142-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/00142-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00143-swift-parentype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00143-swift-parentype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00144-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/00144-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00145-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/00145-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00146-swift-parser-parseexpridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00146-swift-parser-parseexpridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00147-swift-parser-parseexprstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/00147-swift-parser-parseexprstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00148-swift-parser-parseexprunary.swift
+++ b/validation-test/compiler_crashers_fixed/00148-swift-parser-parseexprunary.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00149-swift-typechecker-callwitness.swift
+++ b/validation-test/compiler_crashers_fixed/00149-swift-typechecker-callwitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00150-swift-parser-parseparameterclause.swift
+++ b/validation-test/compiler_crashers_fixed/00150-swift-parser-parseparameterclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00151-swift-parser-parsetype.swift
+++ b/validation-test/compiler_crashers_fixed/00151-swift-parser-parsetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00152-swift-parser-parsetypeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00152-swift-parser-parsetypeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00153-swift-parser-parsetypesimple.swift
+++ b/validation-test/compiler_crashers_fixed/00153-swift-parser-parsetypesimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00154-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00154-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00155-swift-protocoldecl-requiresclassslow.swift
+++ b/validation-test/compiler_crashers_fixed/00155-swift-protocoldecl-requiresclassslow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00156-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/00156-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00157-swift-sourcefile-getcache.swift
+++ b/validation-test/compiler_crashers_fixed/00157-swift-sourcefile-getcache.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00158-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/00158-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00160-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00160-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00161-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00161-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00162-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00162-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00163-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00163-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00164-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00164-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00165-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/00165-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00166-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/00166-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00167-swift-typebase-isexistentialtype.swift
+++ b/validation-test/compiler_crashers_fixed/00167-swift-typebase-isexistentialtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00168-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/00168-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00169-swift-typebase-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00169-swift-typebase-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00170-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/00170-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00171-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/00171-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00172-swift-archetypebuilder-inferrequirementswalker-walktotypepost.swift
+++ b/validation-test/compiler_crashers_fixed/00172-swift-archetypebuilder-inferrequirementswalker-walktotypepost.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00173-swift-typealiasdecl-typealiasdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00173-swift-typealiasdecl-typealiasdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00174-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/00174-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00175-swift-parser-parseexprlist.swift
+++ b/validation-test/compiler_crashers_fixed/00175-swift-parser-parseexprlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00176-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00176-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00177-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/00177-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00178-llvm-foldingset-swift-genericsignature-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00178-llvm-foldingset-swift-genericsignature-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00179-swift-protocolcompositiontype-build.swift
+++ b/validation-test/compiler_crashers_fixed/00179-swift-protocolcompositiontype-build.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00180-szone-free-definite-size.swift
+++ b/validation-test/compiler_crashers_fixed/00180-szone-free-definite-size.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00181-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/00181-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00182-swift-astcontext-getconformance.swift
+++ b/validation-test/compiler_crashers_fixed/00182-swift-astcontext-getconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00183-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/00183-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00184-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/00184-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00185-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/00185-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00186-swift-genericsignature-profile.swift
+++ b/validation-test/compiler_crashers_fixed/00186-swift-genericsignature-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00187-swift-lowering-typeconverter-getfunctiontypewithcaptures.swift
+++ b/validation-test/compiler_crashers_fixed/00187-swift-lowering-typeconverter-getfunctiontypewithcaptures.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00188-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/00188-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00189-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/00189-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00190-swift-constraints-constraintgraph-unbindtypevariable.swift
+++ b/validation-test/compiler_crashers_fixed/00190-swift-constraints-constraintgraph-unbindtypevariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00191-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/00191-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00192-swift-astcontext-setconformsto.swift
+++ b/validation-test/compiler_crashers_fixed/00192-swift-astcontext-setconformsto.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00193-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/00193-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00194-swift-parser-parseexprsequence.swift
+++ b/validation-test/compiler_crashers_fixed/00194-swift-parser-parseexprsequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00195-swift-namelookup-lookupinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/00195-swift-namelookup-lookupinmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00196-swift-constraints-constraint-create.swift
+++ b/validation-test/compiler_crashers_fixed/00196-swift-constraints-constraint-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00197-swift-performstmtdiagnostics.swift
+++ b/validation-test/compiler_crashers_fixed/00197-swift-performstmtdiagnostics.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00198-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/00198-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00199-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00199-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00200-swift-parser-parsestmtreturn.swift
+++ b/validation-test/compiler_crashers_fixed/00200-swift-parser-parsestmtreturn.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00201-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/00201-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00202-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/00202-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00203-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/00203-swift-type-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00204-swift-parser-parsedeclprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/00204-swift-parser-parsedeclprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00205-swift-exprhandle-get.swift
+++ b/validation-test/compiler_crashers_fixed/00205-swift-exprhandle-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00206-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00206-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00207-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/00207-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00208-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/00208-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00209-swift-parser-parseclosuresignatureifpresent.swift
+++ b/validation-test/compiler_crashers_fixed/00209-swift-parser-parseclosuresignatureifpresent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00210-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00210-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00211-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/00211-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00212-swift-constraints-solution-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/00212-swift-constraints-solution-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00213-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/00213-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00214-swift-typebase-gettypeofmember.swift
+++ b/validation-test/compiler_crashers_fixed/00214-swift-typebase-gettypeofmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00215-swift-optional-swift-infixoperatordecl.swift
+++ b/validation-test/compiler_crashers_fixed/00215-swift-optional-swift-infixoperatordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00216-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/00216-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00217-swift-associatedtypedecl-associatedtypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00217-swift-associatedtypedecl-associatedtypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00218-swift-parser-parsegenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/00218-swift-parser-parsegenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00219-swift-module-isstdlibmodule.swift
+++ b/validation-test/compiler_crashers_fixed/00219-swift-module-isstdlibmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00220-llvm-foldingsetimpl-findnodeorinsertpos.swift
+++ b/validation-test/compiler_crashers_fixed/00220-llvm-foldingsetimpl-findnodeorinsertpos.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00221-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00221-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00222-swift-modulefile-modulefile.swift
+++ b/validation-test/compiler_crashers_fixed/00222-swift-modulefile-modulefile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00223-swift-stringliteralexpr-stringliteralexpr.swift
+++ b/validation-test/compiler_crashers_fixed/00223-swift-stringliteralexpr-stringliteralexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00224-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00224-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00225-swift-classdecl-recordobjcmember.swift
+++ b/validation-test/compiler_crashers_fixed/00225-swift-classdecl-recordobjcmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00227-swift-clangimporter-implementation-getknownobjcmethod.swift
+++ b/validation-test/compiler_crashers_fixed/00227-swift-clangimporter-implementation-getknownobjcmethod.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00228-swift-clangimporter-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/00228-swift-clangimporter-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00229-getarchetypesubstitution.random.swift
+++ b/validation-test/compiler_crashers_fixed/00229-getarchetypesubstitution.random.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00230-llvm-foldingset-swift-structtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00230-llvm-foldingset-swift-structtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00231-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/00231-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00232-swift-lookupresult-filter.swift
+++ b/validation-test/compiler_crashers_fixed/00232-swift-lookupresult-filter.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00233-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/00233-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00234-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00234-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00235-swift-genericparamlist-print.swift
+++ b/validation-test/compiler_crashers_fixed/00235-swift-genericparamlist-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00236-swift-typechecker-typecheckforeachbinding.swift
+++ b/validation-test/compiler_crashers_fixed/00236-swift-typechecker-typecheckforeachbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00237-swift-declrefexpr-setspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/00237-swift-declrefexpr-setspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00238-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00238-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00239-swiftdeclconverter-importconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/00239-swiftdeclconverter-importconstructor.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00240-argemitter-emitexpanded.swift
+++ b/validation-test/compiler_crashers_fixed/00240-argemitter-emitexpanded.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00241-swift-lowering-typeconverter-getconstantinfo.swift
+++ b/validation-test/compiler_crashers_fixed/00241-swift-lowering-typeconverter-getconstantinfo.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00242-swift-lowering-silgenfunction-emitclosurevalue.swift
+++ b/validation-test/compiler_crashers_fixed/00242-swift-lowering-silgenfunction-emitclosurevalue.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00244-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00244-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00245-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/00245-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00246-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/00246-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00247-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00247-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00248-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/00248-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00249-swift-nominaltypedecl-computeinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/00249-swift-nominaltypedecl-computeinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00250-swift-parser-consumestartinggreater.swift
+++ b/validation-test/compiler_crashers_fixed/00250-swift-parser-consumestartinggreater.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00251-swift-constraints-constraintsystem-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00251-swift-constraints-constraintsystem-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00252-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00252-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00253-swift-constraints-constraintsystem-constraintsystem.swift
+++ b/validation-test/compiler_crashers_fixed/00253-swift-constraints-constraintsystem-constraintsystem.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00254-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00254-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00255-swift-tuplepattern-createsimple.swift
+++ b/validation-test/compiler_crashers_fixed/00255-swift-tuplepattern-createsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00256-swift-tupleexpr-create.swift
+++ b/validation-test/compiler_crashers_fixed/00256-swift-tupleexpr-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00257-swift-partialgenerictypetoarchetyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/00257-swift-partialgenerictypetoarchetyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00258-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers_fixed/00258-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00259-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/00259-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00260-swift-declname-printpretty.random.swift
+++ b/validation-test/compiler_crashers_fixed/00260-swift-declname-printpretty.random.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00261-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/00261-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00262-swift-camel-case-getfirstword.swift
+++ b/validation-test/compiler_crashers_fixed/00262-swift-camel-case-getfirstword.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00263-swift-constraints-constraintsystem-opentype.swift
+++ b/validation-test/compiler_crashers_fixed/00263-swift-constraints-constraintsystem-opentype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00264-isvalididentifiercontinuationcodepoint.swift
+++ b/validation-test/compiler_crashers_fixed/00264-isvalididentifiercontinuationcodepoint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00265-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00265-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00266-swift-parser-parseexprorstmt.swift
+++ b/validation-test/compiler_crashers_fixed/00266-swift-parser-parseexprorstmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00267-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/00267-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00268-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/00268-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00272-llvm-irbuilder-createcall.swift
+++ b/validation-test/compiler_crashers_fixed/00272-llvm-irbuilder-createcall.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00273-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers_fixed/00273-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00274-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/00274-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00275-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/00275-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00276-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/00276-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00277-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00277-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00278-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00278-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00279-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00279-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00280-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00280-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00281-void.swift
+++ b/validation-test/compiler_crashers_fixed/00281-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00282-malloc-zone-malloc.swift
+++ b/validation-test/compiler_crashers_fixed/00282-malloc-zone-malloc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00283-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/00283-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00284-swift-modulefile-maybereadconformance.swift
+++ b/validation-test/compiler_crashers_fixed/00284-swift-modulefile-maybereadconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00285-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/00285-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00286-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00286-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00287-clang-astcontext-getobjcinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/00287-clang-astcontext-getobjcinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00288-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00288-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00289-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00289-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00290-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00290-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00291-swift-clangmoduleunit-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/00291-swift-clangmoduleunit-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00293-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00293-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00294-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00294-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00295-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00295-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00296-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00296-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00297-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00297-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00298-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00298-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00299-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00299-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00300-swift-typebase-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00300-swift-typebase-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00301-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00301-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00302-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00302-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00303-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00303-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00304-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/00304-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00305-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00305-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00306-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/00306-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00307-addminimumprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/00307-addminimumprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00308-llvm-raw-ostream-write.swift
+++ b/validation-test/compiler_crashers_fixed/00308-llvm-raw-ostream-write.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00309-llvm-prettystacktraceentry-prettystacktraceentry.swift
+++ b/validation-test/compiler_crashers_fixed/00309-llvm-prettystacktraceentry-prettystacktraceentry.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00311-clang-astreader-readtyperecord.swift
+++ b/validation-test/compiler_crashers_fixed/00311-clang-astreader-readtyperecord.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00312-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/00312-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00313-swift-typechecker-getprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/00313-swift-typechecker-getprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00314-swift-lowering-typeconverter-getloweredastfunctiontype.swift
+++ b/validation-test/compiler_crashers_fixed/00314-swift-lowering-typeconverter-getloweredastfunctiontype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00315-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/00315-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00316-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/00316-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00317-swift-typebase-gettypeofmember.swift
+++ b/validation-test/compiler_crashers_fixed/00317-swift-typebase-gettypeofmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00318-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00318-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00319-std-function-func-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00319-std-function-func-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00320-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00320-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00321-swift-typechecker-callwitness.swift
+++ b/validation-test/compiler_crashers_fixed/00321-swift-typechecker-callwitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00323-swift-apply-generic-protocol.swift
+++ b/validation-test/compiler_crashers_fixed/00323-swift-apply-generic-protocol.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00324-swift-shortcircuit-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/00324-swift-shortcircuit-isequal.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00327-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00327-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00328-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00328-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00329-swift-parser-parsedeclfunc.swift
+++ b/validation-test/compiler_crashers_fixed/00329-swift-parser-parsedeclfunc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00330-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00330-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00331-llvm-raw-fd-ostream-write-impl.swift
+++ b/validation-test/compiler_crashers_fixed/00331-llvm-raw-fd-ostream-write-impl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00332-swift-typechecker-getbridgedtoobjc.swift
+++ b/validation-test/compiler_crashers_fixed/00332-swift-typechecker-getbridgedtoobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00333-swift-objcattr-createunnamedimplicit.swift
+++ b/validation-test/compiler_crashers_fixed/00333-swift-objcattr-createunnamedimplicit.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00334-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/00334-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00335-llvm-raw-fd-ostream-write-impl.swift
+++ b/validation-test/compiler_crashers_fixed/00335-llvm-raw-fd-ostream-write-impl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00336-swift-parser-parsetoplevelcodedecldelayed.swift
+++ b/validation-test/compiler_crashers_fixed/00336-swift-parser-parsetoplevelcodedecldelayed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00337-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00337-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00338-llvm-smallptrsetimplbase-smallptrsetimplbase.swift
+++ b/validation-test/compiler_crashers_fixed/00338-llvm-smallptrsetimplbase-smallptrsetimplbase.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00339-swift-clangimporter-implementation-mapselectortodeclname.swift
+++ b/validation-test/compiler_crashers_fixed/00339-swift-clangimporter-implementation-mapselectortodeclname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00340-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/00340-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00341-cleanupillformedexpression.swift
+++ b/validation-test/compiler_crashers_fixed/00341-cleanupillformedexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00342-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00342-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00343-connectedcomponentsdfs.swift
+++ b/validation-test/compiler_crashers_fixed/00343-connectedcomponentsdfs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00344-substituteinputsugarargumenttype.swift
+++ b/validation-test/compiler_crashers_fixed/00344-substituteinputsugarargumenttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00345-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00345-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00346-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00346-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00347-llvm-smallvectorbase-grow-pod.swift
+++ b/validation-test/compiler_crashers_fixed/00347-llvm-smallvectorbase-grow-pod.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00348-llvm-densemapbase-llvm-smalldensemap-std-pair-swift-cantype.swift
+++ b/validation-test/compiler_crashers_fixed/00348-llvm-densemapbase-llvm-smalldensemap-std-pair-swift-cantype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00349-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/00349-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00350-swift-constraints-constraintsystem-simplify.swift
+++ b/validation-test/compiler_crashers_fixed/00350-swift-constraints-constraintsystem-simplify.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00351-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00351-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00352-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/00352-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00353-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00353-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00354-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/00354-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00355-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00355-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00356-swift-parser-parsegenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/00356-swift-parser-parsegenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00357-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00357-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00358-swift-constraints-constraintsystem-lookthroughimplicitlyunwrappedoptionaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00358-swift-constraints-constraintsystem-lookthroughimplicitlyunwrappedoptionaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00359-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00359-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00360-swift-parser-parseexprlist.swift
+++ b/validation-test/compiler_crashers_fixed/00360-swift-parser-parseexprlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00361-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/00361-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00362-clang-stmt-statisticsenabled.swift
+++ b/validation-test/compiler_crashers_fixed/00362-clang-stmt-statisticsenabled.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00363-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/00363-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00364-swift-typechecker-isrepresentableinobjc.swift
+++ b/validation-test/compiler_crashers_fixed/00364-swift-typechecker-isrepresentableinobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00365-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00365-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00366-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00366-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00367-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/00367-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00368-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00368-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00369-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00369-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00370-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/00370-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00371-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00371-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00372-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00372-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00373-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00373-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00374-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00374-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00375-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00375-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00376-void.swift
+++ b/validation-test/compiler_crashers_fixed/00376-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00377-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00377-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00378-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00378-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00379-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00379-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00380-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00380-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00381-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00381-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00382-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/00382-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00383-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00383-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00384-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00384-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00385-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00385-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00386-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00386-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00388-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/00388-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00389-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00389-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00390-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00390-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00391-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00391-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00392-llvm-prettystacktraceentry-prettystacktraceentry.swift
+++ b/validation-test/compiler_crashers_fixed/00392-llvm-prettystacktraceentry-prettystacktraceentry.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00393-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00393-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00394-void.swift
+++ b/validation-test/compiler_crashers_fixed/00394-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00395-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00395-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00396-llvm-raw-fd-ostream-write-impl.random.swift
+++ b/validation-test/compiler_crashers_fixed/00396-llvm-raw-fd-ostream-write-impl.random.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00397-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00397-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00398-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00398-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00399-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00399-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00400-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00400-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00401-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00401-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00402-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00402-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00403-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00403-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00404-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00404-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00405-void.swift
+++ b/validation-test/compiler_crashers_fixed/00405-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00406-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00406-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00407-void.swift
+++ b/validation-test/compiler_crashers_fixed/00407-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00408-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00408-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00409-llvm-raw-fd-ostream-write-impl.swift
+++ b/validation-test/compiler_crashers_fixed/00409-llvm-raw-fd-ostream-write-impl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00410-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00410-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00411-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00411-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00412-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00412-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00413-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00413-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00414-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/00414-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00415-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00415-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00416-swift-typechecker-conformstoprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/00416-swift-typechecker-conformstoprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00417-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00417-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00418-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00418-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00419-llvm-raw-fd-ostream-write-impl.swift
+++ b/validation-test/compiler_crashers_fixed/00419-llvm-raw-fd-ostream-write-impl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00420-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00420-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00421-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00421-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00422-void.swift
+++ b/validation-test/compiler_crashers_fixed/00422-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00423-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/00423-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00424-no-stacktrace.random.swift
+++ b/validation-test/compiler_crashers_fixed/00424-no-stacktrace.random.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00425-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00425-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00426-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00426-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00427-void.swift
+++ b/validation-test/compiler_crashers_fixed/00427-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00428-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/00428-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00429-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00429-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00430-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00430-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00431-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00431-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00432-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00432-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00433-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00433-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00434-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00434-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00435-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00435-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00436-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00436-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00437-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00437-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00438-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/00438-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00439-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00439-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00440-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00440-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00441-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00441-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00442-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00442-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00443-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00443-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00444-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00444-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00445-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00445-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00446-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00446-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00447-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00447-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00448-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00448-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00449-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00449-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00450-llvm-foldingsetimpl-findnodeorinsertpos.swift
+++ b/validation-test/compiler_crashers_fixed/00450-llvm-foldingsetimpl-findnodeorinsertpos.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00451-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00451-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00452-nanl.random.swift
+++ b/validation-test/compiler_crashers_fixed/00452-nanl.random.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00453-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00453-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00454-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00454-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00455-swift-parser-parseexprimpl.swift
+++ b/validation-test/compiler_crashers_fixed/00455-swift-parser-parseexprimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00456-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/00456-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00457-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00457-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00458-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00458-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00459-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00459-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00460-bool.swift
+++ b/validation-test/compiler_crashers_fixed/00460-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00461-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00461-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00462-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00462-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00463-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00463-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00464-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00464-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00465-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/00465-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00466-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00466-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00467-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00467-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00468-swift-parentype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00468-swift-parentype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00469-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00469-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00470-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00470-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00471-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00471-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00472-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00472-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00473-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00473-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00474-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00474-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00475-void.swift
+++ b/validation-test/compiler_crashers_fixed/00475-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00476-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00476-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00477-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00477-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00478-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00478-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00479-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00479-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00480-szone-free-definite-size.swift
+++ b/validation-test/compiler_crashers_fixed/00480-szone-free-definite-size.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00481-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00481-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00482-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00482-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00483-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00483-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00484-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/00484-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00485-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00485-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00486-llvm-smallvectorbase-grow-pod.swift
+++ b/validation-test/compiler_crashers_fixed/00486-llvm-smallvectorbase-grow-pod.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00487-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00487-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00488-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00488-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00489-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00489-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00490-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00490-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00491-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00491-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00492-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00492-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00493-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00493-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00494-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00494-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00495-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00495-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00496-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/00496-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00497-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00497-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00498-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00498-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00499-llvm-foldingsetimpl-findnodeorinsertpos.swift
+++ b/validation-test/compiler_crashers_fixed/00499-llvm-foldingsetimpl-findnodeorinsertpos.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00500-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/00500-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00501-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00501-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00502-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/00502-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00503-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00503-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00504-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00504-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00505-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00505-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00506-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00506-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00507-std-basic-string-char.swift
+++ b/validation-test/compiler_crashers_fixed/00507-std-basic-string-char.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00508-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00508-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00509-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00509-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00510-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00510-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00511-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/00511-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00512-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00512-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00513-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00513-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00514-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00514-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00515-bool.swift
+++ b/validation-test/compiler_crashers_fixed/00515-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00516-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00516-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00517-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00517-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00518-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00518-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00519-void.swift
+++ b/validation-test/compiler_crashers_fixed/00519-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00520-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00520-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00521-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/00521-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00522-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00522-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00523-swift-typevisitor.swift
+++ b/validation-test/compiler_crashers_fixed/00523-swift-typevisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00524-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00524-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00525-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/00525-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00526-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00526-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00527-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00527-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00528-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00528-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00529-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00529-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00530-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00530-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00531-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00531-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00532-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/00532-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00533-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00533-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00534-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00534-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00535-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00535-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00536-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00536-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00537-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00537-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00538-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00538-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00539-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00539-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00540-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00540-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00541-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00541-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00542-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00542-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00543-swift-nominaltypedecl-computeinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/00543-swift-nominaltypedecl-computeinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00544-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00544-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00545-llvm-prettystacktraceentry-prettystacktraceentry.swift
+++ b/validation-test/compiler_crashers_fixed/00545-llvm-prettystacktraceentry-prettystacktraceentry.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00546-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00546-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00547-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00547-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00548-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00548-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00549-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00549-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00550-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00550-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00551-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00551-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00552-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00552-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00553-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00553-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00554-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00554-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00555-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00555-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00556-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00556-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00557-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00557-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00558-ioctl.swift
+++ b/validation-test/compiler_crashers_fixed/00558-ioctl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00559-void.swift
+++ b/validation-test/compiler_crashers_fixed/00559-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00560-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00560-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00561-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00561-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00562-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/00562-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00563-cerror.swift
+++ b/validation-test/compiler_crashers_fixed/00563-cerror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00564-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00564-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00565-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/00565-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00566-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00566-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00567-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00567-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00568-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00568-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00569-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00569-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00570-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00570-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00571-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00571-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00572-resolvetypedecl.random.swift
+++ b/validation-test/compiler_crashers_fixed/00572-resolvetypedecl.random.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00573-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00573-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00574-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00574-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00575-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00575-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00576-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/00576-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00577-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00577-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00578-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00578-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00579-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/00579-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00580-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00580-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00581-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00581-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00582-a.swift
+++ b/validation-test/compiler_crashers_fixed/00582-a.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00583-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/00583-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00584-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/00584-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00585-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00585-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00586-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00586-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00587-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/00587-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00588-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00588-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00589-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/00589-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00590-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00590-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00591-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00591-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00592-swift-parser-parseexpridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00592-swift-parser-parseexpridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00593-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00593-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00594-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00594-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00595-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/00595-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00596-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/00596-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00597-llvm-prettystacktraceentry-prettystacktraceentry.swift
+++ b/validation-test/compiler_crashers_fixed/00597-llvm-prettystacktraceentry-prettystacktraceentry.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00598-clang-sema-lookupname.swift
+++ b/validation-test/compiler_crashers_fixed/00598-clang-sema-lookupname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00599-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/00599-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00601-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00601-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00602-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/00602-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00603-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00603-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00604-swift-typebase-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00604-swift-typebase-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00605-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00605-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00606-swift-typechecker-conformstoprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/00606-swift-typechecker-conformstoprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00607-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00607-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00608-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/00608-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00609-llvm-prettystacktraceentry-prettystacktraceentry.swift
+++ b/validation-test/compiler_crashers_fixed/00609-llvm-prettystacktraceentry-prettystacktraceentry.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00610-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00610-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00611-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/00611-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00612-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00612-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00613-connectedcomponentsdfs.swift
+++ b/validation-test/compiler_crashers_fixed/00613-connectedcomponentsdfs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00614-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00614-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00615-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00615-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00616-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00616-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00617-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/00617-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00618-swift-parser-parseexprsequence.swift
+++ b/validation-test/compiler_crashers_fixed/00618-swift-parser-parseexprsequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00619-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00619-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00620-llvm-bitstreamcursor-readabbreviatedfield.swift
+++ b/validation-test/compiler_crashers_fixed/00620-llvm-bitstreamcursor-readabbreviatedfield.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00621-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00621-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00622-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00622-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00623-validateattributes.swift
+++ b/validation-test/compiler_crashers_fixed/00623-validateattributes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00624-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/00624-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00625-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00625-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00626-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00626-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00627-bool.swift
+++ b/validation-test/compiler_crashers_fixed/00627-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00628-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00628-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00629-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00629-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00630-llvm-smalldensemap-swift-constraints-constraint.swift
+++ b/validation-test/compiler_crashers_fixed/00630-llvm-smalldensemap-swift-constraints-constraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00631-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00631-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00632-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/00632-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00633-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00633-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00634-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00634-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00635-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/00635-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00636-llvm-twine-str.swift
+++ b/validation-test/compiler_crashers_fixed/00636-llvm-twine-str.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00637-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/00637-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00638-swift-typechecker-typecheckexpressionshallow.swift
+++ b/validation-test/compiler_crashers_fixed/00638-swift-typechecker-typecheckexpressionshallow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00639-void.swift
+++ b/validation-test/compiler_crashers_fixed/00639-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00640-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00640-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00641-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/00641-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00642-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/00642-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00643-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/00643-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00644-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00644-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00645-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00645-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00646-llvm-raw-fd-ostream-write-impl.swift
+++ b/validation-test/compiler_crashers_fixed/00646-llvm-raw-fd-ostream-write-impl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00647-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00647-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00648-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00648-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00649-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00649-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00650-szone-malloc-should-clear.swift
+++ b/validation-test/compiler_crashers_fixed/00650-szone-malloc-should-clear.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00651-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00651-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00652-swift-constraints-constraintgraphnode-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00652-swift-constraints-constraintgraphnode-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00653-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/00653-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00654-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00654-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00655-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00655-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00656-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00656-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00657-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00657-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00658-swift-constraints-constraint-create.swift
+++ b/validation-test/compiler_crashers_fixed/00658-swift-constraints-constraint-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00659-s.swift
+++ b/validation-test/compiler_crashers_fixed/00659-s.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00660-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00660-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00661-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00661-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00662-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/00662-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00663-swift-module-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/00663-swift-module-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00664-swift-pattern-operator.swift
+++ b/validation-test/compiler_crashers_fixed/00664-swift-pattern-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00665-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/00665-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00666-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00666-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00667-swift-typedecl-getdeclaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/00667-swift-typedecl-getdeclaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00668-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00668-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00669-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00669-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00670-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00670-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00671-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00671-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00672-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/00672-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00673-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00673-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00674-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00674-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00675-swift-astcontext-getprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/00675-swift-astcontext-getprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00676-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00676-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00677-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/00677-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00678-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/00678-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00679-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/00679-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00680-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00680-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00681-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00681-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00682-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00682-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00683-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00683-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00684-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00684-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00685-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00685-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00686-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00686-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00687-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00687-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00688-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00688-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00689-b.swift
+++ b/validation-test/compiler_crashers_fixed/00689-b.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00690-swift-declname-declname.swift
+++ b/validation-test/compiler_crashers_fixed/00690-swift-declname-declname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00691-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00691-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00692-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00692-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00693-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/00693-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00694-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00694-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00695-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/00695-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00696-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00696-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00697-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00697-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00698-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00698-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00699-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/00699-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00700-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/compiler_crashers_fixed/00700-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00701-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00701-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00702-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00702-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00703-swift-sourcemanager-addnewsourcebuffer.swift
+++ b/validation-test/compiler_crashers_fixed/00703-swift-sourcemanager-addnewsourcebuffer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00704-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00704-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00705-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/00705-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00706-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00706-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00707-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00707-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00708-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/00708-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00709-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00709-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00710-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00710-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00711-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00711-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00712-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/00712-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00713-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00713-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00714-void.swift
+++ b/validation-test/compiler_crashers_fixed/00714-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00715-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/00715-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00716-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00716-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00717-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/00717-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00718-swift-parentype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00718-swift-parentype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00719-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00719-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00720-szone-malloc-should-clear.swift
+++ b/validation-test/compiler_crashers_fixed/00720-szone-malloc-should-clear.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00721-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00721-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00722-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00722-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00723-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00723-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00724-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/00724-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00725-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00725-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00726-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00726-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00727-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00727-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00728-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00728-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00729-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/00729-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00730-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/00730-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00731-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/00731-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00732-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00732-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00733-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00733-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00734-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00734-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00735-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00735-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00736-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00736-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00737-bool.swift
+++ b/validation-test/compiler_crashers_fixed/00737-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00738-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00738-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00739-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00739-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00740-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00740-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00741-szone-malloc-should-clear.swift
+++ b/validation-test/compiler_crashers_fixed/00741-szone-malloc-should-clear.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00742-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00742-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00743-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00743-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00744-swift-constraints-constraintsystem-applysolution.swift
+++ b/validation-test/compiler_crashers_fixed/00744-swift-constraints-constraintsystem-applysolution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00745-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00745-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00746-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00746-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00747-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00747-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00748-getmemberforbasetype.swift
+++ b/validation-test/compiler_crashers_fixed/00748-getmemberforbasetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00749-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00749-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00750-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/00750-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00751-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00751-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00752-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/00752-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00753-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00753-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00754-x.swift
+++ b/validation-test/compiler_crashers_fixed/00754-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00755-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00755-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00756-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/00756-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00757-x.swift
+++ b/validation-test/compiler_crashers_fixed/00757-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00758-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/00758-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00759-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00759-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00760-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00760-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00761-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00761-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00762-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/00762-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00763-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00763-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00764-as.swift
+++ b/validation-test/compiler_crashers_fixed/00764-as.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00765-swift-langoptions-gettargetconfigoption.swift
+++ b/validation-test/compiler_crashers_fixed/00765-swift-langoptions-gettargetconfigoption.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00766-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00766-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00767-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/00767-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00768-llvm-bitstreamcursor-readrecord.swift
+++ b/validation-test/compiler_crashers_fixed/00768-llvm-bitstreamcursor-readrecord.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00769-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00769-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00770-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/00770-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00771-x.swift
+++ b/validation-test/compiler_crashers_fixed/00771-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00772-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00772-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00773-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00773-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00774-unowned.swift
+++ b/validation-test/compiler_crashers_fixed/00774-unowned.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00775-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00775-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00776-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00776-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00777-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00777-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00778-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00778-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00779-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/00779-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00780-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00780-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00781-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/00781-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00782-d.swift
+++ b/validation-test/compiler_crashers_fixed/00782-d.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00783-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00783-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00784-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00784-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00785-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00785-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00786-end.swift
+++ b/validation-test/compiler_crashers_fixed/00786-end.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00787-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00787-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00788-t.swift
+++ b/validation-test/compiler_crashers_fixed/00788-t.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00789-swift-typebase-isexistentialtype.swift
+++ b/validation-test/compiler_crashers_fixed/00789-swift-typebase-isexistentialtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00790-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00790-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00791-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00791-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00792-swift-parser-parseexprarray.swift
+++ b/validation-test/compiler_crashers_fixed/00792-swift-parser-parseexprarray.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00793-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00793-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00794-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/00794-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00795-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00795-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00796-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00796-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00797-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00797-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00798-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/00798-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00799-e.swift
+++ b/validation-test/compiler_crashers_fixed/00799-e.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00800-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/00800-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00801-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00801-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00802-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00802-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00803-void.swift
+++ b/validation-test/compiler_crashers_fixed/00803-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00804-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/00804-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00805-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/00805-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00806-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/00806-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00807-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/00807-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00808-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00808-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00809-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00809-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00810-a-cd-x.swift
+++ b/validation-test/compiler_crashers_fixed/00810-a-cd-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00811-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00811-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00812-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/00812-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00813-swift-tupleexpr-create.swift
+++ b/validation-test/compiler_crashers_fixed/00813-swift-tupleexpr-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00814-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00814-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00815-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00815-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00816-swift-isplatformactive.swift
+++ b/validation-test/compiler_crashers_fixed/00816-swift-isplatformactive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00818-c.swift
+++ b/validation-test/compiler_crashers_fixed/00818-c.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00819-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/00819-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00820-x.swift
+++ b/validation-test/compiler_crashers_fixed/00820-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00822-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00822-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00824-x.swift
+++ b/validation-test/compiler_crashers_fixed/00824-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00825-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00825-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00826-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00826-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00827-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/00827-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00828-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/00828-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00829-swift-constraints-constraintsystem-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00829-swift-constraints-constraintsystem-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00830-void.swift
+++ b/validation-test/compiler_crashers_fixed/00830-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00831-x.swift
+++ b/validation-test/compiler_crashers_fixed/00831-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00832-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/00832-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00833-clang-declvisitor-base-clang-declvisitor-make-const-ptr.swift
+++ b/validation-test/compiler_crashers_fixed/00833-clang-declvisitor-base-clang-declvisitor-make-const-ptr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00834-t.swift
+++ b/validation-test/compiler_crashers_fixed/00834-t.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00835-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00835-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00836-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00836-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00837-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00837-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00838-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00838-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00839-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00839-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00840-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00840-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00842-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00842-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00843-anyobject.swift
+++ b/validation-test/compiler_crashers_fixed/00843-anyobject.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00844-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00844-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00845-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00845-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00846-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/00846-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00847-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00847-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00848-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00848-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00849-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/00849-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00850-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00850-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00851-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00851-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00852-void.swift
+++ b/validation-test/compiler_crashers_fixed/00852-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00853-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00853-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00854-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00854-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00855-swift-parser-parsetypesimple.swift
+++ b/validation-test/compiler_crashers_fixed/00855-swift-parser-parsetypesimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00856-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/00856-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00857-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/00857-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00858-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00858-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00859-x.swift
+++ b/validation-test/compiler_crashers_fixed/00859-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00860-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00860-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00861-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00861-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00862-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00862-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00863-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00863-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00864-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00864-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00865-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00865-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00866-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00866-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00867-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00867-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00868-x.swift
+++ b/validation-test/compiler_crashers_fixed/00868-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00870-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00870-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00871-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00871-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00872-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/00872-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00873-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00873-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00874-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00874-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00875-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00875-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00876-x.swift
+++ b/validation-test/compiler_crashers_fixed/00876-x.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00877-as.swift
+++ b/validation-test/compiler_crashers_fixed/00877-as.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00878-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00878-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00879-swift-classtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00879-swift-classtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00880-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00880-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00881-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00881-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00882-a.swift
+++ b/validation-test/compiler_crashers_fixed/00882-a.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00883-t.swift
+++ b/validation-test/compiler_crashers_fixed/00883-t.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00884-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00884-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00885-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/00885-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00886-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/00886-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00887-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/00887-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00888-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00888-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00889-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00889-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00890-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/00890-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00891-a.swift
+++ b/validation-test/compiler_crashers_fixed/00891-a.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00892-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/00892-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00893-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00893-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00894-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/00894-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00895-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/00895-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00896-void.swift
+++ b/validation-test/compiler_crashers_fixed/00896-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00897-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/00897-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00898-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00898-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00899-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00899-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00900-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00900-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00901-ab.swift
+++ b/validation-test/compiler_crashers_fixed/00901-ab.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00902-c.swift
+++ b/validation-test/compiler_crashers_fixed/00902-c.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00903-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/00903-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00904-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/00904-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00905-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00905-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00906-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00906-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00907-c-t.swift
+++ b/validation-test/compiler_crashers_fixed/00907-c-t.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00908-l.swift
+++ b/validation-test/compiler_crashers_fixed/00908-l.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00909-a.swift
+++ b/validation-test/compiler_crashers_fixed/00909-a.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00910-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00910-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00911-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00911-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00912-a.swift
+++ b/validation-test/compiler_crashers_fixed/00912-a.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00913-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00913-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00914-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00914-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00915-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00915-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00916-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00916-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00917-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/00917-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00919-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00919-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00920-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/00920-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00921-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00921-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00922-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/00922-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00923-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00923-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00924-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/00924-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00925-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00925-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00926-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/00926-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00927-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00927-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00928-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00928-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00929-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00929-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00930-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00930-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00931-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00931-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00932-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00932-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00933-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00933-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00934-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00934-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00935-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/00935-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00936-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00936-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00937-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00937-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00938-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/00938-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00939-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/00939-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00940-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00940-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00941-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/00941-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00942-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00942-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00943-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/00943-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00944-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00944-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00945-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/00945-swift-lexer-lexstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00946-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/00946-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00947-void.swift
+++ b/validation-test/compiler_crashers_fixed/00947-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00948-swift-modulefile-readmembers.swift
+++ b/validation-test/compiler_crashers_fixed/00948-swift-modulefile-readmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00949-d.swift
+++ b/validation-test/compiler_crashers_fixed/00949-d.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00950-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00950-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00951-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00951-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00952-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/00952-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00953-swift-inflightdiagnostic-highlight.swift
+++ b/validation-test/compiler_crashers_fixed/00953-swift-inflightdiagnostic-highlight.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00954-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/00954-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00955-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/00955-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00956-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/00956-swift-type-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00957-void.swift
+++ b/validation-test/compiler_crashers_fixed/00957-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00958-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00958-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00959-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00959-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00960-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/00960-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00961-bool.swift
+++ b/validation-test/compiler_crashers_fixed/00961-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00962-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/00962-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00963-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00963-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00964-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00964-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00965-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/00965-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00966-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/00966-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00967-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00967-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00968-swift-typebase-isexistentialtype.swift
+++ b/validation-test/compiler_crashers_fixed/00968-swift-typebase-isexistentialtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00969-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00969-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00970-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00970-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00971-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/00971-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00972-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00972-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00973-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00973-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00974-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00974-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00975-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00975-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00976-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/00976-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00977-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/00977-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00978-llvm-foldingset-swift-structtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00978-llvm-foldingset-swift-structtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00979-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00979-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00980-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/00980-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00981-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00981-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00982-b.swift
+++ b/validation-test/compiler_crashers_fixed/00982-b.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00983-a.swift
+++ b/validation-test/compiler_crashers_fixed/00983-a.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00984-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/00984-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00985-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/00985-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00986-swift-unboundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00986-swift-unboundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00987-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00987-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00988-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00988-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00989-swift-typechecker-computecaptures.swift
+++ b/validation-test/compiler_crashers_fixed/00989-swift-typechecker-computecaptures.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00990-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00990-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00991-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/00991-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00992-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/00992-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00993-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/00993-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00994-swift-typealiasdecl.swift
+++ b/validation-test/compiler_crashers_fixed/00994-swift-typealiasdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00995-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/00995-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00996-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00996-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00997-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/00997-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00998-bool.swift
+++ b/validation-test/compiler_crashers_fixed/00998-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/00999-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/00999-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01000-swift-parser-parsetypeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01000-swift-parser-parsetypeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01001-swift-parser-parsedeclimport.swift
+++ b/validation-test/compiler_crashers_fixed/01001-swift-parser-parsedeclimport.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01002-swift-parentype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01002-swift-parentype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01003-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01003-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01004-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/01004-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01005-swift-nominaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01005-swift-nominaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01006-swift-modulefile-resolvecrossreference.swift
+++ b/validation-test/compiler_crashers_fixed/01006-swift-modulefile-resolvecrossreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01007-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/01007-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01008-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/01008-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01009-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01009-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01010-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01010-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01011-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01011-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01012-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01012-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01013-swift-module-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/01013-swift-module-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01014-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01014-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01015-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01015-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01016-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/01016-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01017-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01017-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01018-diagnoseunknowntype.swift
+++ b/validation-test/compiler_crashers_fixed/01018-diagnoseunknowntype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01019-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01019-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01020-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01020-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01021-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01021-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01022-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/01022-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01023-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01023-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01024-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01024-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01025-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01025-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01026-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01026-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01027-llvm-foldingset-swift-genericsignature-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01027-llvm-foldingset-swift-genericsignature-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01028-swift-camel-case-getfirstword.swift
+++ b/validation-test/compiler_crashers_fixed/01028-swift-camel-case-getfirstword.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01029-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/01029-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01030-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/01030-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01031-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01031-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01032-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01032-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01033-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01033-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01034-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01034-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01035-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/01035-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01037-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/01037-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01038-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01038-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01039-swift-typechecker-conformstoprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/01039-swift-typechecker-conformstoprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01040-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/01040-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01041-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01041-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01042-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01042-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01043-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01043-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01044-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01044-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01045-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01045-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01046-swift-constraints-constraintsystem-simplify.swift
+++ b/validation-test/compiler_crashers_fixed/01046-swift-constraints-constraintsystem-simplify.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01047-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01047-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01048-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01048-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01049-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/01049-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01050-swift-generictypeparamdecl-generictypeparamdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01050-swift-generictypeparamdecl-generictypeparamdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01051-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01051-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01052-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/01052-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01053-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01053-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01054-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01054-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01055-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01055-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01056-swift-typechecker-conformstoprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/01056-swift-typechecker-conformstoprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01057-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01057-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01058-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01058-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01059-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/01059-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01060-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01060-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01061-swift-typebase-gettypeofmember.swift
+++ b/validation-test/compiler_crashers_fixed/01061-swift-typebase-gettypeofmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01062-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01062-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01063-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/01063-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01064-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/01064-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01065-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/01065-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01066-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01066-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01067-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01067-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01068-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01068-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01069-swift-nominaltypedecl-getprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/01069-swift-nominaltypedecl-getprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01070-void.swift
+++ b/validation-test/compiler_crashers_fixed/01070-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01071-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01071-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01072-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01072-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01073-swift-constraints-constraintgraphnode-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01073-swift-constraints-constraintgraphnode-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01074-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/01074-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01075-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01075-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01076-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/01076-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01077-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01077-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01078-void.swift
+++ b/validation-test/compiler_crashers_fixed/01078-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01079-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01079-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01080-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/01080-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01081-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01081-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01082-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01082-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01083-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/01083-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01084-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01084-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01085-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01085-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01086-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/01086-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01087-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01087-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01088-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01088-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01089-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01089-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01090-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/01090-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01091-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/01091-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01092-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01092-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01093-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01093-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01094-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01094-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01095-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01095-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01096-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01096-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01097-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01097-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01098-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01098-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01099-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01099-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01100-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01100-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01101-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01101-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01102-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01102-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01103-swift-unboundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01103-swift-unboundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01104-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01104-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01105-void.swift
+++ b/validation-test/compiler_crashers_fixed/01105-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01106-swift-constraints-constraintsystem-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01106-swift-constraints-constraintsystem-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01107-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01107-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01108-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/01108-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01109-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01109-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01110-swift-archetypetype-getnestedtype.swift
+++ b/validation-test/compiler_crashers_fixed/01110-swift-archetypetype-getnestedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01111-swift-astcontext-setconformsto.swift
+++ b/validation-test/compiler_crashers_fixed/01111-swift-astcontext-setconformsto.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01112-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01112-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01113-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01113-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01114-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01114-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01115-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01115-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01116-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/01116-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01117-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01117-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01118-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01118-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01119-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01119-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01120-clang-codegen-codegenfunction-emitlvalueforfield.swift
+++ b/validation-test/compiler_crashers_fixed/01120-clang-codegen-codegenfunction-emitlvalueforfield.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01121-swift-derivedconformance-deriveequatable.swift
+++ b/validation-test/compiler_crashers_fixed/01121-swift-derivedconformance-deriveequatable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01122-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/01122-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01123-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01123-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01124-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01124-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01125-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01125-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01126-swift-parser-parseexprorstmt.swift
+++ b/validation-test/compiler_crashers_fixed/01126-swift-parser-parseexprorstmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01127-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01127-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01128-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01128-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01129-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01129-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01130-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01130-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01131-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01131-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01132-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01132-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01133-swift-clangimporter-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/01133-swift-clangimporter-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01134-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01134-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01135-swift-constraints-constraintsystem-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01135-swift-constraints-constraintsystem-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01136-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01136-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01137-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01137-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01138-void.swift
+++ b/validation-test/compiler_crashers_fixed/01138-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01139-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/01139-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01140-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01140-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01141-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/01141-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01142-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01142-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01143-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01143-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01144-swift-arrayslicetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01144-swift-arrayslicetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01145-swift-constraints-constraintsystem-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01145-swift-constraints-constraintsystem-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01146-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01146-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01147-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01147-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01148-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/01148-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01149-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01149-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01150-void.swift
+++ b/validation-test/compiler_crashers_fixed/01150-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01151-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01151-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01152-swift-derivedconformance-deriveequatable.swift
+++ b/validation-test/compiler_crashers_fixed/01152-swift-derivedconformance-deriveequatable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01153-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01153-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01154-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01154-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01155-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01155-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01156-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01156-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01157-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01157-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01158-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01158-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01159-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01159-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01160-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/01160-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01161-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01161-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01162-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/01162-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01163-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01163-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01164-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01164-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01165-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/01165-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01166-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01166-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01167-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/01167-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01168-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/01168-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01169-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/01169-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01170-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01170-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01171-swift-parentype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01171-swift-parentype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01172-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01172-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01173-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/01173-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01174-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01174-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01175-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/01175-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01176-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01176-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01177-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01177-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01178-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01178-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01179-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01179-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01180-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/01180-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01181-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/01181-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01182-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01182-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01183-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01183-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01184-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01184-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01185-swift-parser-parsetypeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01185-swift-parser-parsetypeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01186-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01186-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01187-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01187-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01188-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01188-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01189-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01189-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01190-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/01190-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01191-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01191-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01192-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01192-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01193-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01193-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01194-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01194-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01195-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01195-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01196-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01196-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01197-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/01197-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01198-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01198-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01199-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/01199-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01200-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01200-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01201-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01201-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01202-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01202-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01203-swift-typebase-gettypeofmember.swift
+++ b/validation-test/compiler_crashers_fixed/01203-swift-typebase-gettypeofmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01204-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/01204-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01205-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01205-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01206-swift-parser-parseexpridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01206-swift-parser-parseexpridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01207-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01207-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01208-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01208-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01209-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/01209-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01210-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01210-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01211-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01211-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01212-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/01212-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01213-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01213-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01214-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/01214-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01215-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01215-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01216-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01216-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01217-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/01217-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01218-void.swift
+++ b/validation-test/compiler_crashers_fixed/01218-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01219-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01219-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01220-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01220-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01221-swift-typealiasdecl-typealiasdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01221-swift-typealiasdecl-typealiasdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01222-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/01222-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01223-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/01223-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01224-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/01224-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01225-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01225-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01226-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01226-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01227-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01227-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01228-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/01228-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01229-void.swift
+++ b/validation-test/compiler_crashers_fixed/01229-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01230-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01230-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01231-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01231-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01232-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/01232-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01233-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01233-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01234-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/01234-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01235-bool.swift
+++ b/validation-test/compiler_crashers_fixed/01235-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01236-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01236-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01237-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01237-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01238-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01238-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01239-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/01239-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01240-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01240-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01241-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/01241-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01242-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01242-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01243-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01243-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01244-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01244-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01245-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01245-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01246-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01246-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01247-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01247-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01248-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/01248-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01249-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01249-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01250-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01250-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01251-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/01251-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01252-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/01252-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01253-swift-tuplepattern-createsimple.swift
+++ b/validation-test/compiler_crashers_fixed/01253-swift-tuplepattern-createsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01254-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/01254-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01255-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01255-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01256-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01256-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01257-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01257-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01258-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01258-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01259-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01259-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01260-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01260-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01261-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01261-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01262-swift-modulefile-maybereadconformance.swift
+++ b/validation-test/compiler_crashers_fixed/01262-swift-modulefile-maybereadconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01263-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01263-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01264-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01264-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01265-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/01265-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01266-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01266-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01267-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/01267-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01268-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01268-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01269-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01269-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01270-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01270-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01271-swift-parser-parseexprunary.swift
+++ b/validation-test/compiler_crashers_fixed/01271-swift-parser-parseexprunary.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01272-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01272-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01273-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01273-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01274-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01274-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01275-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/01275-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01276-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01276-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01277-diagnoseunknowntype.swift
+++ b/validation-test/compiler_crashers_fixed/01277-diagnoseunknowntype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01278-swift-modulefile-maybereadconformance.swift
+++ b/validation-test/compiler_crashers_fixed/01278-swift-modulefile-maybereadconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01279-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01279-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01280-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01280-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01281-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/01281-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01282-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01282-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01283-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01283-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01284-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01284-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01285-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01285-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01286-swift-parser-parseexpridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01286-swift-parser-parseexpridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01287-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01287-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01288-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01288-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01289-void.swift
+++ b/validation-test/compiler_crashers_fixed/01289-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01290-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01290-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01291-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01291-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01292-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01292-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01293-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01293-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01294-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01294-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01295-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01295-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01296-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01296-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01297-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01297-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01298-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01298-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01299-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01299-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01300-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01300-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01301-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01301-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01302-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01302-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01303-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01303-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01304-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01304-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01305-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01305-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01306-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/01306-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01307-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01307-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01308-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01308-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01309-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01309-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01310-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01310-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01311-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/01311-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01312-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01312-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01313-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01313-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01314-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01314-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01315-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/01315-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01316-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/01316-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01317-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/01317-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01318-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01318-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01319-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01319-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01320-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01320-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01321-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01321-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01322-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01322-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01323-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/01323-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01324-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01324-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01325-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/01325-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01326-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01326-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01327-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01327-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01328-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01328-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01329-llvm-bitstreamcursor-readrecord.swift
+++ b/validation-test/compiler_crashers_fixed/01329-llvm-bitstreamcursor-readrecord.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01330-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01330-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01331-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01331-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01332-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01332-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01333-swift-abstractstoragedecl-makecomputed.swift
+++ b/validation-test/compiler_crashers_fixed/01333-swift-abstractstoragedecl-makecomputed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01334-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01334-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01335-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/01335-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01336-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01336-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01340-llvm-getelementptrinst-getindexedtype.swift
+++ b/validation-test/compiler_crashers_fixed/01340-llvm-getelementptrinst-getindexedtype.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01341-broken-function-found-compilation-aborted.swift
+++ b/validation-test/compiler_crashers_fixed/01341-broken-function-found-compilation-aborted.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01342-swift-parser-parsegetsetimpl.swift
+++ b/validation-test/compiler_crashers_fixed/01342-swift-parser-parsegetsetimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01343-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01343-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01344-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01344-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01345-swift-typechecker-getdefaulttype.swift
+++ b/validation-test/compiler_crashers_fixed/01345-swift-typechecker-getdefaulttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01346-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01346-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01347-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01347-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01348-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01348-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01349-swift-typebase-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01349-swift-typebase-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01350-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/01350-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01351-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/01351-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01352-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01352-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01353-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/01353-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01354-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01354-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01355-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01355-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01356-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/01356-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01357-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01357-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01358-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/01358-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01359-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01359-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01360-void.swift
+++ b/validation-test/compiler_crashers_fixed/01360-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01361-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/01361-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01362-swift-constraints-constraintgraph-unbindtypevariable.swift
+++ b/validation-test/compiler_crashers_fixed/01362-swift-constraints-constraintgraph-unbindtypevariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01363-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/01363-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01364-swift-enumtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01364-swift-enumtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01365-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01365-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01366-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01366-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01367-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01367-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01368-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/01368-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01369-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01369-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01370-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01370-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01371-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/01371-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01372-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01372-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01373-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/01373-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01374-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01374-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01375-clang-declvisitor-base-clang-declvisitor-make-const-ptr.swift
+++ b/validation-test/compiler_crashers_fixed/01375-clang-declvisitor-base-clang-declvisitor-make-const-ptr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01376-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/01376-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01377-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01377-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01378-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/01378-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01379-swift-parser-parsedeclinit.swift
+++ b/validation-test/compiler_crashers_fixed/01379-swift-parser-parsedeclinit.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01380-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01380-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01381-bool.swift
+++ b/validation-test/compiler_crashers_fixed/01381-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01382-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01382-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01383-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01383-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01384-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01384-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01385-swift-typedecl-getdeclaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/01385-swift-typedecl-getdeclaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01386-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01386-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01387-swift-astcontext-setconformsto.swift
+++ b/validation-test/compiler_crashers_fixed/01387-swift-astcontext-setconformsto.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01388-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01388-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01389-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01389-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01390-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/01390-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01391-swift-typechecker-callwitness.swift
+++ b/validation-test/compiler_crashers_fixed/01391-swift-typechecker-callwitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01392-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01392-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01393-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01393-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01394-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/01394-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01395-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/01395-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01396-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/01396-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01397-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/01397-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01398-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01398-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01399-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01399-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01400-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01400-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01401-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/01401-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01402-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/01402-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01403-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01403-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01404-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01404-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01405-swift-clangimporter-implementation-finishloadingclangmodule.swift
+++ b/validation-test/compiler_crashers_fixed/01405-swift-clangimporter-implementation-finishloadingclangmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01406-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/01406-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01407-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/01407-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01408-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01408-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01409-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01409-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01410-swift-constraints-constraintsystem-lookupmember.swift
+++ b/validation-test/compiler_crashers_fixed/01410-swift-constraints-constraintsystem-lookupmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01411-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01411-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01412-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/01412-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01413-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/01413-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01414-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/01414-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01415-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/01415-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01416-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/01416-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01417-swift-extensiondecl-create.swift
+++ b/validation-test/compiler_crashers_fixed/01417-swift-extensiondecl-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01418-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01418-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01419-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/01419-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01420-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01420-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01421-void.swift
+++ b/validation-test/compiler_crashers_fixed/01421-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01422-swift-parser-parsestmtreturn.swift
+++ b/validation-test/compiler_crashers_fixed/01422-swift-parser-parsestmtreturn.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01423-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01423-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01424-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01424-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01425-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01425-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01426-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01426-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01427-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01427-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01428-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01428-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01429-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01429-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01430-swift-expr-getsourcerange.swift
+++ b/validation-test/compiler_crashers_fixed/01430-swift-expr-getsourcerange.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01431-swift-unboundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01431-swift-unboundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01432-swift-bracestmt-create.swift
+++ b/validation-test/compiler_crashers_fixed/01432-swift-bracestmt-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01433-swift-constraints-solution-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/01433-swift-constraints-solution-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01434-std-function-func-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/01434-std-function-func-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01435-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/01435-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01436-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01436-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01437-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/01437-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01438-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/01438-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01439-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01439-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01440-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/01440-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01441-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01441-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01442-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01442-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01443-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/01443-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01444-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/01444-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01445-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01445-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01446-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/01446-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01447-swift-parentype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01447-swift-parentype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01448-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01448-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01449-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01449-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01450-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/01450-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01451-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01451-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01452-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01452-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01453-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/01453-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01454-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01454-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01455-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01455-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01456-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01456-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01457-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01457-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01458-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/01458-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01459-swift-abstractstoragedecl-makecomputed.swift
+++ b/validation-test/compiler_crashers_fixed/01459-swift-abstractstoragedecl-makecomputed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01460-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01460-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01461-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01461-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01462-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/01462-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01463-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01463-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01464-llvm-bitstreamcursor-readabbreviatedfield.swift
+++ b/validation-test/compiler_crashers_fixed/01464-llvm-bitstreamcursor-readabbreviatedfield.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01465-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/01465-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01466-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01466-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01467-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01467-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01468-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01468-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01469-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01469-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01470-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01470-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01471-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01471-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01472-swift-modulefile-configurestorage.swift
+++ b/validation-test/compiler_crashers_fixed/01472-swift-modulefile-configurestorage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01473-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/01473-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01474-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01474-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01475-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01475-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01476-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/01476-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01477-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01477-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01478-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01478-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01479-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01479-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01480-swift-typebase-getcanonicaltype-edited.swift
+++ b/validation-test/compiler_crashers_fixed/01480-swift-typebase-getcanonicaltype-edited.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01480-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01480-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01481-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01481-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01482-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01482-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01483-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01483-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01484-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01484-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01485-swift-constraints-constraintsystem-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01485-swift-constraints-constraintsystem-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01487-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01487-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01488-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/01488-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01489-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01489-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01490-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01490-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01491-llvm-raw-ostream-write.swift
+++ b/validation-test/compiler_crashers_fixed/01491-llvm-raw-ostream-write.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01492-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01492-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01493-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/01493-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01495-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01495-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01496-swift-nominaltypedecl-getprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/01496-swift-nominaltypedecl-getprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01497-swift-bracestmt-create.swift
+++ b/validation-test/compiler_crashers_fixed/01497-swift-bracestmt-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01498-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01498-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01499-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/01499-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01501-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01501-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01502-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01502-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01503-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/01503-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01504-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01504-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01505-swift-constraints-constraintsystem-simplifymemberconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01505-swift-constraints-constraintsystem-simplifymemberconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01506-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/01506-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01507-swift-constraints-matchcallarguments.swift
+++ b/validation-test/compiler_crashers_fixed/01507-swift-constraints-matchcallarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01508-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01508-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01509-bool-edited.swift
+++ b/validation-test/compiler_crashers_fixed/01509-bool-edited.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01509-bool.swift
+++ b/validation-test/compiler_crashers_fixed/01509-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01510-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01510-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01512-swift-optional-swift-infixoperatordecl.swift
+++ b/validation-test/compiler_crashers_fixed/01512-swift-optional-swift-infixoperatordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01513-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01513-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01514-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01514-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01515-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01515-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01516-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01516-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01517-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/01517-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01518-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/01518-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01519-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01519-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01520-llvm-bitstreamcursor-readrecord.swift
+++ b/validation-test/compiler_crashers_fixed/01520-llvm-bitstreamcursor-readrecord.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01521-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01521-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01522-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01522-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01523-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01523-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01524-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01524-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01525-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/01525-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01526-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01526-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01527-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01527-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01528-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01528-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01530-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01530-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01531-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01531-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01532-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01532-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01533-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/01533-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01534-bool.swift
+++ b/validation-test/compiler_crashers_fixed/01534-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01535-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01535-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01536-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01536-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01537-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01537-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01538-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01538-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01539-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01539-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01540-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/01540-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01541-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01541-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01542-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01542-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01543-bool.swift
+++ b/validation-test/compiler_crashers_fixed/01543-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01544-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01544-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01545-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/01545-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01546-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/01546-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01547-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01547-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01548-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/01548-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01549-llvm-foldingset-swift-declname-compounddeclname-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01549-llvm-foldingset-swift-declname-compounddeclname-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01550-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01550-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01551-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01551-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01552-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/01552-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01553-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01553-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01554-swift-typealiasdecl-typealiasdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01554-swift-typealiasdecl-typealiasdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01555-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/01555-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01556-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01556-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01557-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01557-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01558-swift-parser-parseexprunary.swift
+++ b/validation-test/compiler_crashers_fixed/01558-swift-parser-parseexprunary.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01559-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01559-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01560-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/01560-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01561-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01561-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01562-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01562-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01563-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01563-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01564-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01564-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01565-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01565-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01566-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01566-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01567-swift-tuplepattern-createsimple.swift
+++ b/validation-test/compiler_crashers_fixed/01567-swift-tuplepattern-createsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01568-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01568-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01569-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01569-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01570-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01570-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01571-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01571-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01572-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/01572-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01573-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01573-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01574-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01574-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01575-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01575-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01576-swift-generictypeparamdecl-generictypeparamdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01576-swift-generictypeparamdecl-generictypeparamdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01577-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/01577-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01578-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01578-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01579-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01579-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01580-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01580-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01581-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/01581-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01582-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01582-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01583-llvm-prettystacktraceentry-prettystacktraceentry.swift
+++ b/validation-test/compiler_crashers_fixed/01583-llvm-prettystacktraceentry-prettystacktraceentry.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01584-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01584-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01585-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01585-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01586-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01586-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01587-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01587-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01588-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01588-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01589-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01589-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01590-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01590-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01591-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01591-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01592-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/01592-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01593-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01593-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01594-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01594-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01595-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01595-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01596-llvm-bitstreamcursor-readvbr.swift
+++ b/validation-test/compiler_crashers_fixed/01596-llvm-bitstreamcursor-readvbr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01597-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01597-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01598-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/01598-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01599-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01599-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01600-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/01600-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01601-llvm-prettystacktraceentry-prettystacktraceentry.swift
+++ b/validation-test/compiler_crashers_fixed/01601-llvm-prettystacktraceentry-prettystacktraceentry.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01602-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01602-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01603-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01603-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01604-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01604-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01605-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/01605-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01606-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01606-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01607-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01607-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01608-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/01608-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01609-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01609-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01610-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01610-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01611-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01611-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01613-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01613-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01614-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01614-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01615-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01615-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01616-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/01616-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01617-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/01617-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01618-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01618-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01619-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01619-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01620-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01620-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01621-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/01621-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01622-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/01622-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01623-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01623-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01624-swift-namelookup-lookupinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/01624-swift-namelookup-lookupinmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01626-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/01626-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01627-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01627-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01628-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/01628-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01629-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01629-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01630-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01630-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01631-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/01631-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01632-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01632-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01633-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01633-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01634-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01634-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01635-swift-mangle-mangler-mangletype.swift
+++ b/validation-test/compiler_crashers_fixed/01635-swift-mangle-mangler-mangletype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01636-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01636-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01637-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01637-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01638-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01638-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01640-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01640-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01641-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/01641-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01642-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01642-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01643-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01643-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01644-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01644-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01645-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/01645-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01647-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01647-no-stacktrace.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01649-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/01649-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01650-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/01650-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01651-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01651-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01653-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/01653-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01654-swift-astprinter-printname.swift
+++ b/validation-test/compiler_crashers_fixed/01654-swift-astprinter-printname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01655-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01655-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01656-swift-astcontext-getconformsto.swift
+++ b/validation-test/compiler_crashers_fixed/01656-swift-astcontext-getconformsto.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01657-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01657-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01658-swift-parser-parsetypeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01658-swift-parser-parsetypeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01659-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01659-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01660-swift-parser-parseexprsequence.swift
+++ b/validation-test/compiler_crashers_fixed/01660-swift-parser-parseexprsequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01661-swift-parser-parsedeclfunc.swift
+++ b/validation-test/compiler_crashers_fixed/01661-swift-parser-parsedeclfunc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01662-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/01662-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01664-swift-parser-parsetypetuplebody.swift
+++ b/validation-test/compiler_crashers_fixed/01664-swift-parser-parsetypetuplebody.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01665-llvm-foldingset-swift-enumtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01665-llvm-foldingset-swift-enumtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01666-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01666-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01667-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/01667-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01668-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01668-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01669-void.swift
+++ b/validation-test/compiler_crashers_fixed/01669-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01670-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/01670-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01671-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01671-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01673-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/01673-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01674-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01674-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01675-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/01675-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01676-swift-parser-parseexprsequence.swift
+++ b/validation-test/compiler_crashers_fixed/01676-swift-parser-parseexprsequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01677-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01677-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01678-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01678-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01679-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01679-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01681-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/01681-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01682-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01682-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01683-swift-nominaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01683-swift-nominaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01685-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/01685-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01686-swift-astcontext-setconformsto.swift
+++ b/validation-test/compiler_crashers_fixed/01686-swift-astcontext-setconformsto.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01687-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01687-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01688-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01688-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01689-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01689-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01691-clang-astcontext-getrecordtype.swift
+++ b/validation-test/compiler_crashers_fixed/01691-clang-astcontext-getrecordtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01692-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01692-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01693-swift-typealiasdecl-typealiasdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01693-swift-typealiasdecl-typealiasdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01694-void.swift
+++ b/validation-test/compiler_crashers_fixed/01694-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01695-swift-pattern-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01695-swift-pattern-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01696-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01696-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01698-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01698-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01699-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01699-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01700-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01700-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01701-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01701-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01702-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01702-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01703-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/01703-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01704-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01704-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01705-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/01705-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01706-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01706-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01707-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/01707-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01708-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01708-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01709-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/01709-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01710-swift-typechecker-callwitness.swift
+++ b/validation-test/compiler_crashers_fixed/01710-swift-typechecker-callwitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01711-swift-module-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01711-swift-module-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01712-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01712-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01713-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01713-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01714-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01714-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01715-void.swift
+++ b/validation-test/compiler_crashers_fixed/01715-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01716-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01716-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01717-getcallerdefaultarg.swift
+++ b/validation-test/compiler_crashers_fixed/01717-getcallerdefaultarg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01718-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/01718-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01719-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/01719-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01720-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01720-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01721-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01721-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01722-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01722-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01723-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01723-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01724-llvm-tinyptrvector-swift-valuedecl-push-back.swift
+++ b/validation-test/compiler_crashers_fixed/01724-llvm-tinyptrvector-swift-valuedecl-push-back.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01725-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01725-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01726-getmemberforbasetype.swift
+++ b/validation-test/compiler_crashers_fixed/01726-getmemberforbasetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01728-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01728-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01729-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/01729-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01730-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/01730-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01731-swift-dictionarytype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01731-swift-dictionarytype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01732-swift-parser-parsebraceitemlist.swift
+++ b/validation-test/compiler_crashers_fixed/01732-swift-parser-parsebraceitemlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01733-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01733-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01734-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01734-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01735-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01735-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01736-void.swift
+++ b/validation-test/compiler_crashers_fixed/01736-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01737-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/01737-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01738-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/01738-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01739-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/01739-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01740-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01740-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01741-swift-constraints-constraintsystem-simplifymemberconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01741-swift-constraints-constraintsystem-simplifymemberconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01742-swift-arrayslicetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01742-swift-arrayslicetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01743-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01743-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01745-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01745-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01746-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01746-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01747-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/01747-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01748-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/01748-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01749-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01749-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01750-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01750-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01751-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01751-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01752-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/01752-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01753-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/01753-swift-lexer-lexstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01754-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01754-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01755-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/01755-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01756-swift-constraints-constraintsystem-matchfunctiontypes.swift
+++ b/validation-test/compiler_crashers_fixed/01756-swift-constraints-constraintsystem-matchfunctiontypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01757-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01757-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01758-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01758-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01759-bool.swift
+++ b/validation-test/compiler_crashers_fixed/01759-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01760-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01760-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01761-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01761-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01762-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/01762-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01763-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/01763-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01764-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/01764-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01765-swift-inflightdiagnostic-highlight.swift
+++ b/validation-test/compiler_crashers_fixed/01765-swift-inflightdiagnostic-highlight.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01766-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01766-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01767-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01767-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01768-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01768-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01769-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01769-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01770-swift-typechecker-buildarrayinjectionfnref.swift
+++ b/validation-test/compiler_crashers_fixed/01770-swift-typechecker-buildarrayinjectionfnref.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01771-swift-sourcefile-getcache.swift
+++ b/validation-test/compiler_crashers_fixed/01771-swift-sourcefile-getcache.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01772-void.swift
+++ b/validation-test/compiler_crashers_fixed/01772-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01773-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01773-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01774-getmemberforbasetype.swift
+++ b/validation-test/compiler_crashers_fixed/01774-getmemberforbasetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01775-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01775-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01776-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/01776-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01777-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01777-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01778-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01778-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01779-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01779-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01780-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01780-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01781-swift-optional-std-pair-swift-api-notes-contextid.swift
+++ b/validation-test/compiler_crashers_fixed/01781-swift-optional-std-pair-swift-api-notes-contextid.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01782-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/01782-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01783-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01783-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01784-swift-constraints-constraintgraph-lookupnode.swift
+++ b/validation-test/compiler_crashers_fixed/01784-swift-constraints-constraintgraph-lookupnode.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01785-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/01785-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01786-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01786-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01787-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01787-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01788-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01788-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01789-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01789-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01790-swift-constraints-constraintgraph-unbindtypevariable.swift
+++ b/validation-test/compiler_crashers_fixed/01790-swift-constraints-constraintgraph-unbindtypevariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01791-swift-typedecl-getdeclaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/01791-swift-typedecl-getdeclaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01792-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/01792-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01793-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01793-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01794-swift-astcontext-setconformsto.swift
+++ b/validation-test/compiler_crashers_fixed/01794-swift-astcontext-setconformsto.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01795-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/01795-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01796-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01796-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01797-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01797-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01798-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/01798-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01799-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01799-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01800-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01800-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01801-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01801-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01802-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/01802-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01803-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01803-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01804-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/01804-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01805-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01805-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01806-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01806-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01807-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01807-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01808-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/01808-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01809-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01809-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01810-swift-clangimporter-implementation-finishloadingclangmodule.swift
+++ b/validation-test/compiler_crashers_fixed/01810-swift-clangimporter-implementation-finishloadingclangmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01811-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/01811-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01812-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/01812-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01813-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/01813-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01814-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01814-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01815-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01815-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01816-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01816-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01817-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01817-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01818-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/01818-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01819-swift-typevisitor.swift
+++ b/validation-test/compiler_crashers_fixed/01819-swift-typevisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01820-cleanupillformedexpression.swift
+++ b/validation-test/compiler_crashers_fixed/01820-cleanupillformedexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01821-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01821-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01822-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/01822-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01823-llvm-sys-path-append.swift
+++ b/validation-test/compiler_crashers_fixed/01823-llvm-sys-path-append.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01824-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01824-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01825-swift-module-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01825-swift-module-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01826-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/01826-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01827-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01827-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01828-swift-typealiasdecl-typealiasdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01828-swift-typealiasdecl-typealiasdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01829-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01829-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01830-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers_fixed/01830-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01831-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01831-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01832-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/01832-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01833-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01833-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01834-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01834-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01835-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01835-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01836-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01836-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01837-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01837-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01838-void.swift
+++ b/validation-test/compiler_crashers_fixed/01838-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01839-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01839-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01840-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01840-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01841-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01841-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01842-swift-associatedtypedecl-associatedtypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01842-swift-associatedtypedecl-associatedtypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01843-llvm-bitstreamcursor-readrecord.swift
+++ b/validation-test/compiler_crashers_fixed/01843-llvm-bitstreamcursor-readrecord.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01844-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/01844-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01845-swift-typebase-gettypeofmember.swift
+++ b/validation-test/compiler_crashers_fixed/01845-swift-typebase-gettypeofmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01846-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/01846-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01847-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01847-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01848-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/01848-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01849-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01849-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01850-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01850-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01851-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/01851-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01852-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/01852-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01853-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/01853-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01854-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01854-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01855-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/01855-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01856-swift-parser-parsetypesimple.swift
+++ b/validation-test/compiler_crashers_fixed/01856-swift-parser-parsetypesimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01857-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01857-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01858-llvm-densemap-swift-valuedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01858-llvm-densemap-swift-valuedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01859-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/01859-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01860-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01860-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01861-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/01861-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01862-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/01862-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01863-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/01863-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01864-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/01864-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01865-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/01865-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01866-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01866-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01867-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01867-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01868-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01868-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01870-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/01870-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01872-void.swift
+++ b/validation-test/compiler_crashers_fixed/01872-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01873-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/01873-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01874-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01874-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01875-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01875-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01876-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01876-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01877-swift-typebase-isexistentialtype.swift
+++ b/validation-test/compiler_crashers_fixed/01877-swift-typebase-isexistentialtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01878-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01878-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01880-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01880-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01881-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01881-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01882-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01882-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01883-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01883-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01884-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01884-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01885-swift-constraints-solution-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/01885-swift-constraints-solution-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01886-swift-typebase-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01886-swift-typebase-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01887-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01887-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01888-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/01888-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01889-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01889-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01890-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/01890-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01892-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01892-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01893-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01893-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01894-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01894-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01895-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01895-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01896-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01896-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01897-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01897-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01898-swift-parser-parsefunctionarguments.swift
+++ b/validation-test/compiler_crashers_fixed/01898-swift-parser-parsefunctionarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01899-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01899-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01900-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01900-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01901-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01901-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01902-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01902-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01903-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01903-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01905-swift-optionaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01905-swift-optionaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01906-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/01906-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01907-swift-generictypeparamdecl-generictypeparamdecl.swift
+++ b/validation-test/compiler_crashers_fixed/01907-swift-generictypeparamdecl-generictypeparamdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01908-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/01908-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01910-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/01910-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01911-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/01911-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01912-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01912-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01914-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/01914-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01915-swift-typechecker-getprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/01915-swift-typechecker-getprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01916-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01916-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01917-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01917-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01918-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01918-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01919-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01919-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01920-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/01920-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01921-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/01921-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01922-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01922-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01923-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/01923-swift-lexer-lexstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01924-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01924-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01925-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/01925-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01926-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01926-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01927-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01927-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01928-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01928-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01929-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/01929-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01930-void.swift
+++ b/validation-test/compiler_crashers_fixed/01930-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01931-swift-protocolcompositiontype-build.swift
+++ b/validation-test/compiler_crashers_fixed/01931-swift-protocolcompositiontype-build.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01932-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/01932-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01933-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/01933-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01935-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01935-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01936-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01936-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01937-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01937-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01938-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/01938-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01939-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01939-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01940-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01940-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01941-swift-optionaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01941-swift-optionaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01942-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01942-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01943-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01943-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01944-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/01944-swift-type-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01945-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01945-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01946-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01946-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01947-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01947-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01948-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01948-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01949-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/01949-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01950-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01950-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01951-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/01951-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01952-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01952-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01953-swift-module-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/01953-swift-module-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01954-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/01954-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01955-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01955-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01957-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01957-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01958-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01958-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01960-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01960-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01961-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01961-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01962-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01962-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01963-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/01963-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01964-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01964-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01965-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/01965-swift-constraints-constraintsystem-diagnosefailurefromconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01966-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/01966-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01967-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/01967-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01968-bool.swift
+++ b/validation-test/compiler_crashers_fixed/01968-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01969-getmemberforbasetype.swift
+++ b/validation-test/compiler_crashers_fixed/01969-getmemberforbasetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01970-void.swift
+++ b/validation-test/compiler_crashers_fixed/01970-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01971-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01971-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01972-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01972-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01973-void.swift
+++ b/validation-test/compiler_crashers_fixed/01973-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01974-swift-declname-declname.swift
+++ b/validation-test/compiler_crashers_fixed/01974-swift-declname-declname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01975-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/01975-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01976-llvm-yaml-scalartraits-float-input.swift
+++ b/validation-test/compiler_crashers_fixed/01976-llvm-yaml-scalartraits-float-input.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01977-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/01977-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01978-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/01978-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01979-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/01979-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01980-swift-typebase-operator.swift
+++ b/validation-test/compiler_crashers_fixed/01980-swift-typebase-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01981-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/01981-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01982-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01982-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01983-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01983-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01984-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/01984-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01985-swift-parser-parsestmtforeach.swift
+++ b/validation-test/compiler_crashers_fixed/01985-swift-parser-parsestmtforeach.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01986-swift-parser-parseexprunary.swift
+++ b/validation-test/compiler_crashers_fixed/01986-swift-parser-parseexprunary.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01987-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01987-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01988-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01988-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01989-void.swift
+++ b/validation-test/compiler_crashers_fixed/01989-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01990-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/01990-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01991-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/01991-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01992-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/01992-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01993-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01993-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01994-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/01994-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01995-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/01995-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01996-swift-parser-parsedeclenumcase.swift
+++ b/validation-test/compiler_crashers_fixed/01996-swift-parser-parsedeclenumcase.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01997-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/01997-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01998-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/01998-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/01999-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/01999-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02000-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/02000-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02001-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02001-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02002-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02002-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02003-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/02003-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02004-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/02004-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02005-swift-parser-parsedeclvargetset.swift
+++ b/validation-test/compiler_crashers_fixed/02005-swift-parser-parsedeclvargetset.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02006-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/02006-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02007-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02007-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02008-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02008-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02009-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02009-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02010-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02010-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02011-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/02011-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02012-inferdynamic.swift
+++ b/validation-test/compiler_crashers_fixed/02012-inferdynamic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02013-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/02013-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02014-swift-parser-parsetypesimple.swift
+++ b/validation-test/compiler_crashers_fixed/02014-swift-parser-parsetypesimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02015-swift-typebase-gettypeofmember.swift
+++ b/validation-test/compiler_crashers_fixed/02015-swift-typebase-gettypeofmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02016-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/02016-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02017-swift-astcontext-getdictionarydecl.swift
+++ b/validation-test/compiler_crashers_fixed/02017-swift-astcontext-getdictionarydecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02018-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/02018-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02019-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/02019-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02020-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/02020-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02021-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/02021-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02022-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/02022-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02023-void.swift
+++ b/validation-test/compiler_crashers_fixed/02023-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02024-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02024-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02025-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02025-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02026-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/02026-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02027-swift-unboundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02027-swift-unboundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02028-swift-constraints-constraintsystem-simplify.swift
+++ b/validation-test/compiler_crashers_fixed/02028-swift-constraints-constraintsystem-simplify.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02029-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02029-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02030-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/02030-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02031-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/02031-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02032-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/02032-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02033-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02033-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02034-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/02034-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02035-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/compiler_crashers_fixed/02035-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02036-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02036-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02037-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02037-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02038-llvm-bitstreamcursor-readvbr.swift
+++ b/validation-test/compiler_crashers_fixed/02038-llvm-bitstreamcursor-readvbr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02039-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02039-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02040-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02040-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02041-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/02041-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02042-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02042-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02043-std-function-func-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/02043-std-function-func-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02044-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/02044-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02045-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02045-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02046-swift-pattern-operator.swift
+++ b/validation-test/compiler_crashers_fixed/02046-swift-pattern-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02047-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02047-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02048-swift-enumdecl-issimpleenum.swift
+++ b/validation-test/compiler_crashers_fixed/02048-swift-enumdecl-issimpleenum.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02049-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/02049-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02050-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02050-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02051-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02051-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02052-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/02052-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02053-swift-modulefile-maybereadsubstitution.swift
+++ b/validation-test/compiler_crashers_fixed/02053-swift-modulefile-maybereadsubstitution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02054-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/02054-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02055-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/02055-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02056-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02056-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02057-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/02057-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02058-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/02058-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02059-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02059-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02060-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/02060-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02061-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/02061-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02062-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02062-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02063-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02063-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02064-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/02064-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02065-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/02065-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02066-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/02066-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02067-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02067-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02068-swift-parser-parsedeclfunc.swift
+++ b/validation-test/compiler_crashers_fixed/02068-swift-parser-parsedeclfunc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02069-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02069-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02072-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02072-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02073-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/02073-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02074-swift-constraints-constraintlocatorbuilder-trysimplifytoexpr.swift
+++ b/validation-test/compiler_crashers_fixed/02074-swift-constraints-constraintlocatorbuilder-trysimplifytoexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02075-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/02075-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02076-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/02076-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02077-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02077-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02078-swift-parser-parsedeclinit.swift
+++ b/validation-test/compiler_crashers_fixed/02078-swift-parser-parsedeclinit.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02079-swift-module-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/02079-swift-module-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02080-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02080-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02081-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02081-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02082-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/02082-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02084-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02084-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02085-swift-range-swift-nestedgenericparamlistiterator-swift-archetypetype.swift
+++ b/validation-test/compiler_crashers_fixed/02085-swift-range-swift-nestedgenericparamlistiterator-swift-archetypetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02086-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/02086-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02087-swift-generictypeparamdecl-generictypeparamdecl.swift
+++ b/validation-test/compiler_crashers_fixed/02087-swift-generictypeparamdecl-generictypeparamdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02088-swift-constraints-constraintsystem-matchfunctiontypes.swift
+++ b/validation-test/compiler_crashers_fixed/02088-swift-constraints-constraintsystem-matchfunctiontypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02089-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02089-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02090-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02090-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02091-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/02091-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02092-swift-abstractstoragedecl-makecomputed.swift
+++ b/validation-test/compiler_crashers_fixed/02092-swift-abstractstoragedecl-makecomputed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02093-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02093-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02094-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02094-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02095-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/02095-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02096-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02096-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02097-swift-singlerawcomment-singlerawcomment.swift
+++ b/validation-test/compiler_crashers_fixed/02097-swift-singlerawcomment-singlerawcomment.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02098-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/02098-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02099-swift-clangimporter-loadmodule.swift
+++ b/validation-test/compiler_crashers_fixed/02099-swift-clangimporter-loadmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02100-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/02100-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02101-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02101-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02102-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02102-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02103-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02103-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02104-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02104-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02105-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/02105-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02106-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02106-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02107-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02107-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02108-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/02108-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02109-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/02109-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02110-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/02110-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02111-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/02111-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02112-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02112-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02113-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02113-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02114-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02114-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02115-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/02115-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02116-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/02116-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02117-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02117-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02118-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/02118-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02119-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02119-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02120-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02120-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02121-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02121-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02122-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/02122-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02123-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/02123-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02124-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/02124-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02125-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/02125-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02126-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02126-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02127-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/02127-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02128-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02128-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02129-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/02129-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02130-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/02130-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02131-swift-parser-parsedeclclass.swift
+++ b/validation-test/compiler_crashers_fixed/02131-swift-parser-parsedeclclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02132-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02132-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02133-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02133-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02134-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/02134-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02135-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02135-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02136-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/02136-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02137-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02137-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02138-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/02138-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02139-swift-constraints-constraintgraphnode-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/02139-swift-constraints-constraintgraphnode-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02140-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02140-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02141-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/02141-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02142-formatdiagnostictext.swift
+++ b/validation-test/compiler_crashers_fixed/02142-formatdiagnostictext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02143-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02143-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02144-swift-parser-parsestmt.swift
+++ b/validation-test/compiler_crashers_fixed/02144-swift-parser-parsestmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02145-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02145-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02146-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/02146-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02147-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/02147-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02148-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/02148-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02149-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/02149-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02150-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/02150-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02151-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02151-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02153-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/02153-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02154-swift-sourcefile-getcache.swift
+++ b/validation-test/compiler_crashers_fixed/02154-swift-sourcefile-getcache.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02155-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/02155-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02156-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02156-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02157-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/02157-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02158-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02158-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02159-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/02159-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02161-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02161-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02162-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02162-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02163-swift-parser-parseexprlist.swift
+++ b/validation-test/compiler_crashers_fixed/02163-swift-parser-parseexprlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02164-swift-typechecker-checksubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/02164-swift-typechecker-checksubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02165-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/02165-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02166-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02166-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02167-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02167-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02168-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02168-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02169-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02169-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02170-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02170-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02171-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02171-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02172-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02172-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02173-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/02173-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02174-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/02174-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02175-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/02175-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02176-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02176-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02177-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02177-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02178-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/02178-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02179-llvm-bitstreamcursor-readrecord.swift
+++ b/validation-test/compiler_crashers_fixed/02179-llvm-bitstreamcursor-readrecord.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02180-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02180-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02181-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/02181-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02182-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/02182-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02183-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02183-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02184-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02184-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02185-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/02185-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02186-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02186-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02187-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/02187-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02188-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/02188-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02189-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02189-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02190-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02190-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02191-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/02191-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02192-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/02192-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02193-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02193-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02194-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02194-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02195-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02195-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02196-swift-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/02196-swift-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02197-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02197-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02198-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/02198-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02199-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02199-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02200-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/02200-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02201-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/02201-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02202-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02202-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02203-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/02203-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02204-swift-clangmoduleunit-getadaptermodule.swift
+++ b/validation-test/compiler_crashers_fixed/02204-swift-clangmoduleunit-getadaptermodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02205-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/02205-resolvetypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02206-void.swift
+++ b/validation-test/compiler_crashers_fixed/02206-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02207-swift-nominaltypedecl-getprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/02207-swift-nominaltypedecl-getprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02208-swift-modulefile-configurestorage.swift
+++ b/validation-test/compiler_crashers_fixed/02208-swift-modulefile-configurestorage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02209-swift-typebase-operator.swift
+++ b/validation-test/compiler_crashers_fixed/02209-swift-typebase-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02210-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/02210-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02211-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/02211-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02213-llvm-smallptrsetimplbase-smallptrsetimplbase.swift
+++ b/validation-test/compiler_crashers_fixed/02213-llvm-smallptrsetimplbase-smallptrsetimplbase.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02214-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02214-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02215-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/02215-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02216-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/02216-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02217-swift-bracestmt-create.swift
+++ b/validation-test/compiler_crashers_fixed/02217-swift-bracestmt-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02218-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/02218-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02219-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/02219-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02220-swift-namelookup-lookupinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/02220-swift-namelookup-lookupinmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02221-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02221-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02222-swift-generictypeparamdecl-generictypeparamdecl.swift
+++ b/validation-test/compiler_crashers_fixed/02222-swift-generictypeparamdecl-generictypeparamdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02223-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/02223-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02224-swift-typebase-operator.swift
+++ b/validation-test/compiler_crashers_fixed/02224-swift-typebase-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02225-swift-sourcemanager-getmessage.swift
+++ b/validation-test/compiler_crashers_fixed/02225-swift-sourcemanager-getmessage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02226-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/02226-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02227-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02227-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02228-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02228-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02229-swift-parser-parsedeclextension.swift
+++ b/validation-test/compiler_crashers_fixed/02229-swift-parser-parsedeclextension.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02230-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/02230-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02231-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02231-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02232-swift-parser-parsedaccessors-record.swift
+++ b/validation-test/compiler_crashers_fixed/02232-swift-parser-parsedaccessors-record.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02234-bool.swift
+++ b/validation-test/compiler_crashers_fixed/02234-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02235-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/02235-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02236-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/02236-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02237-swift-parser-parsetypecomposition.swift
+++ b/validation-test/compiler_crashers_fixed/02237-swift-parser-parsetypecomposition.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02238-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/02238-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02239-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/02239-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02240-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02240-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02241-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/02241-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02243-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/02243-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02244-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/02244-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02245-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02245-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02246-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/02246-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02247-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/02247-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02248-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/02248-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02249-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/02249-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02250-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/02250-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02251-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/02251-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02252-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/02252-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02253-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02253-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02254-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/02254-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02255-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/02255-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02256-swift-sourcefile-getcache.swift
+++ b/validation-test/compiler_crashers_fixed/02256-swift-sourcefile-getcache.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02257-swift-any-from-nsmutablearray.swift
+++ b/validation-test/compiler_crashers_fixed/02257-swift-any-from-nsmutablearray.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/02327-swift-clangimporter-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/02327-swift-clangimporter-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/03204-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/03204-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/03326-swift-archetypetype-setnestedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/03326-swift-archetypetype-setnestedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/04450-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/04450-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/04592-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/04592-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/05045-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/05045-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/05431-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/05431-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/06207-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/06207-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/06252-swift-typechecker-conformstoprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/06252-swift-typechecker-conformstoprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/06542-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/06542-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/07285-swift-astprinter-printname.swift
+++ b/validation-test/compiler_crashers_fixed/07285-swift-astprinter-printname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/08008-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/08008-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/08893-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/08893-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/09354-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/09354-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/09385-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/09385-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/09650-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/09650-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/09990-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/09990-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/10023-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/10023-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/10248-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/10248-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/10659-swift-printingdiagnosticconsumer-handlediagnostic.timeout.swift
+++ b/validation-test/compiler_crashers_fixed/10659-swift-printingdiagnosticconsumer-handlediagnostic.timeout.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/11093-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/11093-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/12748-swift-constraints-constraintsystem-simplify.swift
+++ b/validation-test/compiler_crashers_fixed/12748-swift-constraints-constraintsystem-simplify.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/13000-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/13000-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/13737-swift-availabilityattr-isunavailable.swift
+++ b/validation-test/compiler_crashers_fixed/13737-swift-availabilityattr-isunavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/16694-swift-constraints-constraintsystem-opentype.swift
+++ b/validation-test/compiler_crashers_fixed/16694-swift-constraints-constraintsystem-opentype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/21655-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/21655-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/21765-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/21765-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/21847-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/21847-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/21852-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/21852-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/22250-swift-typevisitor.swift
+++ b/validation-test/compiler_crashers_fixed/22250-swift-typevisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/22253-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/22253-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/22391-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/22391-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/22582-swift-clangmoduleunit-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/22582-swift-clangmoduleunit-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/22725-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/22725-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/23060-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/23060-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/23086-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/23086-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/23445-swift-constraints-constraintgraph-unbindtypevariable.swift
+++ b/validation-test/compiler_crashers_fixed/23445-swift-constraints-constraintgraph-unbindtypevariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/23680-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/23680-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/23974-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/23974-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24232-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/24232-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24245-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/24245-swift-constraints-constraintsystem-solve.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24394-swift-typevariabletype-implementation-getrepresentative.swift
+++ b/validation-test/compiler_crashers_fixed/24394-swift-typevariabletype-implementation-getrepresentative.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24440-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/24440-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24531-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/24531-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24558-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/24558-swift-typebase-gatherallsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24624-swift-module-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/24624-swift-module-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24645-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/24645-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24670-isunknownobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/24670-isunknownobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24680-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/24680-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24769-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/24769-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24797-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/24797-no-stacktrace.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24798-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/24798-no-stacktrace.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24800-swift-constraints-constraintsystem-matchsuperclasstypes.swift
+++ b/validation-test/compiler_crashers_fixed/24800-swift-constraints-constraintsystem-matchsuperclasstypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24864-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/24864-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24879-getmemberforbasetype.swift
+++ b/validation-test/compiler_crashers_fixed/24879-getmemberforbasetype.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24900-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/24900-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24915-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/24915-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24947-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/24947-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24960-swift-typedecl-getdeclaredinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/24960-swift-typedecl-getdeclaredinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24969-swift-vardecl-emitlettovarnoteifsimple.swift
+++ b/validation-test/compiler_crashers_fixed/24969-swift-vardecl-emitlettovarnoteifsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/24987-swift-expr-findexistinginitializercontext.swift
+++ b/validation-test/compiler_crashers_fixed/24987-swift-expr-findexistinginitializercontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25009-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/25009-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25011-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/25011-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25128-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/25128-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25152-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/25152-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25154-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/25154-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25163-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/25163-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25327-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25327-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25329-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/25329-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25340-findlocalval-checkpattern.swift
+++ b/validation-test/compiler_crashers_fixed/25340-findlocalval-checkpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25341-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/25341-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25342-swift-sourcemanager-getbytedistance.swift
+++ b/validation-test/compiler_crashers_fixed/25342-swift-sourcemanager-getbytedistance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25343-swift-parser-parsedeclfunc.swift
+++ b/validation-test/compiler_crashers_fixed/25343-swift-parser-parsedeclfunc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25344-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25344-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25345-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25345-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25346-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/25346-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25347-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/25347-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25348-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/25348-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25349-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25349-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25350-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/25350-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25351-swift-serialization-serializer-writenormalconformance.swift
+++ b/validation-test/compiler_crashers_fixed/25351-swift-serialization-serializer-writenormalconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25352-swift-boundgenerictype-getsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/25352-swift-boundgenerictype-getsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25353-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25353-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25354-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/25354-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25355-swift-typechecker-typecheckpatternbinding.swift
+++ b/validation-test/compiler_crashers_fixed/25355-swift-typechecker-typecheckpatternbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25356-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25356-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25357-swift-parser-parseexprorstmt.swift
+++ b/validation-test/compiler_crashers_fixed/25357-swift-parser-parseexprorstmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25358-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25358-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25359-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/25359-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25360-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/25360-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25361-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/25361-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25362-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/25362-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25363-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/25363-swift-archetypebuilder-addrequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25364-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/25364-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25365-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/25365-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25366-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/25366-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25367-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/25367-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25368-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25368-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25369-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/25369-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25370-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/25370-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25371-llvm-raw-fd-ostream-write-impl.swift
+++ b/validation-test/compiler_crashers_fixed/25371-llvm-raw-fd-ostream-write-impl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25372-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25372-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25373-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25373-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25374-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25374-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25375-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/25375-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25376-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25376-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25377-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/25377-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25378-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/compiler_crashers_fixed/25378-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25379-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25379-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25380-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25380-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25381-swift-nominaltypedecl-makemembervisible.swift
+++ b/validation-test/compiler_crashers_fixed/25381-swift-nominaltypedecl-makemembervisible.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25382-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/25382-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25383-void.swift
+++ b/validation-test/compiler_crashers_fixed/25383-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25384-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/25384-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25385-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/25385-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25386-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/25386-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25387-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/25387-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25388-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25388-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25389-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/25389-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25390-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25390-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25391-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25391-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25392-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/25392-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25393-swift-protocolconformance-subst.swift
+++ b/validation-test/compiler_crashers_fixed/25393-swift-protocolconformance-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25394-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/25394-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25395-std-function-func.swift
+++ b/validation-test/compiler_crashers_fixed/25395-std-function-func.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25396-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/25396-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25397-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/25397-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25398-swift-serialization-serializer-writenormalconformance.swift
+++ b/validation-test/compiler_crashers_fixed/25398-swift-serialization-serializer-writenormalconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25399-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25399-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25401-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25401-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25402-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/25402-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25403-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/25403-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25404-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25404-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25405-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25405-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25406-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25406-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25407-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers_fixed/25407-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25408-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25408-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25409-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25409-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25410-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/25410-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25411-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25411-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25412-swift-sourcemanager-getbytedistance.swift
+++ b/validation-test/compiler_crashers_fixed/25412-swift-sourcemanager-getbytedistance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25413-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/25413-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25414-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25414-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25415-swift-astcontext-getimplicitlyunwrappedoptionaldecl.swift
+++ b/validation-test/compiler_crashers_fixed/25415-swift-astcontext-getimplicitlyunwrappedoptionaldecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25416-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25416-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25417-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25417-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25418-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/25418-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25419-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/25419-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25420-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/25420-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25421-swift-conformancelookuptable-getimplicitprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/25421-swift-conformancelookuptable-getimplicitprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25422-swift-nominaltypedecl-setgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/25422-swift-nominaltypedecl-setgenericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25423-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25423-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25424-swift-typechecker-computeaccessibility.swift
+++ b/validation-test/compiler_crashers_fixed/25424-swift-typechecker-computeaccessibility.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25425-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25425-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25426-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25426-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25427-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/25427-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25428-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/25428-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25429-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/25429-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25430-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25430-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25431-swift-prettystacktracetyperepr-print.swift
+++ b/validation-test/compiler_crashers_fixed/25431-swift-prettystacktracetyperepr-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25432-abort.swift
+++ b/validation-test/compiler_crashers_fixed/25432-abort.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25433-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/25433-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25434-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25434-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25435-swift-valuedecl-setinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25435-swift-valuedecl-setinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25436-swift-derivedfileunit-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/25436-swift-derivedfileunit-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25437-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/25437-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25438-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25438-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25439-swift-conformancelookuptable-addprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/25439-swift-conformancelookuptable-addprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25440-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/25440-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25441-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25441-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25442-llvm-smdiagnostic-smdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25442-llvm-smdiagnostic-smdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25443-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25443-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25444-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/25444-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25445-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/25445-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25446-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/25446-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25447-llvm-tinyptrvector-swift-valuedecl-push-back.swift
+++ b/validation-test/compiler_crashers_fixed/25447-llvm-tinyptrvector-swift-valuedecl-push-back.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25448-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/25448-swift-archetypebuilder-addrequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25449-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25449-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25450-void.swift
+++ b/validation-test/compiler_crashers_fixed/25450-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25451-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/25451-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25452-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/25452-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25453-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25453-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25454-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/25454-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25455-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/25455-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25456-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/25456-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25457-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/25457-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25458-swift-archetypetype-getnestedtype.swift
+++ b/validation-test/compiler_crashers_fixed/25458-swift-archetypetype-getnestedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25459-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/25459-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25460-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/25460-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25461-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/25461-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25462-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25462-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25463-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/25463-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25464-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/25464-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25465-swift-namelookup-lookupinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/25465-swift-namelookup-lookupinmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25466-swift-parser-parsebraceitemlist.swift
+++ b/validation-test/compiler_crashers_fixed/25466-swift-parser-parsebraceitemlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25467-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25467-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25468-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/25468-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25469-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/25469-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25470-swift-typechecker-checkdeclarationavailability.swift
+++ b/validation-test/compiler_crashers_fixed/25470-swift-typechecker-checkdeclarationavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25471-swift-iterabledeclcontext-setloader.swift
+++ b/validation-test/compiler_crashers_fixed/25471-swift-iterabledeclcontext-setloader.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25472-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/25472-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25473-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25473-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25474-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/25474-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25475-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25475-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25476-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25476-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25477-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/25477-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25478-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/25478-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25479-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25479-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25480-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25480-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25481-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/25481-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25482-void.swift
+++ b/validation-test/compiler_crashers_fixed/25482-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25483-swift-performexprdiagnostics.swift
+++ b/validation-test/compiler_crashers_fixed/25483-swift-performexprdiagnostics.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25484-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/25484-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25485-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/25485-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25486-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25486-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25487-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/25487-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25488-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/25488-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25489-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25489-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25490-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/25490-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25491-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/25491-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25492-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/25492-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25493-swift-sourcemanager-getbytedistance.swift
+++ b/validation-test/compiler_crashers_fixed/25493-swift-sourcemanager-getbytedistance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25494-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/25494-swift-type-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25495-void.swift
+++ b/validation-test/compiler_crashers_fixed/25495-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25496-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/25496-swift-typechecker-lookupmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25497-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25497-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25498-swift-constraints-constraint-constraint.swift
+++ b/validation-test/compiler_crashers_fixed/25498-swift-constraints-constraint-constraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25499-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/25499-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25500-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25500-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25501-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/25501-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25502-swift-typedecl-getdeclaredinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25502-swift-typedecl-getdeclaredinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25503-swift-namelookup-lookupinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/25503-swift-namelookup-lookupinmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25504-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers_fixed/25504-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25505-swift-constraints-constraintsystem-salvage.swift
+++ b/validation-test/compiler_crashers_fixed/25505-swift-constraints-constraintsystem-salvage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25506-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/25506-swift-type-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25507-void.swift
+++ b/validation-test/compiler_crashers_fixed/25507-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25508-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/25508-swift-archetypebuilder-addrequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25509-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25509-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25510-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/25510-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25511-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25511-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25512-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/25512-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25513-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/25513-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25514-bool.swift
+++ b/validation-test/compiler_crashers_fixed/25514-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25515-swift-memberlookuptable-addmember.swift
+++ b/validation-test/compiler_crashers_fixed/25515-swift-memberlookuptable-addmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25516-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25516-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25517-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/25517-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25518-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25518-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25519-void.swift
+++ b/validation-test/compiler_crashers_fixed/25519-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25520-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/25520-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25521-swift-ide-printdeclusr.swift
+++ b/validation-test/compiler_crashers_fixed/25521-swift-ide-printdeclusr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25522-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/25522-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25523-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/25523-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25524-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/25524-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25525-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/25525-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25526-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25526-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25527-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/25527-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25528-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/25528-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25529-void.swift
+++ b/validation-test/compiler_crashers_fixed/25529-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25530-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25530-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25531-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/25531-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25532-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/25532-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25533-bool.swift
+++ b/validation-test/compiler_crashers_fixed/25533-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25534-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25534-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25535-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/25535-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25536-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25536-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25537-swift-parser-parsegenericparameters.swift
+++ b/validation-test/compiler_crashers_fixed/25537-swift-parser-parsegenericparameters.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25538-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/25538-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25539-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/25539-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25540-swift-parser-parsedeclstruct.swift
+++ b/validation-test/compiler_crashers_fixed/25540-swift-parser-parsedeclstruct.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25541-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/25541-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25542-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25542-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25543-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/25543-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25544-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25544-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25545-swift-parser-parsestmt.swift
+++ b/validation-test/compiler_crashers_fixed/25545-swift-parser-parsestmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25546-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25546-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25547-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25547-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25548-void.swift
+++ b/validation-test/compiler_crashers_fixed/25548-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25549-swift-constraints-constraintsystem-gettypeofreference.swift
+++ b/validation-test/compiler_crashers_fixed/25549-swift-constraints-constraintsystem-gettypeofreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25550-swift-unboundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25550-swift-unboundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25551-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/25551-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25552-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/25552-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25553-swift-performexprdiagnostics.swift
+++ b/validation-test/compiler_crashers_fixed/25553-swift-performexprdiagnostics.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25554-swift-archetypetype-getnestedtype.swift
+++ b/validation-test/compiler_crashers_fixed/25554-swift-archetypetype-getnestedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25555-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/25555-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25556-swift-modulefile-getcommentfordecl.swift
+++ b/validation-test/compiler_crashers_fixed/25556-swift-modulefile-getcommentfordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25557-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/25557-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25558-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25558-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25559-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25559-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25560-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/25560-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25561-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25561-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25562-swift-serialization-serializer-writedeclattribute.swift
+++ b/validation-test/compiler_crashers_fixed/25562-swift-serialization-serializer-writedeclattribute.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25563-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/25563-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25564-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/25564-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25565-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/25565-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25566-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/25566-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25567-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/25567-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25568-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25568-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25569-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25569-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25570-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/25570-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25571-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25571-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25572-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/25572-swift-type-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25573-swift-typechecker-lookupmember.swift
+++ b/validation-test/compiler_crashers_fixed/25573-swift-typechecker-lookupmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25574-llvm-foldingset-swift-declname-compounddeclname-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25574-llvm-foldingset-swift-declname-compounddeclname-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25575-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/25575-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25576-swift-serialization-serializer-writeblockinfoblock.swift
+++ b/validation-test/compiler_crashers_fixed/25576-swift-serialization-serializer-writeblockinfoblock.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25577-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/25577-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25578-swift-parser-parsedeclvar.swift
+++ b/validation-test/compiler_crashers_fixed/25578-swift-parser-parsedeclvar.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25579-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25579-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25580-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/25580-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25581-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/25581-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25582-swift-typechecker-resolvesuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/25582-swift-typechecker-resolvesuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25583-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25583-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25584-addnestedrequirements.swift
+++ b/validation-test/compiler_crashers_fixed/25584-addnestedrequirements.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25585-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/25585-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25586-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/25586-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25587-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/25587-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25588-swift-typedecl-getdeclaredinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25588-swift-typedecl-getdeclaredinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25589-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25589-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25590-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/25590-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25591-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/25591-std-function-func-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25592-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/25592-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25593-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25593-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25594-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25594-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25595-swift-parser-parsegetset.swift
+++ b/validation-test/compiler_crashers_fixed/25595-swift-parser-parsegetset.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25596-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/25596-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25597-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25597-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25598-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/25598-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25599-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/25599-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25600-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/25600-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25601-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/25601-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25602-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/25602-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25603-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/25603-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25604-swift-funcdecl-funcdecl.swift
+++ b/validation-test/compiler_crashers_fixed/25604-swift-funcdecl-funcdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25605-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/25605-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25606-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/25606-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25607-swift-parserunit-implementation-implementation.swift
+++ b/validation-test/compiler_crashers_fixed/25607-swift-parserunit-implementation-implementation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25608-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/25608-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25609-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25609-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25610-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25610-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25611-std-function-func-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/25611-std-function-func-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25612-swift-patternbindingdecl-create.swift
+++ b/validation-test/compiler_crashers_fixed/25612-swift-patternbindingdecl-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25613-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25613-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25614-llvm-mutablearrayref-swift-protocoldecl.swift
+++ b/validation-test/compiler_crashers_fixed/25614-llvm-mutablearrayref-swift-protocoldecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25615-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/25615-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25616-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/25616-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25617-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/25617-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25618-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/25618-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25619-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25619-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25620-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/25620-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25621-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25621-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25622-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25622-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25623-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25623-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25624-swift-moduledecl-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/25624-swift-moduledecl-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25625-swift-typechecker-resolveinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/25625-swift-typechecker-resolveinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25626-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/25626-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25627-swift-archetypebuilder-addconformancerequirement.swift
+++ b/validation-test/compiler_crashers_fixed/25627-swift-archetypebuilder-addconformancerequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25628-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/25628-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25629-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/25629-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25630-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/25630-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25631-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/25631-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25632-swift-stmt-walk.swift
+++ b/validation-test/compiler_crashers_fixed/25632-swift-stmt-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25633-llvm-smdiagnostic-print.swift
+++ b/validation-test/compiler_crashers_fixed/25633-llvm-smdiagnostic-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25634-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/25634-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25635-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/25635-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25636-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/25636-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25637-swift-typechecker-lookupmember.swift
+++ b/validation-test/compiler_crashers_fixed/25637-swift-typechecker-lookupmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25638-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25638-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25639-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/25639-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25640-swift-modulefile-declcommenttableinfo-readdata.swift
+++ b/validation-test/compiler_crashers_fixed/25640-swift-modulefile-declcommenttableinfo-readdata.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25641-swift-constraints-constraintsystem-computeassigndesttype.swift
+++ b/validation-test/compiler_crashers_fixed/25641-swift-constraints-constraintsystem-computeassigndesttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25642-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25642-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25643-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/25643-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25644-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25644-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25645-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/25645-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25646-swift-parser-applyattributetotype.swift
+++ b/validation-test/compiler_crashers_fixed/25646-swift-parser-applyattributetotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25647-swift-astcontext-setrawcomment.swift
+++ b/validation-test/compiler_crashers_fixed/25647-swift-astcontext-setrawcomment.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25648-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/25648-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25649-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/25649-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25650-checktypedeclavailability.swift
+++ b/validation-test/compiler_crashers_fixed/25650-checktypedeclavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25651-swift-constraints-constraintsystem-addoverloadset.swift
+++ b/validation-test/compiler_crashers_fixed/25651-swift-constraints-constraintsystem-addoverloadset.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25652-bool.swift
+++ b/validation-test/compiler_crashers_fixed/25652-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25653-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25653-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25654-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/25654-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25655-void.swift
+++ b/validation-test/compiler_crashers_fixed/25655-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25656-swift-parser-applyattributetotype.swift
+++ b/validation-test/compiler_crashers_fixed/25656-swift-parser-applyattributetotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25657-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/25657-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25658-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25658-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25659-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25659-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25660-swift-typechecker-buildrefexpr.swift
+++ b/validation-test/compiler_crashers_fixed/25660-swift-typechecker-buildrefexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25661-swift-parser-parsestmtif.swift
+++ b/validation-test/compiler_crashers_fixed/25661-swift-parser-parsestmtif.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25662-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/25662-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25663-swift-concretedeclref-specializeddeclref-create.swift
+++ b/validation-test/compiler_crashers_fixed/25663-swift-concretedeclref-specializeddeclref-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25664-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/25664-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25665-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/25665-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25666-swift-constraints-generalfailurediagnosis-diagnosegeneralconversionfailure.swift
+++ b/validation-test/compiler_crashers_fixed/25666-swift-constraints-generalfailurediagnosis-diagnosegeneralconversionfailure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25667-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/25667-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25668-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25668-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25669-swift-sourcefile-lookupcache-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/25669-swift-sourcefile-lookupcache-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25670-swift-conformancelookuptable-addprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/25670-swift-conformancelookuptable-addprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25671-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/25671-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25672-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/25672-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25673-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25673-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25674-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25674-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25675-swift-typechecker-resolvesuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/25675-swift-typechecker-resolvesuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25676-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25676-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25677-swift-genericsignature-profile.swift
+++ b/validation-test/compiler_crashers_fixed/25677-swift-genericsignature-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25678-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/25678-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25679-swift-declrefexpr-setspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/25679-swift-declrefexpr-setspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25680-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/25680-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25681-std-function-func-swift-constraints-constraintgraph-verify.swift
+++ b/validation-test/compiler_crashers_fixed/25681-std-function-func-swift-constraints-constraintgraph-verify.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25682-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25682-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25683-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25683-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25684-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/25684-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25685-swift-parser-parsedeclenum.swift
+++ b/validation-test/compiler_crashers_fixed/25685-swift-parser-parsedeclenum.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25686-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/25686-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25687-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/25687-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25688-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25688-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25689-swift-patternbindingdecl-getpatternentryindexforvardecl.swift
+++ b/validation-test/compiler_crashers_fixed/25689-swift-patternbindingdecl-getpatternentryindexforvardecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25690-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/25690-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25691-bool.swift
+++ b/validation-test/compiler_crashers_fixed/25691-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25692-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/25692-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25693-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25693-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25694-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25694-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25695-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/25695-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25696-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/25696-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25697-swift-parser-parsegetsetimpl.swift
+++ b/validation-test/compiler_crashers_fixed/25697-swift-parser-parsegetsetimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25698-swift-parser-parsedeclinit.swift
+++ b/validation-test/compiler_crashers_fixed/25698-swift-parser-parsedeclinit.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25699-swift-sourcefile-getcache.swift
+++ b/validation-test/compiler_crashers_fixed/25699-swift-sourcefile-getcache.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25700-llvm-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/25700-llvm-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25701-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25701-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25702-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25702-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25703-void.swift
+++ b/validation-test/compiler_crashers_fixed/25703-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25704-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/25704-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25705-swift-typechecker-availablerange.swift
+++ b/validation-test/compiler_crashers_fixed/25705-swift-typechecker-availablerange.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25706-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/25706-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25707-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25707-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25708-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/25708-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25709-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25709-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25710-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25710-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25711-swift-constraints-constraintsystem-optimizeconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/25711-swift-constraints-constraintsystem-optimizeconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25712-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/25712-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25713-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25713-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25714-llvm-densemap-swift-identifier.swift
+++ b/validation-test/compiler_crashers_fixed/25714-llvm-densemap-swift-identifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25715-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/25715-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25716-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/25716-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25717-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25717-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25718-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/25718-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25719-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/25719-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25720-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/25720-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25721-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/25721-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25722-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/25722-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25723-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/25723-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25724-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25724-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25725-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/25725-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25726-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/25726-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25727-swift-serialization-serializer-addconformanceref.swift
+++ b/validation-test/compiler_crashers_fixed/25727-swift-serialization-serializer-addconformanceref.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25728-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/25728-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25729-void.swift
+++ b/validation-test/compiler_crashers_fixed/25729-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25730-swift-nominaltypedecl-computeinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25730-swift-nominaltypedecl-computeinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25731-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/25731-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25732-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/25732-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25733-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/25733-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25734-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/25734-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25735-swift-modulefile-readmembers.swift
+++ b/validation-test/compiler_crashers_fixed/25735-swift-modulefile-readmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25736-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25736-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25737-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25737-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25738-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/25738-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25739-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/25739-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25740-swift-valuedecl-setinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25740-swift-valuedecl-setinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25741-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/25741-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25742-swift-moduledecl-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/25742-swift-moduledecl-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25743-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/25743-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25744-swift-sourcefile-lookupcache-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/25744-swift-sourcefile-lookupcache-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25745-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25745-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25746-swift-normalprotocolconformance-setwitness.swift
+++ b/validation-test/compiler_crashers_fixed/25746-swift-normalprotocolconformance-setwitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25747-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/25747-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25748-swift-patternbindingdecl-hasstorage.swift
+++ b/validation-test/compiler_crashers_fixed/25748-swift-patternbindingdecl-hasstorage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25749-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/25749-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25750-swift-lvaluetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25750-swift-lvaluetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25751-swift-expr-findexistinginitializercontext.swift
+++ b/validation-test/compiler_crashers_fixed/25751-swift-expr-findexistinginitializercontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25752-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/25752-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25753-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/25753-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25754-swift-astcontext-getconformance.swift
+++ b/validation-test/compiler_crashers_fixed/25754-swift-astcontext-getconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25755-void.swift
+++ b/validation-test/compiler_crashers_fixed/25755-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25756-void.swift
+++ b/validation-test/compiler_crashers_fixed/25756-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25757-bool.swift
+++ b/validation-test/compiler_crashers_fixed/25757-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25758-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/25758-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25759-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/25759-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25760-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25760-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25761-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/25761-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25762-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/25762-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25763-std-function-func.swift
+++ b/validation-test/compiler_crashers_fixed/25763-std-function-func.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25764-swift-archetypebuilder-inferrequirementswalker-walktotypepost.swift
+++ b/validation-test/compiler_crashers_fixed/25764-swift-archetypebuilder-inferrequirementswalker-walktotypepost.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25765-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/25765-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25766-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25766-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25767-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/25767-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25768-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/25768-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25769-llvm-foldingset-swift-structtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25769-llvm-foldingset-swift-structtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25770-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/25770-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25771-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25771-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25772-swift-parser-parsenewdeclattribute.swift
+++ b/validation-test/compiler_crashers_fixed/25772-swift-parser-parsenewdeclattribute.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25773-swift-declcontext-isprotocolorprotocolextensioncontext.swift
+++ b/validation-test/compiler_crashers_fixed/25773-swift-declcontext-isprotocolorprotocolextensioncontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25774-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/25774-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25775-void.swift
+++ b/validation-test/compiler_crashers_fixed/25775-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25776-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25776-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25777-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25777-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25778-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/25778-swift-type-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25779-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25779-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25780-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/25780-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25781-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/25781-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25782-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/25782-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25783-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/25783-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25784-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25784-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25785-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25785-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25786-void.swift
+++ b/validation-test/compiler_crashers_fixed/25786-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25787-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25787-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25788-swift-astcontext-implementation-implementation.swift
+++ b/validation-test/compiler_crashers_fixed/25788-swift-astcontext-implementation-implementation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25789-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25789-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25790-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/25790-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25791-swift-modulefile-getdeclcontext.swift
+++ b/validation-test/compiler_crashers_fixed/25791-swift-modulefile-getdeclcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25792-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/25792-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25793-swift-typechecker-checkunsupportedprotocoltype.swift
+++ b/validation-test/compiler_crashers_fixed/25793-swift-typechecker-checkunsupportedprotocoltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25794-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25794-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25795-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25795-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25796-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/25796-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25797-void.swift
+++ b/validation-test/compiler_crashers_fixed/25797-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25798-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/25798-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25799-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/25799-swift-typechecker-checkconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25800-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25800-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25801-swift-sourcefile-lookupcache-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/25801-swift-sourcefile-lookupcache-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25802-extractparameteroutline.swift
+++ b/validation-test/compiler_crashers_fixed/25802-extractparameteroutline.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25803-swift-constructordecl-setbodyparams.swift
+++ b/validation-test/compiler_crashers_fixed/25803-swift-constructordecl-setbodyparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25804-swift-parser-parseexprsequence.swift
+++ b/validation-test/compiler_crashers_fixed/25804-swift-parser-parseexprsequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25805-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/25805-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25806-swift-derivedfileunit-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/25806-swift-derivedfileunit-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25807-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25807-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25808-swift-typechecker-validategenerictypesignature.swift
+++ b/validation-test/compiler_crashers_fixed/25808-swift-typechecker-validategenerictypesignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25809-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/25809-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25810-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/25810-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25811-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25811-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25812-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/25812-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25813-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25813-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25814-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/25814-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25815-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/25815-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25816-swift-parser-parsedeclclass.swift
+++ b/validation-test/compiler_crashers_fixed/25816-swift-parser-parsedeclclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25817-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/25817-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25818-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/25818-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25819-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/25819-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25820-swift-decl-getrawcomment.swift
+++ b/validation-test/compiler_crashers_fixed/25820-swift-decl-getrawcomment.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25821-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25821-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25822-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/25822-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25823-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/25823-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25824-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/25824-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25825-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/25825-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25826-swift-modulefile-readmembers.swift
+++ b/validation-test/compiler_crashers_fixed/25826-swift-modulefile-readmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25827-swift-typechecker-resolveinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/25827-swift-typechecker-resolveinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25828-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/25828-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25829-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/25829-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25830-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/25830-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25831-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25831-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25832-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/25832-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25833-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/25833-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25834-llvm-smallvectorimpl-swift-decl-insert.swift
+++ b/validation-test/compiler_crashers_fixed/25834-llvm-smallvectorimpl-swift-decl-insert.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25835-swift-genericsignature-profile.swift
+++ b/validation-test/compiler_crashers_fixed/25835-swift-genericsignature-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25836-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/25836-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25837-swift-parser-parsedeclfunc.swift
+++ b/validation-test/compiler_crashers_fixed/25837-swift-parser-parsedeclfunc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25838-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25838-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25839-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/25839-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25840-swift-valuedecl-overwritetype.swift
+++ b/validation-test/compiler_crashers_fixed/25840-swift-valuedecl-overwritetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25841-swift-astcontext-getloadedmodule.swift
+++ b/validation-test/compiler_crashers_fixed/25841-swift-astcontext-getloadedmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25842-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/25842-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25843-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25843-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25844-void.swift
+++ b/validation-test/compiler_crashers_fixed/25844-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25845-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/25845-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25846-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/25846-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25847-emitsimpleassignment.swift
+++ b/validation-test/compiler_crashers_fixed/25847-emitsimpleassignment.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25848-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25848-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25849-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25849-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25850-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25850-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25851-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/25851-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25852-swift-funcdecl-create.swift
+++ b/validation-test/compiler_crashers_fixed/25852-swift-funcdecl-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25853-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/25853-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25854-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/25854-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25855-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25855-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25856-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/25856-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25857-swift-abstractstoragedecl-makecomputed.swift
+++ b/validation-test/compiler_crashers_fixed/25857-swift-abstractstoragedecl-makecomputed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25858-swift-nominaltypedecl-computeinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25858-swift-nominaltypedecl-computeinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25859-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25859-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25860-swift-parser-parsetypeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25860-swift-parser-parsetypeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25861-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25861-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25862-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/25862-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25863-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/25863-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25864-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/25864-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25865-llvm-raw-fd-ostream-write-impl.swift
+++ b/validation-test/compiler_crashers_fixed/25865-llvm-raw-fd-ostream-write-impl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25866-swift-silbuilder-createdeallocbox.swift
+++ b/validation-test/compiler_crashers_fixed/25866-swift-silbuilder-createdeallocbox.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25867-swift-valuedecl-getoverloadsignature.swift
+++ b/validation-test/compiler_crashers_fixed/25867-swift-valuedecl-getoverloadsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25868-swift-synthesizematerializeforset.swift
+++ b/validation-test/compiler_crashers_fixed/25868-swift-synthesizematerializeforset.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25869-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/25869-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25870-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/25870-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25871-swift-constraints-matchcallarguments.swift
+++ b/validation-test/compiler_crashers_fixed/25871-swift-constraints-matchcallarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25872-swift-modulefile-maybereadforeignerrorconvention.swift
+++ b/validation-test/compiler_crashers_fixed/25872-swift-modulefile-maybereadforeignerrorconvention.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25873-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25873-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25874-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25874-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25875-swift-valuedecl-overwritetype.swift
+++ b/validation-test/compiler_crashers_fixed/25875-swift-valuedecl-overwritetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25876-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/25876-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25877-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/25877-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25878-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25878-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25879-swift-sourcefile-getcache.swift
+++ b/validation-test/compiler_crashers_fixed/25879-swift-sourcefile-getcache.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25880-swift-conformancelookuptable-conformancelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/25880-swift-conformancelookuptable-conformancelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25881-swift-sourcefile-lookupcache-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/25881-swift-sourcefile-lookupcache-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25882-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/25882-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25883-swift-constraints-simplifylocator.swift
+++ b/validation-test/compiler_crashers_fixed/25883-swift-constraints-simplifylocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25884-swift-parser-parsedeclvargetset.swift
+++ b/validation-test/compiler_crashers_fixed/25884-swift-parser-parsedeclvargetset.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25885-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/25885-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25886-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25886-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25887-swift-funcdecl-funcdecl.swift
+++ b/validation-test/compiler_crashers_fixed/25887-swift-funcdecl-funcdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25888-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25888-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25889-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25889-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25890-swift-typechecker-checkdeclattributesearly.swift
+++ b/validation-test/compiler_crashers_fixed/25890-swift-typechecker-checkdeclattributesearly.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25891-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/25891-swift-type-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25892-llvm-mutablearrayref-swift-protocoldecl.swift
+++ b/validation-test/compiler_crashers_fixed/25892-llvm-mutablearrayref-swift-protocoldecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25893-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/25893-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25894-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25894-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25895-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25895-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25896-swift-serialization-serializer-writedeclattribute.swift
+++ b/validation-test/compiler_crashers_fixed/25896-swift-serialization-serializer-writedeclattribute.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25897-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/25897-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25898-swift-parser-parsedeclinit.swift
+++ b/validation-test/compiler_crashers_fixed/25898-swift-parser-parsedeclinit.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25899-swift-tupleexpr-tupleexpr.swift
+++ b/validation-test/compiler_crashers_fixed/25899-swift-tupleexpr-tupleexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25900-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/25900-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25901-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/25901-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25902-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/25902-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25903-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25903-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25904-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/25904-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25905-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/25905-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25906-swift-typechecker-checkdeclarationavailability.swift
+++ b/validation-test/compiler_crashers_fixed/25906-swift-typechecker-checkdeclarationavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25907-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/25907-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25908-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/25908-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25909-swift-constraints-solution-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/25909-swift-constraints-solution-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25910-swift-valuedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25910-swift-valuedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25911-swift-valuedecl-setinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25911-swift-valuedecl-setinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25912-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/25912-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25913-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/25913-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25914-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/25914-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25915-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/25915-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25916-swift-classtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25916-swift-classtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25917-void.swift
+++ b/validation-test/compiler_crashers_fixed/25917-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25918-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25918-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25919-llvm-foldingsetimpl-findnodeorinsertpos.swift
+++ b/validation-test/compiler_crashers_fixed/25919-llvm-foldingsetimpl-findnodeorinsertpos.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25920-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/25920-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25921-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/25921-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25922-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25922-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25923-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/25923-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25924-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/25924-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25925-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/25925-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25926-swift-parser-isstartofdecl.swift
+++ b/validation-test/compiler_crashers_fixed/25926-swift-parser-isstartofdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25927-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/25927-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25928-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/25928-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25929-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/25929-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25930-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/25930-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25931-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/25931-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25932-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25932-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25933-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/25933-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25934-swift-vardecl-getparentinitializer.swift
+++ b/validation-test/compiler_crashers_fixed/25934-swift-vardecl-getparentinitializer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25935-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25935-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25936-swift-conformancelookuptable-getimplicitprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/25936-swift-conformancelookuptable-getimplicitprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25937-swift-valuedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25937-swift-valuedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25938-swift-typechecker-checkdeclarationavailability.swift
+++ b/validation-test/compiler_crashers_fixed/25938-swift-typechecker-checkdeclarationavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25939-swift-tupleexpr-tupleexpr.swift
+++ b/validation-test/compiler_crashers_fixed/25939-swift-tupleexpr-tupleexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25940-swift-parser-parseexprsequence.swift
+++ b/validation-test/compiler_crashers_fixed/25940-swift-parser-parseexprsequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25941-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25941-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25942-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25942-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25943-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25943-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25944-swift-parser-parsestmtfor.swift
+++ b/validation-test/compiler_crashers_fixed/25944-swift-parser-parsestmtfor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25945-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers_fixed/25945-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25946-cleanupillformedexpression.swift
+++ b/validation-test/compiler_crashers_fixed/25946-cleanupillformedexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25947-llvm-tinyptrvector-swift-valuedecl-push-back.swift
+++ b/validation-test/compiler_crashers_fixed/25947-llvm-tinyptrvector-swift-valuedecl-push-back.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25948-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/25948-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25949-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/25949-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25950-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/25950-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25951-swift-modulefile-maybereadforeignerrorconvention.swift
+++ b/validation-test/compiler_crashers_fixed/25951-swift-modulefile-maybereadforeignerrorconvention.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25952-swift-tuplepattern-createsimple.swift
+++ b/validation-test/compiler_crashers_fixed/25952-swift-tuplepattern-createsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25953-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25953-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25954-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/25954-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25955-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25955-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25956-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25956-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25957-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/25957-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25958-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25958-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25959-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/25959-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25960-std-function-func-setboundvarstypeerror.swift
+++ b/validation-test/compiler_crashers_fixed/25960-std-function-func-setboundvarstypeerror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25961-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/25961-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25963-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/25963-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25964-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/25964-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25965-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/25965-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25966-llvm-densemap-swift-normalprotocolconformance.swift
+++ b/validation-test/compiler_crashers_fixed/25966-llvm-densemap-swift-normalprotocolconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25967-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/25967-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25968-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/25968-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25969-swift-protocoldecl-existentialtypesupportedslow.swift
+++ b/validation-test/compiler_crashers_fixed/25969-swift-protocoldecl-existentialtypesupportedslow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25970-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25970-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25971-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25971-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25972-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/25972-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25973-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/25973-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25974-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/25974-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25975-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/25975-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25976-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25976-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25977-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/25977-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25978-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25978-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25979-swift-constraints-constraintsystem-optimizeconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/25979-swift-constraints-constraintsystem-optimizeconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25980-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/25980-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25981-llvm-smallvectorimpl-swift-decl-insert.swift
+++ b/validation-test/compiler_crashers_fixed/25981-llvm-smallvectorimpl-swift-decl-insert.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25982-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/25982-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25983-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25983-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25984-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/25984-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25985-swift-constructordecl-setbodyparams.swift
+++ b/validation-test/compiler_crashers_fixed/25985-swift-constructordecl-setbodyparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25986-swift-constraints-constraintsystem-optimizeconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/25986-swift-constraints-constraintsystem-optimizeconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25987-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/25987-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25988-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/25988-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25989-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/25989-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25990-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/25990-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25991-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25991-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25992-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/25992-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25993-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/25993-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25994-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/25994-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25995-swift-modulefile-getcommentfordecl.swift
+++ b/validation-test/compiler_crashers_fixed/25995-swift-modulefile-getcommentfordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25996-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/25996-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25997-swift-parser-parsedeclstruct.swift
+++ b/validation-test/compiler_crashers_fixed/25997-swift-parser-parsedeclstruct.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25998-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/25998-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/25999-swift-nominaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25999-swift-nominaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26000-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26000-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26001-swift-astcontext-astcontext.swift
+++ b/validation-test/compiler_crashers_fixed/26001-swift-astcontext-astcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26002-swift-nominaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26002-swift-nominaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26003-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/26003-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26004-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26004-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26005-swift-typechecker-resolvepattern.swift
+++ b/validation-test/compiler_crashers_fixed/26005-swift-typechecker-resolvepattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26006-swift-typechecker-checkdeclarationavailability.swift
+++ b/validation-test/compiler_crashers_fixed/26006-swift-typechecker-checkdeclarationavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26007-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/26007-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26008-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26008-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26009-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26009-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26010-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/26010-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26011-swift-typechecker-definedefaultconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/26011-swift-typechecker-definedefaultconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26013-swift-parser-parseparameterclause.swift
+++ b/validation-test/compiler_crashers_fixed/26013-swift-parser-parseparameterclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26014-swift-conformancelookuptable-getallprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26014-swift-conformancelookuptable-getallprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26015-llvm-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26015-llvm-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26016-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/26016-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26017-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26017-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26018-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26018-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26019-swift-compilerinvocation-parseargs.swift
+++ b/validation-test/compiler_crashers_fixed/26019-swift-compilerinvocation-parseargs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26020-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26020-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26021-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26021-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26022-swift-conformancelookuptable-getsatisfiedprotocolrequirementsformember.swift
+++ b/validation-test/compiler_crashers_fixed/26022-swift-conformancelookuptable-getsatisfiedprotocolrequirementsformember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26023-swift-createimplicitconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/26023-swift-createimplicitconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26024-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/26024-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26025-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26025-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26026-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/26026-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26027-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26027-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26028-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26028-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26029-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26029-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26030-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/26030-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26031-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/26031-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26032-swift-typechecker-availablerange.swift
+++ b/validation-test/compiler_crashers_fixed/26032-swift-typechecker-availablerange.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26033-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/26033-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26034-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/26034-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26035-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26035-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26036-bool.swift
+++ b/validation-test/compiler_crashers_fixed/26036-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26037-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/26037-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26038-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/26038-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26039-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/26039-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26040-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/26040-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26041-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26041-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26042-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/26042-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26043-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/26043-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26044-llvm-raw-ostream-write.swift
+++ b/validation-test/compiler_crashers_fixed/26044-llvm-raw-ostream-write.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26045-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26045-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26046-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/26046-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26047-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/26047-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26048-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/26048-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26049-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26049-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26050-swift-parser-parsedeclenumcase.swift
+++ b/validation-test/compiler_crashers_fixed/26050-swift-parser-parsedeclenumcase.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26051-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26051-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26052-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26052-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26053-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/26053-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26054-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26054-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26055-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26055-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26056-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26056-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26057-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/26057-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26058-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/26058-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26059-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/26059-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26060-swift-parser-parsetypeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26060-swift-parser-parsetypeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26061-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/26061-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26062-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26062-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26063-swift-tuplepattern-createsimple.swift
+++ b/validation-test/compiler_crashers_fixed/26063-swift-tuplepattern-createsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26064-bool.swift
+++ b/validation-test/compiler_crashers_fixed/26064-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26065-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/26065-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26066-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26066-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26067-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26067-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26068-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/26068-swift-archetypebuilder-addrequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26069-swift-archetypebuilder-potentialarchetype-getdependenttype.swift
+++ b/validation-test/compiler_crashers_fixed/26069-swift-archetypebuilder-potentialarchetype-getdependenttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26070-swift-serialization-serializer-writedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26070-swift-serialization-serializer-writedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26071-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/26071-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26072-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26072-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26073-finalizegenericparamlist.swift
+++ b/validation-test/compiler_crashers_fixed/26073-finalizegenericparamlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26074-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26074-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26075-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26075-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26076-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26076-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26077-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26077-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26078-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/26078-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26079-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/26079-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26080-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/26080-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26081-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26081-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26082-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26082-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26083-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26083-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26084-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/26084-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26085-swift-archetypebuilder-resolvearchetype.swift
+++ b/validation-test/compiler_crashers_fixed/26085-swift-archetypebuilder-resolvearchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26086-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/26086-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26087-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/26087-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26088-swift-arrayslicetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26088-swift-arrayslicetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26089-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/26089-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26090-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/26090-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26092-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26092-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26093-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/26093-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26094-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/26094-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26095-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26095-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26096-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/26096-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26097-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26097-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26098-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26098-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26099-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/26099-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26100-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26100-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26101-swift-parser-parsenewdeclattribute.swift
+++ b/validation-test/compiler_crashers_fixed/26101-swift-parser-parsenewdeclattribute.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26102-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26102-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26103-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/26103-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26104-swift-vardecl-getparentinitializer.swift
+++ b/validation-test/compiler_crashers_fixed/26104-swift-vardecl-getparentinitializer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26105-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26105-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26106-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/26106-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26107-llvm-foldingset-swift-structtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26107-llvm-foldingset-swift-structtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26108-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26108-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26109-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/26109-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26110-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/26110-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26111-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26111-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26112-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/26112-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26113-swift-archetypebuilder-addgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26113-swift-archetypebuilder-addgenericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26114-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26114-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26115-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/26115-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26116-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26116-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26117-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26117-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26118-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26118-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26119-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/26119-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26120-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/26120-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26121-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/26121-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26122-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26122-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26123-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26123-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26124-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26124-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26125-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26125-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26126-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26126-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26127-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26127-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26128-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26128-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26129-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26129-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26130-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26130-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26131-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26131-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26132-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26132-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26133-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26133-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26134-swift-constraints-constraintsystem-solverstate-solverstate.swift
+++ b/validation-test/compiler_crashers_fixed/26134-swift-constraints-constraintsystem-solverstate-solverstate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26136-swift-astcontext-getloadedmodule.swift
+++ b/validation-test/compiler_crashers_fixed/26136-swift-astcontext-getloadedmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26137-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/26137-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26138-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26138-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26139-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/26139-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26140-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26140-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26141-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/26141-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26142-llvm-raw-ostream-setbuffered.swift
+++ b/validation-test/compiler_crashers_fixed/26142-llvm-raw-ostream-setbuffered.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26143-swift-declattribute-canattributeappearondeclkind.swift
+++ b/validation-test/compiler_crashers_fixed/26143-swift-declattribute-canattributeappearondeclkind.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26144-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26144-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26145-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/26145-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26146-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26146-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26147-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26147-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26148-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/26148-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26149-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26149-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26150-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26150-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26151-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26151-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26152-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26152-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26153-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/26153-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26154-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26154-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26155-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/26155-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26156-swift-parser-consumeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26156-swift-parser-consumeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26157-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/26157-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26158-swift-parser-parsetypeattribute.swift
+++ b/validation-test/compiler_crashers_fixed/26158-swift-parser-parsetypeattribute.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26159-llvm-foldingset-swift-structtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26159-llvm-foldingset-swift-structtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26160-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26160-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26161-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26161-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26162-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/26162-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26163-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26163-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26164-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26164-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26165-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26165-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26166-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26166-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26167-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26167-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26168-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26168-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26169-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26169-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26170-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26170-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26171-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26171-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26172-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26172-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26173-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26173-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26174-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26174-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26175-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26175-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26176-swift-declcontext-isprotocolorprotocolextensioncontext.swift
+++ b/validation-test/compiler_crashers_fixed/26176-swift-declcontext-isprotocolorprotocolextensioncontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26177-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/26177-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26178-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26178-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26179-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26179-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26180-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26180-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26181-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26181-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26183-swift-constraints-constraintgraphnode-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26183-swift-constraints-constraintgraphnode-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26184-llvm-yaml-input-preflightkey.swift
+++ b/validation-test/compiler_crashers_fixed/26184-llvm-yaml-input-preflightkey.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26185-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/26185-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26186-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26186-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26187-void.swift
+++ b/validation-test/compiler_crashers_fixed/26187-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26188-swift-typechecker-checkgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/26188-swift-typechecker-checkgenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26189-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26189-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26190-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26190-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26191-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/26191-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26192-swift-maybeaddaccessorstovariable.swift
+++ b/validation-test/compiler_crashers_fixed/26192-swift-maybeaddaccessorstovariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26193-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26193-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26194-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26194-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26195-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/26195-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26196-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26196-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26197-load-method-type.swift
+++ b/validation-test/compiler_crashers_fixed/26197-load-method-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26198-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26198-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26199-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26199-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26200-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/26200-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26201-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26201-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26202-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26202-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26203-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26203-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26204-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26204-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26205-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26205-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26206-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/26206-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26207-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26207-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26208-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26208-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26209-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26209-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26210-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26210-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26211-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/26211-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26212-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/26212-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26213-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/26213-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26214-swift-conformancelookuptable-getconformance.swift
+++ b/validation-test/compiler_crashers_fixed/26214-swift-conformancelookuptable-getconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26215-swift-parser-consumeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26215-swift-parser-consumeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26216-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/26216-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26217-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/26217-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26218-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26218-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26219-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26219-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26220-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26220-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26221-swift-astcontext-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/26221-swift-astcontext-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26222-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26222-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26223-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26223-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26224-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26224-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26225-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26225-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26226-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/26226-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26227-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26227-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26228-void.swift
+++ b/validation-test/compiler_crashers_fixed/26228-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26229-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26229-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26230-swift-modulefile-getdeclcontext.swift
+++ b/validation-test/compiler_crashers_fixed/26230-swift-modulefile-getdeclcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26231-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/26231-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26232-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/26232-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26233-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26233-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26234-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26234-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26235-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/26235-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26236-swift-astcontext-getloadedmodule.swift
+++ b/validation-test/compiler_crashers_fixed/26236-swift-astcontext-getloadedmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26237-swift-modulefile-maybereadforeignerrorconvention.swift
+++ b/validation-test/compiler_crashers_fixed/26237-swift-modulefile-maybereadforeignerrorconvention.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26238-swift-archetypebuilder-potentialarchetype-isbetterarchetypeanchor.swift
+++ b/validation-test/compiler_crashers_fixed/26238-swift-archetypebuilder-potentialarchetype-isbetterarchetypeanchor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26239-swift-parser-parsedeclvar.swift
+++ b/validation-test/compiler_crashers_fixed/26239-swift-parser-parsedeclvar.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26240-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26240-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26241-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26241-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26242-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26242-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26243-swift-parser-consumeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26243-swift-parser-consumeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26244-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/26244-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26246-llvm-raw-ostream-setbuffered.swift
+++ b/validation-test/compiler_crashers_fixed/26246-llvm-raw-ostream-setbuffered.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26247-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/26247-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26248-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26248-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26249-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/26249-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26250-swift-constraints-constraintsystem-recordopenedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/26250-swift-constraints-constraintsystem-recordopenedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26251-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26251-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26253-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26253-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26254-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/26254-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26255-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26255-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26256-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26256-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26257-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26257-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26258-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/26258-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26259-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26259-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26260-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/26260-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26261-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26261-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26262-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/26262-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26263-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26263-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26264-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/26264-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26265-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/26265-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26266-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26266-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26267-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/26267-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26268-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26268-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26269-swift-modulefile-readmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26269-swift-modulefile-readmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26270-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26270-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26271-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26271-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26272-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26272-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26273-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26273-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26274-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/26274-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26275-llvm-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26275-llvm-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26276-swift-modulefile-maybereadforeignerrorconvention.swift
+++ b/validation-test/compiler_crashers_fixed/26276-swift-modulefile-maybereadforeignerrorconvention.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26277-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/26277-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26278-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/26278-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26279-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26279-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26280-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26280-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26281-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26281-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26282-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26282-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26283-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26283-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26284-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/26284-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26285-swift-parser-consumeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26285-swift-parser-consumeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26286-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26286-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26287-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/26287-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26288-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/26288-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26289-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/26289-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26290-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26290-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26291-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26291-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26292-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/26292-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26293-swift-conformancelookuptable-getconformance.swift
+++ b/validation-test/compiler_crashers_fixed/26293-swift-conformancelookuptable-getconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26294-void.swift
+++ b/validation-test/compiler_crashers_fixed/26294-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26298-llvm-densemapbase.swift
+++ b/validation-test/compiler_crashers_fixed/26298-llvm-densemapbase.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26303-llvm-llvm-unreachable-internal.swift
+++ b/validation-test/compiler_crashers_fixed/26303-llvm-llvm-unreachable-internal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26305-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26305-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26306-llvm-stringmapimpl-lookupbucketfor.swift
+++ b/validation-test/compiler_crashers_fixed/26306-llvm-stringmapimpl-lookupbucketfor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26307-swift-parser-isstartofdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26307-swift-parser-isstartofdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26308-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/26308-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26309-swift-typebase-getimplicitlyunwrappedoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/26309-swift-typebase-getimplicitlyunwrappedoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26310-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26310-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26311-swift-parser-parseanyidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26311-swift-parser-parseanyidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26312-swift-typechecker-resolvesuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/26312-swift-typechecker-resolvesuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26313-llvm-densemapbase-llvm-densemap-swift-silbasicblock.swift
+++ b/validation-test/compiler_crashers_fixed/26313-llvm-densemapbase-llvm-densemap-swift-silbasicblock.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26314-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26314-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26315-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26315-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26316-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/26316-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26317-swift-memberlookuptable-addmember.swift
+++ b/validation-test/compiler_crashers_fixed/26317-swift-memberlookuptable-addmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26318-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26318-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26319-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26319-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26320-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/26320-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26321-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/26321-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26322-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers_fixed/26322-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26323-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26323-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26324-llvm-raw-ostream-write.swift
+++ b/validation-test/compiler_crashers_fixed/26324-llvm-raw-ostream-write.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26325-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26325-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26326-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/26326-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26327-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26327-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26328-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26328-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26329-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/26329-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26330-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/26330-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26331-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26331-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26332-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26332-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26333-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26333-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26334-swift-arrayslicetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26334-swift-arrayslicetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26335-swift-parser-parsedeclenumcase.swift
+++ b/validation-test/compiler_crashers_fixed/26335-swift-parser-parsedeclenumcase.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26336-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/26336-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26337-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/26337-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26338-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26338-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26339-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/26339-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26340-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/26340-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26341-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/26341-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26342-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26342-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26343-swift-constraints-constraintsystem-simplify.swift
+++ b/validation-test/compiler_crashers_fixed/26343-swift-constraints-constraintsystem-simplify.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26344-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/26344-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26345-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/26345-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26346-llvm-smallvectorimpl-swift-decl-insert.swift
+++ b/validation-test/compiler_crashers_fixed/26346-llvm-smallvectorimpl-swift-decl-insert.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26347-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26347-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26348-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/26348-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26349-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26349-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26350-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26350-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26351-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26351-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26352-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/26352-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26353-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26353-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26354-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/26354-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26355-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26355-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26356-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26356-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26357-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/26357-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26358-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/26358-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26359-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26359-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26360-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26360-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26361-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/26361-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26362-swift-archetypetype-getnew.swift
+++ b/validation-test/compiler_crashers_fixed/26362-swift-archetypetype-getnew.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26363-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/26363-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26364-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26364-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26365-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/26365-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26366-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/26366-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26367-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26367-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26368-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/26368-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26369-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26369-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26370-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26370-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26371-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/26371-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26372-void.swift
+++ b/validation-test/compiler_crashers_fixed/26372-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26373-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26373-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26374-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26374-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26375-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/26375-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26376-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26376-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26377-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26377-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26378-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26378-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26379-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26379-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26380-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26380-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26381-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26381-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26382-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26382-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26383-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/26383-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26384-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/26384-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26385-swift-typevariabletype-implementation-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/26385-swift-typevariabletype-implementation-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26386-swift-typevisitor.swift
+++ b/validation-test/compiler_crashers_fixed/26386-swift-typevisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26387-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/26387-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26388-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26388-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26389-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26389-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26390-swift-mangle-mangler-mangledeclname.swift
+++ b/validation-test/compiler_crashers_fixed/26390-swift-mangle-mangler-mangledeclname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26391-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/26391-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26392-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/26392-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26393-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26393-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26394-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26394-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26395-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
+++ b/validation-test/compiler_crashers_fixed/26395-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26396-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26396-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26397-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26397-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26398-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/26398-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26399-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26399-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26400-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26400-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26401-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/26401-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26402-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/26402-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26403-llvm-densemapbase-llvm-smalldensemap-std-pair-llvm-arrayref-std-pair-swift-identifier.swift
+++ b/validation-test/compiler_crashers_fixed/26403-llvm-densemapbase-llvm-smalldensemap-std-pair-llvm-arrayref-std-pair-swift-identifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26404-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26404-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26405-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26405-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26406-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/26406-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26407-llvm-smallvectorbase-grow-pod.swift
+++ b/validation-test/compiler_crashers_fixed/26407-llvm-smallvectorbase-grow-pod.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26408-swift-iterabledeclcontext-addmember.swift
+++ b/validation-test/compiler_crashers_fixed/26408-swift-iterabledeclcontext-addmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26409-swift-tuplepattern-createsimple.swift
+++ b/validation-test/compiler_crashers_fixed/26409-swift-tuplepattern-createsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26410-std-function-func-swift-typechecker-typecheckbinding.swift
+++ b/validation-test/compiler_crashers_fixed/26410-std-function-func-swift-typechecker-typecheckbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26411-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26411-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26412-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/26412-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26413-swift-sourcemanager-getbytedistance.swift
+++ b/validation-test/compiler_crashers_fixed/26413-swift-sourcemanager-getbytedistance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26414-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26414-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26415-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/26415-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26416-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26416-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26417-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26417-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26418-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/26418-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26419-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26419-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26420-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26420-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26421-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26421-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26422-swift-typevariabletype-implementation-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/26422-swift-typevariabletype-implementation-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26423-llvm-bumpptrallocatorimpl-llvm-mallocallocator.swift
+++ b/validation-test/compiler_crashers_fixed/26423-llvm-bumpptrallocatorimpl-llvm-mallocallocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26424-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/26424-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26425-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26425-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26426-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26426-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26427-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26427-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26428-swift-parser-parsegenericwhereclause.swift
+++ b/validation-test/compiler_crashers_fixed/26428-swift-parser-parsegenericwhereclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26429-getfileaux.swift
+++ b/validation-test/compiler_crashers_fixed/26429-getfileaux.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26430-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/26430-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26431-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26431-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26432-llvm-foldingsetimpl-findnodeorinsertpos.swift
+++ b/validation-test/compiler_crashers_fixed/26432-llvm-foldingsetimpl-findnodeorinsertpos.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26433-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26433-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26434-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/26434-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26435-swift-arrayexpr-create.swift
+++ b/validation-test/compiler_crashers_fixed/26435-swift-arrayexpr-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26436-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26436-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26437-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26437-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26438-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/26438-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26439-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26439-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26440-swift-constraints-constraintsystem-salvage.swift
+++ b/validation-test/compiler_crashers_fixed/26440-swift-constraints-constraintsystem-salvage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26441-swift-parser-parseexprcollection.swift
+++ b/validation-test/compiler_crashers_fixed/26441-swift-parser-parseexprcollection.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26442-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/26442-swift-typebase-gatherallsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26443-swift-parser-parsedeclvar.swift
+++ b/validation-test/compiler_crashers_fixed/26443-swift-parser-parsedeclvar.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26444-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/26444-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26445-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/26445-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26446-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26446-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26447-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/26447-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26448-swift-declcontext-isprotocolorprotocolextensioncontext.swift
+++ b/validation-test/compiler_crashers_fixed/26448-swift-declcontext-isprotocolorprotocolextensioncontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26449-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/26449-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26450-swift-constraints-constraintsystem-applysolution.swift
+++ b/validation-test/compiler_crashers_fixed/26450-swift-constraints-constraintsystem-applysolution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26451-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26451-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26452-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26452-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26453-swift-astcontext-getloadedmodule.swift
+++ b/validation-test/compiler_crashers_fixed/26453-swift-astcontext-getloadedmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26454-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/26454-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26455-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26455-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26456-swift-lvaluetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26456-swift-lvaluetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26457-swift-constraints-constraintsystem-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26457-swift-constraints-constraintsystem-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26458-swift-constraints-constraintsystem-simplifymemberconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26458-swift-constraints-constraintsystem-simplifymemberconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26459-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26459-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26460-std-function-func-swift-constraints-solution-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26460-std-function-func-swift-constraints-solution-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26461-void.swift
+++ b/validation-test/compiler_crashers_fixed/26461-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26462-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26462-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26463-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26463-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26464-getfileaux.swift
+++ b/validation-test/compiler_crashers_fixed/26464-getfileaux.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26465-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/26465-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26466-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26466-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26467-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26467-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26468-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26468-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26469-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/26469-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26470-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26470-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26471-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26471-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26472-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/26472-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26473-swift-constraints-constraint-constraint.swift
+++ b/validation-test/compiler_crashers_fixed/26473-swift-constraints-constraint-constraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26474-std-function-func-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26474-std-function-func-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26475-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/26475-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26476-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26476-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26477-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26477-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26478-swift-archetypetype-resolvenestedtype.swift
+++ b/validation-test/compiler_crashers_fixed/26478-swift-archetypetype-resolvenestedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26479-swift-parser-applyattributetotype.swift
+++ b/validation-test/compiler_crashers_fixed/26479-swift-parser-applyattributetotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26480-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/26480-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26481-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/26481-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26482-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26482-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26483-swift-archetypebuilder-inferrequirementswalker-walktotypepost.swift
+++ b/validation-test/compiler_crashers_fixed/26483-swift-archetypebuilder-inferrequirementswalker-walktotypepost.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26484-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26484-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26485-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers_fixed/26485-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26486-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26486-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26487-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26487-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26488-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/26488-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26489-swift-parser-parseexpridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26489-swift-parser-parseexpridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26490-swift-conformancelookuptable-resolveconformances.swift
+++ b/validation-test/compiler_crashers_fixed/26490-swift-conformancelookuptable-resolveconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26491-swift-abstractstoragedecl-makecomputed.swift
+++ b/validation-test/compiler_crashers_fixed/26491-swift-abstractstoragedecl-makecomputed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26492-swift-astcontext-getidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26492-swift-astcontext-getidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26493-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26493-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26494-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26494-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26495-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26495-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26496-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26496-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26497-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26497-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26498-swift-sourcefile-lookupcache-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26498-swift-sourcefile-lookupcache-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26499-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26499-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26500-swift-modulefile-getdeclcontext.swift
+++ b/validation-test/compiler_crashers_fixed/26500-swift-modulefile-getdeclcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26501-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26501-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26502-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26502-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26503-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26503-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26504-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26504-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26505-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26505-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26506-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26506-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26507-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26507-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26508-llvm-smallvectorbase-grow-pod.swift
+++ b/validation-test/compiler_crashers_fixed/26508-llvm-smallvectorbase-grow-pod.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26509-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26509-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26510-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26510-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26511-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26511-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26512-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26512-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26513-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/26513-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26514-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26514-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26515-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26515-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26516-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26516-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26517-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/26517-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26518-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26518-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26519-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/26519-swift-lexer-lexstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26520-swift-typechecker-checkgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/26520-swift-typechecker-checkgenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26521-swift-modulefile-getdeclcontext.swift
+++ b/validation-test/compiler_crashers_fixed/26521-swift-modulefile-getdeclcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26522-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/26522-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26523-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/26523-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26524-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26524-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26525-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/26525-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26526-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26526-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26527-swift-parser-isstartofdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26527-swift-parser-isstartofdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26528-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26528-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26529-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/26529-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26530-llvm-foldingsetimpl-findnodeorinsertpos.swift
+++ b/validation-test/compiler_crashers_fixed/26530-llvm-foldingsetimpl-findnodeorinsertpos.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26531-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/26531-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26532-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26532-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26533-checktypeaccessibility.swift
+++ b/validation-test/compiler_crashers_fixed/26533-checktypeaccessibility.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26534-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26534-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26535-swift-typebase-getimplicitlyunwrappedoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/26535-swift-typebase-getimplicitlyunwrappedoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26536-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26536-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26537-swift-abstractstoragedecl-getobjcgetterselector.swift
+++ b/validation-test/compiler_crashers_fixed/26537-swift-abstractstoragedecl-getobjcgetterselector.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26538-swift-parser-parsegetsetimpl.swift
+++ b/validation-test/compiler_crashers_fixed/26538-swift-parser-parsegetsetimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26539-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26539-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26540-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/26540-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26541-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/26541-swift-lexer-lexstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26542-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26542-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26543-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26543-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26544-swift-sourcefile-lookupcache-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26544-swift-sourcefile-lookupcache-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26545-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26545-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26546-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26546-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26547-swift-sourcefile-lookupcache-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26547-swift-sourcefile-lookupcache-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26548-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26548-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26549-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/26549-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26550-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26550-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26551-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26551-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26552-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26552-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26553-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/26553-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26554-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26554-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26555-swift-typechecker-checkgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/26555-swift-typechecker-checkgenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26556-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/26556-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26557-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/26557-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26558-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/26558-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26559-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26559-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26560-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26560-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26561-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26561-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26562-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26562-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26563-swift-constraints-constraintgraph-unbindtypevariable.swift
+++ b/validation-test/compiler_crashers_fixed/26563-swift-constraints-constraintgraph-unbindtypevariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26564-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26564-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26565-swift-constraints-constraintsystem-salvage.swift
+++ b/validation-test/compiler_crashers_fixed/26565-swift-constraints-constraintsystem-salvage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26566-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26566-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26567-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26567-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26568-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26568-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26569-swift-constraints-constraintsystem-optimizeconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/26569-swift-constraints-constraintsystem-optimizeconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26570-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/26570-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26571-swift-constraints-constraintsystem-recordopenedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/26571-swift-constraints-constraintsystem-recordopenedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26572-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/26572-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26573-swift-parser-parseanyidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26573-swift-parser-parseanyidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26574-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26574-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26575-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/26575-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26576-llvm-foldingset-swift-structtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26576-llvm-foldingset-swift-structtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26577-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/26577-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26578-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/26578-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26579-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26579-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26580-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26580-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26581-swift-typechecker-checkdeclarationavailability.swift
+++ b/validation-test/compiler_crashers_fixed/26581-swift-typechecker-checkdeclarationavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26582-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26582-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26583-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26583-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26584-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/26584-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26585-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26585-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26586-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26586-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26587-swift-typechecker-computeaccessibility.swift
+++ b/validation-test/compiler_crashers_fixed/26587-swift-typechecker-computeaccessibility.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26588-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/26588-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26589-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26589-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26590-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26590-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26591-swift-modulefile-getdeclcontext.swift
+++ b/validation-test/compiler_crashers_fixed/26591-swift-modulefile-getdeclcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26592-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26592-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26593-void.swift
+++ b/validation-test/compiler_crashers_fixed/26593-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26594-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/26594-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26595-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26595-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26596-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/26596-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26597-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/26597-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26598-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26598-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26599-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/26599-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26600-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26600-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26601-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26601-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26602-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26602-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26603-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26603-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26604-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26604-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26605-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/26605-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26606-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/26606-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26607-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26607-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26608-std-function-func.swift
+++ b/validation-test/compiler_crashers_fixed/26608-std-function-func.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26609-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26609-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26610-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26610-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26611-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/26611-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26612-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26612-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26613-swift-archetypebuilder-potentialarchetype-addconformance.swift
+++ b/validation-test/compiler_crashers_fixed/26613-swift-archetypebuilder-potentialarchetype-addconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26614-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26614-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26615-swift-abstractstoragedecl-makecomputed.swift
+++ b/validation-test/compiler_crashers_fixed/26615-swift-abstractstoragedecl-makecomputed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26616-swift-maybeaddaccessorstovariable.swift
+++ b/validation-test/compiler_crashers_fixed/26616-swift-maybeaddaccessorstovariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26617-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26617-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26618-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26618-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26619-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26619-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26620-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26620-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26621-swift-astcontext-allocate.swift
+++ b/validation-test/compiler_crashers_fixed/26621-swift-astcontext-allocate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26622-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26622-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26623-std-function-func-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/26623-std-function-func-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26624-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26624-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26625-swift-typechecker-resolveinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/26625-swift-typechecker-resolveinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26626-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/26626-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26627-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26627-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26628-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26628-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26629-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26629-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26630-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/26630-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26631-swift-sourcemanager-getbytedistance.swift
+++ b/validation-test/compiler_crashers_fixed/26631-swift-sourcemanager-getbytedistance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26632-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26632-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26633-swift-constraints-constraintsystem-applysolutionshallow.swift
+++ b/validation-test/compiler_crashers_fixed/26633-swift-constraints-constraintsystem-applysolutionshallow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26634-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26634-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26635-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26635-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26636-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/26636-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26637-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26637-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26638-bool.swift
+++ b/validation-test/compiler_crashers_fixed/26638-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26639-void.swift
+++ b/validation-test/compiler_crashers_fixed/26639-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26640-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26640-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26641-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26641-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26642-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/26642-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26643-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/26643-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26644-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26644-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26645-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26645-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26646-swift-constraints-constraintgraphnode-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26646-swift-constraints-constraintgraphnode-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26647-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26647-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26648-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26648-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26649-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26649-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26650-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26650-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26651-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/26651-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26652-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/26652-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26653-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26653-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26654-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/26654-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26655-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/26655-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26656-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/26656-swift-lexer-lexstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26657-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26657-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26658-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26658-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26659-swift-genericsignature-getcanonicalmanglingsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26659-swift-genericsignature-getcanonicalmanglingsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26660-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/26660-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26661-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/26661-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26662-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/26662-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26663-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/26663-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26664-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26664-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26665-swift-conformancelookuptable-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/26665-swift-conformancelookuptable-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26666-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26666-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26667-swift-iterabledeclcontext-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26667-swift-iterabledeclcontext-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26668-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/26668-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26669-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26669-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26670-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26670-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26671-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/26671-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26672-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26672-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26673-llvm-triple-getosname.swift
+++ b/validation-test/compiler_crashers_fixed/26673-llvm-triple-getosname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26674-swift-sourcemanager-getbytedistance.swift
+++ b/validation-test/compiler_crashers_fixed/26674-swift-sourcemanager-getbytedistance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26675-llvm-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26675-llvm-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26676-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/26676-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26677-swift-parser-diagnoseredefinition.swift
+++ b/validation-test/compiler_crashers_fixed/26677-swift-parser-diagnoseredefinition.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26678-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26678-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26679-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/26679-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26680-swift-modulefile-getdeclcontext.swift
+++ b/validation-test/compiler_crashers_fixed/26680-swift-modulefile-getdeclcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26681-swift-sourcemanager-getbytedistance.swift
+++ b/validation-test/compiler_crashers_fixed/26681-swift-sourcemanager-getbytedistance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26682-swift-constraints-constraint-constraint.swift
+++ b/validation-test/compiler_crashers_fixed/26682-swift-constraints-constraint-constraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26683-swift-generictypetoarchetyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/26683-swift-generictypetoarchetyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26684-swift-arrayexpr-create.swift
+++ b/validation-test/compiler_crashers_fixed/26684-swift-arrayexpr-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26685-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26685-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26686-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26686-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26687-bool.swift
+++ b/validation-test/compiler_crashers_fixed/26687-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26688-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/26688-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26689-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/26689-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26690-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26690-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26691-swift-serialization-serializer-writedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26691-swift-serialization-serializer-writedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26692-swift-astcontext-getloadedmodule.swift
+++ b/validation-test/compiler_crashers_fixed/26692-swift-astcontext-getloadedmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26693-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26693-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26694-void.swift
+++ b/validation-test/compiler_crashers_fixed/26694-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26695-swift-genericsignature-profile.swift
+++ b/validation-test/compiler_crashers_fixed/26695-swift-genericsignature-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26696-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/26696-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26697-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26697-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26698-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26698-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26699-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/26699-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26700-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26700-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26701-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26701-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26702-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26702-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26703-swift-modulefile-getdeclcontext.swift
+++ b/validation-test/compiler_crashers_fixed/26703-swift-modulefile-getdeclcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26704-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26704-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26705-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/26705-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26706-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/26706-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26707-swift-moduledecl-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/26707-swift-moduledecl-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26708-swift-parser-parseversiontuple.swift
+++ b/validation-test/compiler_crashers_fixed/26708-swift-parser-parseversiontuple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26709-swift-parser-parseexprcallsuffix.swift
+++ b/validation-test/compiler_crashers_fixed/26709-swift-parser-parseexprcallsuffix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26710-swift-constraints-constraintsystem-computeassigndesttype.swift
+++ b/validation-test/compiler_crashers_fixed/26710-swift-constraints-constraintsystem-computeassigndesttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26711-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/26711-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26712-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26712-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26713-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/26713-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26714-swift-parser-parsedeclextension.swift
+++ b/validation-test/compiler_crashers_fixed/26714-swift-parser-parsedeclextension.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26715-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/26715-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26716-swift-patternbindingdecl-create.swift
+++ b/validation-test/compiler_crashers_fixed/26716-swift-patternbindingdecl-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26717-swift-typevisitor.swift
+++ b/validation-test/compiler_crashers_fixed/26717-swift-typevisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26718-swift-parser-parsedeclvar.swift
+++ b/validation-test/compiler_crashers_fixed/26718-swift-parser-parsedeclvar.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26719-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26719-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26720-void.swift
+++ b/validation-test/compiler_crashers_fixed/26720-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26721-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26721-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26722-swift-parser-parsedaccessors-record.swift
+++ b/validation-test/compiler_crashers_fixed/26722-swift-parser-parsedaccessors-record.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26723-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26723-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26724-clang-declvisitor-base-clang-declvisitor-make-const-ptr.swift
+++ b/validation-test/compiler_crashers_fixed/26724-clang-declvisitor-base-clang-declvisitor-make-const-ptr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26725-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26725-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26726-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26726-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26727-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26727-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26728-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/26728-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26729-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26729-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26730-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/26730-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26731-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26731-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26732-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26732-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26733-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26733-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26734-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26734-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26735-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26735-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26736-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26736-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26737-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26737-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26738-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/26738-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26739-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/26739-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26740-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26740-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26741-swift-abstractstoragedecl-makecomputed.swift
+++ b/validation-test/compiler_crashers_fixed/26741-swift-abstractstoragedecl-makecomputed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26742-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/26742-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26743-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/26743-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26744-bool.swift
+++ b/validation-test/compiler_crashers_fixed/26744-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26745-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/26745-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26746-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26746-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26747-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/26747-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26748-swift-constraints-constraintsystem-recordfix.swift
+++ b/validation-test/compiler_crashers_fixed/26748-swift-constraints-constraintsystem-recordfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26749-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/26749-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26750-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26750-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26751-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26751-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26752-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/26752-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26753-swift-parser-parsegenericwhereclause.swift
+++ b/validation-test/compiler_crashers_fixed/26753-swift-parser-parsegenericwhereclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26754-swift-abstractstoragedecl-setinvalidbracesrange.swift
+++ b/validation-test/compiler_crashers_fixed/26754-swift-abstractstoragedecl-setinvalidbracesrange.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26755-swift-constraints-constraintsystem-solverstate-solverstate.swift
+++ b/validation-test/compiler_crashers_fixed/26755-swift-constraints-constraintsystem-solverstate-solverstate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26756-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/26756-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26757-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26757-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26758-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26758-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26759-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26759-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26760-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26760-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26761-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/26761-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26762-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26762-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26763-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26763-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26764-swift-parser-parsedeclenumcase.swift
+++ b/validation-test/compiler_crashers_fixed/26764-swift-parser-parsedeclenumcase.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26765-swift-conformancelookuptable-getimplicitprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26765-swift-conformancelookuptable-getimplicitprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26766-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26766-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26767-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/26767-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26768-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/26768-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26769-swift-tuplepattern-createsimple.swift
+++ b/validation-test/compiler_crashers_fixed/26769-swift-tuplepattern-createsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26770-swift-protocoltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26770-swift-protocoltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26771-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26771-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26772-swift-sourcemanager-extracttext.swift
+++ b/validation-test/compiler_crashers_fixed/26772-swift-sourcemanager-extracttext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26773-swift-diagnosticengine-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/26773-swift-diagnosticengine-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26774-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26774-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26775-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26775-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26776-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/26776-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26777-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/26777-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26778-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/26778-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26779-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/26779-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26780-swift-parser-parsestmt.swift
+++ b/validation-test/compiler_crashers_fixed/26780-swift-parser-parsestmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26781-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26781-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26782-swift-genericfunctiontype-partialsubstgenericargs.swift
+++ b/validation-test/compiler_crashers_fixed/26782-swift-genericfunctiontype-partialsubstgenericargs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26783-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26783-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26784-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/26784-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26785-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/26785-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26786-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26786-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26787-swift-declname-printpretty.swift
+++ b/validation-test/compiler_crashers_fixed/26787-swift-declname-printpretty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26788-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/26788-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26789-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26789-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26790-swift-type-getstring.swift
+++ b/validation-test/compiler_crashers_fixed/26790-swift-type-getstring.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26791-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26791-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26792-swift-classtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26792-swift-classtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26793-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/26793-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26794-firsttarget.swift
+++ b/validation-test/compiler_crashers_fixed/26794-firsttarget.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26795-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/26795-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26796-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26796-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26797-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26797-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26798-void.swift
+++ b/validation-test/compiler_crashers_fixed/26798-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26799-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26799-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26800-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/26800-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26801-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26801-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26802-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26802-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26803-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/26803-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26804-swift-conformancelookuptable-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/26804-swift-conformancelookuptable-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26805-void.swift
+++ b/validation-test/compiler_crashers_fixed/26805-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26806-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/26806-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26807-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26807-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26816-checkenumrawvalues.swift
+++ b/validation-test/compiler_crashers_fixed/26816-checkenumrawvalues.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26817-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26817-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26818-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/26818-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26819-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26819-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26820-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/26820-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26821-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/26821-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26822-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26822-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26823-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/26823-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26824-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/26824-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26825-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/26825-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26826-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/26826-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26827-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26827-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26828-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26828-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26829-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/26829-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26830-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26830-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26831-llvm-densemapbase-llvm-smalldensemap-swift-typevariabletype.swift
+++ b/validation-test/compiler_crashers_fixed/26831-llvm-densemapbase-llvm-smalldensemap-swift-typevariabletype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26832-swift-typechecker-conformstoprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/26832-swift-typechecker-conformstoprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26833-llvm-mapvector-swift-declcontext.swift
+++ b/validation-test/compiler_crashers_fixed/26833-llvm-mapvector-swift-declcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26834-swift-constraints-constraintsystem-generateconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/26834-swift-constraints-constraintsystem-generateconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26835-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26835-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26836-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/26836-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26837-swift-abstractfunctiondecl-getobjcselector.swift
+++ b/validation-test/compiler_crashers_fixed/26837-swift-abstractfunctiondecl-getobjcselector.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26838-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26838-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26839-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/26839-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26840-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26840-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26841-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26841-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26842-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/26842-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26843-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/26843-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26844-swift-typechecker-isdeclavailable.swift
+++ b/validation-test/compiler_crashers_fixed/26844-swift-typechecker-isdeclavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26845-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26845-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26846-formatdiagnostictext.swift
+++ b/validation-test/compiler_crashers_fixed/26846-formatdiagnostictext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26847-swift-valuedecl-getoverloadsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26847-swift-valuedecl-getoverloadsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26848-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26848-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26849-swift-constraints-constraintsystem-generateconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/26849-swift-constraints-constraintsystem-generateconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26850-swift-existentialmetatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26850-swift-existentialmetatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26851-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26851-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26852-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26852-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26853-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26853-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26854-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/compiler_crashers_fixed/26854-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26855-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/26855-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26856-swift-constraints-constraintsystem-solverec.swift
+++ b/validation-test/compiler_crashers_fixed/26856-swift-constraints-constraintsystem-solverec.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26857-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26857-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26858-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/26858-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26859-swift-classdecl-classdecl.swift
+++ b/validation-test/compiler_crashers_fixed/26859-swift-classdecl-classdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26860-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/26860-swift-typebase-gatherallsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26861-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/26861-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26862-swift-typechecker-resolvepattern.swift
+++ b/validation-test/compiler_crashers_fixed/26862-swift-typechecker-resolvepattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26863-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26863-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26864-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26864-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26865-swift-conformancelookuptable-getimplicitprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/26865-swift-conformancelookuptable-getimplicitprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26866-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26866-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26867-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26867-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26868-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26868-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26869-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26869-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26870-swift-mangle-mangler-mangleidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26870-swift-mangle-mangler-mangleidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26871-swift-typechecker-computeaccessibility.swift
+++ b/validation-test/compiler_crashers_fixed/26871-swift-typechecker-computeaccessibility.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26872-std-function-func.swift
+++ b/validation-test/compiler_crashers_fixed/26872-std-function-func.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26873-void.swift
+++ b/validation-test/compiler_crashers_fixed/26873-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26874-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26874-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26875-swift-typechecker-checkunsupportedprotocoltype.swift
+++ b/validation-test/compiler_crashers_fixed/26875-swift-typechecker-checkunsupportedprotocoltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26876-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26876-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26877-swift-constraints-constraint-create.swift
+++ b/validation-test/compiler_crashers_fixed/26877-swift-constraints-constraint-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26878-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/26878-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26879-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/26879-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26880-swift-astvisitor.random.swift
+++ b/validation-test/compiler_crashers_fixed/26880-swift-astvisitor.random.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26881-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26881-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26882-swift-typechecker-definedefaultconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/26882-swift-typechecker-definedefaultconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26883-swift-modulefile-readmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26883-swift-modulefile-readmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26884-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26884-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26885-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26885-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26886-swift-stmt-walk.swift
+++ b/validation-test/compiler_crashers_fixed/26886-swift-stmt-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26887-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26887-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26888-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/26888-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26889-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26889-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26890-swift-typechecker-isdeclavailable.swift
+++ b/validation-test/compiler_crashers_fixed/26890-swift-typechecker-isdeclavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26891-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/26891-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26892-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26892-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26893-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/26893-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26894-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26894-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26895-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26895-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26896-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26896-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26897-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26897-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26898-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/26898-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26899-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26899-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26900-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26900-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26901-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/26901-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26902-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/26902-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26903-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26903-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26904-swift-typechecker-definedefaultconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/26904-swift-typechecker-definedefaultconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26905-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/26905-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26906-swift-declcontext-isclassorclassextensioncontext.swift
+++ b/validation-test/compiler_crashers_fixed/26906-swift-declcontext-isclassorclassextensioncontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26907-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26907-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26908-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26908-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26909-swift-constraints-constraintsystem-solverec.swift
+++ b/validation-test/compiler_crashers_fixed/26909-swift-constraints-constraintsystem-solverec.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26910-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/26910-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26911-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/26911-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26912-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26912-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26913-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/26913-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26914-void.swift
+++ b/validation-test/compiler_crashers_fixed/26914-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26915-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/26915-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26916-swift-typechecker-definedefaultconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/26916-swift-typechecker-definedefaultconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26917-swift-nominaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26917-swift-nominaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26918-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/26918-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26919-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/26919-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26920-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/26920-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26921-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/26921-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26922-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/26922-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26923-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/26923-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26924-mapsignaturefunctiontype.swift
+++ b/validation-test/compiler_crashers_fixed/26924-mapsignaturefunctiontype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26925-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/26925-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26926-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/26926-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26927-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/26927-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26928-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/26928-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26929-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26929-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26930-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/26930-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26931-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26931-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26932-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/26932-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26933-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/26933-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26934-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/26934-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26935-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26935-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26936-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/26936-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26937-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26937-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26938-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/26938-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26939-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/26939-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26940-swift-conformancelookuptable-getconformance.swift
+++ b/validation-test/compiler_crashers_fixed/26940-swift-conformancelookuptable-getconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26941-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/26941-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26942-swift-nominaltypedecl-computeinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/26942-swift-nominaltypedecl-computeinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26943-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/26943-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26944-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/26944-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26945-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/26945-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26946-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/26946-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26947-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/26947-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26948-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26948-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26949-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/26949-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26950-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/26950-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26951-swift-modulefile-resolvecrossreference.swift
+++ b/validation-test/compiler_crashers_fixed/26951-swift-modulefile-resolvecrossreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26952-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/26952-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26953-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/26953-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26954-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26954-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26955-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26955-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26956-swift-constructordecl-constructordecl.swift
+++ b/validation-test/compiler_crashers_fixed/26956-swift-constructordecl-constructordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26957-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26957-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26958-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/26958-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26959-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26959-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26960-void.swift
+++ b/validation-test/compiler_crashers_fixed/26960-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26961-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/26961-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26962-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/26962-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26963-checkenumrawvalues.swift
+++ b/validation-test/compiler_crashers_fixed/26963-checkenumrawvalues.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26964-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/26964-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26965-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26965-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26966-swift-parentype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26966-swift-parentype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26967-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26967-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26968-swift-typechecker-isdeclavailable.swift
+++ b/validation-test/compiler_crashers_fixed/26968-swift-typechecker-isdeclavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26969-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/26969-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26970-swift-abstractstoragedecl-makeaddressedwithobservers.swift
+++ b/validation-test/compiler_crashers_fixed/26970-swift-abstractstoragedecl-makeaddressedwithobservers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26971-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/26971-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26972-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/26972-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26973-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26973-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26974-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/26974-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26975-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/26975-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26976-swift-constraints-constraintsystem-opentype.swift
+++ b/validation-test/compiler_crashers_fixed/26976-swift-constraints-constraintsystem-opentype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26977-checkenumrawvalues.swift
+++ b/validation-test/compiler_crashers_fixed/26977-checkenumrawvalues.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26978-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/26978-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26979-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26979-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26980-swift-conformancelookuptable-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/26980-swift-conformancelookuptable-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26981-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/26981-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26982-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/26982-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26983-swift-archetypebuilder-potentialarchetype-isbetterarchetypeanchor.swift
+++ b/validation-test/compiler_crashers_fixed/26983-swift-archetypebuilder-potentialarchetype-isbetterarchetypeanchor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26984-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26984-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26985-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/26985-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26986-swift-modulefile-maybereadforeignerrorconvention.swift
+++ b/validation-test/compiler_crashers_fixed/26986-swift-modulefile-maybereadforeignerrorconvention.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26987-swift-constraints-constraintsystem-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/26987-swift-constraints-constraintsystem-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26988-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/26988-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26989-swift-typechecker-definedefaultconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/26989-swift-typechecker-definedefaultconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26990-swift-importdecl-findbestimportkind.swift
+++ b/validation-test/compiler_crashers_fixed/26990-swift-importdecl-findbestimportkind.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26991-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/26991-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26992-swift-archetypetype-getnew.swift
+++ b/validation-test/compiler_crashers_fixed/26992-swift-archetypetype-getnew.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26993-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/26993-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26994-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/26994-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26995-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/26995-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26996-swift-classtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/26996-swift-classtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26997-swift-stmt-walk.swift
+++ b/validation-test/compiler_crashers_fixed/26997-swift-stmt-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26998-std-function-func-setboundvarstypeerror.swift
+++ b/validation-test/compiler_crashers_fixed/26998-std-function-func-setboundvarstypeerror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/26999-swift-genericsignature-profile.swift
+++ b/validation-test/compiler_crashers_fixed/26999-swift-genericsignature-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27000-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/27000-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27001-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/27001-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27002-swift-pattern-clone.swift
+++ b/validation-test/compiler_crashers_fixed/27002-swift-pattern-clone.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27003-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27003-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27004-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/27004-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27005-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27005-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27006-formatdiagnostictext.swift
+++ b/validation-test/compiler_crashers_fixed/27006-formatdiagnostictext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27007-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27007-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27008-llvm-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27008-llvm-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27009-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27009-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27010-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27010-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27011-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/27011-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27012-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/27012-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27013-mapsignaturefunctiontype.swift
+++ b/validation-test/compiler_crashers_fixed/27013-mapsignaturefunctiontype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27014-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27014-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27015-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27015-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27016-swift-constraints-constraintsystem-solverec.swift
+++ b/validation-test/compiler_crashers_fixed/27016-swift-constraints-constraintsystem-solverec.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27017-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
+++ b/validation-test/compiler_crashers_fixed/27017-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27018-swift-conformancelookuptable-getallprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27018-swift-conformancelookuptable-getallprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27019-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27019-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27020-llvm-foldingset-swift-tupletype-getnodeprofile.swift
+++ b/validation-test/compiler_crashers_fixed/27020-llvm-foldingset-swift-tupletype-getnodeprofile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27021-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27021-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27022-swift-classtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27022-swift-classtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27023-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27023-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27024-swift-constraints-solution-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27024-swift-constraints-solution-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27025-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/27025-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27026-void.swift
+++ b/validation-test/compiler_crashers_fixed/27026-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27027-swift-namelookup-lookupinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/27027-swift-namelookup-lookupinmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27028-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27028-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27029-swift-typebase-isemptyexistentialcomposition.swift
+++ b/validation-test/compiler_crashers_fixed/27029-swift-typebase-isemptyexistentialcomposition.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27030-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27030-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27031-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27031-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27032-swift-nominaltypedecl-computeinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/27032-swift-nominaltypedecl-computeinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27033-swift-mangle-mangler-mangleidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27033-swift-mangle-mangler-mangleidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27034-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27034-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27035-swift-constraints-constraintgraph-unbindtypevariable.swift
+++ b/validation-test/compiler_crashers_fixed/27035-swift-constraints-constraintgraph-unbindtypevariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27036-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/27036-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27037-swift-nominaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27037-swift-nominaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27038-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/27038-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27039-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27039-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27040-swift-clangimporter-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27040-swift-clangimporter-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27041-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27041-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27042-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27042-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27043-swift-typechecker-typecheckexpressionshallow.swift
+++ b/validation-test/compiler_crashers_fixed/27043-swift-typechecker-typecheckexpressionshallow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27044-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27044-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27045-swift-lexer-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/27045-swift-lexer-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27046-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27046-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27047-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27047-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27048-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/27048-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27049-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27049-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27050-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/27050-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27051-swift-constraints-constraint-create.swift
+++ b/validation-test/compiler_crashers_fixed/27051-swift-constraints-constraint-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27052-swift-moduledecl-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27052-swift-moduledecl-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27053-swift-typechecker-checkdeclarationavailability.swift
+++ b/validation-test/compiler_crashers_fixed/27053-swift-typechecker-checkdeclarationavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27054-void.swift
+++ b/validation-test/compiler_crashers_fixed/27054-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27055-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/27055-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27056-swift-classtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27056-swift-classtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27057-addminimumprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27057-addminimumprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27058-llvm-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27058-llvm-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27059-swift-optionaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27059-swift-optionaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27060-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27060-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27061-swift-archetypebuilder-getallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27061-swift-archetypebuilder-getallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27062-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27062-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27063-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27063-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27064-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27064-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27065-swift-typechecker-typecheckclosurebody.swift
+++ b/validation-test/compiler_crashers_fixed/27065-swift-typechecker-typecheckclosurebody.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27066-swift-constraints-constraintsystem-applysolution.swift
+++ b/validation-test/compiler_crashers_fixed/27066-swift-constraints-constraintsystem-applysolution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27067-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/27067-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27068-swift-conformancelookuptable-conformancelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27068-swift-conformancelookuptable-conformancelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27069-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27069-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27070-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/27070-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27071-swift-nominaltypedecl-computeinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/27071-swift-nominaltypedecl-computeinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27072-swift-createimplicitconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/27072-swift-createimplicitconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27073-swift-constraints-constraint-create.swift
+++ b/validation-test/compiler_crashers_fixed/27073-swift-constraints-constraint-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27074-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27074-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27075-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27075-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27076-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27076-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27077-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27077-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27078-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27078-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27079-swift-clangmoduleunit-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27079-swift-clangmoduleunit-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27080-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27080-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27081-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27081-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27082-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27082-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27083-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/27083-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27084-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27084-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27085-swift-protocoldecl-existentialconformstoselfslow.swift
+++ b/validation-test/compiler_crashers_fixed/27085-swift-protocoldecl-existentialconformstoselfslow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27086-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/27086-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27087-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27087-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27088-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27088-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27089-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27089-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27090-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27090-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27091-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27091-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27092-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/27092-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27093-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/27093-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27094-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/27094-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27095-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27095-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27096-void.swift
+++ b/validation-test/compiler_crashers_fixed/27096-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27097-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/27097-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27098-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27098-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27099-swift-decl-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27099-swift-decl-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27100-swift-genericsignature-getcanonical.swift
+++ b/validation-test/compiler_crashers_fixed/27100-swift-genericsignature-getcanonical.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27101-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/27101-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27102-void.swift
+++ b/validation-test/compiler_crashers_fixed/27102-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27103-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/27103-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27104-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27104-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27105-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/27105-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27106-llvm-foldingset-swift-structtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27106-llvm-foldingset-swift-structtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27107-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/27107-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27108-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27108-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27109-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27109-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27110-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27110-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27111-swift-valuedecl-getoverloadsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27111-swift-valuedecl-getoverloadsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27112-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27112-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27113-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27113-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27114-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/27114-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27115-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27115-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27116-swift-constraints-constraintgraph-unbindtypevariable.swift
+++ b/validation-test/compiler_crashers_fixed/27116-swift-constraints-constraintgraph-unbindtypevariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27117-swift-clangimporter-implementation-importdeclimpl.swift
+++ b/validation-test/compiler_crashers_fixed/27117-swift-clangimporter-implementation-importdeclimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27118-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27118-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27119-void.swift
+++ b/validation-test/compiler_crashers_fixed/27119-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27120-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27120-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27121-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27121-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27122-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/27122-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27123-swift-valuedecl-getoverloadsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27123-swift-valuedecl-getoverloadsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27124-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27124-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27125-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/27125-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27126-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/27126-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27127-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/27127-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27128-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27128-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27129-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27129-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27130-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/27130-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27131-isvalidoverload.swift
+++ b/validation-test/compiler_crashers_fixed/27131-isvalidoverload.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27132-swift-availabilityinference-applyinferredavailableattrs.swift
+++ b/validation-test/compiler_crashers_fixed/27132-swift-availabilityinference-applyinferredavailableattrs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27133-swift-genericparamlist-getasgenericsignatureelements.swift
+++ b/validation-test/compiler_crashers_fixed/27133-swift-genericparamlist-getasgenericsignatureelements.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27134-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27134-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27135-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27135-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27136-swift-constructordecl-setbodyparams.swift
+++ b/validation-test/compiler_crashers_fixed/27136-swift-constructordecl-setbodyparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27137-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/27137-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27138-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27138-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27139-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27139-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27140-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27140-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27141-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27141-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27142-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27142-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27143-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27143-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27144-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/27144-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27145-swift-archetypebuilder-addgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27145-swift-archetypebuilder-addgenericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27146-llvm-foldingset-swift-structtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27146-llvm-foldingset-swift-structtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27147-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27147-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27148-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27148-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27149-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/27149-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27150-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/27150-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27151-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27151-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27152-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/27152-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27153-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27153-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27154-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/27154-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27155-swift-attributebase-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27155-swift-attributebase-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27156-swift-typechecker-applygenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/27156-swift-typechecker-applygenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27157-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27157-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27158-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27158-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27159-swift-protocoldecl-existentialconformstoselfslow.swift
+++ b/validation-test/compiler_crashers_fixed/27159-swift-protocoldecl-existentialconformstoselfslow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27160-swift-classtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27160-swift-classtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27161-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27161-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27162-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27162-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27163-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27163-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27164-swift-parser-parsetypeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27164-swift-parser-parsetypeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27165-swift-typechecker-checkunsupportedprotocoltype.swift
+++ b/validation-test/compiler_crashers_fixed/27165-swift-typechecker-checkunsupportedprotocoltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27166-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/27166-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27167-swift-valuedecl-overwritetype.swift
+++ b/validation-test/compiler_crashers_fixed/27167-swift-valuedecl-overwritetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27168-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/27168-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27169-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27169-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27170-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27170-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27171-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/27171-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27172-swift-typebase-isemptyexistentialcomposition.swift
+++ b/validation-test/compiler_crashers_fixed/27172-swift-typebase-isemptyexistentialcomposition.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27173-swift-namelookup-findlocalval-visitbracestmt.swift
+++ b/validation-test/compiler_crashers_fixed/27173-swift-namelookup-findlocalval-visitbracestmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27174-swift-valuedecl-getoverloadsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27174-swift-valuedecl-getoverloadsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27175-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27175-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27176-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/27176-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27177-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27177-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27178-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27178-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27179-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27179-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27180-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27180-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27181-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27181-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27182-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/27182-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27183-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27183-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27184-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/27184-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27185-swift-astcontext-getbridgedtoobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27185-swift-astcontext-getbridgedtoobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27186-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27186-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27187-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27187-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27188-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27188-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27189-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/27189-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27190-swift-typechecker-checkunsupportedprotocoltype.swift
+++ b/validation-test/compiler_crashers_fixed/27190-swift-typechecker-checkunsupportedprotocoltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27191-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27191-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27192-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27192-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27193-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/27193-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27194-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/27194-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27195-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27195-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27196-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/27196-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27197-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27197-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27198-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27198-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27199-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27199-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27200-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27200-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27201-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27201-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27202-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/27202-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27203-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/27203-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27204-swift-expr-getloc.swift
+++ b/validation-test/compiler_crashers_fixed/27204-swift-expr-getloc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27205-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27205-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27206-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27206-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27207-swift-stmt-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27207-swift-stmt-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27208-swift-archetypebuilder-potentialarchetype-isbetterarchetypeanchor.swift
+++ b/validation-test/compiler_crashers_fixed/27208-swift-archetypebuilder-potentialarchetype-isbetterarchetypeanchor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27209-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27209-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27210-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27210-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27211-llvm-foldingsetnodeid-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27211-llvm-foldingsetnodeid-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27212-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/27212-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27213-llvm-foldingset-swift-structtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27213-llvm-foldingset-swift-structtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27214-checkenumrawvalues.swift
+++ b/validation-test/compiler_crashers_fixed/27214-checkenumrawvalues.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27215-llvm-smallvectorimpl-swift-protocolconformance-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27215-llvm-smallvectorimpl-swift-protocolconformance-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27216-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27216-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27217-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27217-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27218-swift-vardecl-getparentpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27218-swift-vardecl-getparentpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27219-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27219-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27220-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/27220-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27221-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/compiler_crashers_fixed/27221-swift-typechecker-lookupunqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27222-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/27222-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27223-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/27223-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27224-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/27224-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27225-swift-polymorphicfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27225-swift-polymorphicfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27226-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/27226-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27227-swift-constraints-constraintsystem-lookthroughimplicitlyunwrappedoptionaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27227-swift-constraints-constraintsystem-lookthroughimplicitlyunwrappedoptionaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27228-swift-conformancelookuptable-addprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/27228-swift-conformancelookuptable-addprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27229-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/27229-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27230-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/27230-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27231-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27231-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27232-swift-funcdecl-isunaryoperator.swift
+++ b/validation-test/compiler_crashers_fixed/27232-swift-funcdecl-isunaryoperator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27233-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27233-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27234-swift-protocoldecl-existentialtypesupportedslow.swift
+++ b/validation-test/compiler_crashers_fixed/27234-swift-protocoldecl-existentialtypesupportedslow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27235-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/27235-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27236-swift-typechecker-typecheckbinding.swift
+++ b/validation-test/compiler_crashers_fixed/27236-swift-typechecker-typecheckbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27237-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27237-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27238-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27238-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27239-swift-typechecker-definedefaultconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/27239-swift-typechecker-definedefaultconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27240-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/27240-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27241-swift-constraints-constraintsystem-recordopenedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/27241-swift-constraints-constraintsystem-recordopenedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27242-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27242-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27243-swift-typebase-gettypevariables.swift
+++ b/validation-test/compiler_crashers_fixed/27243-swift-typebase-gettypevariables.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27244-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27244-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27245-swift-archetypebuilder-addconformancerequirement.swift
+++ b/validation-test/compiler_crashers_fixed/27245-swift-archetypebuilder-addconformancerequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27246-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/27246-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27247-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27247-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27248-swift-conformancelookuptable-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27248-swift-conformancelookuptable-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27249-std-function-func.swift
+++ b/validation-test/compiler_crashers_fixed/27249-std-function-func.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27250-swift-nominaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27250-swift-nominaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27251-swift-nominaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27251-swift-nominaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27252-swift-moduledecl-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27252-swift-moduledecl-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27253-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/27253-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27254-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27254-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27255-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/27255-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27256-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/27256-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27257-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27257-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27258-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27258-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27259-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27259-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27260-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/27260-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27261-swift-modulefile-getcommentfordecl.swift
+++ b/validation-test/compiler_crashers_fixed/27261-swift-modulefile-getcommentfordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27262-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/27262-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27263-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/27263-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27264-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/27264-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27265-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/27265-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27266-swift-constraints-constraintsystem-solverec.swift
+++ b/validation-test/compiler_crashers_fixed/27266-swift-constraints-constraintsystem-solverec.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27267-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/27267-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27268-swift-astcontext-getsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/27268-swift-astcontext-getsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27269-void.swift
+++ b/validation-test/compiler_crashers_fixed/27269-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27270-swift-astcontext-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27270-swift-astcontext-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27271-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27271-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27272-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27272-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27273-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/27273-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27274-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27274-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27275-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27275-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27276-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27276-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27277-swift-stmt-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27277-swift-stmt-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27278-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/27278-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27279-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27279-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27280-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27280-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27281-swift-constraints-simplifylocator.swift
+++ b/validation-test/compiler_crashers_fixed/27281-swift-constraints-simplifylocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27282-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27282-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27283-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27283-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27284-swift-associatedtypedecl-associatedtypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27284-swift-associatedtypedecl-associatedtypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27285-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27285-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27286-swift-extensiondecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27286-swift-extensiondecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27287-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27287-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27288-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27288-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27289-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27289-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27290-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27290-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27291-swift-modulefile-getdeclcontext.swift
+++ b/validation-test/compiler_crashers_fixed/27291-swift-modulefile-getdeclcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27292-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27292-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27293-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27293-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27294-swift-existentialmetatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27294-swift-existentialmetatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27295-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27295-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27296-swift-astcontext-getstringdecl.swift
+++ b/validation-test/compiler_crashers_fixed/27296-swift-astcontext-getstringdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27297-llvm-bitstreamcursor-readrecord.swift
+++ b/validation-test/compiler_crashers_fixed/27297-llvm-bitstreamcursor-readrecord.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27298-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27298-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27299-swift-enumtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27299-swift-enumtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27300-swift-unboundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27300-swift-unboundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27301-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27301-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27302-swift-conformancelookuptable-conformancelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27302-swift-conformancelookuptable-conformancelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27303-swift-typechecker-substituteinputsugartypeforresult.swift
+++ b/validation-test/compiler_crashers_fixed/27303-swift-typechecker-substituteinputsugartypeforresult.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27304-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27304-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27305-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27305-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27306-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27306-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27307-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27307-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27308-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27308-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27309-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/27309-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27310-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27310-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27311-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/27311-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27312-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27312-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27313-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27313-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27314-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27314-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27315-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27315-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27316-swift-constraints-constraintsystem-solverscope-solverscope.swift
+++ b/validation-test/compiler_crashers_fixed/27316-swift-constraints-constraintsystem-solverscope-solverscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27317-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27317-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27318-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27318-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27319-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27319-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27320-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27320-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27321-swift-createimplicitconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/27321-swift-createimplicitconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27322-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27322-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27323-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27323-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27324-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/27324-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27325-swift-maybeaddaccessorstovariable.swift
+++ b/validation-test/compiler_crashers_fixed/27325-swift-maybeaddaccessorstovariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27326-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27326-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27327-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27327-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27328-swift-moduledecl-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27328-swift-moduledecl-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27329-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27329-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27330-swift-conformancelookuptable-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27330-swift-conformancelookuptable-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27331-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27331-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27332-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27332-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27333-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/27333-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27334-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
+++ b/validation-test/compiler_crashers_fixed/27334-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27335-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/27335-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27336-swift-existentialmetatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27336-swift-existentialmetatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27337-swift-valuedecl-overwritetype.swift
+++ b/validation-test/compiler_crashers_fixed/27337-swift-valuedecl-overwritetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27338-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27338-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27339-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27339-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27340-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27340-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27341-swift-conformancelookuptable-getallprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27341-swift-conformancelookuptable-getallprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27342-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/27342-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27343-llvm-smallvectorimpl-swift-protocolconformance-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27343-llvm-smallvectorimpl-swift-protocolconformance-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27344-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27344-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27345-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27345-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27346-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27346-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27347-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27347-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27348-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/27348-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27349-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/27349-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27350-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27350-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27351-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27351-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27352-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/27352-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27353-void.swift
+++ b/validation-test/compiler_crashers_fixed/27353-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27354-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/27354-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27355-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27355-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27356-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27356-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27357-swift-constraints-constraintsystem-lookupmember.swift
+++ b/validation-test/compiler_crashers_fixed/27357-swift-constraints-constraintsystem-lookupmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27358-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27358-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27359-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/27359-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27360-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27360-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27361-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27361-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27362-swift-stmt-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27362-swift-stmt-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27363-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27363-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27364-swift-typechecker-conformstoprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/27364-swift-typechecker-conformstoprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27365-swift-modulefile-getcommentfordecl.swift
+++ b/validation-test/compiler_crashers_fixed/27365-swift-modulefile-getcommentfordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27366-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27366-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27367-swift-boundgenerictype-getsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/27367-swift-boundgenerictype-getsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27368-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27368-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27369-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27369-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27370-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/27370-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27371-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27371-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27372-void.swift
+++ b/validation-test/compiler_crashers_fixed/27372-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27373-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27373-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27374-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27374-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27375-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27375-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27376-swift-abstractstoragedecl-getobjcgetterselector.swift
+++ b/validation-test/compiler_crashers_fixed/27376-swift-abstractstoragedecl-getobjcgetterselector.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27377-swift-typechecker-isdeclavailable.swift
+++ b/validation-test/compiler_crashers_fixed/27377-swift-typechecker-isdeclavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27378-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27378-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27379-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers_fixed/27379-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27380-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27380-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27381-std-function-func-mapsignaturetype.swift
+++ b/validation-test/compiler_crashers_fixed/27381-std-function-func-mapsignaturetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27382-void.swift
+++ b/validation-test/compiler_crashers_fixed/27382-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27383-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/27383-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27385-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/27385-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27386-swift-cantype-isobjcexistentialtypeimpl.swift
+++ b/validation-test/compiler_crashers_fixed/27386-swift-cantype-isobjcexistentialtypeimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27387-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27387-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27388-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27388-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27389-swift-typeexpr-typeexpr.swift
+++ b/validation-test/compiler_crashers_fixed/27389-swift-typeexpr-typeexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27390-swift-typechecker-computeaccessibility.swift
+++ b/validation-test/compiler_crashers_fixed/27390-swift-typechecker-computeaccessibility.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27391-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/27391-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27392-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/27392-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27393-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27393-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27394-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/27394-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27395-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27395-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27396-swift-typebase-getimplicitlyunwrappedoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/27396-swift-typebase-getimplicitlyunwrappedoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27397-swift-patternbindingdecl-setpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27397-swift-patternbindingdecl-setpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27398-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27398-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27399-swift-constraints-constraintsystem-getfixedtyperecursive.swift
+++ b/validation-test/compiler_crashers_fixed/27399-swift-constraints-constraintsystem-getfixedtyperecursive.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27400-swift-protocolconformance-getinheritedconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27400-swift-protocolconformance-getinheritedconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27401-void.swift
+++ b/validation-test/compiler_crashers_fixed/27401-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27402-std-function-func-checkaccessibility.swift
+++ b/validation-test/compiler_crashers_fixed/27402-std-function-func-checkaccessibility.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27403-swift-typechecker-resolveinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/27403-swift-typechecker-resolveinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27404-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/27404-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27405-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27405-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27406-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27406-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27407-swift-constraints-simplifylocator.swift
+++ b/validation-test/compiler_crashers_fixed/27407-swift-constraints-simplifylocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27408-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/27408-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27409-llvm-foldingset-swift-enumtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27409-llvm-foldingset-swift-enumtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27410-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/27410-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27411-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27411-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27412-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27412-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27413-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/27413-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27414-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/27414-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27415-swift-namelookup-lookupinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/27415-swift-namelookup-lookupinmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27416-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27416-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27417-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27417-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27418-swift-typechecker-lookupmember.swift
+++ b/validation-test/compiler_crashers_fixed/27418-swift-typechecker-lookupmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27419-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27419-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27420-llvm-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27420-llvm-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27421-formatdiagnostictext.swift
+++ b/validation-test/compiler_crashers_fixed/27421-formatdiagnostictext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27422-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/27422-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27423-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/27423-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27424-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27424-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27425-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27425-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27426-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27426-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27427-swift-protocolcompositiontyperepr-create.swift
+++ b/validation-test/compiler_crashers_fixed/27427-swift-protocolcompositiontyperepr-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27428-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27428-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27429-swift-typechecker-typecheckexpressionshallow.swift
+++ b/validation-test/compiler_crashers_fixed/27429-swift-typechecker-typecheckexpressionshallow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27430-swift-boundgenerictype-getsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/27430-swift-boundgenerictype-getsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27431-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/27431-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27432-swift-typechecker-validatetype.swift
+++ b/validation-test/compiler_crashers_fixed/27432-swift-typechecker-validatetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27433-std-function-func-swift-parser-parsenominaldeclmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27433-std-function-func-swift-parser-parsenominaldeclmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27434-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/27434-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27435-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/27435-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27436-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27436-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27437-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27437-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27438-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/27438-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27439-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27439-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27440-void.swift
+++ b/validation-test/compiler_crashers_fixed/27440-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27441-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27441-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27442-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/27442-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27443-matchwitness.swift
+++ b/validation-test/compiler_crashers_fixed/27443-matchwitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27444-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/27444-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27445-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27445-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27446-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27446-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27447-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27447-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27448-swift-nominaltypedecl-computeinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/27448-swift-nominaltypedecl-computeinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27449-swift-constraints-constraintsystem-solverec.swift
+++ b/validation-test/compiler_crashers_fixed/27449-swift-constraints-constraintsystem-solverec.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27450-bool.swift
+++ b/validation-test/compiler_crashers_fixed/27450-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27451-swift-parser-parsedeclstruct.swift
+++ b/validation-test/compiler_crashers_fixed/27451-swift-parser-parsedeclstruct.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27452-swift-nominaltypedecl-computetype.swift
+++ b/validation-test/compiler_crashers_fixed/27452-swift-nominaltypedecl-computetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27453-diagnoseredundantaccessors.swift
+++ b/validation-test/compiler_crashers_fixed/27453-diagnoseredundantaccessors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27454-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/27454-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27455-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27455-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27456-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27456-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27457-llvm-tinyptrvector-swift-valuedecl-push-back.swift
+++ b/validation-test/compiler_crashers_fixed/27457-llvm-tinyptrvector-swift-valuedecl-push-back.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27458-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/27458-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27459-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/27459-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27460-swift-protocoltype-compareprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27460-swift-protocoltype-compareprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27461-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27461-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27462-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27462-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27463-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/27463-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27464-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/27464-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27465-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/27465-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27466-swift-lexer-lexidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27466-swift-lexer-lexidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27467-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27467-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27468-swift-funcdecl-isunaryoperator.swift
+++ b/validation-test/compiler_crashers_fixed/27468-swift-funcdecl-isunaryoperator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27469-swift-patternbindingdecl-create.swift
+++ b/validation-test/compiler_crashers_fixed/27469-swift-patternbindingdecl-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27470-swift-constraints-constraintsystem-solverec.swift
+++ b/validation-test/compiler_crashers_fixed/27470-swift-constraints-constraintsystem-solverec.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27471-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27471-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27472-swift-decl-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27472-swift-decl-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27473-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27473-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27474-swift-typechecker-checkdeclarationavailability.swift
+++ b/validation-test/compiler_crashers_fixed/27474-swift-typechecker-checkdeclarationavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27475-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27475-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27476-swift-modulefile-maybereadforeignerrorconvention.swift
+++ b/validation-test/compiler_crashers_fixed/27476-swift-modulefile-maybereadforeignerrorconvention.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27477-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
+++ b/validation-test/compiler_crashers_fixed/27477-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27478-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/27478-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27479-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27479-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27480-void.swift
+++ b/validation-test/compiler_crashers_fixed/27480-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27481-swift-conformancelookuptable-resolveconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27481-swift-conformancelookuptable-resolveconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27482-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/27482-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27483-swift-namelookup-findlocalval-visitbracestmt.swift
+++ b/validation-test/compiler_crashers_fixed/27483-swift-namelookup-findlocalval-visitbracestmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27484-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/27484-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift
+++ b/validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27486-swift-constraints-constraintsystem-findbestsolution.swift
+++ b/validation-test/compiler_crashers_fixed/27486-swift-constraints-constraintsystem-findbestsolution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27487-swift-sourcemanager-addnewsourcebuffer.swift
+++ b/validation-test/compiler_crashers_fixed/27487-swift-sourcemanager-addnewsourcebuffer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27488-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27488-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27489-swift-typechecker-checkgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/27489-swift-typechecker-checkgenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27490-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27490-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27491-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/27491-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27492-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27492-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27493-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/27493-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27494-swift-conformancelookuptable-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27494-swift-conformancelookuptable-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27495-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/27495-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27496-swift-modulefile-declcommenttableinfo-readdata.swift
+++ b/validation-test/compiler_crashers_fixed/27496-swift-modulefile-declcommenttableinfo-readdata.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27497-swift-decl-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27497-swift-decl-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27498-swift-typechecker-typecheckpatternbinding.swift
+++ b/validation-test/compiler_crashers_fixed/27498-swift-typechecker-typecheckpatternbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27499-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/27499-llvm-bitstreamcursor-read.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27500-swift-constructordecl-constructordecl.swift
+++ b/validation-test/compiler_crashers_fixed/27500-swift-constructordecl-constructordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27501-swift-namelookup-lookupinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/27501-swift-namelookup-lookupinmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27502-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/27502-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27503-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27503-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27504-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/27504-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27505-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27505-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27506-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27506-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27507-swift-modulefile-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27507-swift-modulefile-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27508-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/27508-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27509-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27509-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27510-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27510-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27511-swift-constraints-constraintsystem-performmemberlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27511-swift-constraints-constraintsystem-performmemberlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27512-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27512-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27513-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/27513-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27514-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/27514-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27515-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/27515-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27516-swift-nominaltypedecl-classifyasoptionaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27516-swift-nominaltypedecl-classifyasoptionaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27517-swift-valuedecl-overwritetype.swift
+++ b/validation-test/compiler_crashers_fixed/27517-swift-valuedecl-overwritetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27518-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27518-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27519-swift-pattern-buildforwardingrefexpr.swift
+++ b/validation-test/compiler_crashers_fixed/27519-swift-pattern-buildforwardingrefexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27520-swift-typechecker-substituteinputsugartypeforresult.swift
+++ b/validation-test/compiler_crashers_fixed/27520-swift-typechecker-substituteinputsugartypeforresult.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27521-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/27521-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27522-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27522-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27523-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/27523-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27524-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27524-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27525-swift-constraints-constraintsystem-matchtupletypes.swift
+++ b/validation-test/compiler_crashers_fixed/27525-swift-constraints-constraintsystem-matchtupletypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27526-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27526-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27527-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27527-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27528-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/27528-swift-constraints-constraintsystem-solve.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27529-swift-typechecker-gettypeofrvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27529-swift-typechecker-gettypeofrvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27530-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/27530-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27531-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/27531-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27532-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/compiler_crashers_fixed/27532-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27533-swift-ide-printdeclusr.swift
+++ b/validation-test/compiler_crashers_fixed/27533-swift-ide-printdeclusr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27534-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27534-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27535-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27535-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27536-swift-namelookup-findlocalval-visitbracestmt.swift
+++ b/validation-test/compiler_crashers_fixed/27536-swift-namelookup-findlocalval-visitbracestmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27537-swift-clangimporter-implementation-finishpendingactions.swift
+++ b/validation-test/compiler_crashers_fixed/27537-swift-clangimporter-implementation-finishpendingactions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27538-swift-typebase-getanyoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/27538-swift-typebase-getanyoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27539-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/27539-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27540-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27540-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27541-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/27541-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27542-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27542-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27543-swift-typechecker-checkgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/27543-swift-typechecker-checkgenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27544-bool.swift
+++ b/validation-test/compiler_crashers_fixed/27544-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27545-swift-nominaltypedecl-classifyasoptionaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27545-swift-nominaltypedecl-classifyasoptionaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27546-swift-clangimporter-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27546-swift-clangimporter-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27547-swift-constraints-constraintsystem-getalternativeliteraltypes.swift
+++ b/validation-test/compiler_crashers_fixed/27547-swift-constraints-constraintsystem-getalternativeliteraltypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27548-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/27548-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27549-swift-namelookup-findlocalval-visitbracestmt.swift
+++ b/validation-test/compiler_crashers_fixed/27549-swift-namelookup-findlocalval-visitbracestmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27550-swift-moduledecl-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27550-swift-moduledecl-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27551-swift-protocoldecl-existentialtypesupportedslow.swift
+++ b/validation-test/compiler_crashers_fixed/27551-swift-protocoldecl-existentialtypesupportedslow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27552-swift-constraints-constraintsystem-solverstate-solverstate.swift
+++ b/validation-test/compiler_crashers_fixed/27552-swift-constraints-constraintsystem-solverstate-solverstate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27553-swift-conformancelookuptable-getconformingcontext.swift
+++ b/validation-test/compiler_crashers_fixed/27553-swift-conformancelookuptable-getconformingcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27554-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27554-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27555-swift-constraints-constraintgraph-lookupnode.swift
+++ b/validation-test/compiler_crashers_fixed/27555-swift-constraints-constraintgraph-lookupnode.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27556-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27556-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27557-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27557-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27558-swift-parser-parsetypeidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27558-swift-parser-parsetypeidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27559-swift-modulefile-maybereadforeignerrorconvention.swift
+++ b/validation-test/compiler_crashers_fixed/27559-swift-modulefile-maybereadforeignerrorconvention.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27560-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/27560-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27561-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27561-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27562-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/27562-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27563-swift-funcdecl-isunaryoperator.swift
+++ b/validation-test/compiler_crashers_fixed/27563-swift-funcdecl-isunaryoperator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27564-swift-constraints-constraintsystem-matchfunctiontypes.swift
+++ b/validation-test/compiler_crashers_fixed/27564-swift-constraints-constraintsystem-matchfunctiontypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27565-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/27565-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27566-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/27566-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27567-swift-constraints-constraintsystem-addoverloadset.swift
+++ b/validation-test/compiler_crashers_fixed/27567-swift-constraints-constraintsystem-addoverloadset.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27568-swift-polymorphicfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27568-swift-polymorphicfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27569-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27569-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27570-checkenumrawvalues.swift
+++ b/validation-test/compiler_crashers_fixed/27570-checkenumrawvalues.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27571-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27571-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27572-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27572-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27573-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27573-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27574-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27574-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27575-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27575-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27576-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27576-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27577-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27577-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27578-void.swift
+++ b/validation-test/compiler_crashers_fixed/27578-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27579-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27579-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27580-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/27580-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27581-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/27581-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27582-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/27582-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27583-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27583-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27584-swift-typechecker-isdeclavailable.swift
+++ b/validation-test/compiler_crashers_fixed/27584-swift-typechecker-isdeclavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27585-swift-astcontext-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27585-swift-astcontext-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27586-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/27586-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27587-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27587-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27588-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27588-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27589-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27589-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27590-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27590-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27591-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27591-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27592-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27592-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27593-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27593-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27594-swift-getbuiltinvaluedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27594-swift-getbuiltinvaluedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27595-swift-parser-parsedeclvar.swift
+++ b/validation-test/compiler_crashers_fixed/27595-swift-parser-parsedeclvar.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27596-llvm-foldingset-swift-enumtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27596-llvm-foldingset-swift-enumtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27597-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27597-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27598-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/27598-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27599-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27599-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27600-swift-constraints-constraintsystem-recordopenedtypes.swift
+++ b/validation-test/compiler_crashers_fixed/27600-swift-constraints-constraintsystem-recordopenedtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27601-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27601-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27602-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27602-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27603-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27603-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27604-swift-valuedecl-getoverloadsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27604-swift-valuedecl-getoverloadsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27605-swift-parser-parsedeclprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/27605-swift-parser-parsedeclprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27606-swift-astcontext-addedexternaldecl.swift
+++ b/validation-test/compiler_crashers_fixed/27606-swift-astcontext-addedexternaldecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27607-swift-constraints-constraintsystem-matchfunctiontypes.swift
+++ b/validation-test/compiler_crashers_fixed/27607-swift-constraints-constraintsystem-matchfunctiontypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27608-llvm-errs.swift
+++ b/validation-test/compiler_crashers_fixed/27608-llvm-errs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27609-std-function-func-checkaccessibility.swift
+++ b/validation-test/compiler_crashers_fixed/27609-std-function-func-checkaccessibility.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27610-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27610-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27611-swift-parser-parsegetsetimpl.swift
+++ b/validation-test/compiler_crashers_fixed/27611-swift-parser-parsegetsetimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27612-swift-typechecker-checkunsupportedprotocoltype.swift
+++ b/validation-test/compiler_crashers_fixed/27612-swift-typechecker-checkunsupportedprotocoltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27613-swift-patternbindingdecl-hasstorage.swift
+++ b/validation-test/compiler_crashers_fixed/27613-swift-patternbindingdecl-hasstorage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27614-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27614-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27615-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27615-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27616-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27616-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27617-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27617-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27618-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/27618-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27619-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/27619-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27620-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27620-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27621-swift-getbuiltinvaluedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27621-swift-getbuiltinvaluedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27622-swift-typebase-isemptyexistentialcomposition.swift
+++ b/validation-test/compiler_crashers_fixed/27622-swift-typebase-isemptyexistentialcomposition.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27623-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27623-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27624-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/27624-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27625-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27625-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27626-llvm-smdiagnostic-smdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27626-llvm-smdiagnostic-smdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27627-swift-typechecker-checkdeclarationavailability.swift
+++ b/validation-test/compiler_crashers_fixed/27627-swift-typechecker-checkdeclarationavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27628-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27628-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27629-swift-associatedtypedecl-associatedtypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27629-swift-associatedtypedecl-associatedtypedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27630-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/27630-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27631-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27631-swift-nominaltypedecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27632-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/27632-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27633-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27633-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27634-swift-lexer-kindofidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27634-swift-lexer-kindofidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27635-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27635-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27636-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27636-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27637-swift-typechecker-checkunsupportedprotocoltype.swift
+++ b/validation-test/compiler_crashers_fixed/27637-swift-typechecker-checkunsupportedprotocoltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27638-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27638-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27639-swift-enumtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27639-swift-enumtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27640-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27640-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27641-swift-parser-parseexprpostfix.swift
+++ b/validation-test/compiler_crashers_fixed/27641-swift-parser-parseexprpostfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27642-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27642-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27643-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/27643-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27644-llvm-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27644-llvm-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27645-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/compiler_crashers_fixed/27645-swift-typechecker-lookupunqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27646-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27646-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27647-swift-tuplepattern-createsimple.swift
+++ b/validation-test/compiler_crashers_fixed/27647-swift-tuplepattern-createsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27648-llvm-smallvectorimpl-swift-decl-insert.swift
+++ b/validation-test/compiler_crashers_fixed/27648-llvm-smallvectorimpl-swift-decl-insert.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27649-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/27649-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27650-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27650-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27651-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27651-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27652-swift-typechecker-checkdeclattributes.swift
+++ b/validation-test/compiler_crashers_fixed/27652-swift-typechecker-checkdeclattributes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27653-swift-archetypebuilder-getallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27653-swift-archetypebuilder-getallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27654-swift-streamprinter-printtext.swift
+++ b/validation-test/compiler_crashers_fixed/27654-swift-streamprinter-printtext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27655-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/27655-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27656-swift-abstractfunctiondecl-getobjcselector.swift
+++ b/validation-test/compiler_crashers_fixed/27656-swift-abstractfunctiondecl-getobjcselector.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27657-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27657-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27658-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27658-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27659-swift-parser-parsedeclclass.swift
+++ b/validation-test/compiler_crashers_fixed/27659-swift-parser-parsedeclclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27660-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/27660-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27661-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27661-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27662-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/27662-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27663-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27663-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27664-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27664-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27665-swift-conformancelookuptable-getallprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27665-swift-conformancelookuptable-getallprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27666-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27666-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27667-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/27667-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27668-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27668-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27669-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/27669-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27670-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27670-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27671-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27671-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27672-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27672-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27673-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27673-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27674-swift-extensiondecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27674-swift-extensiondecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27675-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27675-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27676-swift-moduledecl-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27676-swift-moduledecl-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27677-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27677-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27678-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27678-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27679-swift-constraints-constraintsystem-solverstate-solverstate.swift
+++ b/validation-test/compiler_crashers_fixed/27679-swift-constraints-constraintsystem-solverstate-solverstate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27680-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27680-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27681-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/27681-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27682-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/27682-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27683-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/27683-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27684-swift-constraints-constraintsystem-getalternativeliteraltypes.swift
+++ b/validation-test/compiler_crashers_fixed/27684-swift-constraints-constraintsystem-getalternativeliteraltypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27685-swift-pattern-foreachvariable.swift
+++ b/validation-test/compiler_crashers_fixed/27685-swift-pattern-foreachvariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27686-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27686-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27687-swift-classtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27687-swift-classtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27688-swift-vardecl-isanonclosureparam.swift
+++ b/validation-test/compiler_crashers_fixed/27688-swift-vardecl-isanonclosureparam.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27689-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/27689-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27690-swift-typechecker-substituteinputsugartypeforresult.swift
+++ b/validation-test/compiler_crashers_fixed/27690-swift-typechecker-substituteinputsugartypeforresult.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27691-void.swift
+++ b/validation-test/compiler_crashers_fixed/27691-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27692-swift-constraints-simplifylocator.swift
+++ b/validation-test/compiler_crashers_fixed/27692-swift-constraints-simplifylocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27693-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/compiler_crashers_fixed/27693-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27694-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27694-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27695-swift-constraints-constraintsystem-performmemberlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27695-swift-constraints-constraintsystem-performmemberlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27696-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/27696-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27697-std-function-func-setboundvarstypeerror.swift
+++ b/validation-test/compiler_crashers_fixed/27697-std-function-func-setboundvarstypeerror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27698-swift-parser-parseexprimpl.swift
+++ b/validation-test/compiler_crashers_fixed/27698-swift-parser-parseexprimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27699-swift-typebase-isemptyexistentialcomposition.swift
+++ b/validation-test/compiler_crashers_fixed/27699-swift-typebase-isemptyexistentialcomposition.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27700-swift-modulefile-loadallmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27700-swift-modulefile-loadallmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27701-swift-getllvmintrinsicid.swift
+++ b/validation-test/compiler_crashers_fixed/27701-swift-getllvmintrinsicid.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27702-swift-conformancelookuptable-resolveconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27702-swift-conformancelookuptable-resolveconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27703-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/27703-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27704-swift-modulefile-declcommenttableinfo-readdata.swift
+++ b/validation-test/compiler_crashers_fixed/27704-swift-modulefile-declcommenttableinfo-readdata.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27705-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/27705-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27706-swift-availabilityinference-applyinferredavailableattrs.swift
+++ b/validation-test/compiler_crashers_fixed/27706-swift-availabilityinference-applyinferredavailableattrs.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27707-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27707-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27708-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/27708-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27709-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/27709-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27710-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/27710-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27711-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27711-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27712-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/27712-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27713-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/27713-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27714-llvm-optional-swift-diagnostic-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27714-llvm-optional-swift-diagnostic-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27715-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/27715-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27716-swift-lexer-getlocforendoftoken.swift
+++ b/validation-test/compiler_crashers_fixed/27716-swift-lexer-getlocforendoftoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27717-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/27717-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27718-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/27718-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27719-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27719-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27720-swift-valuedecl-overwritetype.swift
+++ b/validation-test/compiler_crashers_fixed/27720-swift-valuedecl-overwritetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27721-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27721-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27722-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/27722-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27723-swift-constraints-constraint-createbindoverload.swift
+++ b/validation-test/compiler_crashers_fixed/27723-swift-constraints-constraint-createbindoverload.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27724-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/27724-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27725-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27725-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27726-swift-modulefile-declcommenttableinfo-readdata.swift
+++ b/validation-test/compiler_crashers_fixed/27726-swift-modulefile-declcommenttableinfo-readdata.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27727-swift-abstractclosureexpr-setparams.swift
+++ b/validation-test/compiler_crashers_fixed/27727-swift-abstractclosureexpr-setparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27728-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27728-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27729-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/27729-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27730-swift-modulefile-resolvecrossreference.swift
+++ b/validation-test/compiler_crashers_fixed/27730-swift-modulefile-resolvecrossreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27731-swift-removeshadoweddecls.swift
+++ b/validation-test/compiler_crashers_fixed/27731-swift-removeshadoweddecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27732-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/27732-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27733-swift-constraints-constraintsystem-constraintsystem.swift
+++ b/validation-test/compiler_crashers_fixed/27733-swift-constraints-constraintsystem-constraintsystem.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27734-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/27734-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27735-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27735-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27736-void.swift
+++ b/validation-test/compiler_crashers_fixed/27736-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27737-swift-parentype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27737-swift-parentype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27738-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27738-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27739-swift-conformancelookuptable-resolveconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27739-swift-conformancelookuptable-resolveconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27740-swift-modulefile-getdeclcontext.swift
+++ b/validation-test/compiler_crashers_fixed/27740-swift-modulefile-getdeclcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27741-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27741-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27742-matchwitness.swift
+++ b/validation-test/compiler_crashers_fixed/27742-matchwitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27743-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/27743-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27744-swift-astprinter-printtextimpl.swift
+++ b/validation-test/compiler_crashers_fixed/27744-swift-astprinter-printtextimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27745-swift-modulefile-getdecl.swift
+++ b/validation-test/compiler_crashers_fixed/27745-swift-modulefile-getdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27746-void.swift
+++ b/validation-test/compiler_crashers_fixed/27746-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27747-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27747-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27748-swift-conformancelookuptable-getimplicitprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27748-swift-conformancelookuptable-getimplicitprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27749-swift-archetypetype-getnew.swift
+++ b/validation-test/compiler_crashers_fixed/27749-swift-archetypetype-getnew.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27750-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27750-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27751-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27751-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27752-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/27752-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27753-std-function-func-setboundvarstypeerror.swift
+++ b/validation-test/compiler_crashers_fixed/27753-std-function-func-setboundvarstypeerror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27754-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27754-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27755-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27755-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27756-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27756-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27757-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/27757-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27758-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/27758-std-function-func-swift-type-subst.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27759-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/27759-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27760-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27760-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27761-swift-archetypebuilder-addgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27761-swift-archetypebuilder-addgenericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27762-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27762-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27763-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/27763-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27764-swift-constraints-simplifylocator.swift
+++ b/validation-test/compiler_crashers_fixed/27764-swift-constraints-simplifylocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27765-swift-typechecker-typecheckpatternbinding.swift
+++ b/validation-test/compiler_crashers_fixed/27765-swift-typechecker-typecheckpatternbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27766-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/27766-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27767-swift-constructordecl-constructordecl.swift
+++ b/validation-test/compiler_crashers_fixed/27767-swift-constructordecl-constructordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27768-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/compiler_crashers_fixed/27768-swift-typechecker-lookupunqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27769-swift-patternbindingdecl-create.swift
+++ b/validation-test/compiler_crashers_fixed/27769-swift-patternbindingdecl-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27770-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27770-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27771-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/27771-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27772-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27772-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27773-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27773-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27774-filtervalues.swift
+++ b/validation-test/compiler_crashers_fixed/27774-filtervalues.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27775-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27775-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27776-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27776-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27777-swift-clangimporter-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27777-swift-clangimporter-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27778-swift-astcontext-getbridgedtoobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27778-swift-astcontext-getbridgedtoobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27779-swift-abstractstoragedecl-getobjcgetterselector.swift
+++ b/validation-test/compiler_crashers_fixed/27779-swift-abstractstoragedecl-getobjcgetterselector.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27780-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27780-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27781-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27781-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27782-swift-genericsignature-profile.swift
+++ b/validation-test/compiler_crashers_fixed/27782-swift-genericsignature-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27783-swift-genericparamlist-deriveallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/27783-swift-genericparamlist-deriveallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27784-swift-printingdiagnosticconsumer-handlediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27784-swift-printingdiagnosticconsumer-handlediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27785-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27785-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27786-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27786-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27787-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/27787-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27788-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/27788-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27789-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/27789-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27790-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/27790-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27791-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27791-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27792-swift-funcdecl-setdeserializedsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27792-swift-funcdecl-setdeserializedsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27793-swift-typechecker-checkdeclattributes.swift
+++ b/validation-test/compiler_crashers_fixed/27793-swift-typechecker-checkdeclattributes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27794-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/27794-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27795-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/27795-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27796-swift-modulefile-maybereadforeignerrorconvention.swift
+++ b/validation-test/compiler_crashers_fixed/27796-swift-modulefile-maybereadforeignerrorconvention.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27797-swift-typechecker-typecheckbinding.swift
+++ b/validation-test/compiler_crashers_fixed/27797-swift-typechecker-typecheckbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27798-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/27798-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27799-swift-modulefile-getimportedmodules.swift
+++ b/validation-test/compiler_crashers_fixed/27799-swift-modulefile-getimportedmodules.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27800-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27800-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27801-swift-clangimporter-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27801-swift-clangimporter-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27802-swift-constraints-constraintsystem-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/27802-swift-constraints-constraintsystem-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27803-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27803-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27804-swift-constraints-constraintsystem-applysolution.swift
+++ b/validation-test/compiler_crashers_fixed/27804-swift-constraints-constraintsystem-applysolution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27805-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/27805-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27806-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/27806-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27807-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/27807-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27808-swift-constructordecl-constructordecl.swift
+++ b/validation-test/compiler_crashers_fixed/27808-swift-constructordecl-constructordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27809-void.swift
+++ b/validation-test/compiler_crashers_fixed/27809-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27810-swift-sourcefile-getcache.swift
+++ b/validation-test/compiler_crashers_fixed/27810-swift-sourcefile-getcache.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27811-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/27811-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27812-swift-archetypebuilder-addgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27812-swift-archetypebuilder-addgenericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27813-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/27813-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27814-swift-parser-parseexprclosure.swift
+++ b/validation-test/compiler_crashers_fixed/27814-swift-parser-parseexprclosure.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27815-swift-archetypetype-getnew.swift
+++ b/validation-test/compiler_crashers_fixed/27815-swift-archetypetype-getnew.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27821-swift-typechecker-definedefaultconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/27821-swift-typechecker-definedefaultconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27822-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27822-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27823-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/27823-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27824-swift-modulefile-maybereadgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/27824-swift-modulefile-maybereadgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27825-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27825-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27826-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/27826-swift-lexer-lexstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27827-swift-constraints-simplifylocator.swift
+++ b/validation-test/compiler_crashers_fixed/27827-swift-constraints-simplifylocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27828-swift-conformancelookuptable-getallprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27828-swift-conformancelookuptable-getallprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27829-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/27829-swift-typechecker-lookupmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27830-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27830-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27831-swift-bracestmt-create.swift
+++ b/validation-test/compiler_crashers_fixed/27831-swift-bracestmt-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27832-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27832-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27833-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27833-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27834-swift-constraints-constraintgraphscope-constraintgraphscope.swift
+++ b/validation-test/compiler_crashers_fixed/27834-swift-constraints-constraintgraphscope-constraintgraphscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27835-llvm-tinyptrvector-swift-valuedecl-push-back.swift
+++ b/validation-test/compiler_crashers_fixed/27835-llvm-tinyptrvector-swift-valuedecl-push-back.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27836-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27836-llvm-foldingset-swift-constraints-constraintlocator-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27837-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27837-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27838-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27838-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27839-swift-archetypebuilder-potentialarchetype-addconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27839-swift-archetypebuilder-potentialarchetype-addconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27841-swift-parser-createbindingfrompattern.swift
+++ b/validation-test/compiler_crashers_fixed/27841-swift-parser-createbindingfrompattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27842-swift-conformancelookuptable-addprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/27842-swift-conformancelookuptable-addprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27843-llvm-foldingset-swift-classtype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27843-llvm-foldingset-swift-classtype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27844-swift-typechecker-getinterfacetypefrominternaltype.swift
+++ b/validation-test/compiler_crashers_fixed/27844-swift-typechecker-getinterfacetypefrominternaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27845-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/27845-swift-typebase-isequal.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27846-llvm-smallvectorimpl-swift-protocolconformance-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27846-llvm-smallvectorimpl-swift-protocolconformance-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27848-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27848-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27849-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/27849-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27851-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27851-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27852-swift-valuedecl-getoverloadsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27852-swift-valuedecl-getoverloadsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27853-swift-constraints-constraintsystem-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27853-swift-constraints-constraintsystem-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27854-swift-clangimporter-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27854-swift-clangimporter-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27855-swift-nominaltype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27855-swift-nominaltype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27856-swift-constraints-constraintlocator-profile.swift
+++ b/validation-test/compiler_crashers_fixed/27856-swift-constraints-constraintlocator-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27857-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27857-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27858-swift-inouttype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27858-swift-inouttype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27859-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27859-swift-constraints-constraintsystem-simplifyconformstoconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27861-swift-tuplepattern-createsimple.swift
+++ b/validation-test/compiler_crashers_fixed/27861-swift-tuplepattern-createsimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27862-swift-type-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27862-swift-type-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27863-swift-serializedmoduleloader-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27863-swift-serializedmoduleloader-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27865-swift-conformancelookuptable-getimplicitprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27865-swift-conformancelookuptable-getimplicitprotocols.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27866-swift-typebase-getoptionalobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/27866-swift-typebase-getoptionalobjecttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27867-swift-typerepr-getsourcerange.swift
+++ b/validation-test/compiler_crashers_fixed/27867-swift-typerepr-getsourcerange.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27868-swift-typechecker-getdefaulttype.swift
+++ b/validation-test/compiler_crashers_fixed/27868-swift-typechecker-getdefaulttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27869-swift-nominaltypedecl-computeinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/27869-swift-nominaltypedecl-computeinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27870-swift-constraints-constraintsystem-optimizeconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/27870-swift-constraints-constraintsystem-optimizeconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27871-swift-typechecker-typecheckpatternbinding.swift
+++ b/validation-test/compiler_crashers_fixed/27871-swift-typechecker-typecheckpatternbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27872-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27872-swift-metatypetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27873-void.swift
+++ b/validation-test/compiler_crashers_fixed/27873-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27874-swift-enumtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27874-swift-enumtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27876-filtervalues.swift
+++ b/validation-test/compiler_crashers_fixed/27876-filtervalues.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27877-swift-constructordecl-setbodyparams.swift
+++ b/validation-test/compiler_crashers_fixed/27877-swift-constructordecl-setbodyparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27878-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27878-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27879-swift-polymorphicfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27879-swift-polymorphicfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27880-swift-nominaltypedecl-preparelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27880-swift-nominaltypedecl-preparelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27881-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27881-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27882-swift-clangmoduleunit-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27882-swift-clangmoduleunit-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27883-swift-archetypebuilder-addconformancerequirement.swift
+++ b/validation-test/compiler_crashers_fixed/27883-swift-archetypebuilder-addconformancerequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27884-swift-typechecker-callwitness.swift
+++ b/validation-test/compiler_crashers_fixed/27884-swift-typechecker-callwitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27885-bool.swift
+++ b/validation-test/compiler_crashers_fixed/27885-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27887-swift-protocolcompositiontyperepr-create.swift
+++ b/validation-test/compiler_crashers_fixed/27887-swift-protocolcompositiontyperepr-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27888-swift-typechecker-resolveinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/27888-swift-typechecker-resolveinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27889-void.swift
+++ b/validation-test/compiler_crashers_fixed/27889-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27890-swift-typechecker-validategenerictypesignature.swift
+++ b/validation-test/compiler_crashers_fixed/27890-swift-typechecker-validategenerictypesignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27891-swift-typechecker-resolvesuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/27891-swift-typechecker-resolvesuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27892-swift-extensiondecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/27892-swift-extensiondecl-getmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27893-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
+++ b/validation-test/compiler_crashers_fixed/27893-swift-archetypebuilder-potentialarchetype-getarchetypeanchor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27894-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27894-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27895-swift-sourcefile-getcache.swift
+++ b/validation-test/compiler_crashers_fixed/27895-swift-sourcefile-getcache.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27896-swift-modulefile-configurestorage.swift
+++ b/validation-test/compiler_crashers_fixed/27896-swift-modulefile-configurestorage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27897-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers_fixed/27897-swift-typeloc-iserror.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27898-void.swift
+++ b/validation-test/compiler_crashers_fixed/27898-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27899-swift-unboundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27899-swift-unboundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27900-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers_fixed/27900-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27902-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27902-llvm-foldingset-swift-boundgenerictype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27903-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27903-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27904-swift-funcdecl-isdeferbody.swift
+++ b/validation-test/compiler_crashers_fixed/27904-swift-funcdecl-isdeferbody.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27905-swift-constraints-constraintgraph-change-undo.swift
+++ b/validation-test/compiler_crashers_fixed/27905-swift-constraints-constraintgraph-change-undo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27906-swift-valuedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27906-swift-valuedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27907-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/27907-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27908-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/27908-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27909-llvm-densemapbase-llvm-densemap-swift-identifier.swift
+++ b/validation-test/compiler_crashers_fixed/27909-llvm-densemapbase-llvm-densemap-swift-identifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27910-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27910-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27911-swift-declcontext-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27911-swift-declcontext-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27912-swift-classtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27912-swift-classtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27913-swift-typechecker-checkgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/27913-swift-typechecker-checkgenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27915-swift-typechecker-checkomitneedlesswords.swift
+++ b/validation-test/compiler_crashers_fixed/27915-swift-typechecker-checkomitneedlesswords.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27916-swift-sourcemanager-getmessage.swift
+++ b/validation-test/compiler_crashers_fixed/27916-swift-sourcemanager-getmessage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27917-swift-printdecldescription.swift
+++ b/validation-test/compiler_crashers_fixed/27917-swift-printdecldescription.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27918-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27918-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27919-swift-stmt-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27919-swift-stmt-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27920-void.swift
+++ b/validation-test/compiler_crashers_fixed/27920-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27921-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27921-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27922-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27922-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27923-swift-modulefile-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/27923-swift-modulefile-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27924-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_fixed/27924-swift-typechecker-typecheckexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27925-swift-modulefile-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/27925-swift-modulefile-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27926-swift-clangmoduleunit-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27926-swift-clangmoduleunit-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27927-swift-modulefile-maybereadpattern.swift
+++ b/validation-test/compiler_crashers_fixed/27927-swift-modulefile-maybereadpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27928-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27928-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27929-swift-clangimporter-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/27929-swift-clangimporter-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27930-swift-clangimporter-implementation-importattributes.swift
+++ b/validation-test/compiler_crashers_fixed/27930-swift-clangimporter-implementation-importattributes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27931-swift-constraints-constraintsystem-salvage.swift
+++ b/validation-test/compiler_crashers_fixed/27931-swift-constraints-constraintsystem-salvage.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27932-swift-constraints-constraintsystem-generateconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/27932-swift-constraints-constraintsystem-generateconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27933-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/27933-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27934-swift-genericsignature-getcanonical.swift
+++ b/validation-test/compiler_crashers_fixed/27934-swift-genericsignature-getcanonical.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27935-swift-moduledecl-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27935-swift-moduledecl-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27936-swift-structtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27936-swift-structtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27937-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27937-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27938-swift-arrayexpr-create.swift
+++ b/validation-test/compiler_crashers_fixed/27938-swift-arrayexpr-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27939-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27939-vtable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27940-swift-typechecker-resolvesuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/27940-swift-typechecker-resolvesuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27941-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27941-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27942-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/27942-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27943-swift-astcontext-getinheritedconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27943-swift-astcontext-getinheritedconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27944-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/27944-swift-astvisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27945-swift-conformancelookuptable-resolveconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27945-swift-conformancelookuptable-resolveconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27946-swift-archetypebuilder-potentialarchetype-isbetterarchetypeanchor.swift
+++ b/validation-test/compiler_crashers_fixed/27946-swift-archetypebuilder-potentialarchetype-isbetterarchetypeanchor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27947-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/27947-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27948-swift-constraints-constraintsystem-performmemberlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27948-swift-constraints-constraintsystem-performmemberlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27949-swift-genericparamlist-create.swift
+++ b/validation-test/compiler_crashers_fixed/27949-swift-genericparamlist-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27950-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/27950-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27951-swift-astcontext-getspecializedconformance.swift
+++ b/validation-test/compiler_crashers_fixed/27951-swift-astcontext-getspecializedconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27953-swift-modulefile-getcommentfordecl.swift
+++ b/validation-test/compiler_crashers_fixed/27953-swift-modulefile-getcommentfordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27955-swift-declattribute-print.swift
+++ b/validation-test/compiler_crashers_fixed/27955-swift-declattribute-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27956-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/27956-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27957-swift-inflightdiagnostic-fixitremove.swift
+++ b/validation-test/compiler_crashers_fixed/27957-swift-inflightdiagnostic-fixitremove.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27958-swift-typechecker-isdeclavailable.swift
+++ b/validation-test/compiler_crashers_fixed/27958-swift-typechecker-isdeclavailable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27959-swift-conformancelookuptable-conformancelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/27959-swift-conformancelookuptable-conformancelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27960-swift-constraints-constraintsystem-opentype.swift
+++ b/validation-test/compiler_crashers_fixed/27960-swift-constraints-constraintsystem-opentype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27961-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/27961-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27962-swift-rebindselfinconstructorexpr-getcalledconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/27962-swift-rebindselfinconstructorexpr-getcalledconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27963-swift-typechecker-checkunsupportedprotocoltype.swift
+++ b/validation-test/compiler_crashers_fixed/27963-swift-typechecker-checkunsupportedprotocoltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27964-swift-conformancelookuptable-compareprotocolconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27964-swift-conformancelookuptable-compareprotocolconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27965-llvm-foldingset-swift-tupletype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/27965-llvm-foldingset-swift-tupletype-nodeequals.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27966-swift-dependentmembertype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27966-swift-dependentmembertype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27967-swift-valuedecl-getoverloadsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27967-swift-valuedecl-getoverloadsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27969-void.swift
+++ b/validation-test/compiler_crashers_fixed/27969-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27970-swift-typechecker-typecheckbinding.swift
+++ b/validation-test/compiler_crashers_fixed/27970-swift-typechecker-typecheckbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27971-swift-constraints-constraintsystem-applysolution.swift
+++ b/validation-test/compiler_crashers_fixed/27971-swift-constraints-constraintsystem-applysolution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27972-swift-maybeaddaccessorstovariable.swift
+++ b/validation-test/compiler_crashers_fixed/27972-swift-maybeaddaccessorstovariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27973-swift-typechecker-substituteinputsugartypeforresult.swift
+++ b/validation-test/compiler_crashers_fixed/27973-swift-typechecker-substituteinputsugartypeforresult.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27974-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/27974-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27975-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/27975-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27976-swift-mangle-mangler-mangletype.swift
+++ b/validation-test/compiler_crashers_fixed/27976-swift-mangle-mangler-mangletype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27977-swift-substitutedtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/27977-swift-substitutedtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27978-swift-typechecker-solveforexpression.swift
+++ b/validation-test/compiler_crashers_fixed/27978-swift-typechecker-solveforexpression.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27979-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/27979-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27980-matchcallarguments.swift
+++ b/validation-test/compiler_crashers_fixed/27980-matchcallarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27981-std-function-func.swift
+++ b/validation-test/compiler_crashers_fixed/27981-std-function-func.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27982-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/27982-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27984-llvm-densemapbase-llvm-densemap-swift-declname.swift
+++ b/validation-test/compiler_crashers_fixed/27984-llvm-densemapbase-llvm-densemap-swift-declname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27986-swift-abstractfunctiondecl-setgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/27986-swift-abstractfunctiondecl-setgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27988-swift-inflightdiagnostic-fixitreplacechars.swift
+++ b/validation-test/compiler_crashers_fixed/27988-swift-inflightdiagnostic-fixitreplacechars.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27989-swift-typechecker-lookupmember.swift
+++ b/validation-test/compiler_crashers_fixed/27989-swift-typechecker-lookupmember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27990-swift-constraints-constraintsystem-computeassigndesttype.swift
+++ b/validation-test/compiler_crashers_fixed/27990-swift-constraints-constraintsystem-computeassigndesttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27991-void.swift
+++ b/validation-test/compiler_crashers_fixed/27991-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27992-swift-createimplicitconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/27992-swift-createimplicitconstructor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27993-swift-parser-parsedeclfunc.swift
+++ b/validation-test/compiler_crashers_fixed/27993-swift-parser-parsedeclfunc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27995-swift-constraints-constraintsystem-simplifyconstructionconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/27995-swift-constraints-constraintsystem-simplifyconstructionconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27996-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
+++ b/validation-test/compiler_crashers_fixed/27996-llvm-ondiskchainedhashtable-swift-modulefile-decltableinfo-find.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27997-swift-typechecker-computeaccessibility.swift
+++ b/validation-test/compiler_crashers_fixed/27997-swift-typechecker-computeaccessibility.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27998-swift-parser-consumetoken.swift
+++ b/validation-test/compiler_crashers_fixed/27998-swift-parser-consumetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/27999-swift-constraints-solution-solution.swift
+++ b/validation-test/compiler_crashers_fixed/27999-swift-constraints-solution-solution.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28000-swift-astcontext-getimplicitlyunwrappedoptionaldecl.swift
+++ b/validation-test/compiler_crashers_fixed/28000-swift-astcontext-getimplicitlyunwrappedoptionaldecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28001-swift-parser-parsetypesimple.swift
+++ b/validation-test/compiler_crashers_fixed/28001-swift-parser-parsetypesimple.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28002-swift-parser-parsebraceitems.swift
+++ b/validation-test/compiler_crashers_fixed/28002-swift-parser-parsebraceitems.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28003-swift-constraints-constraintsystem-recordfix.swift
+++ b/validation-test/compiler_crashers_fixed/28003-swift-constraints-constraintsystem-recordfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28004-swift-parser-parseexprsequence.swift
+++ b/validation-test/compiler_crashers_fixed/28004-swift-parser-parseexprsequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28005-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers_fixed/28005-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28006-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/28006-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28007-swift-scopeinfo-addtoscope.swift
+++ b/validation-test/compiler_crashers_fixed/28007-swift-scopeinfo-addtoscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28008-swift-builtinunit-lookupcache-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/28008-swift-builtinunit-lookupcache-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28009-swift-parser-parsedeclenum.swift
+++ b/validation-test/compiler_crashers_fixed/28009-swift-parser-parsedeclenum.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28010-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28010-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28011-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28011-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28012-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28012-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28013-std-function-func-swift-archetypebuilder-visitinherited.swift
+++ b/validation-test/compiler_crashers_fixed/28013-std-function-func-swift-archetypebuilder-visitinherited.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28014-swift-decl-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28014-swift-decl-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28015-swift-constraints-constraintgraph-computeconnectedcomponents.swift
+++ b/validation-test/compiler_crashers_fixed/28015-swift-constraints-constraintgraph-computeconnectedcomponents.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28016-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28016-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28017-swift-protocoldecl-existentialtypesupportedslow.swift
+++ b/validation-test/compiler_crashers_fixed/28017-swift-protocoldecl-existentialtypesupportedslow.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28018-swift-valuedecl-overwritetype.swift
+++ b/validation-test/compiler_crashers_fixed/28018-swift-valuedecl-overwritetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28019-swift-typechecker-checkdeclarationavailability.swift
+++ b/validation-test/compiler_crashers_fixed/28019-swift-typechecker-checkdeclarationavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28020-llvm-smallvectorimpl-swift-decl-insert.swift
+++ b/validation-test/compiler_crashers_fixed/28020-llvm-smallvectorimpl-swift-decl-insert.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28021-swift-decl-getrawcomment.swift
+++ b/validation-test/compiler_crashers_fixed/28021-swift-decl-getrawcomment.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28022-swift-typechecker-diagnoseexplicitunavailability.swift
+++ b/validation-test/compiler_crashers_fixed/28022-swift-typechecker-diagnoseexplicitunavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28023-swift-typechecker-diagnoseexplicitunavailability.swift
+++ b/validation-test/compiler_crashers_fixed/28023-swift-typechecker-diagnoseexplicitunavailability.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28024-swift-constraints-constraintlocatorbuilder-trysimplifytoexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28024-swift-constraints-constraintlocatorbuilder-trysimplifytoexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28025-swift-markasobjc.swift
+++ b/validation-test/compiler_crashers_fixed/28025-swift-markasobjc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28026-swift-protocolcompositiontype-build.swift
+++ b/validation-test/compiler_crashers_fixed/28026-swift-protocolcompositiontype-build.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28027-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28027-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28028-swift-astcontext-diagnoseunintendedobjcmethodoverrides.swift
+++ b/validation-test/compiler_crashers_fixed/28028-swift-astcontext-diagnoseunintendedobjcmethodoverrides.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28029-swift-constraints-constraintsystem-performmemberlookup.swift
+++ b/validation-test/compiler_crashers_fixed/28029-swift-constraints-constraintsystem-performmemberlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28031-swift-clangimporter-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/28031-swift-clangimporter-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28032-swift-typechecker-computecaptures.swift
+++ b/validation-test/compiler_crashers_fixed/28032-swift-typechecker-computecaptures.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28033-swift-configureconstructortype.swift
+++ b/validation-test/compiler_crashers_fixed/28033-swift-configureconstructortype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28034-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28034-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28035-swift-archetypebuilder-getallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/28035-swift-archetypebuilder-getallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28037-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28037-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28038-swift-parser-parsetype.swift
+++ b/validation-test/compiler_crashers_fixed/28038-swift-parser-parsetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28039-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28039-swift-constraints-solution-computesubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28040-swift-genericparamlist-addnestedarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/28040-swift-genericparamlist-addnestedarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28041-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/compiler_crashers_fixed/28041-swift-typechecker-lookupunqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28042-void.swift
+++ b/validation-test/compiler_crashers_fixed/28042-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28044-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/28044-swift-completegenerictyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28045-swift-typechecker-typecheckpatternbinding.swift
+++ b/validation-test/compiler_crashers_fixed/28045-swift-typechecker-typecheckpatternbinding.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28046-swift-typechecker-substituteinputsugartypeforresult.swift
+++ b/validation-test/compiler_crashers_fixed/28046-swift-typechecker-substituteinputsugartypeforresult.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28047-swift-constraints-constraintsystem-recordfix.swift
+++ b/validation-test/compiler_crashers_fixed/28047-swift-constraints-constraintsystem-recordfix.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28048-swift-astcontext-getspecializedconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28048-swift-astcontext-getspecializedconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28050-swift-abstractfunctiondecl-setgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/28050-swift-abstractfunctiondecl-setgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28051-swift-parser-parseexprimpl.swift
+++ b/validation-test/compiler_crashers_fixed/28051-swift-parser-parseexprimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28052-swift-moduledecl-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/28052-swift-moduledecl-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28053-swift-parser-parsedeclvar.swift
+++ b/validation-test/compiler_crashers_fixed/28053-swift-parser-parsedeclvar.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28054-ldstninstinfo.swift
+++ b/validation-test/compiler_crashers_fixed/28054-ldstninstinfo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28055-swift-parser-parsegetsetimpl.swift
+++ b/validation-test/compiler_crashers_fixed/28055-swift-parser-parsegetsetimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28056-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/28056-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28057-swift-modulefile-declcommenttableinfo-readdata.swift
+++ b/validation-test/compiler_crashers_fixed/28057-swift-modulefile-declcommenttableinfo-readdata.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28058-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/28058-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28059-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/28059-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28060-std-function-func.swift
+++ b/validation-test/compiler_crashers_fixed/28060-std-function-func.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28061-swift-nominaltypedecl-getdeclaredtypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/28061-swift-nominaltypedecl-getdeclaredtypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28062-swift-classdecl-checkobjcancestry.swift
+++ b/validation-test/compiler_crashers_fixed/28062-swift-classdecl-checkobjcancestry.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28064-swift-stmtconditionelement-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28064-swift-stmtconditionelement-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28065-swift-constraints-constraintsystem-mergeequivalenceclasses.swift
+++ b/validation-test/compiler_crashers_fixed/28065-swift-constraints-constraintsystem-mergeequivalenceclasses.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28066-swift-parentype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28066-swift-parentype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28067-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/28067-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28068-swift-declcontext-getlocalconformances.swift
+++ b/validation-test/compiler_crashers_fixed/28068-swift-declcontext-getlocalconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28069-swift-nominaltypedecl-classifyasoptionaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28069-swift-nominaltypedecl-classifyasoptionaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28070-swift-lexer-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/28070-swift-lexer-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28071-swift-clangimporter-implementation-importdeclandcacheimpl.swift
+++ b/validation-test/compiler_crashers_fixed/28071-swift-clangimporter-implementation-importdeclandcacheimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28072-swift-typechecker-buildrefexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28072-swift-typechecker-buildrefexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28073-swift-parser-parsestmt.swift
+++ b/validation-test/compiler_crashers_fixed/28073-swift-parser-parsestmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28074-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/28074-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28075-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/28075-swift-lexer-lexstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28076-llvm-foldingset-swift-tupletype-getnodeprofile.swift
+++ b/validation-test/compiler_crashers_fixed/28076-llvm-foldingset-swift-tupletype-getnodeprofile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28077-swift-parser-parsedeclsubscript.swift
+++ b/validation-test/compiler_crashers_fixed/28077-swift-parser-parsedeclsubscript.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28078-swift-archetypebuilder-inferrequirementswalker-walktotypepost.swift
+++ b/validation-test/compiler_crashers_fixed/28078-swift-archetypebuilder-inferrequirementswalker-walktotypepost.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28079-swift-lexer-leximpl.swift
+++ b/validation-test/compiler_crashers_fixed/28079-swift-lexer-leximpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28080-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/28080-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28081-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28081-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28082-bool.swift
+++ b/validation-test/compiler_crashers_fixed/28082-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28083-swift-enumtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28083-swift-enumtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28084-swift-modulefile-loadallmembers.swift
+++ b/validation-test/compiler_crashers_fixed/28084-swift-modulefile-loadallmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28085-swift-constraints-constraintsystem-simplifyrestrictedconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/28085-swift-constraints-constraintsystem-simplifyrestrictedconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28086-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28086-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28087-swift-genericsignature-profile.swift
+++ b/validation-test/compiler_crashers_fixed/28087-swift-genericsignature-profile.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28088-swift-nominaltypedecl-markinvalidgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28088-swift-nominaltypedecl-markinvalidgenericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28089-extractsimplefield.swift
+++ b/validation-test/compiler_crashers_fixed/28089-extractsimplefield.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28090-bool.swift
+++ b/validation-test/compiler_crashers_fixed/28090-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28091-swift-diagnosticengine-flushactivediagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28091-swift-diagnosticengine-flushactivediagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28092-swift-parser-parseexpridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/28092-swift-parser-parseexpridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28093-swift-archetypetype-getnew.swift
+++ b/validation-test/compiler_crashers_fixed/28093-swift-archetypetype-getnew.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28094-swift-parser-parsetypedpattern.swift
+++ b/validation-test/compiler_crashers_fixed/28094-swift-parser-parsetypedpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28095-swift-parser-parsedeclstruct.swift
+++ b/validation-test/compiler_crashers_fixed/28095-swift-parser-parsedeclstruct.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28096-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28096-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28097-swift-astprinter-printname.swift
+++ b/validation-test/compiler_crashers_fixed/28097-swift-astprinter-printname.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28098-swift-constraints-constraintsystem-performmemberlookup.swift
+++ b/validation-test/compiler_crashers_fixed/28098-swift-constraints-constraintsystem-performmemberlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28099-swift-conformancelookuptable-updatelookuptable.swift
+++ b/validation-test/compiler_crashers_fixed/28099-swift-conformancelookuptable-updatelookuptable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28100-swift-tupletype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28100-swift-tupletype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28101-swift-constraints-constraint-create.swift
+++ b/validation-test/compiler_crashers_fixed/28101-swift-constraints-constraint-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28102-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/28102-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28103-swift-parser-parsetoken.swift
+++ b/validation-test/compiler_crashers_fixed/28103-swift-parser-parsetoken.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28104-void.swift
+++ b/validation-test/compiler_crashers_fixed/28104-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28105-swift-constraints-constraintsystem-simplifymemberconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/28105-swift-constraints-constraintsystem-simplifymemberconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28106-swift-astcontext-setrawcomment.swift
+++ b/validation-test/compiler_crashers_fixed/28106-swift-astcontext-setrawcomment.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28107-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28107-swift-typechecker-checkconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28108-swift-genericsignature-genericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28108-swift-genericsignature-genericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28109-swift-constraints-constraintgraph-removeconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/28109-swift-constraints-constraintgraph-removeconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28110-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/28110-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28111-swift-modulefile-readnormalconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28111-swift-modulefile-readnormalconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28112-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/28112-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28113-swift-constraints-constraintgraph-gatherconstraints.swift
+++ b/validation-test/compiler_crashers_fixed/28113-swift-constraints-constraintgraph-gatherconstraints.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28114-swift-tuplepattern-create.swift
+++ b/validation-test/compiler_crashers_fixed/28114-swift-tuplepattern-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28115-swift-patternbindingdecl-create.swift
+++ b/validation-test/compiler_crashers_fixed/28115-swift-patternbindingdecl-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28116-swift-parser-skipsingle.swift
+++ b/validation-test/compiler_crashers_fixed/28116-swift-parser-skipsingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28117-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/28117-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28118-resolveidenttypecomponent.swift
+++ b/validation-test/compiler_crashers_fixed/28118-resolveidenttypecomponent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28119-void.swift
+++ b/validation-test/compiler_crashers_fixed/28119-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28120-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers_fixed/28120-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28121-swift-typechecker-coercepatterntotype.swift
+++ b/validation-test/compiler_crashers_fixed/28121-swift-typechecker-coercepatterntotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28122-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28122-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28123-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/compiler_crashers_fixed/28123-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28124-swift-typevisitor.swift
+++ b/validation-test/compiler_crashers_fixed/28124-swift-typevisitor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28125-swift-constraints-constraint-createbindoverload.swift
+++ b/validation-test/compiler_crashers_fixed/28125-swift-constraints-constraint-createbindoverload.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28126-swift-getbuiltinvaluedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28126-swift-getbuiltinvaluedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28127-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28127-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28128-swift-parser-parseidentifier.swift
+++ b/validation-test/compiler_crashers_fixed/28128-swift-parser-parseidentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28129-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/28129-no-stacktrace.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28130-swift-constraints-constraintsystem-solverscope-solverscope.swift
+++ b/validation-test/compiler_crashers_fixed/28130-swift-constraints-constraintsystem-solverscope-solverscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28131-void.swift
+++ b/validation-test/compiler_crashers_fixed/28131-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28132-swift-namelookup-findlocalval-visitifstmt.swift
+++ b/validation-test/compiler_crashers_fixed/28132-swift-namelookup-findlocalval-visitifstmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28133-swift-parser-parsedeclenum.swift
+++ b/validation-test/compiler_crashers_fixed/28133-swift-parser-parsedeclenum.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28134-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28134-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28135-swift-parser-parseexprlist.swift
+++ b/validation-test/compiler_crashers_fixed/28135-swift-parser-parseexprlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28136-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28136-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28137-swift-identtyperepr-create.swift
+++ b/validation-test/compiler_crashers_fixed/28137-swift-identtyperepr-create.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28138-swift-constraints-constraintsystem-addoverloadset.swift
+++ b/validation-test/compiler_crashers_fixed/28138-swift-constraints-constraintsystem-addoverloadset.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28139-swift-classdecl-findoverridingdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28139-swift-classdecl-findoverridingdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28140-swift-typedecl-getdeclaredinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28140-swift-typedecl-getdeclaredinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28141-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28141-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28142-swift-constraints-constraintsystem-simplifymemberconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/28142-swift-constraints-constraintsystem-simplifymemberconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28143-llvm-foldingset-swift-structtype-computenodehash.swift
+++ b/validation-test/compiler_crashers_fixed/28143-llvm-foldingset-swift-structtype-computenodehash.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28144-swift-typechecker-substituteinputsugartypeforresult.swift
+++ b/validation-test/compiler_crashers_fixed/28144-swift-typechecker-substituteinputsugartypeforresult.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28145-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/28145-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28146-swift-clangimporter-implementation-importdeclandcacheimpl.swift
+++ b/validation-test/compiler_crashers_fixed/28146-swift-clangimporter-implementation-importdeclandcacheimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28147-swift-mangle-mangler-mangledefaultargumententity.swift
+++ b/validation-test/compiler_crashers_fixed/28147-swift-mangle-mangler-mangledefaultargumententity.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28148-swift-constraints-constraintsystem-getconstraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/28148-swift-constraints-constraintsystem-getconstraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28149-addcurriedselftype.swift
+++ b/validation-test/compiler_crashers_fixed/28149-addcurriedselftype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28150-swift-astcontext-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/28150-swift-astcontext-loadextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28151-swift-constraints-constraintsystem-simplifymemberconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/28151-swift-constraints-constraintsystem-simplifymemberconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28152-swift-conformancelookuptable-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28152-swift-conformancelookuptable-lookupconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28153-swift-normalprotocolconformance-setwitness.swift
+++ b/validation-test/compiler_crashers_fixed/28153-swift-normalprotocolconformance-setwitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28154-swift-genericsignature-get.swift
+++ b/validation-test/compiler_crashers_fixed/28154-swift-genericsignature-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28155-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28155-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28156-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/compiler_crashers_fixed/28156-swift-typechecker-lookupunqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28157-swift-constraints-constraintsystem-solverstate-solverstate.swift
+++ b/validation-test/compiler_crashers_fixed/28157-swift-constraints-constraintsystem-solverstate-solverstate.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28158-swift-parser-diagnose.swift
+++ b/validation-test/compiler_crashers_fixed/28158-swift-parser-diagnose.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28159-swift-clangimporter-lookupvalue.swift
+++ b/validation-test/compiler_crashers_fixed/28159-swift-clangimporter-lookupvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28160-swift-inflightdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28160-swift-inflightdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28161-swift-constraints-constraintsystem-solvesingle.swift
+++ b/validation-test/compiler_crashers_fixed/28161-swift-constraints-constraintsystem-solvesingle.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28162-swift-astcontext-addedexternaldecl.swift
+++ b/validation-test/compiler_crashers_fixed/28162-swift-astcontext-addedexternaldecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28163-swift-astcontext-getoptionaldecl.swift
+++ b/validation-test/compiler_crashers_fixed/28163-swift-astcontext-getoptionaldecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28164-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28164-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28165-swift-archetypetype-getnestedtype.swift
+++ b/validation-test/compiler_crashers_fixed/28165-swift-archetypetype-getnestedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28166-swift-parser-parsedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28166-swift-parser-parsedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28167-swift-generictypeparamtype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28167-swift-generictypeparamtype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28168-bool.swift
+++ b/validation-test/compiler_crashers_fixed/28168-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28169-swift-parser-parsestmtreturn.swift
+++ b/validation-test/compiler_crashers_fixed/28169-swift-parser-parsestmtreturn.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28171-swift-partialgenerictypetoarchetyperesolver-resolvegenerictypeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/28171-swift-partialgenerictypetoarchetyperesolver-resolvegenerictypeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28172-swift-parser-parsedeclstruct.swift
+++ b/validation-test/compiler_crashers_fixed/28172-swift-parser-parsedeclstruct.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28173-swift-typebase-isspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/28173-swift-typebase-isspecialized.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28174-swift-constraints-constraintsystem-simplify.swift
+++ b/validation-test/compiler_crashers_fixed/28174-swift-constraints-constraintsystem-simplify.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28175-swift-parser-parsedeclextension.swift
+++ b/validation-test/compiler_crashers_fixed/28175-swift-parser-parsedeclextension.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28176-swift-parser-parsegenericparameters.swift
+++ b/validation-test/compiler_crashers_fixed/28176-swift-parser-parsegenericparameters.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28177-swift-constraints-solution-coercetotype.swift
+++ b/validation-test/compiler_crashers_fixed/28177-swift-constraints-solution-coercetotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28178-swift-astcontext-getprotocol.swift
+++ b/validation-test/compiler_crashers_fixed/28178-swift-astcontext-getprotocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28179-void.swift
+++ b/validation-test/compiler_crashers_fixed/28179-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28180-rawrepresentable-extension-with-initializer.swift
+++ b/validation-test/compiler_crashers_fixed/28180-rawrepresentable-extension-with-initializer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28182-anonymous-namespace-favorcalloverloads.swift
+++ b/validation-test/compiler_crashers_fixed/28182-anonymous-namespace-favorcalloverloads.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28183-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/28183-swift-typebase-isequal.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28184-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/28184-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28185-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/28185-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28186-swift-silwitnessvisitor-visitprotocoldecl.swift
+++ b/validation-test/compiler_crashers_fixed/28186-swift-silwitnessvisitor-visitprotocoldecl.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28187-llvm-foldingset-swift-constraints-constraintlocator.swift
+++ b/validation-test/compiler_crashers_fixed/28187-llvm-foldingset-swift-constraints-constraintlocator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28189-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/28189-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28191-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28191-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28192-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28192-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28193-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28193-swift-typechecker-lookupmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28194-swift-abstractstoragedecl-isgettermutating.swift
+++ b/validation-test/compiler_crashers_fixed/28194-swift-abstractstoragedecl-isgettermutating.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28195-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers_fixed/28195-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28196-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/28196-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28197-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28197-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28198-swift-typerepr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28198-swift-typerepr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28199-swift-constraints-constraintsystem-performmemberlookup.swift
+++ b/validation-test/compiler_crashers_fixed/28199-swift-constraints-constraintsystem-performmemberlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28200-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28200-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28201-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28201-swift-typechecker-resolvetypewitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28202-swift-typechecker-applygenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/28202-swift-typechecker-applygenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28203-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28203-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28205-swift-typechecker-checkgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/28205-swift-typechecker-checkgenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28206-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28206-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers_fixed/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28212-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/28212-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28213-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28213-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28216-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers_fixed/28216-swift-expr-propagatelvalueaccesskind.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28217-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28217-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28218-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/28218-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28219-swift-lvaluetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28219-swift-lvaluetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28220-swift-lvaluetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28220-swift-lvaluetype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28221-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28221-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28223-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28223-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28224-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28224-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28225-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28225-swift-typechecker-checkconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28227-swift-typechecker-gettypeofrvalue.swift
+++ b/validation-test/compiler_crashers_fixed/28227-swift-typechecker-gettypeofrvalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28229-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28229-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28231-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/28231-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28232-swift-typechecker-typecheckfunctionbodyuntil.swift
+++ b/validation-test/compiler_crashers_fixed/28232-swift-typechecker-typecheckfunctionbodyuntil.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28233-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28233-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift
+++ b/validation-test/compiler_crashers_fixed/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28236-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28236-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28237-swift-archetypebuilder-addgenericparameter.swift
+++ b/validation-test/compiler_crashers_fixed/28237-swift-archetypebuilder-addgenericparameter.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28239-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers_fixed/28239-swift-declcontext-lookupqualified.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28240-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/28240-swift-archetypebuilder-addrequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28241-swift-valuedecl-isaccessiblefrom.swift
+++ b/validation-test/compiler_crashers_fixed/28241-swift-valuedecl-isaccessiblefrom.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28242-swift-constraints-constraintsystem-simplify.swift
+++ b/validation-test/compiler_crashers_fixed/28242-swift-constraints-constraintsystem-simplify.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28243-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28243-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28244-swift-valuedecl-isinstancemember.swift
+++ b/validation-test/compiler_crashers_fixed/28244-swift-valuedecl-isinstancemember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers_fixed/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28246-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers_fixed/28246-swift-expr-propagatelvalueaccesskind.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift
+++ b/validation-test/compiler_crashers_fixed/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28248-swift-dynamicselftype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28248-swift-dynamicselftype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28249-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28249-swift-typechecker-validategenericfuncsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28250-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28250-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28251-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28251-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/compiler_crashers_fixed/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28254-swift-enumelementdecl-getargumentinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28254-swift-enumelementdecl-getargumentinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
+++ b/validation-test/compiler_crashers_fixed/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28259-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28259-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28260-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28260-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28261-swift-iterativetypechecker-satisfy.swift
+++ b/validation-test/compiler_crashers_fixed/28261-swift-iterativetypechecker-satisfy.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28262-swift-typechecker-applyunboundgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/28262-swift-typechecker-applyunboundgenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28263-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28263-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28264-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28264-swift-valuedecl-getinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28265-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28265-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28266-swift-moduledecl-lookupprefixoperator.swift
+++ b/validation-test/compiler_crashers_fixed/28266-swift-moduledecl-lookupprefixoperator.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28267-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28267-swift-typechecker-checkconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28268-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28268-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28269-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28269-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28270-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28270-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28271-swift-archetypebuilder-getallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/28271-swift-archetypebuilder-getallarchetypes.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28272-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28272-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28274-swift-valuedecl-isinstancemember.swift
+++ b/validation-test/compiler_crashers_fixed/28274-swift-valuedecl-isinstancemember.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28275-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/28275-swift-typebase-getsuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28276-swift-typechecker-computedefaultaccessibility.swift
+++ b/validation-test/compiler_crashers_fixed/28276-swift-typechecker-computedefaultaccessibility.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28277-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28277-swift-archetypebuilder-getgenericsignature.swift
@@ -2,7 +2,7 @@
 // a heap use-after-free (SR-1070).
 
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28278-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28278-swift-archetypebuilder-getgenericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28279-swift-archetypebuilder-potentialarchetype-getnestedtype.swift
+++ b/validation-test/compiler_crashers_fixed/28279-swift-archetypebuilder-potentialarchetype-getnestedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28280-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/28280-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28281-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28281-swift-typechecker-resolvewitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28282-swift-constraints-solution-coercetotype.swift
+++ b/validation-test/compiler_crashers_fixed/28282-swift-constraints-solution-coercetotype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28283-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/28283-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28284-swift-cantype-isreferencetypeimpl.swift
+++ b/validation-test/compiler_crashers_fixed/28284-swift-cantype-isreferencetypeimpl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28285-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers_fixed/28285-swift-typechecker-typecheckpattern.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28286-swift-typechecker-applyunboundgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/28286-swift-typechecker-applyunboundgenericarguments.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28287-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28287-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28288-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28288-swift-genericparamlist-getsubstitutionmap.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28289-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28289-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28290-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28290-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28291-swift-constraints-constraintsystem-comparesolutions.swift
+++ b/validation-test/compiler_crashers_fixed/28291-swift-constraints-constraintsystem-comparesolutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28292-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/28292-swift-valuedecl-settype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28293-irgensilfunction-visitfullapplysite.swift
+++ b/validation-test/compiler_crashers_fixed/28293-irgensilfunction-visitfullapplysite.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28294-swift-archetypebuilder-addsuperclassrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/28294-swift-archetypebuilder-addsuperclassrequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28296-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28296-swift-genericsignature-getsubstitutionmap.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28297-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers_fixed/28297-swift-lookupvisibledecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28298-swift-namealiastype-getsinglydesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28298-swift-namealiastype-getsinglydesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28299-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers_fixed/28299-swift-lookupvisibledecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28300-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28300-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28301-swift-constraints-constraintsystem-simplifyconstructionconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/28301-swift-constraints-constraintsystem-simplifyconstructionconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28302-swift-paramdecl-createunboundself.swift
+++ b/validation-test/compiler_crashers_fixed/28302-swift-paramdecl-createunboundself.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28306-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers_fixed/28306-swift-lookupvisibledecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28309-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28309-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28315-swift-declcontext-iscascadingcontextforlookup.swift
+++ b/validation-test/compiler_crashers_fixed/28315-swift-declcontext-iscascadingcontextforlookup.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28316-swift-typechecker-checkgenericparamlist.swift
+++ b/validation-test/compiler_crashers_fixed/28316-swift-typechecker-checkgenericparamlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28318-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28318-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28319-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28319-swift-typechecker-checkconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28320-swift-archetypebuilder-enumeraterequirements.swift
+++ b/validation-test/compiler_crashers_fixed/28320-swift-archetypebuilder-enumeraterequirements.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28321-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers_fixed/28321-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28322-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/28322-swift-typechecker-resolvetypeincontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28323-swift-typebase-getstring.swift
+++ b/validation-test/compiler_crashers_fixed/28323-swift-typebase-getstring.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28325-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28325-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28326-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28326-swift-typebase-getmembersubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28327-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28327-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28328-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28328-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28329-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers_fixed/28329-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28330-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28330-swift-genericparamlist-getsubstitutionmap.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28331-swift-createdesignatedinitoverride.swift
+++ b/validation-test/compiler_crashers_fixed/28331-swift-createdesignatedinitoverride.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28332-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28332-swift-archetypebuilder-getgenericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28333-swift-typedecl-getdeclaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28333-swift-typedecl-getdeclaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28334-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28334-swift-typechecker-resolvetypewitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28335-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/28335-swift-type-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28336-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/28336-swift-archetypebuilder-addrequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28337-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28337-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28338-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28338-swift-genericsignature-getsubstitutionmap.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28339-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28339-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28340-swift-type-getstring.swift
+++ b/validation-test/compiler_crashers_fixed/28340-swift-type-getstring.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28341-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28341-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28342-getpointerelementtype-is-not-storagetype.swift
+++ b/validation-test/compiler_crashers_fixed/28342-getpointerelementtype-is-not-storagetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28343-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28343-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28344-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28344-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28345-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/28345-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28346-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28346-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28347-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/28347-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28348-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28348-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28349-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28349-swift-typebase-gatherallsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28350-swift-typechecker-performtypocorrection.swift
+++ b/validation-test/compiler_crashers_fixed/28350-swift-typechecker-performtypocorrection.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28351-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28351-swift-functiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28352-swift-typechecker-configureinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28352-swift-typechecker-configureinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28353-swift-removeoverriddendecls.swift
+++ b/validation-test/compiler_crashers_fixed/28353-swift-removeoverriddendecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28354-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/28354-swift-conformancelookuptable-lookupconformances.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28355-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28355-swift-genericsignature-getsubstitutionmap.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28356-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28356-swift-typechecker-resolvetypewitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28357-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/28357-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28358-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28358-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28360-swift-archetypebuilder-maptypeoutofcontext.swift
+++ b/validation-test/compiler_crashers_fixed/28360-swift-archetypebuilder-maptypeoutofcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28361-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/28361-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28362-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers_fixed/28362-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28363-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28363-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28364-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28364-swift-typechecker-addimplicitconstructors.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28365-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28365-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28366-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/28366-swift-archetypebuilder-finalize.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28367-swift-declcontext-isgenericcontext.swift
+++ b/validation-test/compiler_crashers_fixed/28367-swift-declcontext-isgenericcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28368-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers_fixed/28368-swift-expr-propagatelvalueaccesskind.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28369-swift-decl-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28369-swift-decl-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28370-swift-decomposeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/28370-swift-decomposeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28371-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28371-swift-genericparamlist-getsubstitutionmap.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28372-swift-printoptions-setarchetypeanddynamicselftransform.swift
+++ b/validation-test/compiler_crashers_fixed/28372-swift-printoptions-setarchetypeanddynamicselftransform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28373-swift-printoptions-setarchetypeselftransform.swift
+++ b/validation-test/compiler_crashers_fixed/28373-swift-printoptions-setarchetypeselftransform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28374-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28374-swift-typechecker-resolvewitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28375-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28375-swift-typechecker-lookupmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28376-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28376-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28377-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28377-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28378-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28378-swift-typechecker-resolvewitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28380-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28380-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28381-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/28381-swift-archetypebuilder-addrequirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28382-swift-archetypebuilder-maptypeoutofcontext.swift
+++ b/validation-test/compiler_crashers_fixed/28382-swift-archetypebuilder-maptypeoutofcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28383-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28383-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28385-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/28385-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28386-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28386-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28387-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28387-swift-typebase-gatherallsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28388-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28388-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28389-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers_fixed/28389-swift-lookupvisibledecls.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28390-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28390-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28391-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28391-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers_fixed/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28393-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28393-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28394-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28394-swift-typechecker-checkconformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28395-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers_fixed/28395-swift-expr-propagatelvalueaccesskind.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28396-swift-lowering-silgenfunction-emitclosurevalue.swift
+++ b/validation-test/compiler_crashers_fixed/28396-swift-lowering-silgenfunction-emitclosurevalue.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28397-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/28397-getselftypeforcontainer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28398-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28398-swift-archetypebuilder-getgenericsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28399-getpointerelementtype-is-not-storagetype.swift
+++ b/validation-test/compiler_crashers_fixed/28399-getpointerelementtype-is-not-storagetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28400-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/28400-swift-nominaltypedecl-prepareextensions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28401-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28401-swift-boundgenerictype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28402-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28402-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28403-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28403-swift-genericsignature-getsubstitutionmap.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28405-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers_fixed/28405-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28406-swift-decomposeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/28406-swift-decomposeparamtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28407-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28407-swift-genericsignature-getsubstitutionmap.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28408-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/28408-swift-typechecker-checkinheritanceclause.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28409-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/28409-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28410-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28410-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28411-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/28411-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28412-swift-sourcefile-lookupcache-lookupclassmembers.swift
+++ b/validation-test/compiler_crashers_fixed/28412-swift-sourcefile-lookupcache-lookupclassmembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28413-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28413-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28414-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28414-swift-typechecker-resolvewitness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28415-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/28415-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28416-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/28416-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28417-swift-genericsignature-getsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28417-swift-genericsignature-getsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28418-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28418-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28419-swift-silmodule-constructsil.swift
+++ b/validation-test/compiler_crashers_fixed/28419-swift-silmodule-constructsil.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28420-swift-lowering-emitconditionalcheckedcast.swift
+++ b/validation-test/compiler_crashers_fixed/28420-swift-lowering-emitconditionalcheckedcast.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28422-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28422-swift-genericfunctiontype-get.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28423-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28423-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28424-swift-valuedecl-getformalaccessscope.swift
+++ b/validation-test/compiler_crashers_fixed/28424-swift-valuedecl-getformalaccessscope.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift
+++ b/validation-test/compiler_crashers_fixed/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28426-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28426-swift-expr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28427-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/28427-swift-lexer-lexstringliteral.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28428-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28428-swift-typebase-gatherallsubstitutions.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28429-swift-decl-print.swift
+++ b/validation-test/compiler_crashers_fixed/28429-swift-decl-print.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28430-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/28430-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28431-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/28431-swift-lexer-lexoperatoridentifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28432-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28432-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28433-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28433-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28434-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28434-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28435-swift-genericenvironment-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/28435-swift-genericenvironment-maptypeintocontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28436-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28436-swift-typechecker-typecheckdecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28437-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28437-swift-typechecker-validatedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28438-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28438-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28439-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28439-swift-type-transform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28440-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/28440-swift-typechecker-resolveidentifiertype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28441-swift-typerepr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28441-swift-typerepr-walk.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28442-swift-typebase-getrvaluetype.swift
+++ b/validation-test/compiler_crashers_fixed/28442-swift-typebase-getrvaluetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28444-resolver-unable-to-resolve-type-witness-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28444-resolver-unable-to-resolve-type-witness-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28446-activediagnostic-already-have-an-active-diagnostic-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28446-activediagnostic-already-have-an-active-diagnostic-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28447-result-case-not-implemented-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28447-result-case-not-implemented-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28448-dist-nested-type-should-have-matched-associated-type-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28448-dist-nested-type-should-have-matched-associated-type-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28451-boundgeneric-getgenericargs-size-genericsig-getinnermostgenericparams-size-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28451-boundgeneric-getgenericargs-size-genericsig-getinnermostgenericparams-size-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28452-this-genericenv-already-have-generic-context-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28452-this-genericenv-already-have-generic-context-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28454-hasval-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28454-hasval-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28456-unreachable-executed-at-swift-lib-ast-module-cpp-614.swift
+++ b/validation-test/compiler_crashers_fixed/28456-unreachable-executed-at-swift-lib-ast-module-cpp-614.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28457-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
+++ b/validation-test/compiler_crashers_fixed/28457-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28458-resultreplacement-istypeparameter-cant-be-dependent.swift
+++ b/validation-test/compiler_crashers_fixed/28458-resultreplacement-istypeparameter-cant-be-dependent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28459-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28459-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28460-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28460-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28461-child-source-range-not-contained-within-its-parent-if-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28461-child-source-range-not-contained-within-its-parent-if-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28462-segfault-0xcdc361-0xd051ef-0xcdc361-0xd051ef.swift
+++ b/validation-test/compiler_crashers_fixed/28462-segfault-0xcdc361-0xd051ef-0xcdc361-0xd051ef.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28463-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28463-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28464-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28464-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28465-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28465-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28466-segfault-0xc27624-0xc2741f-0xc25bb5-0xbcdbbb.swift
+++ b/validation-test/compiler_crashers_fixed/28466-segfault-0xc27624-0xc2741f-0xc25bb5-0xbcdbbb.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28467-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28467-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28468-segfault-0xd09050-0xd08dfd-0xbe9d76-0xbeb154.swift
+++ b/validation-test/compiler_crashers_fixed/28468-segfault-0xd09050-0xd08dfd-0xbe9d76-0xbeb154.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28469-segfault-0x4674de-0x464be6.swift
+++ b/validation-test/compiler_crashers_fixed/28469-segfault-0x4674de-0x464be6.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28470-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28470-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28471-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28471-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28472-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
+++ b/validation-test/compiler_crashers_fixed/28472-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28473-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers_fixed/28473-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
+++ b/validation-test/compiler_crashers_fixed/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28475-swift-typechecker-validatedecl-swift-valuedecl-bool.swift
+++ b/validation-test/compiler_crashers_fixed/28475-swift-typechecker-validatedecl-swift-valuedecl-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28476-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
+++ b/validation-test/compiler_crashers_fixed/28476-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28477-anonymous-namespace-declchecker-visitconstructordecl-swift-constructordecl.swift
+++ b/validation-test/compiler_crashers_fixed/28477-anonymous-namespace-declchecker-visitconstructordecl-swift-constructordecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28479-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers_fixed/28479-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28480-unreachable-executed-at-swift-lib-sema-csdiag-cpp-6261.swift
+++ b/validation-test/compiler_crashers_fixed/28480-unreachable-executed-at-swift-lib-sema-csdiag-cpp-6261.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28481-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28481-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28482-hasaccessibility-accessibility-not-computed-yet.swift
+++ b/validation-test/compiler_crashers_fixed/28482-hasaccessibility-accessibility-not-computed-yet.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28483-unreachable-executed-at-swift-lib-ast-type-cpp-1117.swift
+++ b/validation-test/compiler_crashers_fixed/28483-unreachable-executed-at-swift-lib-ast-type-cpp-1117.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28484-isa-x-val-cast-ty-argument-of-incompatible-type.swift
+++ b/validation-test/compiler_crashers_fixed/28484-isa-x-val-cast-ty-argument-of-incompatible-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28485-swift-dependentmembertype-getname-const.swift
+++ b/validation-test/compiler_crashers_fixed/28485-swift-dependentmembertype-getname-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28486-this-genericenv-already-have-generic-context.swift
+++ b/validation-test/compiler_crashers_fixed/28486-this-genericenv-already-have-generic-context.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28487-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
+++ b/validation-test/compiler_crashers_fixed/28487-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28488-conforms-replacement-haserror-isopenedanyobject-replacement-replacement-is-gener.swift
+++ b/validation-test/compiler_crashers_fixed/28488-conforms-replacement-haserror-isopenedanyobject-replacement-replacement-is-gener.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28489-this-genericenv-already-have-generic-context.swift
+++ b/validation-test/compiler_crashers_fixed/28489-this-genericenv-already-have-generic-context.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28490-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28490-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28491-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28491-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28492-isa-abstractfunctiondecl-dc-isa-fileunit-dc-unknown-declcontext.swift
+++ b/validation-test/compiler_crashers_fixed/28492-isa-abstractfunctiondecl-dc-isa-fileunit-dc-unknown-declcontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28493-resolveidenttypecomponent-swift-typechecker-swift-declcontext-llvm-arrayref-swif.swift
+++ b/validation-test/compiler_crashers_fixed/28493-resolveidenttypecomponent-swift-typechecker-swift-declcontext-llvm-arrayref-swif.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28494-conforms-type-does-not-conform-to-protocol.swift
+++ b/validation-test/compiler_crashers_fixed/28494-conforms-type-does-not-conform-to-protocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28495-ed-getdeclcontext-ismodulescopecontext-non-top-level-extensions-make-private-fil.swift
+++ b/validation-test/compiler_crashers_fixed/28495-ed-getdeclcontext-ismodulescopecontext-non-top-level-extensions-make-private-fil.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28496-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers_fixed/28496-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28497-unreachable-executed-at-swift-lib-ast-type-cpp-294.swift
+++ b/validation-test/compiler_crashers_fixed/28497-unreachable-executed-at-swift-lib-ast-type-cpp-294.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28498-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28498-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28499-start-isvalid-end-isvalid-start-and-end-should-either-both-be-valid-or-both-be-i.swift
+++ b/validation-test/compiler_crashers_fixed/28499-start-isvalid-end-isvalid-start-and-end-should-either-both-be-valid-or-both-be-i.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28500-unreachable-executed-at-swift-lib-sema-typecheckdecl-cpp-1687.swift
+++ b/validation-test/compiler_crashers_fixed/28500-unreachable-executed-at-swift-lib-sema-typecheckdecl-cpp-1687.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28501-haderror-m-is-sourcefile-m-get-sourcefile-aststage-sourcefile-typechecked-overlo.swift
+++ b/validation-test/compiler_crashers_fixed/28501-haderror-m-is-sourcefile-m-get-sourcefile-aststage-sourcefile-typechecked-overlo.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28502-tok-isnot-tok-eof-lexing-past-eof.swift
+++ b/validation-test/compiler_crashers_fixed/28502-tok-isnot-tok-eof-lexing-past-eof.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28503-iscomplete-missing-inherited-mapping-in-conformance.swift
+++ b/validation-test/compiler_crashers_fixed/28503-iscomplete-missing-inherited-mapping-in-conformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28504-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28504-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28505-failed-call-arguments-did-not-match-up.swift
+++ b/validation-test/compiler_crashers_fixed/28505-failed-call-arguments-did-not-match-up.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28506-swift-iterativetypechecker-issatisfied-swift-typecheckrequest.swift
+++ b/validation-test/compiler_crashers_fixed/28506-swift-iterativetypechecker-issatisfied-swift-typecheckrequest.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28507-swift-typerepr-getsourcerange-const.swift
+++ b/validation-test/compiler_crashers_fixed/28507-swift-typerepr-getsourcerange-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28508-unreachable-executed-at-swift-lib-sema-csgen-cpp-2656.swift
+++ b/validation-test/compiler_crashers_fixed/28508-unreachable-executed-at-swift-lib-sema-csgen-cpp-2656.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28509-allowoverwrite-e-haslvalueaccesskind-l-value-access-kind-has-already-been-set.swift
+++ b/validation-test/compiler_crashers_fixed/28509-allowoverwrite-e-haslvalueaccesskind-l-value-access-kind-has-already-been-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28511-swift-astvisitor-anonymous-namespace-attributechecker-void-void-void-void-void-v.swift
+++ b/validation-test/compiler_crashers_fixed/28511-swift-astvisitor-anonymous-namespace-attributechecker-void-void-void-void-void-v.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28512-anonymous-namespace-traversal-visit-swift-typerepr.swift
+++ b/validation-test/compiler_crashers_fixed/28512-anonymous-namespace-traversal-visit-swift-typerepr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28513-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
+++ b/validation-test/compiler_crashers_fixed/28513-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28514-assign-isfolded-already-folded-assign-expr-in-sequence.swift
+++ b/validation-test/compiler_crashers_fixed/28514-assign-isfolded-already-folded-assign-expr-in-sequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28515-getmutableaddressor.swift
+++ b/validation-test/compiler_crashers_fixed/28515-getmutableaddressor.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28516-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28516-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28517-getstoragekind-stored-storagekind-already-set.swift
+++ b/validation-test/compiler_crashers_fixed/28517-getstoragekind-stored-storagekind-already-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28518-anonymous-namespace-verifier-walktoexprpost-swift-expr.swift
+++ b/validation-test/compiler_crashers_fixed/28518-anonymous-namespace-verifier-walktoexprpost-swift-expr.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28519-conformance-must-conform-to-literal-protocol.swift
+++ b/validation-test/compiler_crashers_fixed/28519-conformance-must-conform-to-literal-protocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28520-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers_fixed/28520-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28521-hastype-declaration-has-no-type-set-yet.swift
+++ b/validation-test/compiler_crashers_fixed/28521-hastype-declaration-has-no-type-set-yet.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28522-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28522-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28523-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
+++ b/validation-test/compiler_crashers_fixed/28523-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28524-swift-iterativetypechecker-issatisfied-swift-typecheckrequest.swift
+++ b/validation-test/compiler_crashers_fixed/28524-swift-iterativetypechecker-issatisfied-swift-typecheckrequest.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28525-tok-isany-tok-identifier-tok-kw-self-tok-kw-self-tok-kw-throws.swift
+++ b/validation-test/compiler_crashers_fixed/28525-tok-isany-tok-identifier-tok-kw-self-tok-kw-self-tok-kw-throws.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28526-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers_fixed/28526-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28527-e-gettype-isassignabletype-setting-access-kind-on-non-l-value.swift
+++ b/validation-test/compiler_crashers_fixed/28527-e-gettype-isassignabletype-setting-access-kind-on-non-l-value.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28528-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
+++ b/validation-test/compiler_crashers_fixed/28528-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28529-arrow-isfolded-already-folded-expr-in-sequence.swift
+++ b/validation-test/compiler_crashers_fixed/28529-arrow-isfolded-already-folded-expr-in-sequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28530-dc-closure-getparent-decl-context-isnt-correct.swift
+++ b/validation-test/compiler_crashers_fixed/28530-dc-closure-getparent-decl-context-isnt-correct.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28531-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
+++ b/validation-test/compiler_crashers_fixed/28531-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28532-unreachable-executed-at-swift-lib-ast-type-cpp-174.swift
+++ b/validation-test/compiler_crashers_fixed/28532-unreachable-executed-at-swift-lib-ast-type-cpp-174.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28533-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28533-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28534-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28534-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28535-unreachable-executed-at-swift-lib-parse-parsedecl-cpp-610.swift
+++ b/validation-test/compiler_crashers_fixed/28535-unreachable-executed-at-swift-lib-parse-parsedecl-cpp-610.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28536-swift-namelookup-lookupinmodule-swift-moduledecl-llvm-arrayref-std-pair-swift-id.swift
+++ b/validation-test/compiler_crashers_fixed/28536-swift-namelookup-lookupinmodule-swift-moduledecl-llvm-arrayref-std-pair-swift-id.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28537-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28537-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28538-swift-removeshadoweddecls-llvm-smallvectorimpl-swift-valuedecl-swift-moduledecl-.swift
+++ b/validation-test/compiler_crashers_fixed/28538-swift-removeshadoweddecls-llvm-smallvectorimpl-swift-valuedecl-swift-moduledecl-.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28539-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28539-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28540-swift-namelookup-findlocalval-visitguardstmt-swift-guardstmt.swift
+++ b/validation-test/compiler_crashers_fixed/28540-swift-namelookup-findlocalval-visitguardstmt-swift-guardstmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28541-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
+++ b/validation-test/compiler_crashers_fixed/28541-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28542-swift-genericsignature-getsubstitutionmap-llvm-arrayref-swift-substitution-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28542-swift-genericsignature-getsubstitutionmap-llvm-arrayref-swift-substitution-swift.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers_fixed/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28544-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
+++ b/validation-test/compiler_crashers_fixed/28544-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28545-swift-archetypebuilder-potentialarchetype-gettype-swift-archetypebuilder.swift
+++ b/validation-test/compiler_crashers_fixed/28545-swift-archetypebuilder-potentialarchetype-gettype-swift-archetypebuilder.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28546-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
+++ b/validation-test/compiler_crashers_fixed/28546-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28547-env-dependent-type-in-non-generic-context.swift
+++ b/validation-test/compiler_crashers_fixed/28547-env-dependent-type-in-non-generic-context.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28548-cantype-hastypeparameter-already-have-an-interface-type.swift
+++ b/validation-test/compiler_crashers_fixed/28548-cantype-hastypeparameter-already-have-an-interface-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28549-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28549-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28550-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers_fixed/28550-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28551-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28551-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28552-as-isfolded-already-folded-as-expr-in-sequence.swift
+++ b/validation-test/compiler_crashers_fixed/28552-as-isfolded-already-folded-as-expr-in-sequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28553-resolver-unable-to-resolve-type-witness.swift
+++ b/validation-test/compiler_crashers_fixed/28553-resolver-unable-to-resolve-type-witness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28554-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers_fixed/28554-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28555-unreachable-executed-at-swift-lib-ast-type-cpp-1318.swift
+++ b/validation-test/compiler_crashers_fixed/28555-unreachable-executed-at-swift-lib-ast-type-cpp-1318.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28556-val-isa-used-on-a-null-pointer.swift
+++ b/validation-test/compiler_crashers_fixed/28556-val-isa-used-on-a-null-pointer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28557-swift-astvisitor-anonymous-namespace-printtyperepr-void-void-void-void-void-void.swift
+++ b/validation-test/compiler_crashers_fixed/28557-swift-astvisitor-anonymous-namespace-printtyperepr-void-void-void-void-void-void.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28558-known-typewitnesses-end-didnt-resolve-witness.swift
+++ b/validation-test/compiler_crashers_fixed/28558-known-typewitnesses-end-didnt-resolve-witness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28559-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28559-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28560-unreachable-executed-at-swift-lib-ast-type-cpp-1104.swift
+++ b/validation-test/compiler_crashers_fixed/28560-unreachable-executed-at-swift-lib-ast-type-cpp-1104.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28561-input-hastypevariable-output-hastypevariable.swift
+++ b/validation-test/compiler_crashers_fixed/28561-input-hastypevariable-output-hastypevariable.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28562-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28562-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28563-swift-modulefile-lookupvalue-swift-declname-llvm-smallvectorimpl-swift-valuedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28563-swift-modulefile-lookupvalue-swift-declname-llvm-smallvectorimpl-swift-valuedecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28564-swift-nominaltypedecl-getdeclaredtype-const.swift
+++ b/validation-test/compiler_crashers_fixed/28564-swift-nominaltypedecl-getdeclaredtype-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28565-swift-constraints-constraintsystem-removeinactiveconstraint-swift-constraints-co.swift
+++ b/validation-test/compiler_crashers_fixed/28565-swift-constraints-constraintsystem-removeinactiveconstraint-swift-constraints-co.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28566-env-dependent-type-in-non-generic-context.swift
+++ b/validation-test/compiler_crashers_fixed/28566-env-dependent-type-in-non-generic-context.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28567-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28567-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28568-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28568-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28569-swift-declcontext-getastypeortypeextensioncontext-const.swift
+++ b/validation-test/compiler_crashers_fixed/28569-swift-declcontext-getastypeortypeextensioncontext-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28570-labelinfo-tryloc-isvalid-unlabeled-directives-should-be-handled-earlier.swift
+++ b/validation-test/compiler_crashers_fixed/28570-labelinfo-tryloc-isvalid-unlabeled-directives-should-be-handled-earlier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28571-hasinterfacetype-no-interface-type-was-set.swift
+++ b/validation-test/compiler_crashers_fixed/28571-hasinterfacetype-no-interface-type-was-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28572-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28572-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28573-type-hasarchetype-archetype-in-interface-type.swift
+++ b/validation-test/compiler_crashers_fixed/28573-type-hasarchetype-archetype-in-interface-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28574-iscomplete-isinvalid-resolver-did-not-resolve-requirement.swift
+++ b/validation-test/compiler_crashers_fixed/28574-iscomplete-isinvalid-resolver-did-not-resolve-requirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28575-unreachable-executed-at-swift-lib-sema-csapply-cpp-5647.swift
+++ b/validation-test/compiler_crashers_fixed/28575-unreachable-executed-at-swift-lib-sema-csapply-cpp-5647.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28576-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28576-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28577-isa-x-val-cast-ty-argument-of-incompatible-type.swift
+++ b/validation-test/compiler_crashers_fixed/28577-isa-x-val-cast-ty-argument-of-incompatible-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28578-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28578-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28579-unreachable-executed-at-swift-lib-sema-csdiag-cpp-5054.swift
+++ b/validation-test/compiler_crashers_fixed/28579-unreachable-executed-at-swift-lib-sema-csdiag-cpp-5054.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28580-hastype-e-expected-type-to-have-been-set.swift
+++ b/validation-test/compiler_crashers_fixed/28580-hastype-e-expected-type-to-have-been-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28581-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28581-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28582-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28582-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28583-unreachable-executed-at-swift-lib-ast-type-cpp-1098.swift
+++ b/validation-test/compiler_crashers_fixed/28583-unreachable-executed-at-swift-lib-ast-type-cpp-1098.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28584-loc-isvalid.swift
+++ b/validation-test/compiler_crashers_fixed/28584-loc-isvalid.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28585-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28585-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28586-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers_fixed/28586-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28587-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
+++ b/validation-test/compiler_crashers_fixed/28587-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28588-unreachable-executed-at-swift-lib-sema-csapply-cpp-5770.swift
+++ b/validation-test/compiler_crashers_fixed/28588-unreachable-executed-at-swift-lib-sema-csapply-cpp-5770.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28589-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
+++ b/validation-test/compiler_crashers_fixed/28589-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28590-exprtypes-e-isequal-e-gettype-expected-type-in-map-to-be-the-same-type-in-expres.swift
+++ b/validation-test/compiler_crashers_fixed/28590-exprtypes-e-isequal-e-gettype-expected-type-in-map-to-be-the-same-type-in-expres.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28591-swift-constraints-constraintsystem-solvesimplified-llvm-smallvectorimpl-swift-co.swift
+++ b/validation-test/compiler_crashers_fixed/28591-swift-constraints-constraintsystem-solvesimplified-llvm-smallvectorimpl-swift-co.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28592-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers_fixed/28592-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28593-unreachable-executed-at-swift-lib-ast-type-cpp-3771.swift
+++ b/validation-test/compiler_crashers_fixed/28593-unreachable-executed-at-swift-lib-ast-type-cpp-3771.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28594-anonymous-namespace-verifier-verifychecked-swift-vardecl.swift
+++ b/validation-test/compiler_crashers_fixed/28594-anonymous-namespace-verifier-verifychecked-swift-vardecl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28595-typeincontext-isnull-no-contextual-type-set-yet.swift
+++ b/validation-test/compiler_crashers_fixed/28595-typeincontext-isnull-no-contextual-type-set-yet.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28596-unreachable-executed-at-swift-lib-sema-csapply-cpp-5466.swift
+++ b/validation-test/compiler_crashers_fixed/28596-unreachable-executed-at-swift-lib-sema-csapply-cpp-5466.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28597-first-char-of-sub-string-may-not-be-a-digit.swift
+++ b/validation-test/compiler_crashers_fixed/28597-first-char-of-sub-string-may-not-be-a-digit.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28598-issatisfied-request.swift
+++ b/validation-test/compiler_crashers_fixed/28598-issatisfied-request.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28599-false-should-have-found-context-by-now.swift
+++ b/validation-test/compiler_crashers_fixed/28599-false-should-have-found-context-by-now.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28600-isinsilmode-sil-should-only-be-a-keyword-in-sil-mode.swift
+++ b/validation-test/compiler_crashers_fixed/28600-isinsilmode-sil-should-only-be-a-keyword-in-sil-mode.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28601-getkind-exprkind-binary-isa-tupleexpr-e-binaryexprs-must-have-a-tupleexpr-as-the.swift
+++ b/validation-test/compiler_crashers_fixed/28601-getkind-exprkind-binary-isa-tupleexpr-e-binaryexprs-must-have-a-tupleexpr-as-the.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28602-c1-size-c2-size.swift
+++ b/validation-test/compiler_crashers_fixed/28602-c1-size-c2-size.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28603-argumentlabels-size-1.swift
+++ b/validation-test/compiler_crashers_fixed/28603-argumentlabels-size-1.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28604-isinheritedprotocolsvalid.swift
+++ b/validation-test/compiler_crashers_fixed/28604-isinheritedprotocolsvalid.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28605-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28605-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28606-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28606-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28607-hasinterfacetype-no-interface-type-was-set.swift
+++ b/validation-test/compiler_crashers_fixed/28607-hasinterfacetype-no-interface-type-was-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28608-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28608-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28609-unreachable-executed-at-swift-lib-sema-csapply-cpp-5859.swift
+++ b/validation-test/compiler_crashers_fixed/28609-unreachable-executed-at-swift-lib-sema-csapply-cpp-5859.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28610-elements-size-1-even-number-of-elements-in-sequence.swift
+++ b/validation-test/compiler_crashers_fixed/28610-elements-size-1-even-number-of-elements-in-sequence.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28611-isa-x-val-cast-ty-argument-of-incompatible-type.swift
+++ b/validation-test/compiler_crashers_fixed/28611-isa-x-val-cast-ty-argument-of-incompatible-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28612-val-isa-used-on-a-null-pointer.swift
+++ b/validation-test/compiler_crashers_fixed/28612-val-isa-used-on-a-null-pointer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28613-matchcanfail-failed-call-arguments-did-not-match-up.swift
+++ b/validation-test/compiler_crashers_fixed/28613-matchcanfail-failed-call-arguments-did-not-match-up.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28614-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers_fixed/28614-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28615-swift-constraints-constraintgraph-bindtypevariable-swift-typevariabletype-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28615-swift-constraints-constraintgraph-bindtypevariable-swift-typevariabletype-swift.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28616-swift-parser-parseexprsequence-swift-diag-bool-bool.swift
+++ b/validation-test/compiler_crashers_fixed/28616-swift-parser-parseexprsequence-swift-diag-bool-bool.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28617-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28617-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28618-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-78.swift
+++ b/validation-test/compiler_crashers_fixed/28618-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-78.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28619-basety-islvaluetype-basety-is-anymetatypetype.swift
+++ b/validation-test/compiler_crashers_fixed/28619-basety-islvaluetype-basety-is-anymetatypetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28620-type-mayhavemembers.swift
+++ b/validation-test/compiler_crashers_fixed/28620-type-mayhavemembers.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28621-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers_fixed/28621-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28622-vd-getdeclcontext-ismodulescopecontext.swift
+++ b/validation-test/compiler_crashers_fixed/28622-vd-getdeclcontext-ismodulescopecontext.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28623-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers_fixed/28623-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28624-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
+++ b/validation-test/compiler_crashers_fixed/28624-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28625-destoptionals-size-destextraoptionals-srcoptionals-size.swift
+++ b/validation-test/compiler_crashers_fixed/28625-destoptionals-size-destextraoptionals-srcoptionals-size.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28626-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers_fixed/28626-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28627-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-79.swift
+++ b/validation-test/compiler_crashers_fixed/28627-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-79.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28628-gettype-e-isassignabletype-setting-access-kind-on-non-l-value.swift
+++ b/validation-test/compiler_crashers_fixed/28628-gettype-e-isassignabletype-setting-access-kind-on-non-l-value.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28629-type-hastypeparameter-already-have-an-interface-type.swift
+++ b/validation-test/compiler_crashers_fixed/28629-type-hastypeparameter-already-have-an-interface-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28630-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28630-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28631-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
+++ b/validation-test/compiler_crashers_fixed/28631-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28632-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
+++ b/validation-test/compiler_crashers_fixed/28632-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28633-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers_fixed/28633-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28635-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers_fixed/28635-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28636-base-base-hastypeparameter.swift
+++ b/validation-test/compiler_crashers_fixed/28636-base-base-hastypeparameter.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28637-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers_fixed/28637-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28638-anonymous-namespace-verifier-checksametype-swift-type-swift-type-char-const.swift
+++ b/validation-test/compiler_crashers_fixed/28638-anonymous-namespace-verifier-checksametype-swift-type-swift-type-char-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28639-unreachable-executed-at-swift-lib-ast-type-cpp-1337.swift
+++ b/validation-test/compiler_crashers_fixed/28639-unreachable-executed-at-swift-lib-ast-type-cpp-1337.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28640-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers_fixed/28640-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28641-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28641-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28642-swift-optionaltype-get-swift-type.swift
+++ b/validation-test/compiler_crashers_fixed/28642-swift-optionaltype-get-swift-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28643-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers_fixed/28643-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28644-swift-functiontype-get-swift-type-swift-type-swift-anyfunctiontype-extinfo-const.swift
+++ b/validation-test/compiler_crashers_fixed/28644-swift-functiontype-get-swift-type-swift-type-swift-anyfunctiontype-extinfo-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28645-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
+++ b/validation-test/compiler_crashers_fixed/28645-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28646-swift-lvaluetype-get-swift-type.swift
+++ b/validation-test/compiler_crashers_fixed/28646-swift-lvaluetype-get-swift-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28647-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers_fixed/28647-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28648-modifierarguments-empty-foundpipe-index-beyond-bounds-in-select-modifier.swift
+++ b/validation-test/compiler_crashers_fixed/28648-modifierarguments-empty-foundpipe-index-beyond-bounds-in-select-modifier.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28649-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
+++ b/validation-test/compiler_crashers_fixed/28649-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28650-unreachable-executed-at-swift-lib-sema-typecheckstmt-cpp-1031.swift
+++ b/validation-test/compiler_crashers_fixed/28650-unreachable-executed-at-swift-lib-sema-typecheckstmt-cpp-1031.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28651-swift-cleanupillformedexpressionraii-doit-swift-expr-swift-astcontext-cleanupill.swift
+++ b/validation-test/compiler_crashers_fixed/28651-swift-cleanupillformedexpressionraii-doit-swift-expr-swift-astcontext-cleanupill.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28652-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28652-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28654-hastype-e-expected-type-to-have-been-set.swift
+++ b/validation-test/compiler_crashers_fixed/28654-hastype-e-expected-type-to-have-been-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28655-base-base-hastypeparameter.swift
+++ b/validation-test/compiler_crashers_fixed/28655-base-base-hastypeparameter.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28656-unreachable-executed-at-swift-lib-ast-type-cpp-1137.swift
+++ b/validation-test/compiler_crashers_fixed/28656-unreachable-executed-at-swift-lib-ast-type-cpp-1137.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28657-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
+++ b/validation-test/compiler_crashers_fixed/28657-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28658-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28658-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28659-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28659-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28660-false-encountered-error-in-diagnostic-text.swift
+++ b/validation-test/compiler_crashers_fixed/28660-false-encountered-error-in-diagnostic-text.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28661-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28661-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28662-isa-x-val-cast-ty-argument-of-incompatible-type.swift
+++ b/validation-test/compiler_crashers_fixed/28662-isa-x-val-cast-ty-argument-of-incompatible-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28663-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
+++ b/validation-test/compiler_crashers_fixed/28663-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28664-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers_fixed/28664-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28665-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28665-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28666-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
+++ b/validation-test/compiler_crashers_fixed/28666-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28667-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28667-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28668-activediagnostic-already-have-an-active-diagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28668-activediagnostic-already-have-an-active-diagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28669-basety-islvaluetype-basety-is-anymetatypetype.swift
+++ b/validation-test/compiler_crashers_fixed/28669-basety-islvaluetype-basety-is-anymetatypetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28670-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers_fixed/28670-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28671-index-this-size-invalid-index.swift
+++ b/validation-test/compiler_crashers_fixed/28671-index-this-size-invalid-index.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28672-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28672-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28673-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28673-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28674-unreachable-executed-at-swift-lib-sema-csapply-cpp-5856.swift
+++ b/validation-test/compiler_crashers_fixed/28674-unreachable-executed-at-swift-lib-sema-csapply-cpp-5856.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28675-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28675-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28676-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28676-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28676-currentconstraintsolverarena-no-constraint-solver-active.swift
+++ b/validation-test/compiler_crashers_fixed/28676-currentconstraintsolverarena-no-constraint-solver-active.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28677-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28677-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28678-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28678-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28679-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28679-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28680-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28680-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28681-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28681-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28683-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28683-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28684-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28684-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28685-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
+++ b/validation-test/compiler_crashers_fixed/28685-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28686-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28686-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28687-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
+++ b/validation-test/compiler_crashers_fixed/28687-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28688-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
+++ b/validation-test/compiler_crashers_fixed/28688-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28690-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28690-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28691-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28691-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28692-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
+++ b/validation-test/compiler_crashers_fixed/28692-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28693-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
+++ b/validation-test/compiler_crashers_fixed/28693-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28694-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28694-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28695-unreachable-executed-at-swift-lib-ast-type-cpp-1351.swift
+++ b/validation-test/compiler_crashers_fixed/28695-unreachable-executed-at-swift-lib-ast-type-cpp-1351.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28696-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28696-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28697-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28697-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28698-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28698-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28699-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28699-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28700-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28700-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28701-false-should-have-found-context-by-now.swift
+++ b/validation-test/compiler_crashers_fixed/28701-false-should-have-found-context-by-now.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28702-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28702-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28703-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28703-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28704-swift-newmangling-astmangler-appendcontext-swift-declcontext-const.swift
+++ b/validation-test/compiler_crashers_fixed/28704-swift-newmangling-astmangler-appendcontext-swift-declcontext-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28705-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28705-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28706-conformance-failed-to-find-pas-conformance-to-known-protocol.swift
+++ b/validation-test/compiler_crashers_fixed/28706-conformance-failed-to-find-pas-conformance-to-known-protocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28707-false-encountered-error-in-diagnostic-text.swift
+++ b/validation-test/compiler_crashers_fixed/28707-false-encountered-error-in-diagnostic-text.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28709-unreachable-executed-at-swift-lib-ast-type-cpp-1005.swift
+++ b/validation-test/compiler_crashers_fixed/28709-unreachable-executed-at-swift-lib-ast-type-cpp-1005.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28710-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28710-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28711-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28711-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28712-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28712-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28713-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28713-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28714-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28714-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28715-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28715-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28716-unreachable-executed-at-swift-lib-ast-type-cpp-1215.swift
+++ b/validation-test/compiler_crashers_fixed/28716-unreachable-executed-at-swift-lib-ast-type-cpp-1215.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28717-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28717-result-case-not-implemented.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28718-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28718-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28719-currentconstraintsolverarena-no-constraint-solver-active.swift
+++ b/validation-test/compiler_crashers_fixed/28719-currentconstraintsolverarena-no-constraint-solver-active.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28720-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28720-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28721-unreachable-executed-at-swift-lib-ast-astmangler-cpp-451.swift
+++ b/validation-test/compiler_crashers_fixed/28721-unreachable-executed-at-swift-lib-ast-astmangler-cpp-451.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift
+++ b/validation-test/compiler_crashers_fixed/28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28723-unreachable-executed-at-swift-lib-sema-csdiag-cpp-4012.swift
+++ b/validation-test/compiler_crashers_fixed/28723-unreachable-executed-at-swift-lib-sema-csdiag-cpp-4012.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28725-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers_fixed/28725-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28726-nominaltypedecl-hasfixedlayout.swift
+++ b/validation-test/compiler_crashers_fixed/28726-nominaltypedecl-hasfixedlayout.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28727-objectty-haserror-cannot-have-errortype-wrapped-inside-lvaluetype.swift
+++ b/validation-test/compiler_crashers_fixed/28727-objectty-haserror-cannot-have-errortype-wrapped-inside-lvaluetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28728-d-isbeingvalidated-d-hasvalidsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28728-d-isbeingvalidated-d-hasvalidsignature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28729-archetype-bad-generic-context-nesting.swift
+++ b/validation-test/compiler_crashers_fixed/28729-archetype-bad-generic-context-nesting.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28730-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1229.swift
+++ b/validation-test/compiler_crashers_fixed/28730-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1229.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28731-genericenv-nullptr-too-much-circularity.swift
+++ b/validation-test/compiler_crashers_fixed/28731-genericenv-nullptr-too-much-circularity.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28732-type-hasarchetype-not-fully-substituted.swift
+++ b/validation-test/compiler_crashers_fixed/28732-type-hasarchetype-not-fully-substituted.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28733-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
+++ b/validation-test/compiler_crashers_fixed/28733-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28734-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
+++ b/validation-test/compiler_crashers_fixed/28734-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28735-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers_fixed/28735-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28736-anonymous-namespacesilverifier-require.swift
+++ b/validation-test/compiler_crashers_fixed/28736-anonymous-namespacesilverifier-require.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28737-genericenv-nullptr-too-much-circularity.swift
+++ b/validation-test/compiler_crashers_fixed/28737-genericenv-nullptr-too-much-circularity.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28738-impl-genericparams-empty-key-depth-impl-genericparams-back-getdepth-key-index-im.swift
+++ b/validation-test/compiler_crashers_fixed/28738-impl-genericparams-empty-key-depth-impl-genericparams-back-getdepth-key-index-im.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28739-unreachable-executed-at-swift-lib-ast-type-cpp-229.swift
+++ b/validation-test/compiler_crashers_fixed/28739-unreachable-executed-at-swift-lib-ast-type-cpp-229.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28740-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1324.swift
+++ b/validation-test/compiler_crashers_fixed/28740-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1324.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28741-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
+++ b/validation-test/compiler_crashers_fixed/28741-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28742-swift-type-subst-llvm-function-ref-swift-type-swift-substitutabletype-llvm-funct.swift
+++ b/validation-test/compiler_crashers_fixed/28742-swift-type-subst-llvm-function-ref-swift-type-swift-substitutabletype-llvm-funct.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28743-swift-typechecker-substmembertypewithbase-swift-moduledecl-swift-typedecl-swift-.swift
+++ b/validation-test/compiler_crashers_fixed/28743-swift-typechecker-substmembertypewithbase-swift-moduledecl-swift-typedecl-swift-.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28744-swift-genericenvironment-maptypeoutofcontext-swift-genericenvironment-swift-type.swift
+++ b/validation-test/compiler_crashers_fixed/28744-swift-genericenvironment-maptypeoutofcontext-swift-genericenvironment-swift-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28745-ty-getnominalorboundgenericnominal-ty-is-dynamicselftype-ty-isexistentialtype-ty.swift
+++ b/validation-test/compiler_crashers_fixed/28745-ty-getnominalorboundgenericnominal-ty-is-dynamicselftype-ty-isexistentialtype-ty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28746-second-missing-second-type.swift
+++ b/validation-test/compiler_crashers_fixed/28746-second-missing-second-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28748-genericenv-nullptr-too-much-circularity.swift
+++ b/validation-test/compiler_crashers_fixed/28748-genericenv-nullptr-too-much-circularity.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28749-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers_fixed/28749-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28750-false-should-have-found-context-by-now.swift
+++ b/validation-test/compiler_crashers_fixed/28750-false-should-have-found-context-by-now.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28751-membertype-missing-type-witness.swift
+++ b/validation-test/compiler_crashers_fixed/28751-membertype-missing-type-witness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28752-hasinterfacetype-no-interface-type-was-set.swift
+++ b/validation-test/compiler_crashers_fixed/28752-hasinterfacetype-no-interface-type-was-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28753-conforms-equivclass-conformsto-end.swift
+++ b/validation-test/compiler_crashers_fixed/28753-conforms-equivclass-conformsto-end.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28754-value-openexistentials-end-didnt-see-this-ove-in-a-containing-openexistentialexp.swift
+++ b/validation-test/compiler_crashers_fixed/28754-value-openexistentials-end-didnt-see-this-ove-in-a-containing-openexistentialexp.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28755-getkind-requirementkind-layout.swift
+++ b/validation-test/compiler_crashers_fixed/28755-getkind-requirementkind-layout.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28756-isobjc-cannot-get-root-type-of-objc-keypath.swift
+++ b/validation-test/compiler_crashers_fixed/28756-isobjc-cannot-get-root-type-of-objc-keypath.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28757-conformance-getwitness-requirement-nullptr-getdecl-match-witness-deduced-differe.swift
+++ b/validation-test/compiler_crashers_fixed/28757-conformance-getwitness-requirement-nullptr-getdecl-match-witness-deduced-differe.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28758-swift-genericsignaturebuilder-resolvesuperconformance-swift-genericsignaturebuil.swift
+++ b/validation-test/compiler_crashers_fixed/28758-swift-genericsignaturebuilder-resolvesuperconformance-swift-genericsignaturebuil.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28759-activediagnostic-already-have-an-active-diagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28759-activediagnostic-already-have-an-active-diagnostic.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28760-dist-0-nested-type-should-have-matched-associated-type.swift
+++ b/validation-test/compiler_crashers_fixed/28760-dist-0-nested-type-should-have-matched-associated-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28761-allowoverwrite-e-haslvalueaccesskind-l-value-access-kind-has-already-been-set.swift
+++ b/validation-test/compiler_crashers_fixed/28761-allowoverwrite-e-haslvalueaccesskind-l-value-access-kind-has-already-been-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28762-valuetype-hasunboundgenerictype-valuetype-hastypeparameter.swift
+++ b/validation-test/compiler_crashers_fixed/28762-valuetype-hasunboundgenerictype-valuetype-hastypeparameter.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28763-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28763-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28764-swift-protocolconformanceref-llvm-function-ref-swift-protocolconformanceref-swif.swift
+++ b/validation-test/compiler_crashers_fixed/28764-swift-protocolconformanceref-llvm-function-ref-swift-protocolconformanceref-swif.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28765-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
+++ b/validation-test/compiler_crashers_fixed/28765-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28766-swift-iterativetypechecker-isqualifiedlookupindeclcontextsatisfied-swift-declcon.swift
+++ b/validation-test/compiler_crashers_fixed/28766-swift-iterativetypechecker-isqualifiedlookupindeclcontextsatisfied-swift-declcon.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28767-ty-getnominalorboundgenericnominal-ty-is-dynamicselftype-ty-isexistentialtype-ty.swift
+++ b/validation-test/compiler_crashers_fixed/28767-ty-getnominalorboundgenericnominal-ty-is-dynamicselftype-ty-isexistentialtype-ty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28768-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28768-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28769-conformance-gettypewitness-assoctype-nullptr-isequal-type-conflicting-type-witne.swift
+++ b/validation-test/compiler_crashers_fixed/28769-conformance-gettypewitness-assoctype-nullptr-isequal-type-conflicting-type-witne.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28770-selfty-isequal-proto-getselfinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28770-selfty-isequal-proto-getselfinterfacetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28771-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
+++ b/validation-test/compiler_crashers_fixed/28771-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28772-loc-isvalid-diagnosing-attribute-with-invalid-location.swift
+++ b/validation-test/compiler_crashers_fixed/28772-loc-isvalid-diagnosing-attribute-with-invalid-location.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28773-unreachable-executed-at-swift-lib-sema-cssimplify-cpp-4808.swift
+++ b/validation-test/compiler_crashers_fixed/28773-unreachable-executed-at-swift-lib-sema-cssimplify-cpp-4808.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28774-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
+++ b/validation-test/compiler_crashers_fixed/28774-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28775-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers_fixed/28775-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28776-type-should-have-type-checked-inheritance-clause-by-now.swift
+++ b/validation-test/compiler_crashers_fixed/28776-type-should-have-type-checked-inheritance-clause-by-now.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28777-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28777-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28778-hasaccessibility-accessibility-not-computed-yet.swift
+++ b/validation-test/compiler_crashers_fixed/28778-hasaccessibility-accessibility-not-computed-yet.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28779-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
+++ b/validation-test/compiler_crashers_fixed/28779-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28780-hasinterfacetype-no-interface-type-was-set.swift
+++ b/validation-test/compiler_crashers_fixed/28780-hasinterfacetype-no-interface-type-was-set.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28783-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
+++ b/validation-test/compiler_crashers_fixed/28783-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28784-genericsigorenv-isnull-getgenericsignature-getcanonicalsignature-genericenv-getg.swift
+++ b/validation-test/compiler_crashers_fixed/28784-genericsigorenv-isnull-getgenericsignature-getcanonicalsignature-genericenv-getg.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28785-membertype-received-null-dependent-member-type.swift
+++ b/validation-test/compiler_crashers_fixed/28785-membertype-received-null-dependent-member-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28786-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
+++ b/validation-test/compiler_crashers_fixed/28786-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28788-conformance-isconcrete-concrete-isexistentialtype.swift
+++ b/validation-test/compiler_crashers_fixed/28788-conformance-isconcrete-concrete-isexistentialtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28789-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
+++ b/validation-test/compiler_crashers_fixed/28789-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28790-conformance-getwitness-requirement-nullptr-getdecl-already-have-a-non-optional-w.swift
+++ b/validation-test/compiler_crashers_fixed/28790-conformance-getwitness-requirement-nullptr-getdecl-already-have-a-non-optional-w.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28791-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
+++ b/validation-test/compiler_crashers_fixed/28791-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28792-conforms-equivclass-conformsto-end.swift
+++ b/validation-test/compiler_crashers_fixed/28792-conforms-equivclass-conformsto-end.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28793-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
+++ b/validation-test/compiler_crashers_fixed/28793-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28794-swift-type-transformrec-llvm-function-ref-llvm-optional-swift-type-swift-typebas.swift
+++ b/validation-test/compiler_crashers_fixed/28794-swift-type-transformrec-llvm-function-ref-llvm-optional-swift-type-swift-typebas.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28795-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
+++ b/validation-test/compiler_crashers_fixed/28795-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28796-result-second.swift
+++ b/validation-test/compiler_crashers_fixed/28796-result-second.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28797-declbits-beingvalidated-ibv.swift
+++ b/validation-test/compiler_crashers_fixed/28797-declbits-beingvalidated-ibv.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28798-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
+++ b/validation-test/compiler_crashers_fixed/28798-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28799-swift-type-subst-swift-substitutionmap-const-swift-substoptions-const.swift
+++ b/validation-test/compiler_crashers_fixed/28799-swift-type-subst-swift-substitutionmap-const-swift-substoptions-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28800-unreachable-executed-at-swift-lib-ast-type-cpp-3247.swift
+++ b/validation-test/compiler_crashers_fixed/28800-unreachable-executed-at-swift-lib-ast-type-cpp-3247.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28801-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
+++ b/validation-test/compiler_crashers_fixed/28801-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28802-constrainttype-missing-constraint-type.swift
+++ b/validation-test/compiler_crashers_fixed/28802-constrainttype-missing-constraint-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28803-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28803-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28804-second.swift
+++ b/validation-test/compiler_crashers_fixed/28804-second.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
+++ b/validation-test/compiler_crashers_fixed/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28808-hasval.swift
+++ b/validation-test/compiler_crashers_fixed/28808-hasval.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28810-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28810-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28811-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers_fixed/28811-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28812-getgenericparams.swift
+++ b/validation-test/compiler_crashers_fixed/28812-getgenericparams.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28813-swift-genericsignature-enumeratepairedrequirements-llvm-function-ref-bool-swift-.swift
+++ b/validation-test/compiler_crashers_fixed/28813-swift-genericsignature-enumeratepairedrequirements-llvm-function-ref-bool-swift-.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28814-basety-hasunboundgenerictype.swift
+++ b/validation-test/compiler_crashers_fixed/28814-basety-hasunboundgenerictype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28815-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
+++ b/validation-test/compiler_crashers_fixed/28815-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28816-unreachable-executed-at-swift-lib-sema-typecheckgeneric-cpp-214.swift
+++ b/validation-test/compiler_crashers_fixed/28816-unreachable-executed-at-swift-lib-sema-typecheckgeneric-cpp-214.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28817-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28817-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28819-formextensioninterfacetype-swift-type-swift-genericparamlist.swift
+++ b/validation-test/compiler_crashers_fixed/28819-formextensioninterfacetype-swift-type-swift-genericparamlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28820-fl-isinout-caller-did-not-set-flags-correctly.swift
+++ b/validation-test/compiler_crashers_fixed/28820-fl-isinout-caller-did-not-set-flags-correctly.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28821-isa-protocoldecl-nominal-cannot-be-a-protocol.swift
+++ b/validation-test/compiler_crashers_fixed/28821-isa-protocoldecl-nominal-cannot-be-a-protocol.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28822-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
+++ b/validation-test/compiler_crashers_fixed/28822-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28823-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
+++ b/validation-test/compiler_crashers_fixed/28823-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28824-hasval.swift
+++ b/validation-test/compiler_crashers_fixed/28824-hasval.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28825-isa-classdecl-nominaldecl-expected-a-class-here.swift
+++ b/validation-test/compiler_crashers_fixed/28825-isa-classdecl-nominaldecl-expected-a-class-here.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28826-type-haserror-should-not-be-assigning-a-type-involving-errortype.swift
+++ b/validation-test/compiler_crashers_fixed/28826-type-haserror-should-not-be-assigning-a-type-involving-errortype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28827-type-ismaterializable-argument-to-setmustbematerializablerecursive-may-not-be-in.swift
+++ b/validation-test/compiler_crashers_fixed/28827-type-ismaterializable-argument-to-setmustbematerializablerecursive-may-not-be-in.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28828-unreachable-executed-at-swift-lib-ast-type-cpp-3237.swift
+++ b/validation-test/compiler_crashers_fixed/28828-unreachable-executed-at-swift-lib-ast-type-cpp-3237.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28829-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
+++ b/validation-test/compiler_crashers_fixed/28829-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28830-formextensioninterfacetype-swift-type-swift-genericparamlist.swift
+++ b/validation-test/compiler_crashers_fixed/28830-formextensioninterfacetype-swift-type-swift-genericparamlist.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28831-type-ismaterializable-argument-to-setmustbematerializablerecursive-may-not-be-in.swift
+++ b/validation-test/compiler_crashers_fixed/28831-type-ismaterializable-argument-to-setmustbematerializablerecursive-may-not-be-in.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28832-superclass-superclass-hasarchetype-superclass-must-be-interface-type.swift
+++ b/validation-test/compiler_crashers_fixed/28832-superclass-superclass-hasarchetype-superclass-must-be-interface-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28833-foundintype-isexistentialtype.swift
+++ b/validation-test/compiler_crashers_fixed/28833-foundintype-isexistentialtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28834-t-isnull-t-is-inouttype.swift
+++ b/validation-test/compiler_crashers_fixed/28834-t-isnull-t-is-inouttype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28835-type-hastypeparameter-already-have-an-interface-type.swift
+++ b/validation-test/compiler_crashers_fixed/28835-type-hastypeparameter-already-have-an-interface-type.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28836-functy-hasarchetype.swift
+++ b/validation-test/compiler_crashers_fixed/28836-functy-hasarchetype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28837-swift-protocolcompositiontype-get-swift-astcontext-const-llvm-arrayref-swift-typ.swift
+++ b/validation-test/compiler_crashers_fixed/28837-swift-protocolcompositiontype-get-swift-astcontext-const-llvm-arrayref-swift-typ.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28838-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers_fixed/28838-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28839-genericsig.swift
+++ b/validation-test/compiler_crashers_fixed/28839-genericsig.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28840-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28840-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28841-swift-valuedecl-getformalaccessscope-swift-declcontext-const-bool-const.swift
+++ b/validation-test/compiler_crashers_fixed/28841-swift-valuedecl-getformalaccessscope-swift-declcontext-const-bool-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28842-hasval.swift
+++ b/validation-test/compiler_crashers_fixed/28842-hasval.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28843-startofcontrol-tok-getloc.swift
+++ b/validation-test/compiler_crashers_fixed/28843-startofcontrol-tok-getloc.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28844-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28844-swift-typebase-getcanonicaltype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28845-llvm-optional-swift-type-llvm-function-ref-llvm-optional-swift-type-swift-typeba.swift
+++ b/validation-test/compiler_crashers_fixed/28845-llvm-optional-swift-type-llvm-function-ref-llvm-optional-swift-type-swift-typeba.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28846-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28846-swift-typebase-getdesugaredtype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28847-type-hasunboundgenerictype.swift
+++ b/validation-test/compiler_crashers_fixed/28847-type-hasunboundgenerictype.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28848-iscanonicaltypeincontext-result-builder.swift
+++ b/validation-test/compiler_crashers_fixed/28848-iscanonicaltypeincontext-result-builder.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28849-hasval.swift
+++ b/validation-test/compiler_crashers_fixed/28849-hasval.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28850-unreachable-executed-at-swift-lib-sema-typecheckgeneric-cpp-220.swift
+++ b/validation-test/compiler_crashers_fixed/28850-unreachable-executed-at-swift-lib-sema-typecheckgeneric-cpp-220.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28851-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
+++ b/validation-test/compiler_crashers_fixed/28851-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28852-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
+++ b/validation-test/compiler_crashers_fixed/28852-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28853-result-second.swift
+++ b/validation-test/compiler_crashers_fixed/28853-result-second.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28854-known-typewitnesses-end-didnt-resolve-witness.swift
+++ b/validation-test/compiler_crashers_fixed/28854-known-typewitnesses-end-didnt-resolve-witness.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28855-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
+++ b/validation-test/compiler_crashers_fixed/28855-swift-genericsignaturebuilder-addrequirement-swift-requirementrepr-const-swift-g.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28856-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers_fixed/28856-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28857-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
+++ b/validation-test/compiler_crashers_fixed/28857-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28858-val-isa-used-on-a-null-pointer.swift
+++ b/validation-test/compiler_crashers_fixed/28858-val-isa-used-on-a-null-pointer.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28860-iscomplete-isinvalid-conformance-already-complete.swift
+++ b/validation-test/compiler_crashers_fixed/28860-iscomplete-isinvalid-conformance-already-complete.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28862-swift-protocoldecl-getinheritedprotocols-const.swift
+++ b/validation-test/compiler_crashers_fixed/28862-swift-protocoldecl-getinheritedprotocols-const.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28863-t-is-archetypetype-t-isexistentialtype-expected-a-class-archetype-or-existential.swift
+++ b/validation-test/compiler_crashers_fixed/28863-t-is-archetypetype-t-isexistentialtype-expected-a-class-archetype-or-existential.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28864-bool-typesig-bool-extensionsig-unexpected-generic-ness-mismatch-on-conformance.swift
+++ b/validation-test/compiler_crashers_fixed/28864-bool-typesig-bool-extensionsig-unexpected-generic-ness-mismatch-on-conformance.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28865-void-lookupinmodule-llvm-smallset-swift-cantype-4u-anonymous-namespace-sortcanty.swift
+++ b/validation-test/compiler_crashers_fixed/28865-void-lookupinmodule-llvm-smallset-swift-cantype-4u-anonymous-namespace-sortcanty.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28866-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
+++ b/validation-test/compiler_crashers_fixed/28866-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28867-swift-iterativetypechecker-issatisfied-swift-typecheckrequest.swift
+++ b/validation-test/compiler_crashers_fixed/28867-swift-iterativetypechecker-issatisfied-swift-typecheckrequest.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28868-known-typebindings-end.swift
+++ b/validation-test/compiler_crashers_fixed/28868-known-typebindings-end.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28869-swift-diagnosticengine-formatdiagnostictext-llvm-raw-ostream-llvm-stringref-llvm.swift
+++ b/validation-test/compiler_crashers_fixed/28869-swift-diagnosticengine-formatdiagnostictext-llvm-raw-ostream-llvm-stringref-llvm.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/compiler_crashers_fixed/28871-nested-second-nested-second-isequal-result-nested-second-haserror-result-haserro.swift
+++ b/validation-test/compiler_crashers_fixed/28871-nested-second-nested-second-isequal-result-nested-second-haserror-result-haserro.swift
@@ -1,5 +1,5 @@
 // This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/lit.cfg
+++ b/validation-test/lit.cfg
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/CollectionCasts.swift.gyb
+++ b/validation-test/stdlib/CollectionCasts.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/Concatenate.swift
+++ b/validation-test/stdlib/Concatenate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/Index.swift.gyb
+++ b/validation-test/stdlib/Index.swift.gyb
@@ -3,7 +3,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/Join.swift.gyb
+++ b/validation-test/stdlib/Join.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/NewArray.swift.gyb
+++ b/validation-test/stdlib/NewArray.swift.gyb
@@ -3,7 +3,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/ParameterPassing.swift.gyb
+++ b/validation-test/stdlib/ParameterPassing.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/SIMDParameterPassing.swift.gyb
+++ b/validation-test/stdlib/SIMDParameterPassing.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/SequenceWrapperTest.swift
+++ b/validation-test/stdlib/SequenceWrapperTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/SwiftNativeNSBase.swift
+++ b/validation-test/stdlib/SwiftNativeNSBase.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/validation-test/stdlib/ValidationNSNumberBridging.swift
+++ b/validation-test/stdlib/ValidationNSNumberBridging.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
<!-- What's in this pull request? -->
Comments changed: Copyright string has 2018 year
// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors

Command for change MAC OS X:
grep -r -l '2014\ -\ 2016\ Apple\ Inc' . | sort | uniq | xargs perl -e "s/2014\ -\ 2016\ Apple\ Inc/2014\ -\ 2018\ Apple\ Inc/" -pi
grep -r -l '2014\ -\ 2017\ Apple\ Inc' . | sort | uniq | xargs perl -e "s/2014\ -\ 2017\ Apple\ Inc/2014\ -\ 2018\ Apple\ Inc/" -pi
