### PR TITLE
Replace 'delete's with std::unique_ptr throughout SILOptimizer

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
@@ -173,22 +173,18 @@ private:
 
   /// A trie of integer indices that gives pointer identity to a path of
   /// projections. This is shared between all functions in the module.
-  IndexTrieNode *SubPathTrie;
+  std::unique_ptr<IndexTrieNode> SubPathTrie;
 
 public:
   AccessSummaryAnalysis() : BottomUpIPAnalysis(SILAnalysisKind::AccessSummary) {
-    SubPathTrie = new IndexTrieNode();
-  }
-
-  ~AccessSummaryAnalysis() {
-    delete SubPathTrie;
+    SubPathTrie.reset(new IndexTrieNode());
   }
 
   /// Returns a summary of the accesses performed by the given function.
   const FunctionSummary &getOrCreateSummary(SILFunction *Fn);
 
   IndexTrieNode *getSubPathTrieRoot() {
-    return SubPathTrie;
+    return SubPathTrie.get();
   }
 
   /// Returns an IndexTrieNode that represents the single subpath accessed from

--- a/include/swift/SILOptimizer/Utils/SCCVisitor.h
+++ b/include/swift/SILOptimizer/Utils/SCCVisitor.h
@@ -73,15 +73,12 @@ private:
 
   llvm::DenseSet<SILNode *> Visited;
   llvm::SetVector<SILNode *> DFSStack;
-  typedef llvm::DenseMap<SILNode *, DFSInfo *> ValueInfoMapType;
+  typedef llvm::DenseMap<SILNode *, std::unique_ptr<DFSInfo>> ValueInfoMapType;
   ValueInfoMapType ValueInfoMap;
 
   void cleanup() {
     Visited.clear();
     DFSStack.clear();
-    for (auto &Entry : ValueInfoMap)
-      delete Entry.second;
-
     ValueInfoMap.clear();
     CurrentNum = 0;
   }
@@ -89,8 +86,8 @@ private:
   DFSInfo &addDFSInfo(SILNode *node) {
     assert(node->isRepresentativeSILNodeInObject());
 
-    auto entry = std::make_pair(node, new DFSInfo(node, CurrentNum++));
-    auto insertion = ValueInfoMap.insert(entry);
+    auto insertion = ValueInfoMap.try_emplace(node,
+                                              new DFSInfo(node, CurrentNum++));
     assert(insertion.second && "Cannot add DFS info more than once!");
     return *insertion.first->second;
   }

--- a/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
+++ b/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
@@ -39,8 +39,8 @@ class SILSSAUpdater {
   friend class llvm::SSAUpdaterTraits<SILSSAUpdater>;
 
   // A map of basic block to available phi value.
-  // using AvailableValsTy = llvm::DenseMap<SILBasicBlock *, SILValue>;
-  void *AV;
+  using AvailableValsTy = llvm::DenseMap<SILBasicBlock *, SILValue>;
+  std::unique_ptr<AvailableValsTy> AV;
 
   SILType ValType;
 

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -419,11 +419,9 @@ bool ARCSequenceDataflowEvaluator::run(bool FreezeOwnedReleases) {
   return NestingDetected;
 }
 
-ARCSequenceDataflowEvaluator::~ARCSequenceDataflowEvaluator() {
-  // We use a malloced pointer here so we don't need to expose the type to the
-  // outside world.
-  delete BBStateInfo;
-}
+// We put the destructor here so we don't need to expose the type of
+// BBStateInfo to the outside world.
+ARCSequenceDataflowEvaluator::~ARCSequenceDataflowEvaluator() = default;
 
 void ARCSequenceDataflowEvaluator::clear() { BBStateInfo->clear(); }
 

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
@@ -67,7 +67,7 @@ private:
   ImmutablePointerSetFactory<SILInstruction> SetFactory;
 
   /// Stashed BB information.
-  ARCBBStateInfo *BBStateInfo;
+  std::unique_ptr<ARCBBStateInfo> BBStateInfo;
 
 public:
   ARCSequenceDataflowEvaluator(

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -466,8 +466,7 @@ AccessSummaryAnalysis::getOrCreateSummary(SILFunction *fn) {
 void AccessSummaryAnalysis::AccessSummaryAnalysis::invalidate() {
   FunctionInfos.clear();
   Allocator.DestroyAll();
-  delete SubPathTrie;
-  SubPathTrie = new IndexTrieNode();
+  SubPathTrie.reset(new IndexTrieNode());
 }
 
 void AccessSummaryAnalysis::invalidate(SILFunction *F, InvalidationKind K) {
@@ -525,7 +524,7 @@ getSingleAddressProjectionUser(SingleValueInstruction *I) {
 
 const IndexTrieNode *
 AccessSummaryAnalysis::findSubPathAccessed(BeginAccessInst *BAI) {
-  IndexTrieNode *SubPath = SubPathTrie;
+  IndexTrieNode *SubPath = getSubPathTrieRoot();
 
   // For each single-user projection of BAI, construct or get a node
   // from the trie representing the index of the field or tuple element

--- a/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
@@ -546,8 +546,8 @@ public:
 /// The output stream to be used for writing the collected statistics.
 /// Use the unique_ptr to ensure that the file is properly closed upon
 /// exit.
-std::unique_ptr<llvm::raw_ostream, std::function<void(llvm::raw_ostream *)>>
-    stats_output_stream;
+std::unique_ptr<llvm::raw_ostream, void(*)(llvm::raw_ostream *)>
+    stats_output_stream = {nullptr, nullptr};
 
 /// Return the output streamm to be used for logging the collected statistics.
 llvm::raw_ostream &stats_os() {
@@ -557,16 +557,15 @@ llvm::raw_ostream &stats_os() {
     if (!SILStatsOutputFile.empty()) {
       // Try to open the file.
       std::error_code EC;
-      llvm::raw_fd_ostream *fd_stream = new llvm::raw_fd_ostream(
+      auto fd_stream = llvm::make_unique<llvm::raw_fd_ostream>(
           SILStatsOutputFile, EC, llvm::sys::fs::OpenFlags::F_Text);
       if (!fd_stream->has_error() && !EC) {
-        stats_output_stream = {fd_stream,
+        stats_output_stream = {fd_stream.release(),
                                [](llvm::raw_ostream *d) { delete d; }};
         return *stats_output_stream.get();
       }
       fd_stream->clear_error();
       llvm::errs() << SILStatsOutputFile << " : " << EC.message() << "\n";
-      delete fd_stream;
     }
     // Otherwise use llvm::errs() as output. No need to destroy it at the end.
     stats_output_stream = {&llvm::errs(), [](llvm::raw_ostream *d) {}};


### PR DESCRIPTION
No functionality change, but clarifies ownership and eliminates explicit cleanup in several cases.