### PR TITLE
[Demangler] Implement isObjCSymbol().

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -274,6 +274,11 @@ bool isProtocol(llvm::StringRef mangledName);
 /// \param mangledName A null-terminated string containing a mangled name.
 bool isStruct(llvm::StringRef mangledName);
 
+/// Returns true if the mangled name is an Objective-C symbol.
+///
+/// \param mangledName A null-terminated string containing a mangled name.
+bool isObjCSymbol(llvm::StringRef mangledName);
+
 /// Returns true if the mangled name has the old scheme of function type
 /// mangling where labels are part of the type.
 ///

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -168,6 +168,10 @@ bool swift::Demangle::isSwiftSymbol(const char *mangledName) {
   return isSwiftSymbol(mangledNameRef);
 }
 
+bool swift::Demangle::isObjCSymbol(llvm::StringRef mangledName) {
+  return dropSwiftManglingPrefix(mangledName).startswith("So");
+}
+
 bool swift::Demangle::isOldFunctionTypeMangling(llvm::StringRef mangledName) {
   return mangledName.startswith("_T");
 }

--- a/unittests/Basic/DemangleTest.cpp
+++ b/unittests/Basic/DemangleTest.cpp
@@ -23,3 +23,10 @@ TEST(Demangle, DemangleWrappers) {
       demangleSymbolAsString(MangledName));
 }
 
+TEST(Demangle, IsObjCSymbol) {
+  EXPECT_EQ("type metadata accessor for __C.NSNumber",
+            demangleSymbolAsString(llvm::StringRef("_$SSo8NSNumberCMa")));
+  EXPECT_EQ(true, isObjCSymbol(llvm::StringRef("_$SSo8NSNumberCMa")));
+  EXPECT_EQ(false,
+            isObjCSymbol(llvm::StringRef("_$S3pat7inlinedSo8NSNumberCvp")));
+}


### PR DESCRIPTION
This function can be queried to find out whether the passed
mangled name is an Objective-C symbol. This will be used
in the debugger to replace an hardcoded check that would
break if the mangling prefix changed.

<rdar://problem/44467875>

[Discussed with Erik/Adrian/Fred].