### PR TITLE
Sema: Fix crash when overriding subscript with mismatched labels

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -481,8 +481,7 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
                                matchDecl->getDescriptiveKind(),
                                matchDecl->getFullName());
     if (attempt == OverrideCheckingAttempt::BaseName) {
-      fixDeclarationName(diag, cast<AbstractFunctionDecl>(decl),
-                         matchDecl->getFullName());
+      fixDeclarationName(diag, decl, matchDecl->getFullName());
     }
   }
 }
@@ -773,8 +772,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
                                isa<ConstructorDecl>(decl),
                                decl->getFullName(),
                                baseDecl->getFullName());
-    fixDeclarationName(diag, cast<AbstractFunctionDecl>(decl),
-                       baseDecl->getFullName());
+    fixDeclarationName(diag, decl, baseDecl->getFullName());
     emittedMatchError = true;
   }
 

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -277,6 +277,17 @@ class Derived24646184 : Base24646184 {
 }
 
 
+// Subscripts
+
+class SubscriptBase {
+  subscript(a a: Int) -> Int { return a }
+}
+
+class SubscriptDerived : SubscriptBase {
+  override subscript(a: Int) -> Int { return a }
+  // expected-error@-1 {{argument labels for method 'subscript' do not match those of overridden method 'subscript(a:)'}}
+}
+
 // Generic subscripts
 
 class GenericSubscriptBase {


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-8752>, <rdar://problem/44460766>.