### PR TITLE
[InterfaceGen] Print abstract accessors in protocols

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -135,12 +135,31 @@ struct PrintOptions {
   /// \brief Whether to print *any* accessors on properties.
   bool PrintPropertyAccessors = true;
 
-  /// \brief Whether to print the accessors of a property abstractly,
-  /// i.e. always as get and set rather than the specific accessors
-  /// actually used to implement the property.
+  /// Whether to print the accessors of a property abstractly,
+  /// i.e. always as:
+  /// ```
+  /// var x: Int { get set }
+  /// ```
+  /// rather than the specific accessors actually used to implement the
+  /// property.
   ///
   /// Printing function definitions takes priority over this setting.
   bool AbstractAccessors = true;
+
+  /// Whether to print a property with only a single getter using the shorthand
+  /// ```
+  /// var x: Int { return y }
+  /// ```
+  /// vs.
+  /// ```
+  /// var x: Int {
+  ///   get { return y }
+  /// }
+  /// ```
+  bool CollapseSingleGetterProperty = true;
+
+  /// Whether to print the bodies of accessors in protocol context.
+  bool PrintAccessorBodiesInProtocols = false;
 
   /// \brief Whether to print type definitions.
   bool TypeDefinitions = false;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1655,8 +1655,8 @@ void PrintAST::printAccessors(AbstractStorageDecl *ASD) {
   // Helper to print an accessor. Returns true if the
   // accessor was present but skipped.
   auto PrintAccessor = [&](AccessorDecl *Accessor) -> bool {
-    if (!Accessor) return false;
-    if (!shouldPrint(Accessor)) return true;
+    if (!Accessor || !shouldPrint(Accessor))
+      return true;
     if (!PrintAccessorBody) {
       if (isAccessorAssumedNonMutating(Accessor->getAccessorKind())) {
         if (Accessor->isMutating()) {
@@ -1728,7 +1728,7 @@ void PrintAST::printAccessors(AbstractStorageDecl *ASD) {
     case WriteImplKind::InheritedWithObservers: {
       bool skippedWillSet = PrintAccessor(ASD->getWillSetFunc());
       bool skippedDidSet = PrintAccessor(ASD->getDidSetFunc());
-      if (skippedDidSet || skippedWillSet) {
+      if (skippedDidSet && skippedWillSet) {
         PrintAccessor(ASD->getGetter());
         PrintAccessor(ASD->getSetter());
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2397,6 +2397,8 @@ printRequirementStub(ValueDecl *Requirement, DeclContext *Adopter,
     Options.AccessFilter = AccessLevel::Private;
     Options.PrintAccess = false;
     Options.SkipAttributes = true;
+    Options.FunctionDefinitions = true;
+    Options.PrintAccessorBodiesInProtocols = true;
     Options.FunctionBody = [&](const ValueDecl *VD, ASTPrinter &Printer) {
       Printer << " {";
       Printer.printNewline();

--- a/test/ModuleInterface/final.swift
+++ b/test/ModuleInterface/final.swift
@@ -6,7 +6,9 @@
 // CHECK: final public class FinalClass {
 public final class FinalClass {
   // CHECK: @inlinable final public class var a: [[INT:(Swift.)?Int]] {
+  // CHECK-NEXT: {{^}} get {
   // CHECK-NEXT: return 3
+  // CHECK-NEXT: }
   // CHECK-NEXT: }
   @inlinable
   public final class var a: Int {

--- a/test/ModuleInterface/inlinable-function.swift
+++ b/test/ModuleInterface/inlinable-function.swift
@@ -26,6 +26,7 @@ public struct Foo: Hashable {
 
   // CHECK: public var hasDidSet: [[INT]] {
   public var hasDidSet: Int {
+    // CHECK-NEXT: @_transparent get{{$}}
     // CHECK-NEXT: set[[NEWVALUE]]{{$}}
     // CHECK-NOT: didSet
     didSet {

--- a/test/ModuleInterface/inlinable-function.swift
+++ b/test/ModuleInterface/inlinable-function.swift
@@ -104,6 +104,78 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
+  // CHECK: @inlinable public var inlinableReadAndModify: [[INT]] {
+  @inlinable
+  public var inlinableReadAndModify: Int {
+    // CHECK: _read {
+    // CHECK-NEXT: yield 0
+    // CHECK-NEXT: }
+    _read {
+      yield 0
+    }
+    // CHECK: _modify {
+    // CHECK-NEXT: var x = 0
+    // CHECK-NEXT: yield &x
+    // CHECK-NEXT: }
+    _modify {
+      var x = 0
+      yield &x
+    }
+    // CHECK-NEXT: }
+  }
+
+  // CHECK: public var inlinableReadNormalModify: [[INT]] {
+  public var inlinableReadNormalModify: Int {
+    // CHECK: @inlinable _read {
+    // CHECK-NEXT: yield 0
+    // CHECK-NEXT: }
+    @inlinable _read {
+      yield 0
+    }
+
+    // CHECK: _modify{{$}}
+    // CHECK-NOT: var x = 0
+    // CHECK-NOT: yield &x
+    // CHECK-NOT: }
+    _modify {
+      var x = 0
+      yield &x
+    }
+    // CHECK-NEXT: }
+  }
+
+  // CHECK: public var normalReadInlinableModify: [[INT]] {
+  public var normalReadInlinableModify: Int {
+    // CHECK: _read{{$}}
+    // CHECK-NOT: yield 0
+    // CHECK-NOT: }
+    _read {
+      yield 0
+    }
+
+    // CHECK: @inlinable _modify {
+    // CHECK-NEXT: var x = 0
+    // CHECK-NEXT: yield &x
+    // CHECK-NEXT: }
+    @inlinable _modify {
+      var x = 0
+      yield &x
+    }
+    // CHECK-NEXT: }
+  }
+
+  // CHECK: public var normalReadAndModify: [[INT]] {
+  public var normalReadAndModify: Int {
+    // CHECK-NEXT: _read{{$}}
+    _read { yield 0 }
+    // CHECK-NEXT: _modify{{$}}
+    _modify {
+      var x = 0
+      yield &x
+    }
+    // CHECK-NEXT: }
+  }
+
   // CHECK: @inlinable public func inlinableMethod() {
   // CHECK-NOT: #if NO
   // CHECK-NOT: print("Hello, world!")

--- a/test/ModuleInterface/inlinable-function.swift
+++ b/test/ModuleInterface/inlinable-function.swift
@@ -26,7 +26,6 @@ public struct Foo: Hashable {
 
   // CHECK: public var hasDidSet: [[INT]] {
   public var hasDidSet: Int {
-    // CHECK-NEXT: @_transparent get{{$}}
     // CHECK-NEXT: set[[NEWVALUE]]{{$}}
     // CHECK-NOT: didSet
     didSet {
@@ -37,7 +36,9 @@ public struct Foo: Hashable {
 
 
   // CHECK: @_transparent public var transparent: [[INT]] {
+  // CHECK-NEXT:   get {
   // CHECK-NEXT:   return 34
+  // CHECK-NEXT: }
   // CHECK-NEXT: }
   @_transparent
   public var transparent: Int {


### PR DESCRIPTION
This patch slightly cleans up printing accessors and ensures we print
accessors abstractly in protocol context for textual interfaces.

It also removes some assuptions around the FunctionBody callback and
makes them more explicit, and makes sure to print `get {}` around computed read-only property getters.