### PR TITLE
[SILGen] Don't emit initializers for nameless properties

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1016,6 +1016,12 @@ void SILGenModule::
 emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
   const PatternBindingEntry &pbdEntry = pbd->getPatternList()[i];
   auto *var = pbdEntry.getAnchoringVarDecl();
+
+  // Nameless vars in interface files should not emit any stored property
+  // initializers.
+  if (var->getBaseName().empty())
+    return;
+
   auto *init = pbdEntry.getInit();
   auto *initDC = pbdEntry.getInitContext();
   assert(!pbdEntry.isInitializerLazy());

--- a/test/ModuleInterface/NamelessVars.swiftinterface
+++ b/test/ModuleInterface/NamelessVars.swiftinterface
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-module -o /dev/null %s
+
+public struct PublicStruct {
+  @_hasInitialValue
+  internal var _: Int
+  public var x: Bool
+}


### PR DESCRIPTION
A var without a name can appear if parsed from a textual interface file.
Avoid trying to emit property initializers for those, as they'll crash
in the mangler.