### PR TITLE
add graph_op builder

### DIFF
--- a/include/swift/SIL/GraphOperationBuilder.h
+++ b/include/swift/SIL/GraphOperationBuilder.h
@@ -1,4 +1,4 @@
-//=== GraphOperationBuilder.cpp - GraphOperationInst Build Logic *- C++ -*-===//
+//=== GraphOperationBuilder.h - GraphOperationInst Build Logic *- C++ ---*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SIL/GraphOperationBuilder.h
+++ b/include/swift/SIL/GraphOperationBuilder.h
@@ -1,0 +1,74 @@
+//=== GraphOperationBuilder.h - GraphOperationInst Build Logic --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the construction logic for a GraphOperationInst, in
+// particular encoding the mangled inst name string for the operands and
+// attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_GRAPH_OPERATION_BUILDER_H
+#define SWIFT_SIL_GRAPH_OPERATION_BUILDER_H
+
+#include "swift/SIL/SILConstants.h"
+#include "swift/SIL/SILValue.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace swift {
+class ASTContext;
+class GraphOperationInst;
+class SILBuilder;
+class SILLocation;
+class SILType;
+
+namespace tf {
+
+class GraphOperationBuilder {
+  std::string MangledName;
+  llvm::SmallVector<SILValue, 4> Operands;
+  llvm::SmallVector<GraphOperationAttribute, 4> Attributes;
+
+public:
+  /// Start building a GraphOperationInst for op `OpName`.
+  GraphOperationBuilder(llvm::StringRef OpName);
+
+  /// Add a single operand to the GraphOperationInst, with an optional name.
+  void addOperand(SILValue operand, llvm::StringRef name = llvm::StringRef());
+
+  /// Add a rank-1 list of operands to the GraphOperationInst, with an optional
+  /// name.
+  void addListOperand(llvm::ArrayRef<SILValue> operands,
+                      llvm::StringRef name = llvm::StringRef());
+
+  /// Add an attribute with known constant value to the GraphOperationInst.
+  GraphOperationAttribute &addAttribute(
+      const GraphOperationAttribute &attribute);
+
+  /// Special method that should only be used for "tfc.scalarToTensor"'s operand,
+  /// because it has special name mangling. (Marker is "s").
+  void addScalarOperand(SILValue operand);
+
+  /// Special method that should only be used for "tf_tensor_to_i1"'s operand,
+  /// because it has special name mangling. (No marker for its operand).
+  void addTFTensorToI1Operand(SILValue operand);
+
+  /// Build the GraphOperationInst.
+  GraphOperationInst* build(
+      SILBuilder &B, ASTContext &C, SILLocation loc,
+      llvm::ArrayRef<SILType> resultSILTypes) const;
+};
+
+} // end namespace tf
+} // end namespace swift
+
+#endif // SWIFT_SIL_GRAPH_OPERATION_BUILDER_H

--- a/include/swift/SIL/GraphOperationBuilder.h
+++ b/include/swift/SIL/GraphOperationBuilder.h
@@ -1,4 +1,4 @@
-//=== GraphOperationBuilder.h - GraphOperationInst Build Logic --*- C++ -*-===//
+//=== GraphOperationBuilder.cpp - GraphOperationInst Build Logic *- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -45,12 +45,14 @@ public:
   /// Add a single operand to the GraphOperationInst, with an optional name.
   void addOperand(SILValue operand, llvm::StringRef name = llvm::StringRef());
 
-  /// Add a rank-1 list of operands to the GraphOperationInst, with an optional
-  /// name.
+  /// Add a list operand to the GraphOperationInst, with an optional name.
   void addListOperand(llvm::ArrayRef<SILValue> operands,
                       llvm::StringRef name = llvm::StringRef());
 
   /// Add an attribute with known constant value to the GraphOperationInst.
+  /// Returns a reference to the attribute, valid for the lifetime of the
+  /// GraphOperationBuilder, that you can use to mutate the attribute before
+  /// buiding the GraphOperationInst.
   GraphOperationAttribute &addAttribute(
       const GraphOperationAttribute &attribute);
 
@@ -60,6 +62,8 @@ public:
 
   /// Special method that should only be used for "tf_tensor_to_i1"'s operand,
   /// because it has special name mangling. (No marker for its operand).
+  /// TODO: Make "tf_tensor_to_i1" support normal name mangling, and then remove
+  /// this.
   void addTFTensorToI1Operand(SILValue operand);
 
   /// Build the GraphOperationInst.

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -96,14 +96,16 @@ struct GraphOperationInfo {
   // }
 
   enum OperandMarkerKind {
-    /// Scalar input, used by tfc.scalarToTensor only. Cannot have name.
+    /// Scalar input, used by tfc.scalarToTensor only. MangledName is ",s".
     OMK_Scalar,
-    /// Operand that is not in a list. Might have name.
+    /// Operand that is not in a list. MangledName is ",i${name}", where ${name}
+    /// is an optional name for the operand.
     OMK_Normal,
-    /// Marker for the start of a list, has no corresponding operand. Might have
-    /// name.
+    /// Marker for the start of a list, has no corresponding operand.
+    /// MangledName is ",L${name}", where ${name} is an optional name for the
+    /// operand.
     OMK_InputList,
-    /// Element of a list. Cannot have name.
+    /// Element of a list. MangledName is ",e".
     OMK_InputListElt,
   };
 
@@ -114,8 +116,8 @@ struct GraphOperationInfo {
 
     OperandMarkerKind Kind;
 
-    /// The mangled name as it appears in the graph_op. Matches regexp:
-    ///   ,([iL][^,]*)|(se)
+    /// The mangled name as it appears in the graph_op. Mangling rules described
+    /// in OperandMarkerKind.
     StringRef MangledName;
 
     OperandMarker(StringRef MangledName);
@@ -129,19 +131,6 @@ struct GraphOperationInfo {
     StringRef getName() const {
       return MangledName.drop_front(2);
     }
-
-    /// A mangled string describing this OperandMarker, suitable for appending
-    /// to a mangled graph_op name.
-    StringRef getMangledName() const {
-      return MangledName;
-    }
-
-    /// Appends an OperandMarker with `kind` and `name` to the passed-in
-    /// `mangledOpName`. `name` must be empty for OMK_Scalar and
-    /// OMK_InputListElt.
-    static void
-    appendTo(std::string &mangledOpName, OperandMarkerKind kind,
-             StringRef name = StringRef());
   };
 
   /// Decode the name of a graph_op into its TensorFlow op name and a list of

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -37,6 +37,7 @@ add_swift_library(swiftAST STATIC
   GenericSignature.cpp
   GenericSignatureBuilder.cpp
   # SWIFT_ENABLE_TENSORFLOW
+  GraphOperationBuilder.cpp
   GraphOperationInfo.cpp
   Identifier.cpp
   LayoutConstraint.cpp

--- a/lib/AST/GraphOperationBuilder.cpp
+++ b/lib/AST/GraphOperationBuilder.cpp
@@ -1,0 +1,73 @@
+//=== GraphOperationBuilder.h - GraphOperationInst Build Logic --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/GraphOperationBuilder.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILLocation.h"
+
+namespace swift {
+namespace tf {
+
+/// Start building a GraphOperationInst for op `OpName`.
+GraphOperationBuilder::GraphOperationBuilder(StringRef OpName)
+    : MangledName(OpName) {}
+
+/// Add a single operand to the GraphOperationInst, with an optional name.
+void GraphOperationBuilder::addOperand(SILValue operand, StringRef name) {
+  MangledName += ",i";
+  MangledName += name;
+  Operands.push_back(operand);
+}
+
+/// Add a rank-1 list of operands to the GraphOperationInst, with an optional
+/// name.
+void GraphOperationBuilder::addListOperand(ArrayRef<SILValue> operands,
+                                           StringRef name) {
+  MangledName += ",L";
+  MangledName += name;
+  for (auto operand : operands) {
+    MangledName += ",e";
+    Operands.push_back(operand);
+  }
+}
+
+/// Add an attribute with known constant value to the GraphOperationInst.
+GraphOperationAttribute &GraphOperationBuilder::addAttribute(
+    const GraphOperationAttribute &attribute) {
+  Attributes.push_back(attribute);
+  return Attributes.back();
+}
+
+/// Special method that should only be used for "tfc.scalarToTensor"'s operand,
+/// because it has special name mangling. (Marker is "s").
+void GraphOperationBuilder::addScalarOperand(SILValue operand) {
+  MangledName += ",s";
+  Operands.push_back(operand);
+}
+
+/// Special method that should only be used for "tf_tensor_to_i1"'s operand,
+/// because it has special name mangling. (No marker for its operand).
+void GraphOperationBuilder::addTFTensorToI1Operand(SILValue operand) {
+  Operands.push_back(operand);
+}
+
+/// Build the GraphOperationInst.
+GraphOperationInst* GraphOperationBuilder::build(
+    SILBuilder &B, ASTContext &C, SILLocation loc,
+    ArrayRef<SILType> resultSILTypes) const {
+  return B.createGraphOperation(loc, C.getIdentifier(MangledName), Operands,
+                                Attributes, resultSILTypes);
+}
+
+} // end namespace tf
+} // end namespace swift

--- a/lib/AST/GraphOperationBuilder.cpp
+++ b/lib/AST/GraphOperationBuilder.cpp
@@ -1,4 +1,4 @@
-//=== GraphOperationBuilder.h - GraphOperationInst Build Logic --*- C++ -*-===//
+//=== GraphOperationBuilder.cpp - GraphOperationInst Build Logic *- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/AST/GraphOperationBuilder.cpp
+++ b/lib/AST/GraphOperationBuilder.cpp
@@ -29,8 +29,7 @@ void GraphOperationBuilder::addOperand(SILValue operand, StringRef name) {
   Operands.push_back(operand);
 }
 
-/// Add a rank-1 list of operands to the GraphOperationInst, with an optional
-/// name.
+/// Add a list operand to the GraphOperationInst, with an optional name.
 void GraphOperationBuilder::addListOperand(ArrayRef<SILValue> operands,
                                            StringRef name) {
   MangledName += ",L";
@@ -42,6 +41,9 @@ void GraphOperationBuilder::addListOperand(ArrayRef<SILValue> operands,
 }
 
 /// Add an attribute with known constant value to the GraphOperationInst.
+/// Returns a reference to the attribute, valid for the lifetime of the
+/// GraphOperationBuilder, that you can use to mutate the attribute before
+/// buiding the GraphOperationInst.
 GraphOperationAttribute &GraphOperationBuilder::addAttribute(
     const GraphOperationAttribute &attribute) {
   Attributes.push_back(attribute);
@@ -57,6 +59,8 @@ void GraphOperationBuilder::addScalarOperand(SILValue operand) {
 
 /// Special method that should only be used for "tf_tensor_to_i1"'s operand,
 /// because it has special name mangling. (No marker for its operand).
+/// TODO: Make "tf_tensor_to_i1" support normal name mangling, and then remove
+/// this.
 void GraphOperationBuilder::addTFTensorToI1Operand(SILValue operand) {
   Operands.push_back(operand);
 }

--- a/lib/AST/GraphOperationInfo.cpp
+++ b/lib/AST/GraphOperationInfo.cpp
@@ -157,30 +157,3 @@ GraphOperationInfo::OperandMarker::OperandMarker(StringRef MangledName)
     llvm_unreachable("unknown marker kind");
   }
 }
-
-/// Appends an OperandMarker with `kind` and `name` to the passed-in
-/// `mangledOpName`. `name` must be empty for OMK_Scalar and
-/// OMK_InputListElt.
-void
-GraphOperationInfo::OperandMarker::appendTo(std::string &mangledOpName,
-                                            OperandMarkerKind kind,
-                                            StringRef name) {
-  switch (kind) {
-  case OMK_Scalar:
-    mangledOpName += ",s";
-    assert(name.empty());
-    break;
-  case OMK_Normal:
-    mangledOpName += ",i";
-    mangledOpName += name;
-    break;
-  case OMK_InputList:
-    mangledOpName += ",L";
-    mangledOpName += name;
-    break;
-  case OMK_InputListElt:
-    mangledOpName += ",e";
-    assert(name.empty());
-    break;
-  }
-}

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1885,9 +1885,9 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
   // TODO: Remove these. They are a temporary way of testing that dynamic
   // attributes make it here.
   LLVM_DEBUG(llvm::dbgs() << "IRGen for graph_op: " << opName << "\n");
-  for (auto oi : operandMarkers) {
-    LLVM_DEBUG(llvm::dbgs() << "  operand: " << oi.getMangledName() << "\n");
-  }
+  LLVM_DEBUG(for (auto oi : operandMarkers) {
+    llvm::dbgs() << "  operand: " << oi.getName() << "\n";
+  });
   LLVM_DEBUG(llvm::dbgs() << "end operands\n");
 
   // The overall workflow is:

--- a/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
+++ b/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
@@ -27,6 +27,7 @@
 
 namespace swift {
 namespace tf {
+class GraphOperationBuilder;
 
 /// The device of a tfop instruction (and its output tensors, if any).
 enum class DeviceType {
@@ -203,8 +204,8 @@ struct GraphFunctionDeviceInfo {
     ++numUsedDeviceTypes;
   }
 
-  // Choose a device for the graphOpInst under construction, extend `attributes`
-  // accordingly with the device attribute, and track the chosen device in
+  // Choose a device for the graphOpInst under construction, add the device
+  // attribute to `opBuilder`, and track the chosen device in
   // `usedDeviceTypes`.
   //
   // If `opDevice` is already set, respects that device choice. Otherwise,
@@ -216,8 +217,7 @@ struct GraphFunctionDeviceInfo {
   // inst). Otherwise SILVerifier will fail on that graph_op inst.
   void
   handleDevicePlacement(llvm::StringRef opType, llvm::StringRef opDevice,
-                        ASTContext &ctx,
-                        SmallVectorImpl<GraphOperationAttribute> &attributes);
+                        ASTContext &ctx, GraphOperationBuilder *opBuilder);
 
 private:
   GraphFunctionDeviceInfo(DeviceType primaryDeviceType, bool isTPUInfeedEnabled)

--- a/test/TensorFlow/dynamic_compilation_irgen.swift
+++ b/test/TensorFlow/dynamic_compilation_irgen.swift
@@ -10,7 +10,7 @@ public func unknownAttribute() {
   let x: TensorHandle<Float> = #tfop("Dummy1", value$tensor: Dynamic.float)
   _hostOp(x)
   // CHECK-LABEL: IRGen for graph_op: Dummy1
-  // CHECK-NEXT: operand: ,ivalue$tensor
+  // CHECK-NEXT: operand: value$tensor
   // CHECK-NEXT: end operands
 }
 


### PR DESCRIPTION
This hides all the name mangling logic from code that builds graph_ops, which makes that code simpler. It'll also make it easier to change name mangling behind the scenes to support more structures (like nested lists).

This should address some of the API comments @mhong had in #19361.