### PR TITLE
Implement the final approved syntax for SE-227 identity key paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ CHANGELOG
 Swift 5.0
 ---------
 
+* [SE-0227][]:
+
+  Key paths now support the `\.self` keypath, which is a `WritableKeyPath`
+  that refers to its entire input value:
+
+    ```swift
+    let id = \Int.self
+
+    var x = 2
+    print(x[keyPath: id]) // prints 2
+    x[keyPath: id] = 3
+    print(x[keyPath: id]) // prints 3
+    ```
+
 * [SE-0214][]:
 
   Renamed the `DictionaryLiteral` type to `KeyValuePairs`.

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -373,11 +373,6 @@ BUILTIN_SIL_OPERATION(AllocWithTailElems, "allocWithTailElems", Special)
 /// Projects the first tail-allocated element of type E from a class C.
 BUILTIN_SIL_OPERATION(ProjectTailElems, "projectTailElems", Special)
 
-/// identityKeyPath : <T> () -> WritableKeyPath<T, T>
-///
-/// Creates an identity key path object. (TODO: replace with proper syntax)
-BUILTIN_SIL_OPERATION(IdentityKeyPath, "identityKeyPath", Special)
-
 #undef BUILTIN_SIL_OPERATION
 
 // BUILTIN_RUNTIME_CALL - A call into a runtime function.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2597,6 +2597,10 @@ public:
         component.getIndexExpr()->print(OS, Indent + 4);
         OS.indent(Indent + 4);
         break;
+      case KeyPathExpr::Component::Kind::Identity:
+        OS << "identity";
+        OS << '\n';
+        break;
       }
       OS << "type=";
       component.getComponentType().print(OS);

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1034,6 +1034,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       case KeyPathExpr::Component::Kind::Property:
       case KeyPathExpr::Component::Kind::UnresolvedProperty:
       case KeyPathExpr::Component::Kind::Invalid:
+      case KeyPathExpr::Component::Kind::Identity:
         // No subexpr to visit.
         break;
       }

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -991,15 +991,6 @@ static ValueDecl *getTypeJoinMetaOperation(ASTContext &Context, Identifier Id) {
   return builder.build(Id);
 }
 
-static ValueDecl *getIdentityKeyPathOperation(ASTContext &Context,
-                                              Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context, 1);
-  auto arg = makeGenericParam();
-  builder.setResult(makeBoundGenericType(Context.getWritableKeyPathDecl(),
-                                         arg, arg));
-  return builder.build(Id);
-}
-
 static ValueDecl *getCanBeObjCClassOperation(ASTContext &Context,
                                              Identifier Id) {
   // <T> T.Type -> Builtin.Int8
@@ -1879,10 +1870,7 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
     return getTypeJoinInoutOperation(Context, Id);
 
   case BuiltinValueKind::TypeJoinMeta:
-    return getTypeJoinMetaOperation(Context, Id);
-      
-  case BuiltinValueKind::IdentityKeyPath:
-    return getIdentityKeyPathOperation(Context, Id);
+    return getTypeJoinMetaOperation(Context, Id);      
   }
 
   llvm_unreachable("bad builtin value!");

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2135,13 +2135,16 @@ KeyPathExpr::Component::Component(ASTContext *ctxForCopyingLabels,
                      Kind kind,
                      Type type,
                      SourceLoc loc)
-    : Decl(decl), SubscriptIndexExprAndKind(indexExpr, kind),
-      SubscriptLabels(subscriptLabels.empty()
-                       ? subscriptLabels
-                       : ctxForCopyingLabels->AllocateCopy(subscriptLabels)),
-      SubscriptHashableConformances(indexHashables),
+    : Decl(decl), SubscriptIndexExpr(indexExpr), KindValue(kind),
       ComponentType(type), Loc(loc)
-  {}
+{
+  assert(subscriptLabels.size() == indexHashables.size()
+         || indexHashables.empty());
+  SubscriptLabelsData = subscriptLabels.data();
+  SubscriptHashableConformancesData = indexHashables.empty()
+    ? nullptr : indexHashables.data();
+  SubscriptSize = subscriptLabels.size();
+}
 
 KeyPathExpr::Component
 KeyPathExpr::Component::forSubscriptWithPrebuiltIndexExpr(
@@ -2157,8 +2160,10 @@ void KeyPathExpr::Component::setSubscriptIndexHashableConformances(
     ArrayRef<ProtocolConformanceRef> hashables) {
   switch (getKind()) {
   case Kind::Subscript:
-    SubscriptHashableConformances = getComponentType()->getASTContext()
-      .AllocateCopy(hashables);
+    assert(hashables.size() == SubscriptSize);
+    SubscriptHashableConformancesData = getComponentType()->getASTContext()
+      .AllocateCopy(hashables)
+      .data();
     return;
     
   case Kind::UnresolvedSubscript:
@@ -2168,6 +2173,7 @@ void KeyPathExpr::Component::setSubscriptIndexHashableConformances(
   case Kind::OptionalForce:
   case Kind::UnresolvedProperty:
   case Kind::Property:
+  case Kind::Identity:
     llvm_unreachable("no hashable conformances for this kind");
   }
 }

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -367,6 +367,7 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:
+      case KeyPathExpr::Component::Kind::Identity:
         break;
       }
     }

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -970,58 +970,6 @@ static ManagedValue emitBuiltinProjectTailElems(SILGenFunction &SGF,
   return ManagedValue::forUnmanaged(result);
 }
 
-static ManagedValue emitBuiltinIdentityKeyPath(SILGenFunction &SGF,
-                                               SILLocation loc,
-                                               SubstitutionMap subs,
-                                               ArrayRef<ManagedValue> args,
-                                               SGFContext C) {
-  assert(subs.getReplacementTypes().size() == 1 &&
-         "identityKeyPath should have one substitution");
-  assert(args.size() == 0 &&
-         "identityKeyPath should have no args");
-
-  auto identityTy = subs.getReplacementTypes()[0]->getCanonicalType();
-  
-  // The `self` key can be used for identity in Cocoa KVC as well.
-  StringRef objcString = SGF.getASTContext().LangOpts.EnableObjCInterop
-    ? "self" : "";
-  
-  // The key path pattern has to capture some generic context if the type is
-  // dependent on this generic context. We only need the specific type, though,
-  // not the entire generic environment.
-  bool isDependent = identityTy->hasArchetype();
-  CanType identityPatternTy = identityTy;
-  CanGenericSignature patternSig = nullptr;
-  SubstitutionMap patternSubs;
-  if (isDependent) {
-    auto param = GenericTypeParamType::get(0, 0, SGF.getASTContext());
-    identityPatternTy = param->getCanonicalType();
-    patternSig = GenericSignature::get(param, {})->getCanonicalSignature();
-    patternSubs = SubstitutionMap::get(patternSig,
-                                       llvm::makeArrayRef((Type)identityTy),
-                                       {});
-  }
-  
-  auto identityPattern = KeyPathPattern::get(SGF.SGM.M,
-                                             patternSig,
-                                             identityPatternTy,
-                                             identityPatternTy,
-                                             {},
-                                             objcString);
-  
-  auto kpTy = BoundGenericType::get(SGF.getASTContext().getWritableKeyPathDecl(),
-                                    Type(),
-                                    {identityTy, identityTy})
-    ->getCanonicalType();
-  
-  auto keyPath = SGF.B.createKeyPath(loc, identityPattern,
-                                     patternSubs,
-                                     {},
-                                     SILType::getPrimitiveObjectType(kpTy));
-  return SGF.emitManagedRValueWithCleanup(keyPath);
-}
-
-
 /// Specialized emitter for type traits.
 template<TypeTraitResult (TypeBase::*Trait)(),
          BuiltinValueKind Kind>

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3849,6 +3849,9 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
                     KeyPathPatternComponent::forOptional(loweredKind, baseTy));
       break;
     }
+    
+    case KeyPathExpr::Component::Kind::Identity:
+      continue;
         
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6635,6 +6635,7 @@ static bool diagnoseKeyPathComponents(ConstraintSystem &CS, KeyPathExpr *KPE,
       break;
 
     case KeyPathExpr::Component::Kind::Invalid:
+    case KeyPathExpr::Component::Kind::Identity:
     case KeyPathExpr::Component::Kind::OptionalChain:
     case KeyPathExpr::Component::Kind::OptionalForce:
       // FIXME: Diagnose optional chaining and forcing properly.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3067,6 +3067,8 @@ namespace {
           base = OptionalType::get(base);
           break;
         }
+        case KeyPathExpr::Component::Kind::Identity:
+          continue;
         }
       }
       

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -638,6 +638,7 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
     case KeyPathExpr::Component::Kind::OptionalForce:
     case KeyPathExpr::Component::Kind::OptionalChain:
     case KeyPathExpr::Component::Kind::OptionalWrap:
+    case KeyPathExpr::Component::Kind::Identity:
       return std::make_tuple(nullptr, 0, argLabels, hasTrailingClosure);
     }
 
@@ -4137,6 +4138,7 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
     
     switch (component.getKind()) {
     case KeyPathExpr::Component::Kind::Invalid:
+    case KeyPathExpr::Component::Kind::Identity:
       break;
       
     case KeyPathExpr::Component::Kind::Property:

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2447,6 +2447,7 @@ private:
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:
+      case KeyPathExpr::Component::Kind::Identity:
         break;
       }
     }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -203,6 +203,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     // TODO: Perhaps we can map subscript components to dictionary keys.
     switch (auto kind = component.getKind()) {
     case KeyPathExpr::Component::Kind::Invalid:
+    case KeyPathExpr::Component::Kind::Identity:
       continue;
 
     case KeyPathExpr::Component::Kind::UnresolvedProperty:

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -329,16 +329,6 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
   }
 }
 
-extension WritableKeyPath where Root == Value {
-  // FIXME: Replace with proper surface syntax
-
-  /// Returns an identity key path that references the entire input value.
-  @inlinable
-  public static var _identity: WritableKeyPath<Root, Root> {
-    return Builtin.identityKeyPath()
-  }
-}
-
 /// A key path that supports reading from and writing to the resulting value
 /// with reference semantics.
 public class ReferenceWritableKeyPath<

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -389,10 +389,10 @@ func subclass_generics<T: C<Int>, U: C<V>, V/*: PoC*/>(_: T, _: U, _: V) {
 // CHECK-LABEL: sil hidden @{{.*}}identity
 func identity<T>(_: T) {
   // CHECK: keypath $WritableKeyPath<T, T>, <τ_0_0> ({{.*}}root $τ_0_0) <T>
-  let _: WritableKeyPath<T, T> = Builtin.identityKeyPath()
-  // CHECK: keypath $WritableKeyPath<Array<T>, Array<T>>, <τ_0_0> ({{.*}}root $τ_0_0) <Array<T>>
-  let _: WritableKeyPath<[T], [T]> = Builtin.identityKeyPath()
+  let _: WritableKeyPath<T, T> = \T.self
+  // CHECK: keypath $WritableKeyPath<Array<T>, Array<T>>, <τ_0_0> ({{.*}}root $Array<τ_0_0>) <T>
+  let _: WritableKeyPath<[T], [T]> = \[T].self
   // CHECK: keypath $WritableKeyPath<String, String>, ({{.*}}root $String)
-  let _: WritableKeyPath<String, String> = Builtin.identityKeyPath()
+  let _: WritableKeyPath<String, String> = \String.self
 }
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -658,6 +658,20 @@ struct Container {
 
 var rdar32057712 = \Container.base?.i
 
+var identity1 = \Container.self
+var identity2: WritableKeyPath = \Container.self
+var identity3: WritableKeyPath<Container, Container> = \Container.self
+var identity4: WritableKeyPath<Container, Container> = \.self
+var identity5: KeyPath = \Container.self
+var identity6: KeyPath<Container, Container> = \Container.self
+var identity7: KeyPath<Container, Container> = \.self
+var identity8: PartialKeyPath = \Container.self
+var identity9: PartialKeyPath<Container> = \Container.self
+var identity10: PartialKeyPath<Container> = \.self
+var identity11: AnyKeyPath = \Container.self
+
+var interleavedIdentityComponents = \Container.self.base.self?.self.i.self
+
 func testSyntaxErrors() { // expected-note{{}}
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -685,7 +685,7 @@ struct NonOffsetableProperties {
 }
 
 func getIdentityKeyPathOfType<T>(_: T.Type) -> KeyPath<T, T> {
-  return WritableKeyPath<T, T>._identity
+  return \.self
 }
 
 keyPath.test("offsets") {
@@ -704,15 +704,14 @@ keyPath.test("offsets") {
   expectNil(NOPLayout.offset(of: \NonOffsetableProperties.y))
   expectNil(NOPLayout.offset(of: \NonOffsetableProperties.z))
 
-  expectEqual(SLayout.offset(of: WritableKeyPath<S<Int>, S<Int>>._identity),
-              0)
+  expectEqual(SLayout.offset(of: \.self), 0)
   expectEqual(SLayout.offset(of: getIdentityKeyPathOfType(S<Int>.self)), 0)
 }
 
 keyPath.test("identity key path") {
   var x = LifetimeTracked(1738)
 
-  let id = WritableKeyPath<LifetimeTracked, LifetimeTracked>._identity
+  let id = \LifetimeTracked.self
   expectTrue(x === x[keyPath: id])
 
   let newX = LifetimeTracked(679)
@@ -731,7 +730,7 @@ keyPath.test("identity key path") {
 
   let valueKey = \LifetimeTracked.value
   let valueKey2 = id.appending(path: valueKey)
-  let valueKey3 = (valueKey as KeyPath).appending(path: WritableKeyPath<Int, Int>._identity)
+  let valueKey3 = (valueKey as KeyPath).appending(path: \Int.self)
 
   expectEqual(valueKey, valueKey2)
   expectEqual(valueKey.hashValue, valueKey2.hashValue)


### PR DESCRIPTION
`\.self` is the final chosen syntax. Implement support for this syntax, and remove the stopgap builtin and `WritableKeyPath._identity` property that were in place before.