### PR TITLE
[WIP][stdlib] Try adding a Prefix type to Sequence, then Collection

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -332,7 +332,7 @@ extension IndexingIterator: IteratorProtocol, Sequence {
 /// or bidirectional collection must traverse the entire collection to count
 /// the number of contained elements, accessing its `count` property is an
 /// O(*n*) operation.
-public protocol Collection: Sequence where SubSequence: Collection {
+public protocol Collection: Sequence where SubSequence: Collection, Prefix == SubSequence {
   // FIXME: ideally this would be in MigrationSupport.swift, but it needs
   // to be on the protocol instead of as an extension
   @available(*, deprecated/*, obsoleted: 5.0*/, message: "all index distances are now of type Int")
@@ -391,6 +391,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// protocol, but it is restated here with stricter constraints. In a
   /// collection, the subsequence should also conform to `Collection`.
   associatedtype SubSequence = Slice<Self> where SubSequence.Index == Index
+  associatedtype Prefix = SubSequence
 
   /// Accesses the element at the specified position.
   ///
@@ -1442,6 +1443,10 @@ extension Collection {
       offsetBy: maxLength, limitedBy: endIndex) ?? endIndex
     return self[startIndex..<end]
   }
+  
+  public func _prefix(_ maxLength: Int) -> SubSequence {
+    return prefix(maxLength)
+  }  
   
   /// Returns a subsequence containing the initial elements until `predicate`
   /// returns `false` and skipping the remaining elements.

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -506,6 +506,8 @@ public protocol Sequence {
   ///   the beginning of the sequence.
   __consuming func prefix(_ maxLength: Int) -> SubSequence
 
+  __consuming func _prefix(_ maxLength: Int) -> Prefix
+
   /// Returns a subsequence containing the initial, consecutive elements that
   /// satisfy the given predicate.
   ///
@@ -768,6 +770,12 @@ extension PrefixSequence: Sequence {
   public __consuming func prefix(_ maxLength: Int) -> SubSequence {
     let length = Swift.min(maxLength, self._maxLength)
     return AnySequence(PrefixSequence(_base, maxLength: length))
+  }
+  
+  @inlinable
+  public func _prefix(_ maxLength: Int) -> Prefix {
+    let length = Swift.min(maxLength, self._maxLength)
+    return PrefixSequence(_base, maxLength: length)
   }
 }
 
@@ -1391,6 +1399,15 @@ extension Sequence where SubSequence == AnySequence<Element> {
       result.append(element)
     }
     return AnySequence(result)
+  }
+}
+
+extension Sequence where Prefix == PrefixSequence<Self> {
+  @inlinable
+  public func _prefix(_ maxLength: Int) -> PrefixSequence<Self> {
+    _precondition(maxLength >= 0, 
+      "Can't take a prefix of negative length from a sequence")
+    return PrefixSequence(self, maxLength: maxLength)
   }
 }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -335,6 +335,11 @@ public protocol Sequence {
     where Element == SubSequence.Element,
           SubSequence.SubSequence == SubSequence
 
+  /// A type that represents a subsequence of some of the sequence's elements.
+  associatedtype Prefix: Sequence = PrefixSequence<Self>
+    where Element == Prefix.Element,
+          Prefix.Prefix == Prefix
+
   /// Returns an iterator over the elements of this sequence.
   __consuming func makeIterator() -> Iterator
 


### PR DESCRIPTION
An attempt to untangle the universal `Sequence.SubSequence` problem. Not currently compiling.

Up to the last commit, just adding a new associated type `Prefix` to `Sequence`, and a `_prefix(_:)` alternative to `prefix(_:)` that uses it, works OK. Then constraining `Collection where Prefix == SubSequence` in the last commit sends it into a tailspin. 