### PR TITLE
hide mangling logic from readers of graph_op

### DIFF
--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -123,14 +123,25 @@ struct GraphOperationInfo {
       ArrayRef<Operand> OperandList;
     };
 
+  public:
+    /// Restricts classes that can construct a StructuredOperand.
+    /// We can't simply make the StructuredOperand constructor private, because
+    /// that would make it impossible to construct a StructuredOperand using
+    /// emplace_back().
+    class ConstructionAllowed {
+      friend struct GraphOperationInfo;
+    private:
+      ConstructionAllowed() {}
+    };
+
     StructuredOperand(StructuredOperandKind Kind, StringRef Name,
-                      SILValue SingleOperand)
+                      SILValue SingleOperand, ConstructionAllowed Permission)
         : Kind(Kind), Name(Name), SingleOperand(SingleOperand) {}
     StructuredOperand(StructuredOperandKind Kind, StringRef Name,
-                      ArrayRef<Operand> OperandList)
+                      ArrayRef<Operand> OperandList,
+                      ConstructionAllowed Permission)
         : Kind(Kind), Name(Name), OperandList(OperandList) {}
 
-  public:
     StructuredOperandKind getKind() const {
       return Kind;
     }

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -125,14 +125,12 @@ struct GraphOperationInfo {
 
     StructuredOperand(StructuredOperandKind Kind, StringRef Name,
                       SILValue SingleOperand)
-        : Kind(Kind), Name(Name), SingleOperand(SingleOperand) {};
+        : Kind(Kind), Name(Name), SingleOperand(SingleOperand) {}
     StructuredOperand(StructuredOperandKind Kind, StringRef Name,
                       ArrayRef<Operand> OperandList)
-        : Kind(Kind), Name(Name), OperandList(OperandList) {};
+        : Kind(Kind), Name(Name), OperandList(OperandList) {}
 
   public:
-    StructuredOperand(const StructuredOperand &other) = default;
-
     StructuredOperandKind getKind() const {
       return Kind;
     }

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -124,22 +124,11 @@ struct GraphOperationInfo {
     };
 
   public:
-    /// Restricts classes that can construct a StructuredOperand.
-    /// We can't simply make the StructuredOperand constructor private, because
-    /// that would make it impossible to construct a StructuredOperand using
-    /// emplace_back().
-    class ConstructionAllowed {
-      friend struct GraphOperationInfo;
-    private:
-      ConstructionAllowed() {}
-    };
-
-    StructuredOperand(StructuredOperandKind Kind, StringRef Name,
-                      SILValue SingleOperand, ConstructionAllowed Permission)
+   StructuredOperand(StructuredOperandKind Kind, StringRef Name,
+                      SILValue SingleOperand)
         : Kind(Kind), Name(Name), SingleOperand(SingleOperand) {}
     StructuredOperand(StructuredOperandKind Kind, StringRef Name,
-                      ArrayRef<Operand> OperandList,
-                      ConstructionAllowed Permission)
+                      ArrayRef<Operand> OperandList)
         : Kind(Kind), Name(Name), OperandList(OperandList) {}
 
     StructuredOperandKind getKind() const {

--- a/lib/AST/GraphOperationInfo.cpp
+++ b/lib/AST/GraphOperationInfo.cpp
@@ -76,17 +76,56 @@ void GraphOperationInfo::assertWithDump(bool cond,
 /// Decode the name of a graph_op into its TensorFlow op name and a list of
 /// information about the operands.
 StringRef GraphOperationInfo::decodeName(
-    SmallVectorImpl<OperandMarker> &operandMarkers) const {
+    SmallVectorImpl<StructuredOperand> &structuredOperands) const {
   PrettyStackTraceSILNode X("decoding graph_op name", inst);
 
-  auto name = inst->getName().str();
-  auto pos = name.find(',');
-  auto opName = name.substr(0, pos);
+  ArrayRef<Operand> remainingOperands = inst->getAllOperands();
+  StringRef remainingMangled = inst->getName().str();
+  auto nextMarkerPos = remainingMangled.find(',');
+  StringRef opName = remainingMangled.substr(0, nextMarkerPos);
 
-  while (pos != StringRef::npos) {
-    name = name.drop_front(pos);
-    pos = name.find(',', 1);
-    operandMarkers.push_back(OperandMarker(name.substr(0, pos)));
+  while (nextMarkerPos != StringRef::npos) {
+    remainingMangled = remainingMangled.drop_front(nextMarkerPos);
+    nextMarkerPos = remainingMangled.find(',', 1);
+
+    StringRef thisMarker = remainingMangled.substr(0, nextMarkerPos);
+    StringRef thisMarkerName = thisMarker.drop_front(2);
+    assert(thisMarker.size() >= 2 && "marker too short");
+    switch (thisMarker[1]) {
+    case 's':
+      // Push a SOK_Scalar.
+      assert(thisMarkerName.empty() && "SOK_Scalar should not have name");
+      structuredOperands.push_back({SOK_Scalar, StringRef(),
+                                    remainingOperands.front().get()});
+      remainingOperands = remainingOperands.drop_front(1);
+      break;
+    case 'i':
+      // Push a SOK_Single.
+      structuredOperands.push_back({SOK_Single, thisMarkerName,
+                                    remainingOperands.front().get()});
+      remainingOperands = remainingOperands.drop_front(1);
+      break;
+    case 'L':
+      // Push a SOK_List with OperandList of size 0 pointing at the right place
+      // in the inst's operands.
+      structuredOperands.push_back({SOK_List, thisMarkerName,
+                                    remainingOperands.take_front(0)});
+      break;
+    case 'e':
+      // Extend the OperandList of the curent SOK_List by 1 to include the next
+      // of the inst's operands.
+      assert(structuredOperands.size() > 0 && "list element not in list");
+      assert(structuredOperands.back().Kind == SOK_List &&
+             "list element not in list");
+      assert(thisMarkerName.empty() && "list element should not have name");
+      structuredOperands.back().OperandList = ArrayRef<Operand>(
+          structuredOperands.back().OperandList.data(),
+          structuredOperands.back().OperandList.size() + 1);
+      remainingOperands = remainingOperands.drop_front(1);
+      break;
+    default:
+      llvm_unreachable("unknown marker kind");
+    }
   }
 
   return opName;
@@ -131,29 +170,4 @@ std::string GraphOperationInfo::getStringAttr(unsigned attrIdx,
   assert(attrInfo.first == attrName);
   auto attrValue = attr.value;
   return attrValue.getStringValue().str();
-}
-
-GraphOperationInfo::OperandMarker::OperandMarker(StringRef MangledName)
-    : MangledName(MangledName) {
-  assert(MangledName.size() >= 2 && "marker too short");
-  assert(MangledName.find_last_of(",") == 0 && "incorrect comma");
-
-  switch (MangledName[1]) {
-  case 's':
-    Kind = OMK_Scalar;
-    assert(getName().empty());
-    break;
-  case 'i':
-    Kind = OMK_Normal;
-    break;
-  case 'L':
-    Kind = OMK_InputList;
-    break;
-  case 'e':
-    Kind = OMK_InputListElt;
-    assert(getName().empty());
-    break;
-  default:
-    llvm_unreachable("unknown marker kind");
-  }
 }

--- a/lib/AST/GraphOperationInfo.cpp
+++ b/lib/AST/GraphOperationInfo.cpp
@@ -96,23 +96,20 @@ StringRef GraphOperationInfo::decodeName(
       // Push a SOK_Scalar.
       assert(thisMarkerName.empty() && "SOK_Scalar should not have name");
       structuredOperands.emplace_back(SOK_Scalar, StringRef(),
-                                      remainingOperands.front().get(),
-                                      StructuredOperand::ConstructionAllowed());
+                                      remainingOperands.front().get());
       remainingOperands = remainingOperands.drop_front(1);
       break;
     case 'i':
       // Push a SOK_Single.
       structuredOperands.emplace_back(SOK_Single, thisMarkerName,
-                                      remainingOperands.front().get(),
-                                      StructuredOperand::ConstructionAllowed());
+                                      remainingOperands.front().get());
       remainingOperands = remainingOperands.drop_front(1);
       break;
     case 'L':
       // Push a SOK_List with OperandList of size 0 pointing at the right place
       // in the inst's operands.
       structuredOperands.emplace_back(SOK_List, thisMarkerName,
-                                      remainingOperands.take_front(0),
-                                      StructuredOperand::ConstructionAllowed());
+                                      remainingOperands.take_front(0));
       break;
     case 'e':
       // Extend the OperandList of the curent SOK_List by 1 to include the next

--- a/lib/AST/GraphOperationInfo.cpp
+++ b/lib/AST/GraphOperationInfo.cpp
@@ -95,21 +95,24 @@ StringRef GraphOperationInfo::decodeName(
     case 's':
       // Push a SOK_Scalar.
       assert(thisMarkerName.empty() && "SOK_Scalar should not have name");
-      structuredOperands.push_back({SOK_Scalar, StringRef(),
-                                    remainingOperands.front().get()});
+      structuredOperands.emplace_back(SOK_Scalar, StringRef(),
+                                      remainingOperands.front().get(),
+                                      StructuredOperand::ConstructionAllowed());
       remainingOperands = remainingOperands.drop_front(1);
       break;
     case 'i':
       // Push a SOK_Single.
-      structuredOperands.push_back({SOK_Single, thisMarkerName,
-                                    remainingOperands.front().get()});
+      structuredOperands.emplace_back(SOK_Single, thisMarkerName,
+                                      remainingOperands.front().get(),
+                                      StructuredOperand::ConstructionAllowed());
       remainingOperands = remainingOperands.drop_front(1);
       break;
     case 'L':
       // Push a SOK_List with OperandList of size 0 pointing at the right place
       // in the inst's operands.
-      structuredOperands.push_back({SOK_List, thisMarkerName,
-                                    remainingOperands.take_front(0)});
+      structuredOperands.emplace_back(SOK_List, thisMarkerName,
+                                      remainingOperands.take_front(0),
+                                      StructuredOperand::ConstructionAllowed());
       break;
     case 'e':
       // Extend the OperandList of the curent SOK_List by 1 to include the next

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1879,14 +1879,14 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
   auto &llvmContext = llvmModule.getContext();
 
   tf::GraphOperationInfo opInfo(i);
-  SmallVector<tf::GraphOperationInfo::OperandMarker, 4> operandMarkers;
-  auto opName = opInfo.decodeName(operandMarkers);
+  SmallVector<tf::GraphOperationInfo::StructuredOperand, 4> structuredOperands;
+  auto opName = opInfo.decodeName(structuredOperands);
 
   // TODO: Remove these. They are a temporary way of testing that dynamic
   // attributes make it here.
   LLVM_DEBUG(llvm::dbgs() << "IRGen for graph_op: " << opName << "\n");
-  LLVM_DEBUG(for (auto oi : operandMarkers) {
-    llvm::dbgs() << "  operand: " << oi.getName() << "\n";
+  LLVM_DEBUG(for (auto structuredOperand : structuredOperands) {
+    llvm::dbgs() << "  operand: " << structuredOperand.getName() << "\n";
   });
   LLVM_DEBUG(llvm::dbgs() << "end operands\n");
 

--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -334,11 +334,11 @@ class DevicePartitionCloner
 
 void DevicePartitionCloner::visitGraphOperationInst(GraphOperationInst *inst) {
   GraphOperationInfo decoder(inst);
-  SmallVector<GraphOperationInfo::OperandMarker, 4> operandMarkers;
-  auto opName = decoder.decodeName(operandMarkers);
+  SmallVector<GraphOperationInfo::StructuredOperand, 4> structuredOperands;
+  auto opName = decoder.decodeName(structuredOperands);
   if (opName == "tfc.TensorTransfer") {
-    assert(operandMarkers.size() == 1);
-    assert(operandMarkers[0].getKind() == GraphOperationInfo::OMK_Normal);
+    assert(structuredOperands.size() == 1);
+    assert(structuredOperands[0].getKind() == GraphOperationInfo::SOK_Single);
     visitTensorTransferInst(decoder);
     return;
   }


### PR DESCRIPTION
This adds an API that deals with graph_op operand demangling, simplifying code that reads the operands, and making it possible to change the mangling logic without disturbing that code too much.