### PR TITLE
[Runtime] Reimplement initialization of resilient witness tables.

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -440,7 +440,8 @@ void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
         }
       }
 
-      // Always produce associated type descriptors.
+      // Always produce associated type descriptors, because they can
+      // be referenced by generic signatures.
       if (auto *assocType = dyn_cast<AssociatedTypeDecl>(member)) {
         if (assocType->getOverriddenDecls().empty())
           addAssociatedTypeDescriptor(assocType);


### PR DESCRIPTION
Replace the quadratic algorithm (currently O(m*n) where m is the number of requirements and n is the number of witnesses) with an O(m+n) algorithm.
Harden the algorithm a against bad and unexpected inputs:
* Fail if the requirement descriptor is out-of-bounds for the protocol
* Skip the witness if the requirement descriptor is null; this can happen
when the witness table was compiled against a newer version of the
protocol, but is deployed to a library containing an older version of the
protocol. It is expected.
* In debug builds of the runtime, complain if an entry is initialized twice
* In debug builds of the runtime, complain if an entry is NULL

Fixes rdar://problem/44434793, which covers the second bullet (backward 
deployment).
