### PR TITLE
[Runtime] Instantiate witness tables even with no resilient witnesses.

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -440,7 +440,8 @@ void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
         }
       }
 
-      // Always produce associated type descriptors.
+      // Always produce associated type descriptors, because they can
+      // be referenced by generic signatures.
       if (auto *assocType = dyn_cast<AssociatedTypeDecl>(member)) {
         if (assocType->getOverriddenDecls().empty())
           addAssociatedTypeDescriptor(assocType);

--- a/validation-test/Evolution/Inputs/protocol_add_requirements.swift
+++ b/validation-test/Evolution/Inputs/protocol_add_requirements.swift
@@ -187,18 +187,10 @@ public struct Wrapper<T>: SimpleProtocol {
 }
 
 public protocol AddAssocTypesProtocol {
-  // FIXME: The presence of a single method requirement causes us to
-  // create a resilient witness table, avoiding a runtime assertion.
-  func dummy()
-
 #if AFTER
   associatedtype AssocType = Self
   associatedtype AssocType2: SimpleProtocol = Wrapper<AssocType>
 #endif
-}
-
-extension AddAssocTypesProtocol {
-  public func dummy() { }
 }
 
 public func doSomethingWithAssocTypes<T: AddAssocTypesProtocol>(_ value: T)


### PR DESCRIPTION
The witness table for an empty, resilient protocol might need to be
instantiated, if a newer version of the protocol contains defaulted
associated type requirements. In such cases, we would either fail to
instantiate or assert in the runtime. Replace the assertion with a
proper check (to require instantiation in such cases) and cope with
filling in defaults even when the provided generic witness table has
no resilient witnesses.