### PR TITLE
[InterfaceGen] Don't print 'final' on accessors

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -821,6 +821,11 @@ void PrintAST::printAttributes(const Decl *D) {
     Options.ExcludeAttrList.push_back(DAK_Final);
   }
 
+  // Don't print 'final' on accessors.
+  if (Options.PrintImplicitAttrs && isa<AccessorDecl>(D)) {
+    Options.ExcludeAttrList.push_back(DAK_Final);
+  }
+
   // If the declaration is implicitly @objc, print the attribute now.
   if (Options.PrintImplicitAttrs) {
     if (auto VD = dyn_cast<ValueDecl>(D)) {

--- a/test/ModuleInterface/final.swift
+++ b/test/ModuleInterface/final.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-interface-path %t/Test.swiftinterface -module-name Test %s
+// RUN: %FileCheck %s < %t/Test.swiftinterface
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-interface-path - -module-name Test | %FileCheck %s
+
+// CHECK: final public class FinalClass {
+public final class FinalClass {
+  // CHECK: @inlinable final public class var a: [[INT:(Swift.)?Int]] {
+  // CHECK-NEXT: return 3
+  // CHECK-NEXT: }
+  @inlinable
+  public final class var a: Int {
+    return 3
+  }
+
+  // CHECK: final public class var b: [[INT]] {
+  // CHECK-NEXT:   {{^}} @inlinable get {
+  // CHECK-NEXT:     return 3
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   set[[NEWVALUE:(\(newValue\))?]]{{$}}
+  // CHECK-NEXT: }
+  public final class var b: Int {
+    @inlinable get {
+      return 3
+    }
+    set {
+      print("x")
+    }
+  }
+
+  // CHECK: public static var c: [[INT]] {
+  // CHECK-NEXT: {{^}} get
+  // CHECK-NEXT:   @inlinable set[[NEWVALUE]] {}
+  // CHECK-NEXT: }
+  public static var c: Int {
+    get {
+      return 0
+    }
+    @inlinable set {}
+  }
+}

--- a/test/attr/attr_dynamic_infer.swift
+++ b/test/attr/attr_dynamic_infer.swift
@@ -65,17 +65,17 @@ extension FinalTests {
 
   // CHECK: @objc final var prop: Super
   @objc final var prop: Super {
-    // CHECK: final get
+    // CHECK: get
     get { return Super() }
-    // CHECK: final set
+    // CHECK: set
     set { }
   }
 
   // CHECK: @objc final subscript(sup: Super) -> Super
   @objc final subscript(sup: Super) -> Super {
-    // CHECK: final get
+    // CHECK: get
     get { return sup }
-    // CHECK: final set
+    // CHECK: set
     set { }
   }
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -841,17 +841,17 @@ class infer_instanceVar1 {
   var observingAccessorsVar1: Int {
   // CHECK: @objc var observingAccessorsVar1: Int {
     willSet {}
-    // CHECK-NEXT: {{^}} final willSet {}
+    // CHECK-NEXT: {{^}} willSet {}
     didSet {}
-    // CHECK-NEXT: {{^}} final didSet {}
+    // CHECK-NEXT: {{^}} didSet {}
   }
 
   @objc var observingAccessorsVar1_: Int {
   // CHECK: {{^}} @objc var observingAccessorsVar1_: Int {
     willSet {}
-    // CHECK-NEXT: {{^}} final willSet {}
+    // CHECK-NEXT: {{^}} willSet {}
     didSet {}
-    // CHECK-NEXT: {{^}} final didSet {}
+    // CHECK-NEXT: {{^}} didSet {}
   }
 
 


### PR DESCRIPTION
We've never allowed overriding specific accessors, and we don't
currently parse this syntax.