### PR TITLE
[Serialization] Ignore OS versions when loading resilient modules

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1360,7 +1360,8 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
   assert(!FileContext && "already associated with an AST module");
   FileContext = file;
 
-  if (file->getParentModule()->getName().str() != Name)
+  ModuleDecl *M = file->getParentModule();
+  if (M->getName().str() != Name)
     return error(Status::NameMismatch);
 
   ASTContext &ctx = getContext();
@@ -1371,6 +1372,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
     return error(Status::TargetIncompatible);
   }
   if (ctx.LangOpts.EnableTargetOSChecking &&
+      M->getResilienceStrategy() != ResilienceStrategy::Resilient &&
       isTargetTooNew(moduleTarget, ctx.LangOpts.Target)) {
     return error(Status::TargetTooNew);
   }

--- a/test/ClangImporter/bad-deployment-target.swift
+++ b/test/ClangImporter/bad-deployment-target.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -target x86_64-apple-macosx10.8 %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -target x86_64-apple-macosx10.8 %s
 //
 // This test ensures that a -target that is too old for the standard library
 // will not crash in the ClangImporter.

--- a/test/IDE/print_module_bad_target.swift
+++ b/test/IDE/print_module_bad_target.swift
@@ -1,8 +1,5 @@
 // RUN: not %swift-ide-test -source-filename %s -print-module -module-to-print Swift -target x86_64-unknown-solaris
 
-// RUN: not %swift-ide-test -source-filename %s -print-module -module-to-print Swift -target x86_64-apple-macosx10.6 -sdk %sdk
-// RUN: not %swift-ide-test -source-filename %s -print-module -module-to-print CoreServices -target x86_64-apple-macosx10.6 -sdk %sdk
-
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t -module-name Dummy -target x86_64-apple-macosx10.99 %s
 // RUN: not %target-swift-ide-test -source-filename %s -print-module -module-to-print Dummy -I %t

--- a/test/Serialization/target-incompatible.swift
+++ b/test/Serialization/target-incompatible.swift
@@ -8,6 +8,16 @@
 // RUN: %S/Inputs/binary_sub.py x86_64-unknown-darwin14 x86_64-unknown-solaris8 < %t/solaris-template.swiftmodule > %t/solaris.swiftmodule
 // RUN: not %target-swift-frontend -I %t -typecheck -parse-stdlib %s -DSOLARIS 2>&1 | %FileCheck -check-prefix=CHECK-SOLARIS %s
 
+// These checks should still hold with -enable-resilience.
+
+// RUN: %swift -target x86_64-unknown-darwin14 -o %t/mips-template.swiftmodule -parse-stdlib -emit-module -module-name mips %S/../Inputs/empty.swift -enable-resilience
+// RUN: %S/Inputs/binary_sub.py x86_64-unknown-darwin14 mips64-unknown-darwin14 < %t/mips-template.swiftmodule > %t/mips.swiftmodule
+// RUN: not %target-swift-frontend -I %t -typecheck -parse-stdlib %s -DMIPS 2>&1 | %FileCheck -check-prefix=CHECK-MIPS %s
+
+// RUN: %swift -target x86_64-unknown-darwin14 -o %t/solaris-template.swiftmodule -parse-stdlib -emit-module -module-name solaris %S/../Inputs/empty.swift -enable-resilience
+// RUN: %S/Inputs/binary_sub.py x86_64-unknown-darwin14 x86_64-unknown-solaris8 < %t/solaris-template.swiftmodule > %t/solaris.swiftmodule
+// RUN: not %target-swift-frontend -I %t -typecheck -parse-stdlib %s -DSOLARIS 2>&1 | %FileCheck -check-prefix=CHECK-SOLARIS %s
+
 #if MIPS
 // CHECK-MIPS: :[[@LINE+1]]:8: error: module 'mips' was created for incompatible target mips64-unknown-darwin14: {{.*}}mips.swiftmodule{{$}}
 import mips

--- a/test/Serialization/target-too-new.swift
+++ b/test/Serialization/target-too-new.swift
@@ -6,6 +6,13 @@
 // RUN: %target-swift-frontend -target x86_64-apple-macosx10.50 -I %t -typecheck %s
 // RUN: %target-swift-frontend -target x86_64-apple-macosx10.50.1 -I %t -typecheck %s
 
+// Allow any version when built with resilience. (Really we should encode a
+// "minimum supported OS", but we don't have that information today.)
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.50 -emit-module -parse-stdlib %S/../Inputs/empty.swift -enable-resilience -o %t
+// RUN: %target-swift-frontend -I %t -target x86_64-apple-macosx10.9 -typecheck %s
+// RUN: %target-swift-frontend -I %t -target x86_64-apple-darwin13 -typecheck %s
+
+
 // REQUIRES: OS=macosx
 
 // CHECK: :[[@LINE+1]]:8: error: compiling for OS X 10.9, but module 'empty' has a minimum deployment target of OS X 10.50: {{.*}}empty.swiftmodule{{$}}


### PR DESCRIPTION
Swift currently checks if an imported module has a deployment target compatible with what’s currently being compiled. For a resilient module, though, you really want to know the *oldest* deployment target the library supports, not the one it was most recently compiled with, and we don’t currently save that information. Disable this check for now when the module is resilient.

(Why not do this on the serialization side? Because the deployment target you compile with is still relevant when trying to match the compilation environment as closely as possible, which LLDB tries to do. It's also just useful information for debugging the compiler.)

rdar://problem/42903218