### PR TITLE
[CSStep] Add state transition verification

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1246,9 +1246,6 @@ void ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions) {
     }
 
     currentState = step->getState();
-    assert(currentState == StepState::Ready ||
-           currentState == StepState::Suspended);
-
     step->transitionTo(StepState::Running);
     return currentState == StepState::Ready ? step->take(prevFailed)
                                             : step->resume(prevFailed);
@@ -1265,10 +1262,6 @@ void ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions) {
     // which should produce another steps to follow,
     // or error, which means that current path is inconsistent.
     {
-      assert(!(step->getState() == StepState::Running ||
-               step->getState() == StepState::Done) &&
-             "Cannot re-take already running/done step.");
-
       auto result = advance(step.get(), prevFailed);
       switch (result.getKind()) {
       // It was impossible to solve this step, let's note that

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -151,9 +151,32 @@ protected:
   ///
   /// \param newState The new state this step should be in.
   void transitionTo(StepState newState) {
-    // TODO: Make sure that ordering of the state transitions is correct,
-    //       because `setup -> ready -> running [-> suspended]* -> done`
-    //       is the only reasonable state transition path.
+#ifndef NDEBUG
+    // Make sure that ordering of the state transitions is correct,
+    // because `setup -> ready -> running [-> suspended]* -> done`
+    // is the only reasonable state transition path.
+    switch (State) {
+    case StepState::Setup:
+      assert(newState == StepState::Ready);
+      break;
+
+    case StepState::Ready:
+      assert(newState == StepState::Running);
+      break;
+
+    case StepState::Running:
+      assert(newState == StepState::Suspended || newState == StepState::Done);
+      break;
+
+    case StepState::Suspended:
+      assert(newState == StepState::Running);
+      break;
+
+    case StepState::Done:
+      llvm_unreachable("step is already done.");
+    }
+#endif
+
     State = newState;
   }
 


### PR DESCRIPTION
Instead of asserting in the solver loop, let's move all of that
logic into `SolverStep::transitionTo(StepState)` and verify state
transition validity there.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
