### PR TITLE
[CSStep] NFC: Unify type binding attempt logging

### DIFF
--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -428,6 +428,13 @@ public:
       if (shouldStopAt(*choice))
         break;
 
+      if (isDebugMode()) {
+        auto &log = getDebugLogger();
+        log << "(attempting ";
+        choice->print(log, &CS.getASTContext().SourceMgr);
+        log << '\n';
+      }
+
       {
         auto scope = llvm::make_unique<Scope>(CS);
         if (attempt(*choice)) {
@@ -435,6 +442,9 @@ public:
           return suspend(llvm::make_unique<SplitterStep>(CS, Solutions));
         }
       }
+
+      if (isDebugMode())
+        getDebugLogger() << ")\n";
 
       // If this binding didn't match, let's check if we've attempted
       // enough bindings to stop, because some producers might need

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3373,6 +3373,7 @@ public:
   bool isSymmetricOperator() const;
 
   void print(llvm::raw_ostream &Out, SourceManager *SM) const {
+    Out << "disjunction choice ";
     Choice->print(Out, SM);
   }
 
@@ -3420,7 +3421,8 @@ public:
   bool attempt(ConstraintSystem &cs) const;
 
   void print(llvm::raw_ostream &Out, SourceManager *) const {
-    Out << TypeVar->getString() << " := " << Binding.BindingType->getString();
+    Out << "type variable " << TypeVar->getString()
+        << " := " << Binding.BindingType->getString();
   }
 };
 


### PR DESCRIPTION
Instead of printing `trying` for type variable and `assuming`
for disjunction choices, unify it so `BindingStep` logs
`attempting {type variable, disjunction choice}`.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
