### PR TITLE
Merge pull request #19321 from davidungar/rdar-44458502-fix-spaces-in-long-paths

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -117,6 +117,10 @@ def driver_force_one_batch_repartition : Flag<["-"], "driver-force-one-batch-rep
   InternalDebugOpt,
   HelpText<"Force one batch repartitioning for testing">;
 
+def driver_force_response_files : Flag<["-"], "driver-force-response-files">,
+  InternalDebugOpt,
+  HelpText<"Force the use of response files for testing">;
+
 def driver_always_rebuild_dependents :
   Flag<["-"], "driver-always-rebuild-dependents">, InternalDebugOpt,
   HelpText<"Always rebuild dependents of files that have been modified">;

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -425,9 +425,8 @@ bool Job::writeArgsToResponseFile() const {
     return true;
   }
   for (const char *arg : Arguments) {
-    OS << "\"";
     escapeAndPrintString(OS, arg);
-    OS << "\" ";
+    OS << " ";
   }
   OS.flush();
   return false;

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -21,6 +21,7 @@
 #include "swift/Driver/Compilation.h"
 #include "swift/Driver/Driver.h"
 #include "swift/Driver/Job.h"
+#include "swift/Option/Options.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Option/ArgList.h"
@@ -116,9 +117,15 @@ std::unique_ptr<Job> ToolChain::constructJob(
 
   const char *responseFilePath = nullptr;
   const char *responseFileArg = nullptr;
-  if (invocationInfo.allowsResponseFiles &&
-      !llvm::sys::commandLineFitsWithinSystemLimits(
-          executablePath, invocationInfo.Arguments)) {
+
+  const bool forceResponseFiles =
+      C.getArgs().hasArg(options::OPT_driver_force_response_files);
+  assert((invocationInfo.allowsResponseFiles || !forceResponseFiles) &&
+         "Cannot force response file if platform does not allow it");
+
+  if (forceResponseFiles || (invocationInfo.allowsResponseFiles &&
+                             !llvm::sys::commandLineFitsWithinSystemLimits(
+                                 executablePath, invocationInfo.Arguments))) {
     responseFilePath = context.getTemporaryFilePath("arguments", "resp");
     responseFileArg = C.getArgs().MakeArgString(Twine("@") + responseFilePath);
   }

--- a/test/Driver/force-response-files.swift
+++ b/test/Driver/force-response-files.swift
@@ -1,0 +1,6 @@
+// Ensure that -driver-force-response-files works.
+
+
+// RUN: %swiftc_driver -driver-force-response-files -typecheck %S/../Inputs/empty.swift -### 2>&1 | %FileCheck %s
+// CHECK: @
+// CHECK: .resp

--- a/test/Driver/response-files-with-spaces-in-filenames.swift
+++ b/test/Driver/response-files-with-spaces-in-filenames.swift
@@ -1,0 +1,4 @@
+// RUN: %empty-directory(%t)
+// RUN: touch "%t/f i l e.swift"
+//
+// RUN: %target-build-swift -driver-force-response-files -parse  "%t/f i l e.swift"


### PR DESCRIPTION
Fix response file quote bug, add flag for testing, add tests.
Fixes rdar://44142091.
Fixes bug in response file code that adds extra quotes, causing compiles to fail when paths were long and included spaces.
Adds -driver-force-response-file mode to allow for testing, and adds tests.
