### PR TITLE
[Sema] QoI: Offer a "self." fixit for assigning to a let which is masking a settable instance variable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3149,8 +3149,8 @@ NOTE(change_to_mutating,none,
      "mark %select{method|accessor}0 'mutating' to make 'self' mutable",
      (bool))
 NOTE(masked_instance_variable,none,
-     "add explicit 'self.' to make %0 an instance variable which is mutable",
-     (DeclName))
+     "add explicit 'self.' to refer to mutable property of %0",
+     (Type))
 
 ERROR(assignment_let_property_delegating_init,none,
       "'let' property %0 may not be initialized directly; use "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3149,7 +3149,8 @@ NOTE(change_to_mutating,none,
      "mark %select{method|accessor}0 'mutating' to make 'self' mutable",
      (bool))
 NOTE(masked_instance_variable,none,
-     "perhaps the instance variable of the same name was intended?", ())
+     "add explicit 'self.' to make %0 an instance variable which is mutable",
+     (DeclName))
 
 ERROR(assignment_let_property_delegating_init,none,
       "'let' property %0 may not be initialized directly; use "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3148,6 +3148,8 @@ ERROR(assignment_bang_has_immutable_subcomponent,none,
 NOTE(change_to_mutating,none,
      "mark %select{method|accessor}0 'mutating' to make 'self' mutable",
      (bool))
+NOTE(masked_instance_variable,none,
+     "perhaps the instance variable of the same name was intended?", ())
 
 ERROR(assignment_let_property_delegating_init,none,
       "'let' property %0 may not be initialized directly; use "

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -766,8 +766,7 @@ bool AssignmentFailure::diagnoseAsError() {
     // If there is a masked instance variable of the same type, emit a
     // note to fixit prepend a 'self.'.
     if (auto typeContext = DC->getInnermostTypeContext()) {
-      auto name = VD->getFullName();
-      UnqualifiedLookup lookup(name, typeContext,
+      UnqualifiedLookup lookup(VD->getFullName(), typeContext,
                                getASTContext().getLazyResolver());
       for (auto &result : lookup.Results) {
         const VarDecl *typeVar = dyn_cast<VarDecl>(result.getValueDecl());
@@ -778,7 +777,8 @@ bool AssignmentFailure::diagnoseAsError() {
           auto AD =
               dyn_cast_or_null<AccessorDecl>(DC->getInnermostMethodContext());
           if (!AD || AD->getStorage() != typeVar) {
-            emitDiagnostic(Loc, diag::masked_instance_variable, name)
+            emitDiagnostic(Loc, diag::masked_instance_variable,
+                           typeContext->getSelfTypeInContext())
                 .fixItInsert(Loc, "self.");
           }
         }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -766,11 +766,11 @@ bool AssignmentFailure::diagnoseAsError() {
     // If there is a masked instance variable of the same type, emit a
     // note to fixit prepend a 'self.'.
     if (auto typeContext = DC->getInnermostTypeContext()) {
-      UnqualifiedLookup lookup(VD->getFullName(), typeContext,
+      auto name = VD->getFullName();
+      UnqualifiedLookup lookup(name, typeContext,
                                getASTContext().getLazyResolver());
       for (auto &result : lookup.Results) {
-        const VarDecl *typeVar =
-            dyn_cast_or_null<VarDecl>(result.getValueDecl());
+        const VarDecl *typeVar = dyn_cast<VarDecl>(result.getValueDecl());
         if (typeVar && typeVar != VD && typeVar->isSettable(DC) &&
             typeVar->isSetterAccessibleFrom(DC) &&
             typeVar->getType()->isEqual(VD->getType())) {
@@ -778,7 +778,7 @@ bool AssignmentFailure::diagnoseAsError() {
           auto AD =
               dyn_cast_or_null<AccessorDecl>(DC->getInnermostMethodContext());
           if (!AD || AD->getStorage() != typeVar) {
-            emitDiagnostic(Loc, diag::masked_instance_variable)
+            emitDiagnostic(Loc, diag::masked_instance_variable, name)
                 .fixItInsert(Loc, "self.");
           }
         }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -763,6 +763,28 @@ bool AssignmentFailure::diagnoseAsError() {
     emitDiagnostic(Loc, DeclDiagnostic, message)
         .highlight(immInfo.first->getSourceRange());
 
+    // If there is a masked instance variable of the same type, emit a
+    // note to fixit prepend a 'self.'.
+    if (auto typeContext = DC->getInnermostTypeContext()) {
+      UnqualifiedLookup lookup(VD->getFullName(), typeContext,
+                               getASTContext().getLazyResolver());
+      for (auto &result : lookup.Results) {
+        const VarDecl *typeVar =
+            dyn_cast_or_null<VarDecl>(result.getValueDecl());
+        if (typeVar && typeVar != VD && typeVar->isSettable(DC) &&
+            typeVar->isSetterAccessibleFrom(DC) &&
+            typeVar->getType()->isEqual(VD->getType())) {
+          // But not in its own accessor.
+          auto AD =
+              dyn_cast_or_null<AccessorDecl>(DC->getInnermostMethodContext());
+          if (!AD || AD->getStorage() != typeVar) {
+            emitDiagnostic(Loc, diag::masked_instance_variable)
+                .fixItInsert(Loc, "self.");
+          }
+        }
+      }
+    }
+
     // If this is a simple variable marked with a 'let', emit a note to fixit
     // hint it to 'var'.
     VD->emitLetToVarNoteIfSimple(DC);

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -665,14 +665,14 @@ struct SS {
 
   init(i: Int, j: Float) {
     i = i // expected-error {{cannot assign to value: 'i' is a 'let' constant}}
-    // expected-note@-1 {{add explicit 'self.' to make 'i' an instance variable which is mutable}}{{5-5=self.}}
+    // expected-note@-1 {{add explicit 'self.' to refer to mutable property of 'SS'}}{{5-5=self.}}
     j = j // expected-error {{cannot assign to value: 'j' is a 'let' constant}}
-    // expected-note@-1 {{add explicit 'self.' to make 'j' an instance variable which is mutable}}{{5-5=self.}}
+    // expected-note@-1 {{add explicit 'self.' to refer to mutable property of 'SS'}}{{5-5=self.}}
   }
 
   mutating func foo(i: Int, j: Float) {
     i = i // expected-error {{cannot assign to value: 'i' is a 'let' constant}}
-    // expected-note@-1 {{add explicit 'self.' to make 'i' an instance variable which is mutable}}{{5-5=self.}}
+    // expected-note@-1 {{add explicit 'self.' to refer to mutable property of 'SS'}}{{5-5=self.}}
     j = j // expected-error {{cannot assign to value: 'j' is a 'let' constant}}
   }
 }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -665,14 +665,14 @@ struct SS {
 
   init(i: Int, j: Float) {
     i = i // expected-error {{cannot assign to value: 'i' is a 'let' constant}}
-    // expected-note@-1 {{perhaps the instance variable of the same name was intended?}}{{5-5=self.}}
+    // expected-note@-1 {{add explicit 'self.' to make 'i' an instance variable which is mutable}}{{5-5=self.}}
     j = j // expected-error {{cannot assign to value: 'j' is a 'let' constant}}
-    // expected-note@-1 {{perhaps the instance variable of the same name was intended?}}{{5-5=self.}}
+    // expected-note@-1 {{add explicit 'self.' to make 'j' an instance variable which is mutable}}{{5-5=self.}}
   }
 
   mutating func foo(i: Int, j: Float) {
     i = i // expected-error {{cannot assign to value: 'i' is a 'let' constant}}
-    // expected-note@-1 {{perhaps the instance variable of the same name was intended?}}{{5-5=self.}}
+    // expected-note@-1 {{add explicit 'self.' to make 'i' an instance variable which is mutable}}{{5-5=self.}}
     j = j // expected-error {{cannot assign to value: 'j' is a 'let' constant}}
   }
 }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -659,3 +659,20 @@ func sr4214() {
   }
 }
 
+struct SS {
+  var i: Int
+  let j: Float
+
+  init(i: Int, j: Float) {
+    i = i // expected-error {{cannot assign to value: 'i' is a 'let' constant}}
+    // expected-note@-1 {{perhaps the instance variable of the same name was intended?}}{{5-5=self.}}
+    j = j // expected-error {{cannot assign to value: 'j' is a 'let' constant}}
+    // expected-note@-1 {{perhaps the instance variable of the same name was intended?}}{{5-5=self.}}
+  }
+
+  mutating func foo(i: Int, j: Float) {
+    i = i // expected-error {{cannot assign to value: 'i' is a 'let' constant}}
+    // expected-note@-1 {{perhaps the instance variable of the same name was intended?}}{{5-5=self.}}
+    j = j // expected-error {{cannot assign to value: 'j' is a 'let' constant}}
+  }
+}


### PR DESCRIPTION
Was in a Slack today where someone had a think-o and wrote something like this:
```
Struct S {
  var x: Int

  init(x: Int) {
    x = x
  }
}
```
and was really disappointed in the resulting inappropriate error message. If we have an error assigning to a vardecl that is masking a settable instance var, offer a fixit to refer to the instance var instead.