### PR TITLE
[stdlib] Give StringProtocol.SubSequence a default to supress warning

### DIFF
--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -29,6 +29,8 @@ public protocol StringProtocol
 
   associatedtype UnicodeScalarView : BidirectionalCollection
   where UnicodeScalarView.Element == Unicode.Scalar
+  
+  associatedtype SubSequence = Substring
 
   var utf8: UTF8View { get }
   var utf16: UTF16View { get }


### PR DESCRIPTION
New associated type resilience means child protocols for whom associated type defaults don't work generate warnings. Assigning a default of `StringProtocol.SubSequence = Substring` suppresses this warning. It doesn't restrict adopters from providing something different.