### PR TITLE
[4.2][Runtime][Foundation] Supplement the class_getImageName patch with a patch to +[NSBundle bundleForClass:] on older "embedded" targets

### DIFF
--- a/stdlib/public/SDK/Foundation/BundleLookup.mm
+++ b/stdlib/public/SDK/Foundation/BundleLookup.mm
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <Foundation/Foundation.h>
+
+#include <objc/runtime.h>
+
+// This method is only used on "embedded" targets. It's not necessary on
+// Mac or simulators.
+#if TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
+
+/// CoreFoundation SPI for finding the enclosing bundle. This is only
+/// ever called on older OSes, so there's no worry of running into
+/// trouble if the implementation is changed later on.
+extern "C" CFURLRef _CFBundleCopyBundleURLForExecutableURL(CFURLRef url);
+
+@implementation NSBundle (SwiftAdditions)
+
+/// Given an executable path as a C string, look up the corresponding
+/// NSBundle instance, if any.
++ (NSBundle *)_swift_bundleWithExecutablePath: (const char *)path {
+  NSString *nspath = [[NSFileManager defaultManager]
+    stringWithFileSystemRepresentation:path length:strlen(path)];
+  NSURL *executableURL = [NSURL fileURLWithPath:nspath];
+  NSURL *bundleURL =
+    (NSURL *)_CFBundleCopyBundleURLForExecutableURL((CFURLRef)executableURL);
+  if (!bundleURL)
+    return nil;
+  
+  NSBundle *bundle = [NSBundle bundleWithURL: bundleURL];
+  [bundleURL release];
+  return bundle;
+}
+
+@end
+
+#endif

--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -4,6 +4,7 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   AffineTransform.swift
   Boxing.swift
+  BundleLookup.mm
   Calendar.swift
   CharacterSet.swift
   Codable.swift

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -31,7 +31,7 @@ set(swift_runtime_objc_sources
     SwiftObject.mm
     SwiftValue.mm
     ReflectionMirror.mm
-    ObjCRuntimeGetImageNameFromClass.cpp
+    ObjCRuntimeGetImageNameFromClass.mm
     "${SWIFT_SOURCE_DIR}/lib/Demangling/OldRemangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/TypeDecoder.cpp"


### PR DESCRIPTION
Cherry-pick #19389 to 4.2.

rdar://problem/44489216