### PR TITLE
Make runtime warnings about missing metadata more descriptive.

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -89,6 +89,10 @@ fatalError(uint32_t flags, const char *format, ...);
 
 /// swift::warning() emits a warning from the runtime.
 extern void
+warningv(uint32_t flags, const char *format, va_list args);
+
+/// swift::warning() emits a warning from the runtime.
+extern void
 warning(uint32_t flags, const char *format, ...);
 
 // swift_dynamicCastFailure halts using fatalError()

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -352,20 +352,27 @@ swift::fatalError(uint32_t flags, const char *format, ...)
 
 // Report a warning to system console and stderr.
 void
-swift::warning(uint32_t flags, const char *format, ...)
+swift::warningv(uint32_t flags, const char *format, va_list args)
 {
-  va_list args;
-  va_start(args, format);
-
   char *log;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
   swift_vasprintf(&log, format, args);
 #pragma GCC diagnostic pop
-
+  
   reportNow(flags, log);
-
+  
   free(log);
+}
+
+// Report a warning to system console and stderr.
+void
+swift::warning(uint32_t flags, const char *format, ...)
+{
+  va_list args;
+  va_start(args, format);
+
+  warningv(flags, format, args);
 }
 
 // Crash when a deleted method is called by accident.

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Reflection.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/Config.h"
@@ -253,6 +254,47 @@ struct TupleImpl : ReflectionMirrorImpl {
     return AnyReturn(result);
   }
 };
+  
+struct swift_closure {
+  void *fptr;
+  HeapObject *context;
+};
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift) swift_closure
+MANGLE_SYM(s20_playgroundPrintHookySScSgvg)();
+
+static bool _shouldReportMissingReflectionMetadataWarnings() {
+  // Missing metadata warnings noise up playground sessions and aren't really
+  // actionable in playground contexts. If we're running in a playground,
+  // suppress warnings.
+  //
+  // Guesstimate whether we're in a playground by looking at the
+  // _playgroundPrintHook variable in the standard library, which is set during
+  // playground execution.
+  auto hook = MANGLE_SYM(s20_playgroundPrintHookySScSgvg)();
+  if (hook.fptr) {
+    swift_release(hook.context);
+    return false;
+  } else {
+    return true;
+  }
+}
+
+/// Raise a warning about reflection metadata that could not be found
+/// at runtime. This is usually mostly harmless, but it's good to alert
+/// users that it happens.
+static void
+missing_reflection_metadata_warning(const char *fmt, ...) {
+  bool shouldWarn =
+    SWIFT_LAZY_CONSTANT(_shouldReportMissingReflectionMetadataWarnings());
+  
+  if (!shouldWarn)
+    return;
+  
+  va_list args;
+  va_start(args, fmt);
+  
+  warningv(0, fmt, args);
+}
 
 static std::pair<StringRef /*name*/, FieldType /*fieldInfo*/>
 getFieldAt(const Metadata *base, unsigned index) {
@@ -262,9 +304,11 @@ getFieldAt(const Metadata *base, unsigned index) {
   // back to returning an empty tuple as a standin.
   auto failedToFindMetadata = [&]() -> std::pair<StringRef, FieldType> {
     auto typeName = swift_getTypeName(base, /*qualified*/ true);
-    warning(0, "SWIFT RUNTIME BUG: no field metadata for type '%*s' that claims "
-               "to be reflectable\n",
-               (int)typeName.length, typeName.data);
+    missing_reflection_metadata_warning(
+      "warning: the Swift runtime found no field metadata for "
+      "type '%*s' that claims to be reflectable. Its fields will show up as "
+      "'unknown' in Mirrors\n",
+      (int)typeName.length, typeName.data);
     return {"unknown",
             FieldType()
               .withType(TypeInfo(&METADATA_SYM(EMPTY_TUPLE_MANGLING), {}))
@@ -331,10 +375,12 @@ getFieldAt(const Metadata *base, unsigned index) {
   // a log message.
   if (typeInfo == nullptr) {
     typeInfo = TypeInfo(&METADATA_SYM(EMPTY_TUPLE_MANGLING), {});
-    warning(0, "SWIFT RUNTIME BUG: unable to demangle type of field '%*s'. "
-               "mangled type name is '%*s'\n",
-               (int)name.size(), name.data(),
-               (int)typeName.size(), typeName.data());
+    missing_reflection_metadata_warning(
+      "warning: the Swift runtime was unable to demangle the type "
+      "of field '%*s'. the mangled type name is '%*s'. this field will "
+      "show up as an empty tuple in Mirrors\n",
+      (int)name.size(), name.data(),
+      (int)typeName.size(), typeName.data());
   }
 
   return {name, FieldType()

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -259,3 +259,15 @@ SWIFT_RUNTIME_STDLIB_SPI
 const HeapObject *swift_getKeyPathImpl(const void *p, const void *a) {
   abort();
 }
+
+// playground print hook
+
+struct swift_closure {
+  void *fptr;
+  HeapObject *context;
+};
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift) swift_closure
+MANGLE_SYM(s20_playgroundPrintHookySScSgvg)() {
+  return {nullptr, nullptr};
+}
+


### PR DESCRIPTION
Describe the consequences of missing metadata instead of just posting a scary
message about a bug.  Furthermore, since these warnings tend to show up in
playgrounds, and probably aren't relevant to the user of a playground, suppress
them when running in a playground. rdar://problem/44642942
