### PR TITLE
[4.2] Make runtime warnings about missing metadata more descriptive.

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -97,6 +97,10 @@ fatalError(uint32_t flags, const char *format, ...);
 
 /// swift::warning() emits a warning from the runtime.
 extern void
+warningv(uint32_t flags, const char *format, va_list args);
+
+/// swift::warning() emits a warning from the runtime.
+extern void
 warning(uint32_t flags, const char *format, ...);
 
 // swift_dynamicCastFailure halts using fatalError()

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -349,20 +349,27 @@ swift::fatalError(uint32_t flags, const char *format, ...)
 
 // Report a warning to system console and stderr.
 void
-swift::warning(uint32_t flags, const char *format, ...)
+swift::warningv(uint32_t flags, const char *format, va_list args)
 {
-  va_list args;
-  va_start(args, format);
-
   char *log;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
   swift_vasprintf(&log, format, args);
 #pragma GCC diagnostic pop
-
+  
   reportNow(flags, log);
-
+  
   free(log);
+}
+
+// Report a warning to system console and stderr.
+void
+swift::warning(uint32_t flags, const char *format, ...)
+{
+  va_list args;
+  va_start(args, format);
+
+  warningv(flags, format, args);
 }
 
 // Crash when a deleted method is called by accident.

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -252,3 +252,15 @@ const long long $Ss12_ClassMirrorVs01_B0sWP[1] = {0};
 // type metadata accessor for Swift._ClassMirror
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $Ss12_ClassMirrorVMa[1] = {0};
+
+// playground print hook
+
+struct swift_closure {
+  void *fptr;
+  HeapObject *context;
+};
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift) swift_closure
+MANGLE_SYM(s20_playgroundPrintHookySScSgvg)() {
+  return {nullptr, nullptr};
+}
+


### PR DESCRIPTION
Explanation: Elaborates some Swift runtime warnings to describe the consequences of missing metadata instead of just posting a scary
message about a bug.  Furthermore, since these warnings tend to show up in
playgrounds, and probably aren't relevant to the user of a playground, suppresses
these warnings when running in a playground.

Scope: Regression from 4.1

Issue: rdar://problem/44642942

Risk: Low, changes warning text output only

Testing: Swift CI

Reviewed by: @mikeash 