### PR TITLE
build: use the target variables for the ICU check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -860,15 +860,14 @@ function(swift_icu_variables_set sdk arch result)
   endif()
 endfunction()
 
-# ICU is provided through CoreFoundation on Darwin.  On other hosts, assume that
-# we are compiling for the build as the host.  In such a case, if the ICU
+# ICU is provided through CoreFoundation on Darwin.  On other hosts, if the ICU
 # unicode and i18n include and library paths are not defined, perform a standard
 # package lookup.  Otherwise, rely on the paths specified by the user.  These
 # need to be defined when cross-compiling.
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
-    swift_icu_variables_set("${SWIFT_HOST_VARIANT_SDK_default}"
-                            "${SWIFT_HOST_VARIANT_ARCH_default}"
+    swift_icu_variables_set("${SWIFT_PRIMARY_VARIANT_SDK}"
+                            "${SWIFT_PRIMARY_VARIANT_ARCH}"
                             ICU_CONFIGURED)
     if("${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "" AND NOT ${ICU_CONFIGURED})
       find_package(ICU REQUIRED COMPONENTS uc i18n)


### PR DESCRIPTION
The ICU library is used for the target library, not the host tools.  Use the
appropriate variable `SWIFT_PRIMARY_VARIANT_SDK` and
`SWIFT_PRIMARY_VARIANT_ARCH` to select the right CMake variables for the ICU
definitions.  There is no need to use the `_default` suffixed versions as the
defaults have already been used to set the value above.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
