### PR TITLE
implement ManagerBuffer.reallocated to allow realloc'ing the storage

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -658,6 +658,9 @@ internal func _isUnique<T>(_ object: inout T) -> Bool {
   return Bool(Builtin.isUnique(&object))
 }
 
+@_silgen_name("_swift_reallocObject")
+internal func _reallocObject(_ object: UnsafeMutableRawPointer, _ newSizeInBytes: Int) -> UnsafeMutableRawPointer?
+
 /// Returns `true` if `object` is uniquely referenced.
 /// This provides sanity checks on top of the Builtin.
 @_transparent

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -88,4 +88,11 @@ NSString *getDescription(OpaqueValue *value, const Metadata *type);
 
 #endif
 
+namespace swift {
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
+HeapObject *_swift_reallocObject(HeapObject *obj, size_t size);
+
+}
+
 #endif

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -82,6 +82,24 @@ const ClassMetadata *swift::_swift_getClass(const void *object) {
 #endif
 }
 
+bool isObjCPinned(HeapObject *obj) {
+  #if SWIFT_OBJC_INTEROP
+    /* future: implement checking the relevant objc runtime bits */
+    return true;
+  #else
+    return false;
+  #endif
+}
+
+// returns non-null if realloc was successful
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
+HeapObject *swift::_swift_reallocObject(HeapObject *obj, size_t size) {
+ if (isObjCPinned(obj) || obj->refCounts.hasSideTable()) {
+   return nullptr;
+ }
+ return (HeapObject *)realloc(obj, size);
+}
+
 #if SWIFT_OBJC_INTEROP
 
 /// \brief Replacement for ObjC object_isClass(), which is unavailable on


### PR DESCRIPTION
## what am I trying to achieve

The end goal of this PR and a bunch of follow-ups is to implement support for [`realloc`](http://man7.org/linux/man-pages/man3/realloc.3p.html)ating Swift objects (to be used for tail-allocated storage) after confirming with a Swift builtin that the type is 'bit-wise takable'. See also the [Swift Forums discussion swift_tailRealloc](https://forums.swift.org/t/swift-tailrealloc/12897).

## what is PR doing?

This pull request adds
- `tryReallocateUniquelyReferenced` which tries to realloc a uniquely referenced `ManagedBuffer`
- (might be removed) `_hasSideTable` (stdlib-only) runtime function to check if an object has a side table or not
- `_swift_reallocObject` runtime function which tries to reallocate a `HeapObject` if it's safe. Does not work on Darwin right now as we can't efficiently check if it's safe or not