### PR TITLE
[CSStep] Allocate component scopes only if siblings didn't fail

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -253,6 +253,9 @@ StepResult ComponentStep::take(bool prevFailed) {
   if (prevFailed || CS.getExpressionTooComplex(Solutions))
     return done(/*isSuccess=*/false);
 
+  // Setup active scope, only if previous component didn't fail.
+  setupScope();
+
   /// Try to figure out what this step is going to be,
   /// after the scope has been established.
   auto *disjunction = CS.selectDisjunction();

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -373,7 +373,18 @@ public:
     OrphanedConstraint = constraint;
   }
 
-  void setup() override {
+  StepResult take(bool prevFailed) override;
+  StepResult resume(bool prevFailed) override;
+
+  // The number of disjunction constraints associated with this component.
+  unsigned disjunctionCount() const { return NumDisjunctions; }
+
+  void print(llvm::raw_ostream &Out) override {
+    Out << "ComponentStep with at #" << Index << '\n';
+  }
+
+private:
+  void setupScope() {
     // If this is a single component, there is no need
     // to preliminary modify constraint system or log anything.
     if (IsSingle)
@@ -386,16 +397,6 @@ public:
     // If this component has oprhaned constraint attached,
     // let's return it ot the graph.
     CS.CG.setOrphanedConstraint(OrphanedConstraint);
-  }
-
-  StepResult take(bool prevFailed) override;
-  StepResult resume(bool prevFailed) override;
-
-  // The number of disjunction constraints associated with this component.
-  unsigned disjunctionCount() const { return NumDisjunctions; }
-
-  void print(llvm::raw_ostream &Out) override {
-    Out << "ComponentStep with at #" << Index << '\n';
   }
 };
 


### PR DESCRIPTION
If sibling components failed, there is no reason to establish new
scope since remaining containers are not really going to be taken
but fail fast instead.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
