### PR TITLE
build: reduce the computation of variant suffixes and directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -789,8 +789,7 @@ precondition(SWIFT_CONFIGURED_SDKS MESSAGE "No SDKs selected.")
 precondition(SWIFT_HOST_VARIANT_SDK MESSAGE "No SDK for host tools.")
 precondition(SWIFT_HOST_VARIANT_ARCH MESSAGE "No arch for host tools")
 
-set(SWIFT_PRIMARY_VARIANT_SUFFIX
-    "-${SWIFT_SDK_${SWIFT_PRIMARY_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_PRIMARY_VARIANT_ARCH}")
+compute_variant_suffix(SWIFT_PRIMARY_VARIANT_SUFFIX "${SWIFT_PRIMARY_VARIANT_SDK}" "${SWIFT_PRIMARY_VARIANT_ARCH}")
 
 # Clear universal library names to prevent adding duplicates
 foreach(sdk ${SWIFT_SDKS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,6 +790,7 @@ precondition(SWIFT_HOST_VARIANT_SDK MESSAGE "No SDK for host tools.")
 precondition(SWIFT_HOST_VARIANT_ARCH MESSAGE "No arch for host tools")
 
 compute_variant_suffix(SWIFT_PRIMARY_VARIANT_SUFFIX "${SWIFT_PRIMARY_VARIANT_SDK}" "${SWIFT_PRIMARY_VARIANT_ARCH}")
+compute_variant_suffix(SWIFT_HOST_VARIANT_SUFFIX "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}")
 
 # Clear universal library names to prevent adding duplicates
 foreach(sdk ${SWIFT_SDKS})

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -27,12 +27,6 @@ function(add_dependencies_multiple_targets)
   endif()
 endfunction()
 
-# Compute the library subdirectory to use for the given sdk and
-# architecture, placing the result in 'result_var_name'.
-function(compute_library_subdir result_var_name sdk arch)
-  set("${result_var_name}" "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}" PARENT_SCOPE)
-endfunction()
-
 function(_compute_lto_flag option out_var)
   string(TOLOWER "${option}" lowercase_option)
   if (lowercase_option STREQUAL "full")
@@ -714,8 +708,7 @@ function(_add_swift_library_single target name)
   endif()
 
   # Determine the subdirectory where this library will be installed.
-  set(SWIFTLIB_SINGLE_SUBDIR
-      "${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}/${SWIFTLIB_SINGLE_ARCHITECTURE}")
+  compute_library_subdir(SWIFTLIB_SINGLE_SUBDIR "${SWIFTLIB_SINGLE_SDK}" "${SWIFTLIB_SINGLE_ARCHITECTURE}")
 
   # Include LLVM Bitcode slices for iOS, Watch OS, and Apple TV OS device libraries.
   set(embed_bitcode_arg)
@@ -854,7 +847,7 @@ function(_add_swift_library_single target name)
 
   # If there were any swift sources, then a .swiftmodule may have been created.
   # If that is the case, then add a target which is an alias of the module files.
-  set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTLIB_SINGLE_ARCHITECTURE}")
+  compute_variant_suffix(VARIANT_SUFFIX "${SWIFTLIB_SINGLE_SDK}" "${SWIFTLIB_SINGLE_ARCHITECTURE}")
   if(NOT "${SWIFTLIB_SINGLE_MODULE_TARGET}" STREQUAL "" AND NOT "${swift_module_dependency_target}" STREQUAL "")
     add_custom_target("${SWIFTLIB_SINGLE_MODULE_TARGET}"
       DEPENDS ${swift_module_dependency_target})
@@ -916,7 +909,7 @@ function(_add_swift_library_single target name)
       # to a version which supports it.
       # target_sources(${target}
       #                PRIVATE
-      #                  $<TARGET_OBJECTS:swiftImageRegistrationObject${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTLIB_SINGLE_ARCHITECTURE}>)
+      #                  $<TARGET_OBJECTS:swiftImageRegistrationObject${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_OBJECT_FORMAT}${VARIANT_SUFFIX}>)
       target_sources(${target}
                      PRIVATE
                        "${SWIFTLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")
@@ -1152,6 +1145,8 @@ function(_add_swift_library_single target name)
   set(library_search_directories
       "${SWIFTLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR}"
       "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFTLIB_SINGLE_SUBDIR}"
+      # NOTE(compnerd) this is specifically for Darwin which does fat binaries
+      # instead of architecture specific paths
       "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}")
 
   # Add variant-specific flags.
@@ -1294,6 +1289,8 @@ function(_add_swift_library_single target name)
     set(library_search_directories
         "${SWIFTSTATICLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR}"
         "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFTLIB_SINGLE_SUBDIR}"
+        # NOTE(compnerd) this is specifically for Darwin which does fat binaries
+        # instead of architecture specific subdirectories.
         "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}")
     swift_target_link_search_directories("${target_static}" "${library_search_directories}")
     target_link_libraries("${target_static}" PRIVATE
@@ -1608,7 +1605,7 @@ function(add_swift_library name)
       # For each architecture supported by this SDK
       foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
         # Configure variables for this subdirectory.
-        set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+        compute_variant_suffix(VARIANT_SUFFIX "${sdk}" "${arch}")
         set(VARIANT_NAME "${name}${VARIANT_SUFFIX}")
         set(MODULE_VARIANT_SUFFIX "-swiftmodule${VARIANT_SUFFIX}")
         set(MODULE_VARIANT_NAME "${name}${MODULE_VARIANT_SUFFIX}")
@@ -1927,7 +1924,7 @@ function(add_swift_library name)
                 swiftStdlibUnicodeUnittest)
 
           foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
-            set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+            compute_variant_suffix(VARIANT_SUFFIX "${sdk}" "${arch}")
             if(TARGET "swift-stdlib${VARIANT_SUFFIX}" AND
                TARGET "swift-test-stdlib${VARIANT_SUFFIX}")
               add_dependencies("swift-stdlib${VARIANT_SUFFIX}"
@@ -2188,7 +2185,7 @@ function(add_swift_target_executable name)
 
   foreach(sdk ${SWIFT_SDKS})
     foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
-      set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+      compute_variant_suffix(VARIANT_SUFFIX "${sdk}" "${arch}")
       set(VARIANT_NAME "${name}${VARIANT_SUFFIX}")
 
       set(SWIFTEXE_TARGET_EXCLUDE_FROM_ALL_FLAG_CURRENT
@@ -2339,7 +2336,7 @@ function(add_swift_host_tool executable)
       ${ARGN})
 
   # Configure variables for this subdirectory.
-  set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
+  compute_variant_suffix(VARIANT_SUFFIX "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}")
   set(MODULE_VARIANT_SUFFIX "-swiftmodule${VARIANT_SUFFIX}")
 
   foreach(mod ${ADDSWIFTHOSTTOOL_SWIFT_MODULE_DEPENDS})

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2336,12 +2336,11 @@ function(add_swift_host_tool executable)
       ${ARGN})
 
   # Configure variables for this subdirectory.
-  compute_variant_suffix(VARIANT_SUFFIX "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}")
-  set(MODULE_VARIANT_SUFFIX "-swiftmodule${VARIANT_SUFFIX}")
+  set(MODULE_VARIANT_SUFFIX "-swiftmodule${SWIFT_HOST_VARIANT_SUFFIX}")
 
   foreach(mod ${ADDSWIFTHOSTTOOL_SWIFT_MODULE_DEPENDS})
     list(APPEND ADDSWIFTHOSTTOOL_DEPENDS "swift${mod}${MODULE_VARIANT_SUFFIX}")
-    list(APPEND ADDSWIFTHOSTTOOL_DEPENDS "swift${mod}${VARIANT_SUFFIX}")
+    list(APPEND ADDSWIFTHOSTTOOL_DEPENDS "swift${mod}${SWIFT_HOST_VARIANT_SUFFIX}")
   endforeach()
 
   # Create the executable rule.

--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -174,3 +174,14 @@ function(is_sdk_requested name result_var_name)
     endif()
   endif()
 endfunction()
+
+# Compute the library subdirectory to use for the given sdk and
+# architecture, placing the result in 'result_var_name'.
+function(compute_library_subdir result_var_name sdk arch)
+  set("${result_var_name}" "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}" PARENT_SCOPE)
+endfunction()
+
+function(compute_variant_suffix result_var_name sdk arch)
+  set("${result_var_name}" "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}" PARENT_SCOPE)
+endfunction()
+

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -64,7 +64,8 @@ foreach(SDK ${SWIFT_SDKS})
       PROPERTY FOLDER "Swift libraries/Aggregate")
 
   foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
-    set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
+    compute_variant_suffix(VARIANT_SUFFIX "${SDK}" "${ARCH}")
+
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}")
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sib")
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibopt")

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -44,82 +44,51 @@ if(SWIFT_BUILD_STATIC_STDLIB)
   list(APPEND SWIFT_STDLIB_LIBRARY_BUILD_TYPES STATIC)
 endif()
 
-add_custom_target(swift-stdlib-all)
-add_custom_target(swift-stdlib-sib-all)
-add_custom_target(swift-stdlib-sibopt-all)
-add_custom_target(swift-stdlib-sibgen-all)
-foreach(SDK ${SWIFT_SDKS})
-  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
-  add_custom_target("swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
-  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib")
-  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt")
-  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen")
+function(define_stdlib_build_targets target suffix all_variant)
+  if(${all_variant})
+    add_custom_target(${target}${suffix}-all)
+    set_target_properties(${target}${suffix}-all
+                          PROPERTIES
+                            FOLDER "Swift libraries/Aggregate")
+  endif()
 
-  set_property(TARGET
-      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-      "swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib"
-      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt"
-      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen"
-      PROPERTY FOLDER "Swift libraries/Aggregate")
+  foreach(SDK ${SWIFT_SDKS})
+    add_custom_target(${target}-${SWIFT_SDK_${SDK}_LIB_SUBDIR}${suffix})
+    set_target_properties(${target}-${SWIFT_SDK_${SDK}_LIB_SUBDIR}${suffix}
+                          PROPERTIES
+                            FOLDER "Swift libraries/Aggregate")
 
-  foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
-    compute_variant_suffix(VARIANT_SUFFIX "${SDK}" "${ARCH}")
+    foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
+      compute_variant_suffix(VARIANT_SUFFIX "${SDK}" "${ARCH}")
+      add_custom_target(${target}${VARIANT_SUFFIX}${suffix})
+      set_target_properties(${target}${VARIANT_SUFFIX}${suffix}
+                            PROPERTIES
+                              FOLDER "Swift libraries/Aggregate")
 
-    add_custom_target("swift-stdlib${VARIANT_SUFFIX}")
-    add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sib")
-    add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibopt")
-    add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibgen")
-    add_custom_target("swift-test-stdlib${VARIANT_SUFFIX}")
-
-    set_property(TARGET
-        "swift-stdlib${VARIANT_SUFFIX}"
-        "swift-stdlib${VARIANT_SUFFIX}-sib"
-        "swift-stdlib${VARIANT_SUFFIX}-sibopt"
-        "swift-stdlib${VARIANT_SUFFIX}-sibgen"
-        "swift-test-stdlib${VARIANT_SUFFIX}"
-        PROPERTY FOLDER "Swift libraries/Aggregate")
-
-    add_dependencies(swift-stdlib-all "swift-stdlib${VARIANT_SUFFIX}")
-    add_dependencies(swift-stdlib-sib-all "swift-stdlib${VARIANT_SUFFIX}-sib")
-    add_dependencies(swift-stdlib-sibopt-all "swift-stdlib${VARIANT_SUFFIX}-sibopt")
-    add_dependencies(swift-stdlib-sibgen-all "swift-stdlib${VARIANT_SUFFIX}-sibgen")
-
-    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-      "swift-stdlib${VARIANT_SUFFIX}")
-    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib"
-      "swift-stdlib${VARIANT_SUFFIX}-sib")
-    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt"
-        "swift-stdlib${VARIANT_SUFFIX}-sibopt")
-    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen"
-        "swift-stdlib${VARIANT_SUFFIX}-sibgen")
-
-    add_dependencies("swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-        "swift-test-stdlib${VARIANT_SUFFIX}")
+      add_dependencies(${target}${suffix}-all
+                       ${target}${VARIANT_SUFFIX}${suffix})
+      add_dependencies(${target}-${SWIFT_SDK_${SDK}_LIB_SUBDIR}${suffix}
+                       ${target}${VARIANT_SUFFIX}${suffix})
+    endforeach()
   endforeach()
-endforeach()
-add_custom_target(swift-stdlib
-    DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}")
-add_custom_target(swift-stdlib-sib
-  DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sib")
-add_custom_target(swift-stdlib-sibopt
-  DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sibopt")
-add_custom_target(swift-stdlib-sibgen
-    DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sibgen")
-add_custom_target(swift-test-stdlib ALL
-    DEPENDS "swift-test-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}")
 
-set_property(TARGET
-    swift-stdlib-all
-    swift-stdlib-sib-all
-    swift-stdlib-sibopt-all
-    swift-stdlib-sibgen-all
-    swift-stdlib
-    swift-stdlib-sib
-    swift-stdlib-sibopt
-    swift-stdlib-sibgen
-    swift-test-stdlib
-    PROPERTY FOLDER "Swift libraries/Aggregate")
+  if(NOT ${all_variant})
+    set(ALL_FLAG ALL)
+  endif()
+  add_custom_target(${target}${suffix}
+                    ${ALL_FLAG}
+                    DEPENDS
+                      ${target}${SWIFT_PRIMARY_VARIANT_SUFFIX}${suffix})
+  set_target_properties(${target}${suffix}
+                        PROPERTIES
+                          FOLDER "Swift libraries/Aggregate")
+endfunction()
+
+define_stdlib_build_targets("swift-stdlib" "" TRUE)
+define_stdlib_build_targets("swift-stdlib" "-sib" TRUE)
+define_stdlib_build_targets("swift-stdlib" "-sibopt" TRUE)
+define_stdlib_build_targets("swift-stdlib" "-sibgen" TRUE)
+define_stdlib_build_targets("swift-test-stdlib" "" FALSE)
 
 add_subdirectory(public)
 add_subdirectory(private)

--- a/stdlib/private/SwiftReflectionTest/CMakeLists.txt
+++ b/stdlib/private/SwiftReflectionTest/CMakeLists.txt
@@ -9,7 +9,7 @@ if (SWIFT_INCLUDE_TESTS)
   foreach(SDK ${SWIFT_SDKS})
     if("${SDK}" IN_LIST SWIFT_APPLE_PLATFORMS)
       foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
-        set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
+        compute_variant_suffix(VARIANT_SUFFIX "${SDK}" "${ARCH}")
         add_dependencies(
           "swiftSwiftReflectionTest${VARIANT_SUFFIX}"
           "swift-reflection-test${VARIANT_SUFFIX}")

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -44,7 +44,7 @@ foreach(sdk ${SWIFT_SDKS})
   endif()
 
   foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
-    set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
+    compute_library_subdir(arch_subdir "${sdk}" "${arch}")
     set(module_dir "${SWIFTLIB_DIR}/${arch_subdir}")
 
     if("${sdk}" STREQUAL "HAIKU")

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -102,7 +102,6 @@ set(sdk "${SWIFT_HOST_VARIANT_SDK}")
 if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   list(REMOVE_ITEM swift_runtime_sources ImageInspectionELF.cpp)
   set(static_binary_lnk_file_list)
-  string(TOLOWER "${sdk}" lowercase_sdk)
 
   # These two libraries are only used with the static swiftcore
   add_swift_library(swiftImageInspectionShared TARGET_LIBRARY STATIC
@@ -112,8 +111,10 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
     INSTALL_IN_COMPONENT stdlib)
 
   foreach(arch IN LISTS SWIFT_SDK_${sdk}_ARCHITECTURES)
-    set(FragileSupportLibrary swiftImageInspectionShared-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch})
-    set(LibraryLocation ${SWIFTSTATICLIB_DIR}/${lowercase_sdk}/${arch})
+    compute_variant_suffix(VARIANT_SUFFIX "${sdk}" "${arch}")
+    compute_library_subdir(LIBRARY_SUBDIR "${sdk}" "${arch}")
+    set(FragileSupportLibrary swiftImageInspectionShared${VARIANT_SUFFIX})
+    set(LibraryLocation ${SWIFTSTATICLIB_DIR}/${LIBRARY_SUDIR})
     add_custom_command_target(swift_image_inspection_${arch}_static
       COMMAND
         "${CMAKE_COMMAND}" -E copy $<TARGET_FILE:${FragileSupportLibrary}> ${LibraryLocation}
@@ -122,11 +123,15 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
       DEPENDS
          ${FragileSupportLibrary})
     swift_install_in_component(stdlib
-      FILES $<TARGET_FILE:${FragileSupportLibrary}>
-      DESTINATION "lib/swift_static/${lowercase_sdk}/${arch}")
+                               FILES
+                                 $<TARGET_FILE:${FragileSupportLibrary}>
+                               DESTINATION
+                                 "lib/swift_static/${LIBRARY_SUBDIR}")
   endforeach()
 
-  set(FragileSupportLibraryPrimary swiftImageInspectionShared-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${SWIFT_PRIMARY_VARIANT_ARCH})
+  string(TOLOWER "${sdk}" lowercase_sdk)
+  compute_variant_suffix(SUFFIX "${sdk}" "${SWIFT_PRIMARY_VARIANT_ARCH}")
+  set(FragileSupportLibraryPrimary swiftImageInspectionShared${SUFFIX})
   set(LibraryLocationPrimary ${SWIFTSTATICLIB_DIR}/${lowercase_sdk})
   add_custom_command_target(swift_image_inspection_static_primary_arch
       COMMAND
@@ -203,8 +208,8 @@ add_swift_library(swiftImageRegistrationObjectCOFF
 
 foreach(sdk ${SWIFT_CONFIGURED_SDKS})
   foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
-    set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
-    set(arch_suffix "${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+    compute_library_subdir(arch_subdir "${sdk}" "${arch}")
+    compute_variant_suffix(arch_suffix "${sdk}" "${arch}")
 
     if("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "ELF" OR
        "${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "COFF")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -158,7 +158,7 @@ endif()
 foreach(SDK ${SWIFT_SDKS})
   foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
     # Configure variables for this subdirectory.
-    set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
+    compute_variant_suffix(VARIANT_SUFFIX "${SDK}" "${ARCH}")
     set(VARIANT_TRIPLE "${SWIFT_SDK_${SDK}_ARCH_${ARCH}_TRIPLE}${SWIFT_SDK_${SDK}_DEPLOYMENT_VERSION}")
     set(VARIANT_SDK "${SWIFT_SDK_${SDK}_ARCH_${ARCH}_PATH}")
 

--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -126,14 +126,13 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     include_directories(AFTER
                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime
                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
-    compute_variant_suffix(VARIANT_SUFFIX "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}")
     add_dependencies(libdispatch
                        swift
                        copy_shim_headers
-                       swiftCore${VARIANT_SUFFIX}
-                       swiftSwiftOnoneSupport${VARIANT_SUFFIX}
-                       swiftCore-swiftmodule-${VARIANT_SUFFIX}
-                       swiftSwiftOnoneSupport-swiftmodule${VARIANT_SUFFIX})
+                       swiftCore${SWIFT_HOST_VARIANT_SUFFIX}
+                       swiftSwiftOnoneSupport${SWIFT_HOST_VARIANT_SUFFIX}
+                       swiftCore-swiftmodule-${SWIFT_HOST_VARIANT_SUFFIX}
+                       swiftSwiftOnoneSupport-swiftmodule${SWIFT_HOST_VARIANT_SUFFIX})
   endif()
 
   ExternalProject_Get_Property(libdispatch install_dir)
@@ -145,7 +144,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                           INTERFACE_INCLUDE_DIRECTORIES
                             ${install_dir}/include
                           IMPORTED_LINK_INTERFACE_LIBRARIES
-                            swiftCore${VARIANT_SUFFIX})
+                            swiftCore${SWIFT_HOST_VARIANT_SUFFIX})
 
   add_library(BlocksRuntime STATIC IMPORTED)
   set_target_properties(BlocksRuntime

--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -126,13 +126,14 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     include_directories(AFTER
                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime
                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
+    compute_variant_suffix(VARIANT_SUFFIX "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}")
     add_dependencies(libdispatch
                        swift
                        copy_shim_headers
-                       swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
-                       swiftSwiftOnoneSupport-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
-                       swiftCore-swiftmodule-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
-                       swiftSwiftOnoneSupport-swiftmodule-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+                       swiftCore${VARIANT_SUFFIX}
+                       swiftSwiftOnoneSupport${VARIANT_SUFFIX}
+                       swiftCore-swiftmodule-${VARIANT_SUFFIX}
+                       swiftSwiftOnoneSupport-swiftmodule${VARIANT_SUFFIX})
   endif()
 
   ExternalProject_Get_Property(libdispatch install_dir)
@@ -144,7 +145,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                           INTERFACE_INCLUDE_DIRECTORIES
                             ${install_dir}/include
                           IMPORTED_LINK_INTERFACE_LIBRARIES
-                            swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+                            swiftCore${VARIANT_SUFFIX})
 
   add_library(BlocksRuntime STATIC IMPORTED)
   set_target_properties(BlocksRuntime

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -3,9 +3,8 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
 
   set(swift_runtime_test_extra_libraries)
   if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-    compuate_variant_suffix(VARIANT_SUFFIX "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}")
     list(APPEND swift_runtime_test_extra_libraries
-         $<TARGET_FILE:swiftImageInspectionShared${VARIANT_SUFFIX}>)
+         $<TARGET_FILE:swiftImageInspectionShared${SWIFT_HOST_VARIANT_SUFFIX}>)
   endif()
 
   add_subdirectory(LongTests)

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -3,8 +3,9 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
 
   set(swift_runtime_test_extra_libraries)
   if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-    list(APPEND swift_runtime_test_extra_libraries 
-      $<TARGET_FILE:swiftImageInspectionShared-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}>)
+    compuate_variant_suffix(VARIANT_SUFFIX "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}")
+    list(APPEND swift_runtime_test_extra_libraries
+         $<TARGET_FILE:swiftImageInspectionShared${VARIANT_SUFFIX}>)
   endif()
 
   add_subdirectory(LongTests)


### PR DESCRIPTION
We currently locally compute the variant suffix and directories all across the
build system.  The computation sometimes is incorrect (like when building
non-MachO targets).  Reduce the number of places that we compute this by using a
helper function through out.  The remaining places that use
`SWIFT_SDK_<SDK>_LIB_SUBDIR` do so as an alias for the sdk variant lowercased
rather than as a means of getting the subdir.  Once those are reduced, the
location where the subdir variable is used should more or less be localised to
the utilities and will permit us to remove the variable entirely which will make
it easier to follow where the files are destined to go.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
