### PR TITLE
[Perf Experiment][CSSolver] Prefer components with fewer type variables with all else …

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -192,7 +192,19 @@ void SplitterStep::computeFollowupSteps(
   std::sort(componentSteps.begin(), componentSteps.end(),
             [](const std::unique_ptr<ComponentStep> &lhs,
                const std::unique_ptr<ComponentStep> &rhs) {
-              return lhs->disjunctionCount() > rhs->disjunctionCount();
+              auto numTypeVarsA = lhs->typeVariableCount();
+              auto numTypeVarsB = rhs->typeVariableCount();
+
+              // If left-hand side doesn't have any type variables,
+              // it's an "orphan" component and has to be scheduled
+              // with the lowest priority, because it's the least
+              // likely to fail.
+              if (numTypeVarsA == 0)
+                return numTypeVarsB != 0;
+
+              return (numTypeVarsA <= numTypeVarsB)
+                      ? lhs->disjunctionCount() > rhs->disjunctionCount()
+                      : true;
             });
 }
 

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -376,6 +376,9 @@ public:
   StepResult take(bool prevFailed) override;
   StepResult resume(bool prevFailed) override;
 
+  /// The number of type variables associated with this component.
+  unsigned typeVariableCount() const { return TypeVars.size(); }
+
   // The number of disjunction constraints associated with this component.
   unsigned disjunctionCount() const { return NumDisjunctions; }
 


### PR DESCRIPTION
…equal

If the number of disjunctions is the same in both components, let's
prefer the one which has fewer type variables because it would result
in less work done if something fails.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
