### PR TITLE
[4.2] Obsolete unsafeArithmetic operations on Integers.

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2938,6 +2938,7 @@ ${assignmentOperatorComment(x.operator, True)}
 #endif
 // end of FIXME(integers)
 
+@available(swift, deprecated: 4.2.1, obsoleted: 5)
 ${unsafeOperationComment(x.operator)}
   @inlinable // FIXME(sil-serialize-all)
   @_transparent

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2938,7 +2938,7 @@ ${assignmentOperatorComment(x.operator, True)}
 #endif
 // end of FIXME(integers)
 
-@available(swift, deprecated: 4.2.1, obsoleted: 5)
+@available(swift, deprecated: 4.2, obsoleted: 5)
 ${unsafeOperationComment(x.operator)}
   @inlinable // FIXME(sil-serialize-all)
   @_transparent


### PR DESCRIPTION
Mark these deprecated as of 4.2, per discussion with core team and https://forums.swift.org/t/removing-unsafe-arithmetic-methods/16169

They will be removed in 5.0 via a second PR.

Scope: Deprecate some operations that are unused and an attractive nuisance.
Radar: <rdar://problem/43688685>
Risk: Low – as far as we know, no one uses these.
Testing: Normal test suite.
Reviewers: @airspeedswift 
