### PR TITLE
[SILOptimizer] Don't diagnose infinite recursion if a block is noreturn

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -119,6 +119,10 @@ static bool hasInfinitelyRecursiveApply(SILFunction &Fn,
   
   while (!WorkList.empty()) {
     SILBasicBlock *CurBlock = WorkList.pop_back_val();
+    // Block will terminate the program.
+    if (CurBlock->isNoReturn())
+      return false;
+
     // Found a path to the exit node without a recursive call.
     if (CurBlock->getTerminator()->isFunctionExiting())
       return false;

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -33,7 +33,7 @@ func f() { e() }
 
 func g() { // expected-warning {{all paths through this function will call itself}}
   while true { // expected-note {{condition always evaluates to true}}
-    g() 
+    g()
   }
 
   g() // expected-warning {{will never be executed}}
@@ -66,6 +66,19 @@ func l() {
     fatalError() // does not trivially recurse due to noreturn function call
   }
   l()
+}
+
+enum CustomNever {}
+
+func returnsCustomNever() -> CustomNever {
+  fatalError()
+}
+
+func m() {
+  if Bool.random() {
+    returnsCustomNever() // does not warn because function is technically noreturn
+  }
+  m()
 }
 
 class S {

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -61,6 +61,13 @@ func k() -> Any {  // expected-warning {{all paths through this function will ca
   return type(of: k())
 }
 
+func l() {
+  if Bool.random() {
+    fatalError() // does not trivially recurse due to noreturn function call
+  }
+  l()
+}
+
 class S {
   convenience init(a: Int) { // expected-warning {{all paths through this function will call itself}}
     self.init(a: a)


### PR DESCRIPTION
Blocks that end in unreachable or otherwise call into noreturn functions
shouldn't trip the infinite recursion diagnostic.

This fixes a recent warning introduced in the stdlib where `_fatalErrorMessage` was erroneously showed infinitely recursive.