### PR TITLE
Unix toolchains will not try to use fat binaries.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -47,10 +47,19 @@ static void updateRuntimeLibraryPath(SearchPathOptions &SearchPathOpts,
   llvm::SmallString<128> LibPath(SearchPathOpts.RuntimeResourcePath);
 
   llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
-  SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  // Darwin platforms use the platform name as runtime library path.
+  if (Triple.isOSDarwin()) {
+    SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  }
 
   llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
   SearchPathOpts.RuntimeLibraryImportPath = LibPath.str();
+
+  // Non-Darwin platforms use the platform name and the architecture as runtime
+  // library path.
+  if (!Triple.isOSDarwin()) {
+    SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  }
 }
 
 void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -204,9 +204,16 @@ foreach(SDK ${SWIFT_SDKS})
       list(APPEND test_dependencies "touch-covering-tests")
     endif()
 
+    # In Darwin, we depend on the fat targets.
+    if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
+      set(validation_test_dependencies_suffix "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
+    else()
+      set(validation_test_dependencies_suffix "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
+    endif()
+
     set(validation_test_dependencies
-        "swiftStdlibCollectionUnittest-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-        "swiftStdlibUnicodeUnittest-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
+        "swiftStdlibCollectionUnittest${validation_test_dependencies_suffix}"
+        "swiftStdlibUnicodeUnittest${validation_test_dependencies_suffix}")
 
     set(command_upload_stdlib)
     set(command_upload_swift_reflection_test)
@@ -234,7 +241,7 @@ foreach(SDK ${SWIFT_SDKS})
               --ndk "${SWIFT_ANDROID_NDK_PATH}"
               --destination "${SWIFT_ANDROID_DEPLOY_DEVICE_PATH}"
               # Build products like libswiftCore.so.
-              "${SWIFTLIB_DIR}/android"
+              "${SWIFTLIB_DIR}/android/${ARCH}"
               # These two directories may contain the same libraries,
               # but upload both to device just in case. Duplicates will be
               # overwritten, and uploading doesn't take very long anyway.

--- a/test/Driver/environment.swift
+++ b/test/Driver/environment.swift
@@ -3,5 +3,5 @@
 
 // RUN: %swift_driver -target x86_64-unknown-gnu-linux -L/foo/ -driver-use-frontend-path %S/Inputs/print-var.sh %s LD_LIBRARY_PATH | %FileCheck -check-prefix=CHECK${LD_LIBRARY_PATH+_LAX} %s
 
-// CHECK: {{^/foo/:[^:]+/lib/swift/linux$}}
-// CHECK_LAX: {{^/foo/:[^:]+/lib/swift/linux}}
+// CHECK: {{^/foo/:[^:]+/lib/swift/linux/x86_64$}}
+// CHECK_LAX: {{^/foo/:[^:]+/lib/swift/linux/x86_64}}

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -18,8 +18,8 @@
 // CHECK-RESOURCE-DIR-ONLY: # DYLD_LIBRARY_PATH=/RSRC/macosx{{$}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -resource-dir /RSRC/ %s | %FileCheck -check-prefix=CHECK-RESOURCE-DIR-ONLY-LINUX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux{{$}}
-// CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux{{$|:}}
+// CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux/x86_64{{$}}
+// CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux/x86_64{{$|:}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -L/foo/ %s | %FileCheck -check-prefix=CHECK-L %s
 // CHECK-L: # DYLD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/macosx$}}
@@ -59,9 +59,9 @@
 // CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx($| )}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}
-// CHECK-L-LINUX_LAX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux($|:)}}
+// CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux/x86_64$}}
+// CHECK-L-LINUX_LAX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux/x86_64($|:)}}
 
 // RUN: env LD_LIBRARY_PATH=/abc/ %swift_driver_plain -### -target x86_64-unknown-linux-gnu -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-LINUX-COMPLEX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-LINUX-COMPLEX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux:/abc/$}}
-// CHECK-LINUX-COMPLEX_LAX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux:/abc/($|:)}}
+// CHECK-LINUX-COMPLEX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux/x86_64:/abc/$}}
+// CHECK-LINUX-COMPLEX_LAX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux/x86_64:/abc/($|:)}}

--- a/validation-test/execution/interpret-with-dependencies-linux.swift
+++ b/validation-test/execution/interpret-with-dependencies-linux.swift
@@ -8,9 +8,9 @@
 // CHECK: {{okay}}
 
 // Now test a dependency on a library in the compiler's resource directory.
-// RUN: %empty-directory(%t/rsrc/%target-sdk-name)
-// RUN: ln -s %t/libabc.so %t/rsrc/%target-sdk-name/
-// RUN: ln -s %platform-module-dir/../* %t/rsrc/%target-sdk-name/
+// RUN: %empty-directory(%t/rsrc/%target-sdk-name/%target-cpu)
+// RUN: ln -s %t/libabc.so %t/rsrc/%target-sdk-name/%target-cpu
+// RUN: ln -s %platform-module-dir/* %t/rsrc/%target-sdk-name/%target-cpu
 // RUN: ln -s %platform-module-dir/../../shims %t/rsrc/
 // RUN: %empty-directory(%t/other)
 // RUN: ln -s %t/libfoo.so %t/other


### PR DESCRIPTION
Unix (other than Darwin) and Windows do not support fat binaries.
However, the build system was trying to "lipo" several
architectures into one file even for those targets (only Windows
was exercising that part of the code, it seems).

This patch removes the copy for a bogus empty target, and modifies
the Unix toolchain to look into the architecture subdirectory,
instead of trying to use the platform directory. The Windows
toolchain already checked the architecture directory, and not the
platform one.

This should allow building two Linux or Android SDKs for different
architures side by side.

Some tests are modified to handle the new structure. The tests are
hardcoded to use x86_64 because their targets were originally
x86_64.