### PR TITLE
runtime: remove unnecessary preprocessor condition, flip cases (NFC)

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -100,11 +100,11 @@ IDENTIFIER(stringValue)
 IDENTIFIER(super)
 IDENTIFIER(superDecoder)
 IDENTIFIER(superEncoder)
-#if __APPLE__ && !SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
+#if SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
+IDENTIFIER_WITH_NAME(SwiftObject, "_TtCs12_SwiftObject")
+#else
 // Pre-stable ABI uses un-mangled name for SwiftObject.
 IDENTIFIER(SwiftObject)
-#else
-IDENTIFIER_WITH_NAME(SwiftObject, "_TtCs12_SwiftObject")
 #endif
 IDENTIFIER(to)
 IDENTIFIER(toRaw)

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -30,12 +30,12 @@
 
 #if SWIFT_OBJC_INTEROP
 
-#if __APPLE__ && !SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
-// Pre-stable ABI uses un-mangled name for SwiftObject
-#else
+#if SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
 // Source code: "SwiftObject"
 // Real class name: mangled "Swift._SwiftObject"
 #define SwiftObject _TtCs12_SwiftObject
+#else
+// Pre-stable ABI uses un-mangled name for SwiftObject
 #endif
 
 #if __has_attribute(objc_root_class)

--- a/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
+++ b/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
@@ -52,13 +52,13 @@ static int Errors;
 
 // Add methods to class SwiftObject that can be called by performSelector: et al
 
-#if __APPLE__ && !SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
-// Pre-stable ABI uses un-mangled name for SwiftObject.
-#define SwiftObjectDemangledName "SwiftObject"
-#else
+#if SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
 // mangled Swift._SwiftObject
 #define SwiftObject _TtCs12_SwiftObject
 #define SwiftObjectDemangledName "Swift._SwiftObject"
+#else
+// Pre-stable ABI uses un-mangled name for SwiftObject.
+#define SwiftObjectDemangledName "SwiftObject"
 #endif
 
 @interface SwiftObject /* trust me, I know what I'm doing */ @end


### PR DESCRIPTION
The use of `__APPLE__` is unnecessary as the case is guarded by the
`SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT` preprocessor guard which is implicitly
specific to that environment.  Additionally, flip the condition around so that
the positive (which is the future) appears ahead of the negative case.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
