### PR TITLE
[sourcekit] Fix line+column -> offset conversion when on the last line of a file with no terminating newline

### DIFF
--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -320,11 +320,10 @@ llvm::Optional<unsigned> SourceManager::resolveFromLineCol(unsigned BufferId,
   const char *Ptr = InputBuf->getBufferStart();
   const char *End = InputBuf->getBufferEnd();
   const char *LineStart = Ptr;
-  for (; Ptr < End; ++Ptr) {
+  --Line;
+  for (; Line && (Ptr < End); ++Ptr) {
     if (*Ptr == '\n') {
       --Line;
-      if (Line == 0)
-        break;
       LineStart = Ptr+1;
     }
   }

--- a/test/SourceKit/Refactoring/semantic-refactoring/line-col-conversion.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/line-col-conversion.swift
@@ -1,0 +1,4 @@
+// RUN: %sourcekitd-test -req=local-rename -pos=4:7 -name new_name %s -- %s
+
+var Foo: Int {
+	var missingNewlineAtEndOfFile

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1963,11 +1963,10 @@ static unsigned resolveFromLineCol(unsigned Line, unsigned Col,
   const char *Ptr = InputBuf->getBufferStart();
   const char *End = InputBuf->getBufferEnd();
   const char *LineStart = Ptr;
-  for (; Ptr < End; ++Ptr) {
+  --Line;
+  for (; Line && (Ptr < End); ++Ptr) {
     if (*Ptr == '\n') {
       --Line;
-      if (Line == 0)
-        break;
       LineStart = Ptr+1;
     }
   }


### PR DESCRIPTION
This was causing local refactorings (which are line+column-based) to fail due to the provided location being considered invalid, even though the available refactorings request (which uses offset directly) reported them as available.