### PR TITLE
[ModuleInterface] Don't print extensions of internal types

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -109,6 +109,14 @@ PrintOptions PrintOptions::printTextualInterfaceFile() {
         }
       }
 
+      // Skip extensions that extend things we wouldn't print.
+      if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
+        if (!shouldPrint(ED->getExtendedNominal(), options))
+          return false;
+        // FIXME: We also need to check the generic signature for constraints
+        // that we can't reference.
+      }
+
       // Skip typealiases that just redeclare generic parameters.
       if (auto *alias = dyn_cast<TypeAliasDecl>(D)) {
         if (alias->isImplicit()) {

--- a/test/ModuleInterface/access-filter.swift
+++ b/test/ModuleInterface/access-filter.swift
@@ -102,3 +102,12 @@ extension PublicStruct {
   // CHECK: public private(set) static var secretlySettable: Int{{$}}
   public private(set) static var secretlySettable: Int = 0
 } // CHECK: {{^[}]$}}
+
+extension InternalStruct_BAD: PublicProto {
+  internal static var dummy: Int { return 0 }
+}
+
+// CHECK: extension UFIStruct : PublicProto {{[{]$}}
+extension UFIStruct: PublicProto {
+  internal static var dummy: Int { return 0 }
+} // CHECK-NEXT: {{^[}]$}}


### PR DESCRIPTION
I admit to doing the easy part of this first. I'll file a bug so I don't forget about the second part, but it looks like nothing in the overlays is using that right now.