### PR TITLE
[test] Separately validate the 'simd' overlay's swiftinterface

### DIFF
--- a/validation-test/ModuleInterface/verify_simd.swift
+++ b/validation-test/ModuleInterface/verify_simd.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %platform-sdk-overlay-dir/simd.swiftinterface -emit-module -o %t/simd.swiftmodule -enable-resilience -parse-stdlib -import-module Swift -swift-version 4
+// RUN: %target-swift-frontend %platform-sdk-overlay-dir/simd.swiftinterface -emit-module -o %t/simd.swiftmodule -enable-resilience -parse-stdlib -import-module Swift -swift-version 4 -O
+
+// REQUIRES: nonexecutable_test
+// REQUIRES: objc_interop


### PR DESCRIPTION
It needs special options that aren't inferred yet, but with those it passes, so let's test it.