### PR TITLE
[CSDiagnostics] Don't mention special names in requirement diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1541,23 +1541,24 @@ ERROR(types_not_equal,none,
 ERROR(type_does_not_conform_owner,none,
       "%0 requires that %1 conform to %2", (Type, Type, Type))
 ERROR(type_does_not_conform_in_decl_ref,none,
-      "referencing %0 %1 on %2 requires that %3 conform to %4",
-      (DescriptiveDeclKind, DeclName, Type, Type, Type))
+      "referencing %0 %select{%2 |}1on %3 requires that %4 conform to %5",
+      (DescriptiveDeclKind, bool, DeclName, Type, Type, Type))
 ERROR(type_does_not_conform_decl_owner,none,
-      "%0 %1 requires that %2 conform to %3",
-      (DescriptiveDeclKind, DeclName, Type, Type))
+      "%0 %select{%2 |}1requires that %3 conform to %4",
+      (DescriptiveDeclKind, bool, DeclName, Type, Type))
 ERROR(types_not_equal_decl,none,
-      "%0 %1 requires the types %2 and %3 be equivalent",
-      (DescriptiveDeclKind, DeclName, Type, Type))
+      "%0 %select{%2 |}1requires the types %3 and %4 be equivalent",
+      (DescriptiveDeclKind, bool, DeclName, Type, Type))
 ERROR(types_not_equal_in_decl_ref,none,
-      "referencing %0 %1 on %2 requires the types %3 and %4 be equivalent",
-      (DescriptiveDeclKind, DeclName, Type, Type, Type))
+      "referencing %0 %select{%2 |}1on %3 requires the types "
+      "%4 and %5 be equivalent",
+      (DescriptiveDeclKind, bool, DeclName, Type, Type, Type))
 ERROR(types_not_inherited_decl,none,
-      "%0 %1 requires that %2 inherit from %3",
-      (DescriptiveDeclKind, DeclName, Type, Type))
+      "%0 %select{%2 |}1requires that %3 inherit from %4",
+      (DescriptiveDeclKind, bool, DeclName, Type, Type))
 ERROR(types_not_inherited_in_decl_ref,none,
-      "referencing %0 %1 on %2 requires that %3 inherit from %4",
-      (DescriptiveDeclKind, DeclName, Type, Type, Type))
+      "referencing %0 %select{%2 |}1on %3 requires that %4 inherit from %5",
+      (DescriptiveDeclKind, bool, DeclName, Type, Type, Type))
 NOTE(where_requirement_failure_one_subst,none,
      "where %0 = %1", (Type, Type))
 NOTE(where_requirement_failure_both_subst,none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -141,16 +141,16 @@ bool RequirementFailure::diagnoseAsError() {
   const auto *reqDC = getRequirementDC();
   auto *genericCtx = AffectedDecl->getAsGenericContext();
 
+  auto declName = AffectedDecl->getFullName();
   if (reqDC != genericCtx) {
     auto *NTD = reqDC->getSelfNominalTypeDecl();
     emitDiagnostic(anchor->getLoc(), getDiagnosticInRereference(),
-                   AffectedDecl->getDescriptiveKind(),
-                   AffectedDecl->getFullName(), NTD->getDeclaredType(),
-                   getLHS(), getRHS());
+                   AffectedDecl->getDescriptiveKind(), declName.isSpecial(),
+                   declName, NTD->getDeclaredType(), getLHS(), getRHS());
   } else {
     emitDiagnostic(anchor->getLoc(), getDiagnosticOnDecl(),
-                   AffectedDecl->getDescriptiveKind(),
-                   AffectedDecl->getFullName(), getLHS(), getRHS());
+                   AffectedDecl->getDescriptiveKind(), declName.isSpecial(),
+                   declName, getLHS(), getRHS());
   }
 
   emitRequirementNote(reqDC->getAsDecl());

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -149,8 +149,9 @@ private:
 class RequirementFailure : public FailureDiagnostic {
 protected:
   using PathEltKind = ConstraintLocator::PathElementKind;
-  using DiagOnDecl = Diag<DescriptiveDeclKind, DeclName, Type, Type>;
-  using DiagInReference = Diag<DescriptiveDeclKind, DeclName, Type, Type, Type>;
+  using DiagOnDecl = Diag<DescriptiveDeclKind, bool, DeclName, Type, Type>;
+  using DiagInReference =
+      Diag<DescriptiveDeclKind, bool, DeclName, Type, Type, Type>;
   using DiagAsNote = Diag<Type, Type, Type, Type, StringRef>;
 
   const ValueDecl *AffectedDecl;

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1199,7 +1199,7 @@ func platypus<T>(a: [T]) {
 func badTypes() {
   let sequence:AnySequence<[Int]> = AnySequence() { AnyIterator() { [3] }}
   let array = [Int](sequence)
-  // expected-error@-1 {{initializer 'init' requires the types 'Int' and '[Int]' be equivalent}}
+  // expected-error@-1 {{initializer requires the types 'Int' and '[Int]' be equivalent}}
 }
 
 // rdar://34357545

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -253,7 +253,7 @@ struct V27515965 {
 
 func test(x: S27515965) -> V27515965 {
   return V27515965(x)
-  // expected-error@-1 {{initializer 'init' requires the types 'Any' and 'Float' be equivalent}}
+  // expected-error@-1 {{initializer requires the types 'Any' and 'Float' be equivalent}}
 }
 
 protocol BaseProto {}
@@ -331,14 +331,14 @@ func testFixIts() {
   _ = AnyClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{28-28=<<#Foo: SubProto & AnyObject#>>}}
   _ = AnyClassAndProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{29-29=<<#Foo: SubProto & AnyObject#>>}}
 
-  _ = ClassAndProtoBound() // expected-error {{referencing initializer 'init()' on 'ClassAndProtoBound' requires that 'X' conform to 'SubProto'}}
+  _ = ClassAndProtoBound() // expected-error {{referencing initializer on 'ClassAndProtoBound' requires that 'X' conform to 'SubProto'}}
 
   _ = ClassAndProtosBound() 
-  // expected-error@-1 {{referencing initializer 'init()' on 'ClassAndProtosBound' requires that 'X' conform to 'NSCopyish'}}
-  // expected-error@-2 {{referencing initializer 'init()' on 'ClassAndProtosBound' requires that 'X' conform to 'SubProto'}}
+  // expected-error@-1 {{referencing initializer on 'ClassAndProtosBound' requires that 'X' conform to 'NSCopyish'}}
+  // expected-error@-2 {{referencing initializer on 'ClassAndProtosBound' requires that 'X' conform to 'SubProto'}}
   _ = ClassAndProtosBound2()
-  // expected-error@-1 {{referencing initializer 'init()' on 'ClassAndProtosBound2' requires that 'X' conform to 'NSCopyish'}}
-  // expected-error@-2 {{referencing initializer 'init()' on 'ClassAndProtosBound2' requires that 'X' conform to 'SubProto'}}
+  // expected-error@-1 {{referencing initializer on 'ClassAndProtosBound2' requires that 'X' conform to 'NSCopyish'}}
+  // expected-error@-2 {{referencing initializer on 'ClassAndProtosBound2' requires that 'X' conform to 'SubProto'}}
 
   _ = Pair() // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<Any, Any>}}
   _ = Pair(first: S()) // expected-error {{generic parameter 'U' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<S, Any>}}
@@ -610,7 +610,7 @@ func rdar40537858() {
   }
 
   var arr: [S] = []
-  _ = List(arr, id: \.id) // expected-error {{referencing initializer 'init(_:id:)' on 'List' requires that 'S.Id' conform to 'Hashable'}}
+  _ = List(arr, id: \.id) // expected-error {{referencing initializer on 'List' requires that 'S.Id' conform to 'Hashable'}}
 
   enum E<T: P> { // expected-note 2 {{where 'T' = 'S'}}
     case foo(T)

--- a/test/Constraints/rdar44569159.swift
+++ b/test/Constraints/rdar44569159.swift
@@ -13,6 +13,6 @@ struct A {
 
 func foo(_ v: Double) {
   _ = A()[S(value: v)]
-// expected-error@-1 {{subscript 'subscript' requires that 'Double' conform to 'P'}}
-// expected-error@-2 {{referencing initializer 'init(value:)' on 'S' requires that 'Double' conform to 'P'}}
+// expected-error@-1 {{subscript requires that 'Double' conform to 'P'}}
+// expected-error@-2 {{referencing initializer on 'S' requires that 'Double' conform to 'P'}}
 }

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -169,7 +169,7 @@ struct MagicKingdom<K> : Kingdom {
 }
 func magify<T>(_ t: T) -> MagicKingdom<T> { return MagicKingdom() }
 func foo(_ pair: (Int, Int)) -> Victory<(x: Int, y: Int)> {
-  return Victory(magify(pair)) // expected-error {{initializer 'init' requires the types '(x: Int, y: Int)' and '(Int, Int)' be equivalent}}
+  return Victory(magify(pair)) // expected-error {{initializer requires the types '(x: Int, y: Int)' and '(Int, Int)' be equivalent}}
 }
 
 

--- a/test/Serialization/builtin.swift
+++ b/test/Serialization/builtin.swift
@@ -11,4 +11,4 @@ var a : TheBuiltinInt64
 
 // Check that it really is Builtin.Int64.
 var wrapped = Int64(a) // okay
-var badWrapped = Int32(a) // expected-error{{initializer 'init' requires that 'TheBuiltinInt64' conform to 'BinaryInteger'}}
+var badWrapped = Int32(a) // expected-error{{initializer requires that 'TheBuiltinInt64' conform to 'BinaryInteger'}}

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -27,7 +27,7 @@ struct A {
 }
 
 extension A: K {
-    static let j = S(\A.id + "id") // expected-error {{initializer 'init' requires that 'String' conform to 'K'}}
+    static let j = S(\A.id + "id") // expected-error {{initializer requires that 'String' conform to 'K'}}
 }
 
 // SR-5034


### PR DESCRIPTION
Instead of `initializer 'init' of ...` diagnostic should only
mention kind e.g. `initializer of ...` of the declaration
with a special name.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
