### PR TITLE
WIP [ConstraintSystem] Ability to treat key path literal syntax as function type (Root) -> Value.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6569,9 +6569,9 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
             AutoClosureExpr(expr, fnTy->getResult(), discriminator, cs.DC);
         auto param = new (context) ParamDecl(
             VarDecl::Specifier::Default, SourceLoc(), SourceLoc(), Identifier(),
-            SourceLoc(), argTy->getNominalOrBoundGenericNominal()->getName(),
-            closure);
-        param->setInterfaceType(fnTy->getParams()[0].getType());
+            SourceLoc(), context.getIdentifier("$0"), closure);
+        param->setType(argTy);
+        param->setInterfaceType(argTy->mapTypeOutOfContext());
         auto *paramRef =
             new (context) DeclRefExpr(param, DeclNameLoc(), /*Implicit=*/true);
         paramRef->setType(argTy);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4274,12 +4274,6 @@ namespace {
         baseTy = fnTy->getParams()[0].getType();
         leafTy = fnTy->getResult();
         isFunctionType = true;
-        // Reset the expr type to be KeyPath so that we'll
-        // perform the KeyPath<Base,Leaf> to (Base)->Leaf coercion.
-        auto kpDecl = cs.getASTContext().getKeyPathDecl();
-        auto resolvedKPTy =
-            BoundGenericType::get(kpDecl, nullptr, {baseTy, leafTy});
-        cs.setType(E, resolvedKPTy);
       } else {
         auto keyPathTy = exprType->castTo<BoundGenericType>();
         baseTy = keyPathTy->getGenericArgs()[0];

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3082,19 +3082,13 @@ namespace {
 
       auto rvalueBase = CS.createTypeVariable(locator);
       CS.addConstraint(ConstraintKind::Equal, base, rvalueBase, locator);
-      
+
       // The result is a KeyPath from the root to the end component.
-      Type kpTy;
-      if (didOptionalChain) {
-        // Optional-chaining key paths are always read-only.
-        kpTy = BoundGenericType::get(kpDecl, Type(), {root, rvalueBase});
-      } else {
-        // The type of key path depends on the overloads chosen for the key
-        // path components.
-        kpTy = CS.createTypeVariable(CS.getConstraintLocator(E));
-        CS.addKeyPathConstraint(kpTy, root, rvalueBase,
-                                CS.getConstraintLocator(E));
-      }
+      // The type of key path depends on the overloads chosen for the key
+      // path components, or may also end up as function type.
+      Type kpTy = CS.createTypeVariable(CS.getConstraintLocator(E));
+      CS.addKeyPathConstraint(kpTy, root, rvalueBase,
+                              CS.getConstraintLocator(E));
       return kpTy;
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4259,9 +4259,8 @@ done:
   }
 
   Type resolvedKPTy = BoundGenericType::get(kpDecl, nullptr, {rootTy, valueTy});
-  Type fnType = FunctionType::get(
-      {AnyFunctionType::Param(rootTy)}, valueTy,
-      AnyFunctionType::ExtInfo().withNoEscape(true).withThrows(false));
+  Type fnType = FunctionType::get({AnyFunctionType::Param(rootTy)}, valueTy,
+                                  AnyFunctionType::ExtInfo().withThrows(false));
   llvm::SmallVector<Constraint *, 2> constraints;
   auto loc = locator.getBaseLocator();
   constraints.push_back(Constraint::create(*this, ConstraintKind::Bind,

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -467,6 +467,8 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[cf-toll-free-bridge-to-objc]";
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
     return "[objc-toll-free-bridge-to-cf]";
+  case ConversionRestrictionKind::KeyPathToFunction:
+    return "[keypath-to-function]";
   }
   llvm_unreachable("bad conversion restriction kind");
 }

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -467,8 +467,6 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[cf-toll-free-bridge-to-objc]";
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
     return "[objc-toll-free-bridge-to-cf]";
-  case ConversionRestrictionKind::KeyPathToFunction:
-    return "[keypath-to-function]";
   }
   llvm_unreachable("bad conversion restriction kind");
 }

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -196,7 +196,8 @@ enum class ConversionRestrictionKind {
   MetatypeToExistentialMetatype,
   /// Existential metatype to metatype conversion.
   ExistentialMetatypeToMetatype,
-  /// T -> U? value to optional conversion (or to implicitly unwrapped optional).
+  /// T -> U? value to optional conversion (or to implicitly unwrapped
+  /// optional).
   ValueToOptional,
   /// T? -> U? optional to optional conversion (or unchecked to unchecked).
   OptionalToOptional,
@@ -214,7 +215,9 @@ enum class ConversionRestrictionKind {
   CFTollFreeBridgeToObjC,
   /// Implicit conversion from an Objective-C class type to its
   /// toll-free-bridged CF type.
-  ObjCTollFreeBridgeToCF
+  ObjCTollFreeBridgeToCF,
+  /// KeyPath<Root, Value> to (Root) -> Value
+  KeyPathToFunction,
 };
 
 /// Return a string representation of a conversion restriction.

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -216,8 +216,6 @@ enum class ConversionRestrictionKind {
   /// Implicit conversion from an Objective-C class type to its
   /// toll-free-bridged CF type.
   ObjCTollFreeBridgeToCF,
-  /// KeyPath<Root, Value> to (Root) -> Value
-  KeyPathToFunction,
 };
 
 /// Return a string representation of a conversion restriction.


### PR DESCRIPTION
A WIP because I haven't added tests yet. Allows coercion from KeyPath to function type in any context that expects a `(Root) -> Value` function type, and allows for the constraint system to figure out the desired KeyPath type from the function type for incomplete key types (e.g. constructions like `\.foo` where the root is unspecified).

Just creates an implicit auto closure to perform the key path application `expr` to `{ $0[keyPath: expr] }`. Generated SIL is identical except for the closure name.

This is the potential feature as discussed in quite a few sorting/mapping threads on evolution, and most specifically here: https://forums.swift.org/t/key-path-getter-promotion/11185/4