### PR TITLE
Add response file support for more Swift jobs.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -574,7 +574,10 @@ ToolChain::InvocationInfo
 ToolChain::constructInvocation(const InterpretJobAction &job,
                                const JobContext &context) const {
   assert(context.OI.CompilerMode == OutputInfo::Mode::Immediate);
-  ArgStringList Arguments;
+
+  InvocationInfo II{SWIFT_EXECUTABLE_NAME};
+  ArgStringList &Arguments = II.Arguments;
+  II.allowsResponseFiles = true;
 
   Arguments.push_back("-frontend");
   Arguments.push_back("-interpret");
@@ -603,7 +606,7 @@ ToolChain::constructInvocation(const InterpretJobAction &job,
   // The immediate arguments must be last.
   context.Args.AddLastArg(Arguments, options::OPT__DASH_DASH);
 
-  return {SWIFT_EXECUTABLE_NAME, Arguments};
+  return II;
 }
 
 ToolChain::InvocationInfo
@@ -751,6 +754,7 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
                                const JobContext &context) const {
   InvocationInfo II{SWIFT_EXECUTABLE_NAME};
   ArgStringList &Arguments = II.Arguments;
+  II.allowsResponseFiles = true;
 
   Arguments.push_back("-frontend");
 
@@ -828,7 +832,9 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
 ToolChain::InvocationInfo
 ToolChain::constructInvocation(const ModuleWrapJobAction &job,
                                const JobContext &context) const {
-  ArgStringList Arguments;
+  InvocationInfo II{SWIFT_EXECUTABLE_NAME};
+  ArgStringList &Arguments = II.Arguments;
+  II.allowsResponseFiles = true;
 
   Arguments.push_back("-modulewrap");
 
@@ -849,7 +855,7 @@ ToolChain::constructInvocation(const ModuleWrapJobAction &job,
   Arguments.push_back(
       context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
 
-  return {SWIFT_EXECUTABLE_NAME, Arguments};
+  return II;
 }
 
 ToolChain::InvocationInfo
@@ -949,7 +955,9 @@ ToolChain::constructInvocation(const GeneratePCHJobAction &job,
          (job.isPersistentPCH() &&
           context.Output.getPrimaryOutputType() == file_types::TY_Nothing));
 
-  ArgStringList Arguments;
+  InvocationInfo II{SWIFT_EXECUTABLE_NAME};
+  ArgStringList &Arguments = II.Arguments;
+  II.allowsResponseFiles = true;
 
   Arguments.push_back("-frontend");
 
@@ -973,7 +981,7 @@ ToolChain::constructInvocation(const GeneratePCHJobAction &job,
         context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
   }
 
-  return {SWIFT_EXECUTABLE_NAME, Arguments};
+  return II;
 }
 
 ToolChain::InvocationInfo

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -85,7 +85,10 @@ ToolChain::InvocationInfo toolchains::GenericUnix::constructInvocation(
     const AutolinkExtractJobAction &job, const JobContext &context) const {
   assert(context.Output.getPrimaryOutputType() == file_types::TY_AutolinkFile);
 
-  ArgStringList Arguments;
+  InvocationInfo II{"swift-autolink-extract"};
+  ArgStringList &Arguments = II.Arguments;
+  II.allowsResponseFiles = true;
+
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
@@ -94,7 +97,7 @@ ToolChain::InvocationInfo toolchains::GenericUnix::constructInvocation(
   Arguments.push_back(
       context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
 
-  return {"swift-autolink-extract", Arguments};
+  return II;
 }
 
 std::string toolchains::GenericUnix::getDefaultLinker() const {

--- a/test/Driver/response-file-merge-modules.swift
+++ b/test/Driver/response-file-merge-modules.swift
@@ -1,0 +1,12 @@
+// RUN: %{python} -c 'for i in range(500001): print "-DTEST_" + str(i)' > %t.resp
+// RUN: %swiftc_driver -driver-print-jobs -module-name merge -emit-module %S/Inputs/main.swift %S/Inputs/lib.swift @%t.resp 2>&1 > %t.jobs.txt
+// RUN: %FileCheck %s < %t.jobs.txt -check-prefix=MERGE
+
+// MERGE: bin/swift{{c?}}
+// MERGE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp # -frontend -emit-module -primary-file {{[^ ]+}}/Inputs/main.swift {{[^ ]+}}/Inputs/lib.swift
+// MERGE: -emit-module-doc-path [[PARTIAL_MODULE_A:[^ ]+]].swiftdoc
+// MERGE: bin/swift{{c?}}
+// MERGE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp # -frontend -emit-module {{[^ ]+}}/Inputs/main.swift -primary-file {{[^ ]+}}/Inputs/lib.swift
+// MERGE: -emit-module-doc-path [[PARTIAL_MODULE_B:[^ ]+]].swiftdoc
+// MERGE: bin/swift{{c?}}
+// MERGE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp # -frontend -merge-modules -emit-module [[PARTIAL_MODULE_A]].swiftmodule [[PARTIAL_MODULE_B]].swiftmodule


### PR DESCRIPTION
We hit an issue where the new response file support allowed us to get through the compilation jobs, but then the `-merge-modules` invocation exceeded the limit because of the huge number of `-Xcc -fmodule-map-file=` arguments we had, and common args like those are passed to _all_ front-end jobs. (Fortunately we have a temporary workaround for 4.2: build with `-wmo` to avoid that job 😬.)

In the interest of not continuing to chase after potential command line issues, this PR enables response files for any job that calls `addCommonFrontendArgs`, as well as `AutolinkExtractJobAction` on Unix. Since those all invoke the same `swift` driver code path, it should be safe.

I've added a test to cover `-merge-modules`, but let me know if you'd like the other combinations covered as well.

Once merged, could we cherry-pick this into `swift-4.2-branch`?