### PR TITLE
[sil] Make ValueOwnershipKind(unsigned) explicit to prevent implicit …

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6094,7 +6094,8 @@ class UncheckedOwnershipConversionInst
 
 public:
   ValueOwnershipKind getConversionOwnershipKind() const {
-    return SILInstruction::Bits.UncheckedOwnershipConversionInst.Kind;
+    unsigned kind = SILInstruction::Bits.UncheckedOwnershipConversionInst.Kind;
+    return ValueOwnershipKind(kind);
   }
 };
 

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -123,7 +123,7 @@ struct ValueOwnershipKind {
                 "ownership value?!");
 
   ValueOwnershipKind(innerty NewValue) : Value(NewValue) {}
-  ValueOwnershipKind(unsigned NewValue) : Value(innerty(NewValue)) {}
+  explicit ValueOwnershipKind(unsigned NewValue) : Value(innerty(NewValue)) {}
   ValueOwnershipKind(SILModule &M, SILType Type,
                      SILArgumentConvention Convention);
 


### PR DESCRIPTION
…casts from ints/bools to ValueOwnershipKind.

I hit this problem while splitting classifying operand ownership from the
ownership verifier itself. There is no reason to allow for this implicit
conversion. Just makes updating code more error prone.

rdar://44667493
