### PR TITLE
[sil] Add convenience method TermInst::getSuccessorBlockArguments().

### DIFF
--- a/include/swift/SIL/SILArgumentArrayRef.h
+++ b/include/swift/SIL/SILArgumentArrayRef.h
@@ -1,0 +1,41 @@
+//===--- SILArgumentArrayRef.h --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// A header file to ensure that we do not create a dependency cycle in between
+/// SILBasicBlock.h and SILInstruction.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILARGUMENTARRAYREF_H
+#define SWIFT_SIL_SILARGUMENTARRAYREF_H
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/STLExtras.h"
+#include "swift/Basic/TransformArrayRef.h"
+
+namespace swift {
+
+class SILArgument;
+class SILPHIArgument;
+class SILFunctionArgument;
+
+using PHIArgumentArrayRef =
+    TransformArrayRef<function_ref<SILPHIArgument *(SILArgument *)>>;
+
+using FunctionArgumentArrayRef =
+    TransformArrayRef<function_ref<SILFunctionArgument *(SILArgument *)>>;
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -20,6 +20,7 @@
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/TransformArrayRef.h"
+#include "swift/SIL/SILArgumentArrayRef.h"
 #include "swift/SIL/SILInstruction.h"
 
 namespace swift {
@@ -192,12 +193,15 @@ public:
   }
 
   ArrayRef<SILArgument *> getArguments() const { return ArgumentList; }
-  using PHIArgumentArrayRefTy =
-      TransformArrayRef<SILPHIArgument *(*)(SILArgument *)>;
-  PHIArgumentArrayRefTy getPHIArguments() const;
-  using FunctionArgumentArrayRefTy =
-      TransformArrayRef<SILFunctionArgument *(*)(SILArgument *)>;
-  FunctionArgumentArrayRefTy getFunctionArguments() const;
+
+  /// Returns a transform array ref that performs llvm::cast<SILPHIArgument> on
+  /// each argument and then returns the downcasted value.
+  PHIArgumentArrayRef getPHIArguments() const;
+
+  /// Returns a transform array ref that performs
+  /// llvm::cast<SILFunctionArgument> on each argument and then returns the
+  /// downcasted value.
+  FunctionArgumentArrayRef getFunctionArguments() const;
 
   unsigned getNumArguments() const { return ArgumentList.size(); }
   const SILArgument *getArgument(unsigned i) const { return ArgumentList[i]; }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -29,6 +29,7 @@
 #include "swift/Basic/Range.h"
 #include "swift/SIL/Consumption.h"
 #include "swift/SIL/SILAllocated.h"
+#include "swift/SIL/SILArgumentArrayRef.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunctionConventions.h"
 #include "swift/SIL/SILLocation.h"
@@ -6603,6 +6604,14 @@ public:
       return BB == SuccBB;
     });
   }
+
+  using SuccessorBlockArgumentsListTy =
+      TransformRange<ConstSuccessorListTy,
+                     function_ref<PHIArgumentArrayRef(const SILSuccessor &)>>;
+
+  /// Return the range of Argument arrays for each successor of this
+  /// block.
+  SuccessorBlockArgumentsListTy getSuccessorBlockArguments() const;
 
   using SuccessorBlockListTy =
       TransformRange<SuccessorListTy,

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -335,18 +335,17 @@ bool SILBasicBlock::isEntry() const {
   return this == &*getParent()->begin();
 }
 
-SILBasicBlock::PHIArgumentArrayRefTy SILBasicBlock::getPHIArguments() const {
-  return PHIArgumentArrayRefTy(getArguments(),
-                               [](SILArgument *A) -> SILPHIArgument * {
-    return cast<SILPHIArgument>(A);
+/// Declared out of line so we can have a declaration of SILArgument.
+PHIArgumentArrayRef SILBasicBlock::getPHIArguments() const {
+  return PHIArgumentArrayRef(getArguments(), [](SILArgument *arg) {
+    return cast<SILPHIArgument>(arg);
   });
 }
 
-SILBasicBlock::FunctionArgumentArrayRefTy
-SILBasicBlock::getFunctionArguments() const {
-  return FunctionArgumentArrayRefTy(getArguments(),
-                                    [](SILArgument *A) -> SILFunctionArgument* {
-    return cast<SILFunctionArgument>(A);
+/// Declared out of line so we can have a declaration of SILArgument.
+FunctionArgumentArrayRef SILBasicBlock::getFunctionArguments() const {
+  return FunctionArgumentArrayRef(getArguments(), [](SILArgument *arg) {
+    return cast<SILFunctionArgument>(arg);
   });
 }
 

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1061,6 +1061,15 @@ bool TermInst::isFunctionExiting() const {
   llvm_unreachable("Unhandled TermKind in switch.");
 }
 
+TermInst::SuccessorBlockArgumentsListTy
+TermInst::getSuccessorBlockArguments() const {
+  function_ref<PHIArgumentArrayRef(const SILSuccessor &)> op;
+  op = [](const SILSuccessor &succ) -> PHIArgumentArrayRef {
+    return succ.getBB()->getPHIArguments();
+  };
+  return SuccessorBlockArgumentsListTy(getSuccessors(), op);
+}
+
 YieldInst *YieldInst::create(SILDebugLocation loc,
                              ArrayRef<SILValue> yieldedValues,
                              SILBasicBlock *normalBB, SILBasicBlock *unwindBB,


### PR DESCRIPTION
This convenience API enables one to iterate over the array of arguments of each
successor of the terminator.

To implement this I needed to implement SILBasicBlock::getPHIArguments(), so I
also implemented SILBasicBlock::getFunctionArguments().

rdar://44667493
