### PR TITLE
[Lexer] Fix assertion failure for unterminated string literal

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1817,6 +1817,12 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         // Successfully scanned the body of the expression literal.
         ++CurPtr;
         continue;
+      } else if ((*CurPtr == '\r' || *CurPtr == '\n') && IsMultilineString) {
+        // The only case we reach here is unterminated single line string in the
+        // interpolation. For better recovery, go on after emitting an error.
+        diagnose(CurPtr, diag::lex_unterminated_string);
+        wasErroneous = true;
+        continue;
       }
 
       // Being diagnosed below.

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -184,3 +184,10 @@ _ = """\
   // FIXME: Bad diagnostics
   // expected-error@-3 {{multi-line string literal content must begin on a new line}}
   // expected-error@-4 {{escaped newline at the last line is not allowed}} {{8-9=}}
+
+let _ = """
+  foo
+  \("bar
+  baz
+  """
+  // expected-error@-3 {{unterminated string literal}}

--- a/test/Parse/string_literal_eof4.swift
+++ b/test/Parse/string_literal_eof4.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift
+
+// NOTE: DO NOT add a newline at EOF.
+// expected-error@+1 {{unterminated string literal}}
+_ = """
+    foo

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+// NOTE: DO NOT add a newline at EOF.
+// expected-error@+1 {{unterminated string literal}}
+_ = """
+    foo
+    \(

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+// NOTE: DO NOT add a newline at EOF.
+// expected-error@+1 {{unterminated string literal}}
+_ = """
+    foo
+    \("bar

--- a/test/Parse/string_literal_eof7.swift
+++ b/test/Parse/string_literal_eof7.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+// expected-error@+4 {{unterminated string literal}}
+// expected-error@+1 {{unterminated string literal}}
+_ = """
+    foo
+    \("bar
+    baz
+


### PR DESCRIPTION
in string interpolation in multiline string literal. e.g.

```swift
    """
    \("<-this is unterminated.
    """
```

In this case, the outer multiline literal should form `tok::unknown` along with an error message.
(In Swift4.2, this used to be silently accepted)

Reported in https://github.com/apple/swift/pull/19356#issuecomment-423484025 by @johnno1962 Thanks!