### PR TITLE
Refactor SILCombiner to build ConcreteExistentialInfo uniformly

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -295,6 +295,22 @@ public:
 private:
   FullApplySite rewriteApplyCallee(FullApplySite apply, SILValue callee);
 
+  // Build concrete existential information using findInitExistential.
+  Optional<ConcreteExistentialInfo>
+  buildConcreteExistentialInfo(Operand &ArgOperand);
+
+  // Build concrete existential information using SoleConformingType.
+  Optional<ConcreteExistentialInfo>
+  buildConcreteExistentialInfoFromSoleConformingType(Operand &ArgOperand);
+
+  // Common utility function to build concrete existential information for all
+  // arguments of an apply instruction.
+  void buildConcreteExistentialInfos(
+      FullApplySite Apply,
+      llvm::SmallDenseMap<unsigned, ConcreteExistentialInfo> &CEIs,
+      SILBuilderContext &BuilderCtx,
+      SILOpenedArchetypesTracker &OpenedArchetypesTracker);
+
   bool canReplaceArg(FullApplySite Apply, const ConcreteExistentialInfo &CEI,
                      unsigned ArgIdx);
   SILInstruction *createApplyWithConcreteType(


### PR DESCRIPTION
This PR proposes two uniform interfaces for building ConcreteExistentialInfo in SILCombiner:

(1) 
/* Build CEI for an operand by first using the data flow chain. If that fails, it tries to see if it can use Sole Conforming Type*/
Optional<ConcreteExistentialInfo>
  buildConcreteExistentialInfo(Operand &ArgOperand);

(2) 
/* Build CEIs for all arguments (including self) of an Apply*/
void buildConcreteExistentialInfos(
      FullApplySite Apply,
      llvm::SmallDenseMap<unsigned, ConcreteExistentialInfo> &CEIs,
      SILBuilderContext &BuilderCtx,
      SILOpenedArchetypesTracker &OpenedArchetypesTracker);



