### PR TITLE
[ModuleInterface] Print names for @usableFromInline struct properties

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -64,6 +64,13 @@ void PrintOptions::clearSynthesizedExtension() {
   TransformContext.reset();
 }
 
+static bool isPublicOrUsableFromInline(const ValueDecl *VD) {
+  AccessScope scope =
+      VD->getFormalAccessScope(/*useDC*/nullptr,
+                               /*treatUsableFromInlineAsPublic*/true);
+  return scope.isPublic();
+}
+
 static bool contributesToParentTypeStorage(const AbstractStorageDecl *ASD) {
   auto *DC = ASD->getDeclContext()->getAsDecl();
   if (!DC) return false;
@@ -96,10 +103,7 @@ PrintOptions PrintOptions::printTextualInterfaceFile() {
     bool shouldPrint(const Decl *D, const PrintOptions &options) override {
       // Skip anything that isn't 'public' or '@usableFromInline'.
       if (auto *VD = dyn_cast<ValueDecl>(D)) {
-        AccessScope accessScope =
-            VD->getFormalAccessScope(/*useDC*/nullptr,
-                                     /*treatUsableFromInlineAsPublic*/true);
-        if (!accessScope.isPublic()) {
+        if (!isPublicOrUsableFromInline(VD)) {
           // We do want to print private stored properties, without their
           // original names present.
           if (auto *ASD = dyn_cast<AbstractStorageDecl>(VD))
@@ -863,7 +867,7 @@ void PrintAST::printPattern(const Pattern *pattern) {
     recordDeclLoc(decl, [&]{
       if (Options.OmitNameOfInaccessibleProperties &&
           contributesToParentTypeStorage(decl) &&
-          decl->getFormalAccess() < AccessLevel::Public)
+          !isPublicOrUsableFromInline(decl))
         Printer << "_";
       else
         Printer.printName(named->getBoundName());

--- a/test/ModuleInterface/private-stored-member-type-layout.swift
+++ b/test/ModuleInterface/private-stored-member-type-layout.swift
@@ -17,10 +17,10 @@
 // These two appear out-of-order between run lines
 
 // CHECK-DAG: [[MYCLASS:%T20PrivateStoredMembers7MyClassC]] = type opaque
-// CHECK-DAG: [[MYSTRUCT:%T20PrivateStoredMembers8MyStructV]] = type <{ %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V }>
+// CHECK-DAG: [[MYSTRUCT:%T20PrivateStoredMembers8MyStructV]] = type <{ %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V }>
 
-// CHECK-MAIN-DAG: [[MYCLASS:%T4main7MyClassC]] = type <{ %swift.refcounted, %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V }>
-// CHECK-MAIN-DAG: [[MYSTRUCT:%T4main8MyStructV]] = type <{ %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V }>
+// CHECK-MAIN-DAG: [[MYCLASS:%T4main7MyClassC]] = type <{ %swift.refcounted, %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V }>
+// CHECK-MAIN-DAG: [[MYSTRUCT:%T4main8MyStructV]] = type <{ %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V }>
 
 #if SHOULD_IMPORT
 import PrivateStoredMembers
@@ -29,7 +29,7 @@ import PrivateStoredMembers
 // CHECK-EXEC: swiftcc void @"$s{{[^ ]+}}8makeUseryyF"() #0 {
 public func makeUser() {
   let ptr = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
-  // CHECK-EXEC: %.publicEndVar = getelementptr inbounds [[MYSTRUCT]], [[MYSTRUCT]]* %{{[0-9]+}}, i32 0, i32 [[PUBLIC_END_VAR_IDX:9]]
+  // CHECK-EXEC: %.publicEndVar = getelementptr inbounds [[MYSTRUCT]], [[MYSTRUCT]]* %{{[0-9]+}}, i32 0, i32 [[PUBLIC_END_VAR_IDX:12]]
   // CHECK-EXEC: %.publicEndVar._value = getelementptr inbounds %Ts5Int64V, %Ts5Int64V* %.publicEndVar, i32 0, i32 0
   // CHECK-EXEC: store i64 4, i64* %.publicEndVar._value
   ptr.pointee.publicEndVar = 4

--- a/test/ModuleInterface/private-stored-members.swift
+++ b/test/ModuleInterface/private-stored-members.swift
@@ -29,6 +29,14 @@ public struct MyStruct {
 // RESILIENT-NOT: internal let _: [[BOOL]]{{$}}
   let internalLet: Bool
 
+// COMMON-NEXT: @usableFromInline
+// COMMON-NEXT: internal var ufiVar: [[INT64]]{{$}}
+  @usableFromInline var ufiVar: Int64
+
+// COMMON-NEXT: @usableFromInline
+// COMMON-NEXT: internal let ufiLet: [[BOOL]]{{$}}
+  @usableFromInline let ufiLet: Bool
+
 // CHECK-NEXT: private var _: [[INT64]]{{$}}
 // RESILIENT-NOT: private var _: [[INT64]]{{$}}
   private var privateVar: Int64
@@ -68,6 +76,14 @@ public class MyClass {
 // CHECK-NEXT: internal let _: [[BOOL]]{{$}}
 // RESILIENT-NOT: internal let _: [[BOOL]]{{$}}
   let internalLet: Bool = true
+
+// COMMON-NEXT: @usableFromInline
+// COMMON-NEXT: internal var ufiVar: [[INT64]]{{$}}
+  @usableFromInline var ufiVar: Int64 = 0
+
+// COMMON-NEXT: @usableFromInline
+// COMMON-NEXT: internal let ufiLet: [[BOOL]]{{$}}
+  @usableFromInline let ufiLet: Bool = true
 
 // CHECK-NEXT: private var _: [[INT64]]{{$}}
 // RESILIENT-NOT: private var _: [[INT64]]{{$}}


### PR DESCRIPTION
Because they weren't 'public' we were treating them as layout-only properties and printing `var _`, but they get referenced in inlinable functions. We need the actual name!