### PR TITLE
[ConstraintSystem] Add the notion of disjunction partitioning.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1358,6 +1358,21 @@ static Constraint *selectBestBindingDisjunction(
   return firstBindDisjunction;
 }
 
+void ConstraintSystem::partitionDisjunction(
+    ArrayRef<Constraint *> Choices, SmallVectorImpl<unsigned> &Ordering,
+    SmallVectorImpl<unsigned> &PartitionBeginning) {
+  // Maintain the original ordering, and make a single partition of
+  // disjunction choices.
+  auto originalOrdering = [&]() {
+    for (unsigned long i = 0, e = Choices.size(); i != e; ++i)
+      Ordering.push_back(i);
+
+    PartitionBeginning.push_back(0);
+  };
+
+  originalOrdering();
+}
+
 Constraint *ConstraintSystem::selectDisjunction() {
   SmallVector<Constraint *, 4> disjunctions;
 

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -479,13 +479,15 @@ bool DisjunctionStep::shouldStopAt(const DisjunctionChoice &choice) const {
   auto delta = LastSolvedChoice->second - getCurrentScore();
   bool hasUnavailableOverloads = delta.Data[SK_Unavailable] > 0;
   bool hasFixes = delta.Data[SK_Fix] > 0;
+  auto isBeginningOfPartition = choice.isBeginningOfPartition();
 
   // Attempt to short-circuit evaluation of this disjunction only
   // if the disjunction choice we are comparing to did not involve
   // selecting unavailable overloads or result in fixes being
   // applied to reach a solution.
   return !hasUnavailableOverloads && !hasFixes &&
-         shortCircuitDisjunctionAt(choice, lastChoice);
+         (isBeginningOfPartition ||
+          shortCircuitDisjunctionAt(choice, lastChoice));
 }
 
 bool DisjunctionStep::shortCircuitDisjunctionAt(

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -479,9 +479,15 @@ protected:
   /// Check whether attempting binding choices should be stopped,
   /// after current choice has been attempted, because optimal
   /// solution has already been found,
-  virtual bool shouldStopAfter(const typename P::Element &choice) const = 0;
+  bool shouldStopAfter(const typename P::Element &choice) const {
+    // If there has been at least one solution so far
+    // at a current batch of bindings is done it's a
+    // success because each new batch would be less
+    // and less precise.
+    return AnySolved && isEndOfPartition();
+  }
 
-  bool needsToComputeNext() const { return Producer.needsToComputeNext(); }
+  bool isEndOfPartition() const { return Producer.isEndOfPartition(); }
 
   ConstraintLocator *getLocator() const { return Producer.getLocator(); }
 };
@@ -533,14 +539,6 @@ protected:
     // default literals, don't bother looking at default literals.
     return AnySolved && choice.hasDefaultedProtocol() &&
            !SawFirstLiteralConstraint;
-  }
-
-  bool shouldStopAfter(const TypeVariableBinding &choice) const override {
-    // If there has been at least one solution so far
-    // at a current batch of bindings is done it's a
-    // success because each new batch would be less
-    // and less precise.
-    return AnySolved && needsToComputeNext();
   }
 };
 
@@ -595,10 +593,6 @@ private:
   bool shouldStopAt(const DisjunctionChoice &choice) const override;
   bool shortCircuitDisjunctionAt(Constraint *currentChoice,
                                  Constraint *lastSuccessfulChoice) const;
-
-  bool shouldStopAfter(const DisjunctionChoice &choice) const override {
-    return AnySolved && choice.isEndOfDisjunctionPartition();
-  }
 
   /// Attempt to apply given disjunction choice to constraint system.
   /// This action is going to establish "active choice" of this disjunction

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -479,9 +479,7 @@ protected:
   /// Check whether attempting binding choices should be stopped,
   /// after current choice has been attempted, because optimal
   /// solution has already been found,
-  virtual bool shouldStopAfter(const typename P::Element &choice) const {
-    return false;
-  }
+  virtual bool shouldStopAfter(const typename P::Element &choice) const = 0;
 
   bool needsToComputeNext() const { return Producer.needsToComputeNext(); }
 
@@ -597,6 +595,10 @@ private:
   bool shouldStopAt(const DisjunctionChoice &choice) const override;
   bool shortCircuitDisjunctionAt(Constraint *currentChoice,
                                  Constraint *lastSuccessfulChoice) const;
+
+  bool shouldStopAfter(const DisjunctionChoice &choice) const override {
+    return AnySolved && choice.isEndOfDisjunctionPartition();
+  }
 
   /// Attempt to apply given disjunction choice to constraint system.
   /// This action is going to establish "active choice" of this disjunction

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -479,7 +479,9 @@ protected:
   /// Check whether attempting binding choices should be stopped,
   /// after current choice has been attempted, because optimal
   /// solution has already been found,
-  virtual bool shouldStopAfter(const typename P::Element &choice) const = 0;
+  virtual bool shouldStopAfter(const typename P::Element &choice) const {
+    return false;
+  }
 
   bool needsToComputeNext() const { return Producer.needsToComputeNext(); }
 
@@ -595,10 +597,6 @@ private:
   bool shouldStopAt(const DisjunctionChoice &choice) const override;
   bool shortCircuitDisjunctionAt(Constraint *currentChoice,
                                  Constraint *lastSuccessfulChoice) const;
-
-  bool shouldStopAfter(const DisjunctionChoice &choice) const override {
-    return AnySolved && choice.isEndOfDisjunctionPartition();
-  }
 
   /// Attempt to apply given disjunction choice to constraint system.
   /// This action is going to establish "active choice" of this disjunction


### PR DESCRIPTION
Update DisjunctionChoiceProducer so that it creates a sorted ordering
of the choices in the disjunction as well as a partitioning of those
choices.

If we hit the end of a partition and have found a solution, we'll stop
attempting choices from this disjunction.

For now we'll default to keeping the same order that the disjunctions
initially have, and will put them all into the same partition. A
future commit will implement logic to implement more interesting
partitions of the choices.
