### PR TITLE
[Foundation] Add @usableFromInline to MeasurementBridgeType for now

### DIFF
--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -206,9 +206,15 @@ extension Measurement {
 
 // Implementation note: similar to NSArray, NSDictionary, etc., NSMeasurement's import as an ObjC generic type is suppressed by the importer. Eventually we will need a more general purpose mechanism to correctly import generic types.
 
+// FIXME: Remove @usableFromInline from MeasurementBridgeType once
+// rdar://problem/44662501 is fixed. (The Radar basically just says "look
+// through typealiases and inherited protocols when printing extensions".)
+
 #if DEPLOYMENT_RUNTIME_SWIFT
+@usableFromInline
 internal typealias MeasurementBridgeType = _ObjectTypeBridgeable
 #else
+@usableFromInline
 internal typealias MeasurementBridgeType = _ObjectiveCBridgeable
 #endif
 


### PR DESCRIPTION
Work around a missing feature in textual interfaces by marking this convenience typealias as `@usableFromInline`. Since typealiases don't actually have a run-time presence, we can still take this out at any time.