### PR TITLE
[CSDiagnostics/Requirements] Mention special names only if they are i…

### DIFF
--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -610,7 +610,7 @@ func rdar40537858() {
   }
 
   var arr: [S] = []
-  _ = List(arr, id: \.id) // expected-error {{referencing initializer on 'List' requires that 'S.Id' conform to 'Hashable'}}
+  _ = List(arr, id: \.id) // expected-error {{referencing initializer 'init(_:id:)' on 'List' requires that 'S.Id' conform to 'Hashable'}}
 
   enum E<T: P> { // expected-note 2 {{where 'T' = 'S'}}
     case foo(T)

--- a/test/Constraints/rdar44569159.swift
+++ b/test/Constraints/rdar44569159.swift
@@ -14,5 +14,5 @@ struct A {
 func foo(_ v: Double) {
   _ = A()[S(value: v)]
 // expected-error@-1 {{subscript requires that 'Double' conform to 'P'}}
-// expected-error@-2 {{referencing initializer on 'S' requires that 'Double' conform to 'P'}}
+// expected-error@-2 {{referencing initializer 'init(value:)' on 'S' requires that 'Double' conform to 'P'}}
 }


### PR DESCRIPTION
…nformative

If special name doesn't have any parameters or has a single unlabeled
parameter don't mention it in the requirement diagnostic, otherwise
it'd be printed as `initializer 'init'` or `subscript 'subscript'`
which doesn't carry any useful information.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
