### PR TITLE
More progress on backward deployment support for classes with resiliently-sized fields

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -621,6 +621,24 @@ void swift_initClassMetadata(ClassMetadata *self,
                              const TypeLayout * const *fieldTypes,
                              size_t *fieldOffsets);
 
+#if SWIFT_OBJC_INTEROP
+/// Initialize various fields of the class metadata.
+///
+/// This is a special function only used to re-initialize metadata of
+/// classes that are visible to Objective-C and have resilient fields.
+///
+/// This means the class does not have generic or resilient ancestry,
+/// and is itself not generic. However, it might have fields whose
+/// size is not known at compile time.
+SWIFT_RUNTIME_EXPORT
+void swift_updateClassMetadata(ClassMetadata *self,
+                               ClassMetadata *super,
+                               ClassLayoutFlags flags,
+                               size_t numFields,
+                               const TypeLayout * const *fieldTypes,
+                               size_t *fieldOffsets);
+#endif
+
 /// Given class metadata, a class descriptor and a method descriptor, look up
 /// and load the vtable entry from the given metadata. The metadata must be of
 /// the same class or a subclass of the descriptor.

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -580,13 +580,39 @@ void swift_initStructMetadata(StructMetadata *self,
 ///
 /// This function is only intended to be called from the relocation function
 /// of a resilient class pattern.
+///
+/// The metadata completion function must complete the metadata by calling
+/// swift_initClassMetadata().
 SWIFT_RUNTIME_EXPORT
 ClassMetadata *
 swift_relocateClassMetadata(ClassDescriptor *descriptor,
                             ResilientClassMetadataPattern *pattern);
 
-/// Initialize the field offset vector for a dependent-layout class, using the
-/// "Universal" layout strategy.
+/// Initialize various fields of the class metadata.
+///
+/// Namely:
+/// - The superclass field is set to \p super.
+/// - If the class metadata was allocated at runtime, copies the
+///   vtable entries from the superclass and installs the class's
+///   own vtable entries and overrides of superclass vtable entries.
+/// - Copies the field offsets and generic parameters and conformances
+///   from the superclass.
+/// - Initializes the field offsets using the runtime type layouts
+///   passed in \p fieldTypes.
+///
+/// This initialization pattern in the following cases:
+/// - The class has generic ancestry, or resiliently-sized fields.
+///   In this case the metadata was emitted statically but is incomplete,
+///   because, the superclass field, generic parameters and conformances,
+///   and field offset vector entries require runtime completion.
+///
+/// - The class is not generic, and has resilient ancestry.
+///   In this case the class metadata was allocated from a resilient
+///   class metadata pattern by swift_relocateClassMetadata().
+///
+/// - The class is generic.
+///   In this case the class metadata was allocated from a generic
+///   class metadata pattern by swift_allocateGenericClassMetadata().
 SWIFT_RUNTIME_EXPORT
 void swift_initClassMetadata(ClassMetadata *self,
                              ClassMetadata *super,

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -773,6 +773,21 @@ FUNCTION(InitClassMetadata,
               SizeTy->getPointerTo()),
          ATTRS(NoUnwind))
 
+// struct FieldInfo { size_t Size; size_t AlignMask; };
+// void swift_updateClassMetadata(Metadata *self,
+//                                Metadata *super,
+//                                ClassLayoutFlags flags,
+//                                size_t numFields,
+//                                TypeLayout * const *fieldTypes,
+//                                size_t *fieldOffsets);
+FUNCTION(UpdateClassMetadata,
+         swift_updateClassMetadata, C_CC,
+         RETURNS(VoidTy),
+         ARGS(TypeMetadataPtrTy, TypeMetadataPtrTy, SizeTy, SizeTy,
+              Int8PtrPtrTy->getPointerTo(),
+              SizeTy->getPointerTo()),
+         ATTRS(NoUnwind))
+
 // void *swift_lookUpClassMethod(Metadata *metadata,
 //                               ClassDescriptor *description,
 //                               MethodDescriptor *method);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -79,7 +79,7 @@ namespace {
     const ReferenceCounting Refcount;
     
     ClassLayout generateLayout(IRGenModule &IGM, SILType classType,
-                               bool forMetadata) const;
+                               bool forBackwardDeployment) const;
 
   public:
     ClassTypeInfo(llvm::PointerType *irType, Size size,
@@ -96,7 +96,7 @@ namespace {
 
 
     const ClassLayout &getClassLayout(IRGenModule &IGM, SILType type,
-                                      bool forMetadata) const;
+                                      bool forBackwardDeployment) const;
 
     StructLayout *createLayoutWithTailElems(IRGenModule &IGM,
                                             SILType classType,
@@ -187,6 +187,10 @@ namespace {
     // Is this class or any of its superclasses generic?
     bool ClassHasGenericAncestry = false;
 
+    // Is this class itself generic via the Swift generic system, ie. not a
+    // lightweight Objective-C generic class?
+    bool ClassIsGeneric = false;
+
     // Does the class layout depend on the size or alignment of its
     // generic parameters?
     //
@@ -237,6 +241,10 @@ namespace {
       // Next, add the fields for the given class.
       auto theClass = classType.getClassOrBoundGenericClass();
       assert(theClass);
+
+      if (theClass->isGenericContext() && !theClass->hasClangNode())
+        ClassIsGeneric = true;
+
       addFieldsForClass(theClass, classType, /*superclass=*/false);
 
       if (TailTypes) {
@@ -264,9 +272,6 @@ namespace {
                ClassHasObjCAncestry);
     }
 
-    /// Note that unlike the top-level doesClassMetadataRequireInitialization(),
-    /// this returns false if the class is generic but otherwise fixed size
-    /// and without resilient or generic ancestry.
     bool doesMetadataRequireInitialization() const {
       return (ClassHasMissingMembers ||
               ClassHasResilientMembers ||
@@ -274,10 +279,9 @@ namespace {
               ClassHasGenericAncestry);
     }
 
-    /// Note that unlike the top-level doesClassMetadataRequireRelocation(),
-    /// this returns false if the class is generic and not resilient.
     bool doesMetadataRequireRelocation() const {
-      return ClassHasResilientAncestry;
+      return (ClassHasResilientAncestry ||
+              ClassIsGeneric);
     }
 
     ClassLayout getClassLayout(llvm::Type *classTy) const {
@@ -317,27 +321,17 @@ namespace {
     /// to compute FieldAccesses for them.
     void addFieldsForClass(ClassDecl *theClass, SILType classType,
                            bool superclass) {
-      if (theClass->isGenericContext())
-        ClassHasGenericAncestry = true;
+      if (theClass->hasClangNode()) {
+        ClassHasObjCAncestry = true;
+        return;
+      }
 
       if (theClass->hasSuperclass()) {
         SILType superclassType = classType.getSuperclass();
         auto superclassDecl = superclassType.getClassOrBoundGenericClass();
         assert(superclassType && superclassDecl);
 
-        // If the superclass came from another module, we may have dropped
-        // stored properties due to the Swift language version availability of
-        // their types. In these cases we can't precisely lay out the ivars in
-        // the class object at compile time so we need to do runtime layout.
-        if (classHasIncompleteLayout(IGM, superclassDecl))
-          ClassHasMissingMembers = true;
-
-        if (superclassDecl->hasClangNode()) {
-          // If the superclass was imported from Objective-C, the Objective-C
-          // runtime will slide our instance variable offsets at runtime based
-          // on the actual runtime size of the Objective-C superclass.
-          ClassHasObjCAncestry = true;
-        } else if (IGM.isResilient(superclassDecl, ResilienceExpansion::Maximal)) {
+        if (IGM.isResilient(superclassDecl, ResilienceExpansion::Maximal)) {
           // If the class is resilient, don't walk over its fields; we have to
           // calculate the layout at runtime.
           ClassHasResilientAncestry = true;
@@ -355,11 +349,16 @@ namespace {
         }
       }
 
+      if (theClass->isGenericContext())
+        ClassHasGenericAncestry = true;
+
       if (classHasIncompleteLayout(IGM, theClass))
         ClassHasMissingMembers = true;
 
-      if (IGM.isResilient(theClass, ResilienceExpansion::Maximal))
+      if (IGM.isResilient(theClass, ResilienceExpansion::Maximal)) {
         ClassHasResilientAncestry = true;
+        return;
+      }
 
       // Collect fields from this class and add them to the layout as a chunk.
       addDirectFieldsFromClass(theClass, classType, superclass);
@@ -524,13 +523,13 @@ ClassTypeInfo::createLayoutWithTailElems(IRGenModule &IGM,
 
 const ClassLayout &
 ClassTypeInfo::getClassLayout(IRGenModule &IGM, SILType classType,
-                              bool forMetadata) const {
+                              bool forBackwardDeployment) const {
   // Perform fragile layout only if Objective-C interop is enabled.
   //
   // FIXME: EnableClassResilience staging flag will go away once we can do
   // in-place re-initialization of class metadata.
-  bool completelyFragileLayout = (forMetadata &
-                                  IGM.Context.LangOpts.EnableObjCInterop &
+  bool completelyFragileLayout = (forBackwardDeployment &&
+                                  IGM.Context.LangOpts.EnableObjCInterop &&
                                   !IGM.IRGen.Opts.EnableClassResilience);
 
   // Return the cached layout if available.
@@ -593,7 +592,7 @@ irgen::tryEmitConstantClassFragilePhysicalMemberOffset(IRGenModule &IGM,
   auto &baseClassTI = IGM.getTypeInfo(baseType).as<ClassTypeInfo>();
 
   auto &classLayout = baseClassTI.getClassLayout(IGM, baseType,
-                                                 /*ForMetadata=*/false);
+                                               /*forBackwardDeployment=*/false);
 
   auto fieldInfo = classLayout.getFieldAccessAndElement(field);
   switch (fieldInfo.first) {
@@ -613,7 +612,7 @@ FieldAccess
 irgen::getClassFieldAccess(IRGenModule &IGM, SILType baseType, VarDecl *field) {
   auto &baseClassTI = IGM.getTypeInfo(baseType).as<ClassTypeInfo>();
   auto &classLayout = baseClassTI.getClassLayout(IGM, baseType,
-                                                 /*ForMetadata=*/false);
+                                               /*forBackwardDeployment=*/false);
   return classLayout.getFieldAccessAndElement(field).first;
 }
 
@@ -624,7 +623,7 @@ irgen::getClassFieldOffset(IRGenModule &IGM, SILType baseType, VarDecl *field) {
   // FIXME: For now we just assume fragile layout here, because this is used as
   // part of emitting class metadata.
   auto &classLayout = baseClassTI.getClassLayout(IGM, baseType,
-                                                 /*ForMetadata=*/true);
+                                                /*forBackwardDeployment=*/true);
 
   auto fieldInfo = classLayout.getFieldAccessAndElement(field);
   auto element = fieldInfo.second;
@@ -655,7 +654,7 @@ OwnedAddress irgen::projectPhysicalClassMemberAddress(IRGenFunction &IGF,
   ClassDecl *baseClass = baseClassTI.getClass();
 
   auto &classLayout = baseClassTI.getClassLayout(IGF.IGM, baseType,
-                                                 /*ForMetadata=*/false);
+                                               /*forBackwardDeployment=*/false);
 
   auto fieldInfo = classLayout.getFieldAccessAndElement(field);
 
@@ -693,7 +692,7 @@ irgen::getPhysicalClassMemberAccessStrategy(IRGenModule &IGM,
   ClassDecl *baseClass = baseType.getClassOrBoundGenericClass();
 
   auto &classLayout = baseClassTI.getClassLayout(IGM, baseType,
-                                                 /*ForMetadata=*/false);
+                                               /*forBackwardDeployment=*/false);
   auto fieldInfo = classLayout.getFieldAccessAndElement(field);
 
   switch (fieldInfo.first) {
@@ -725,7 +724,7 @@ Address irgen::emitTailProjection(IRGenFunction &IGF, llvm::Value *Base,
 
   llvm::Value *Offset = nullptr;
   auto &layout = classTI.getClassLayout(IGF.IGM, ClassType,
-                                        /*ForMetadata=*/false);
+                                        /*forBackwardDeployment=*/false);
   Alignment HeapObjAlign = IGF.IGM.TargetInfo.HeapObjectAlignment;
   Alignment Align;
 
@@ -870,7 +869,7 @@ llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
                              MetadataState::Complete);
 
   auto &classLayout = classTI.getClassLayout(IGF.IGM, selfType,
-                                             /*ForMetadata=*/false);
+                                             /*forBackwardDeployment=*/false);
 
   llvm::Value *size, *alignMask;
   if (classLayout.isFixedSize()) {
@@ -922,7 +921,7 @@ llvm::Value *irgen::emitClassAllocationDynamic(IRGenFunction &IGF,
                                              "reference.new");
   auto &classTI = IGF.getTypeInfo(selfType).as<ClassTypeInfo>();
   auto &layout = classTI.getClassLayout(IGF.IGM, selfType,
-                                        /*ForMetadata=*/false);
+                                        /*forBackwardDeployment=*/false);
   llvm::Type *destType = layout.getType()->getPointerTo();
   return IGF.Builder.CreateBitCast(val, destType);
 }
@@ -938,7 +937,7 @@ static void getInstanceSizeAndAlignMask(IRGenFunction &IGF,
   // Try to determine the size of the object we're deallocating.
   auto &info = IGF.IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
   auto &layout = info.getClassLayout(IGF.IGM, selfType,
-                                     /*ForMetadata=*/false);
+                                     /*forBackwardDeployment=*/false);
 
   // If it's fixed, emit the constant size and alignment mask.
   if (layout.isFixedLayout()) {
@@ -1006,11 +1005,11 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
 
   // FIXME: For now, always use the fragile layout when emitting metadata.
   auto &fragileLayout =
-    classTI.getClassLayout(*this, selfType, /*ForMetadata=*/true);
+    classTI.getClassLayout(*this, selfType, /*forBackwardDeployment=*/true);
 
   // ... but still compute the resilient layout for better test coverage.
   auto &resilientLayout =
-    classTI.getClassLayout(*this, selfType, /*ForMetadata=*/false);
+    classTI.getClassLayout(*this, selfType, /*forBackwardDeployment=*/false);
   (void) resilientLayout;
 
   // Emit the class metadata.
@@ -2086,7 +2085,7 @@ llvm::Constant *irgen::emitClassPrivateData(IRGenModule &IGM,
 
   // FIXME: For now, always use the fragile layout when emitting metadata.
   auto &fieldLayout = classTI.getClassLayout(IGM, selfType,
-                                             /*ForMetadata=*/true);
+                                             /*forBackwardDeployment=*/true);
   ClassDataBuilder builder(IGM, cls, fieldLayout);
 
   // First, build the metaclass object.
@@ -2108,7 +2107,7 @@ irgen::emitClassPrivateDataFields(IRGenModule &IGM,
 
   // FIXME: For now, always use the fragile layout when emitting metadata.
   auto &fieldLayout = classTI.getClassLayout(IGM, selfType,
-                                             /*ForMetadata=*/true);
+                                             /*forBackwardDeployment=*/true);
 
   ClassDataBuilder builder(IGM, cls, fieldLayout);
 
@@ -2242,14 +2241,6 @@ ClassDecl *irgen::getRootClassForMetaclass(IRGenModule &IGM, ClassDecl *C) {
 
 bool irgen::doesClassMetadataRequireRelocation(IRGenModule &IGM,
                                                ClassDecl *theClass) {
-  // Classes imported from Objective-C never require dynamic initialization.
-  if (theClass->hasClangNode())
-    return false;
-
-  // Generic classes always require relocation.
-  if (theClass->isGenericContext())
-    return true;
-
   SILType selfType = getSelfType(theClass);
   auto &selfTI = IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
 
@@ -2257,26 +2248,20 @@ bool irgen::doesClassMetadataRequireRelocation(IRGenModule &IGM,
   // requires *relocation*, since that only depends on resilient class
   // ancestry, or the class itself being generic.
   auto &layout = selfTI.getClassLayout(IGM, selfType,
-                                       /*completelyFragileLayout=*/false);
+                                       /*forBackwardDeployment=*/false);
   return layout.doesMetadataRequireRelocation();
 }
 
 bool irgen::doesClassMetadataRequireInitialization(IRGenModule &IGM,
                                                    ClassDecl *theClass) {
-  // Classes imported from Objective-C never require dynamic initialization.
-  if (theClass->hasClangNode())
-    return false;
-
-  // Generic classes always require initialization.
-  if (theClass->isGenericContext())
-    return true;
-
   SILType selfType = getSelfType(theClass);
   auto &selfTI = IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
 
-  // FIXME: Remove the completelyFragileLayout parameter here.
+  // If we have a fragile layout used for backward deployment, we must use
+  // idempotent initialization; swift_initClassMetadata() does not work with
+  // statically registered classes.
   auto &layout = selfTI.getClassLayout(IGM, selfType,
-                                       /*CompletelyFragileLayout=*/true);
+                                       /*forBackwardDeployment=*/true);
   return layout.doesMetadataRequireInitialization();
 }
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2265,6 +2265,16 @@ bool irgen::doesClassMetadataRequireInitialization(IRGenModule &IGM,
   return layout.doesMetadataRequireInitialization();
 }
 
+bool irgen::doesClassMetadataRequireUpdate(IRGenModule &IGM,
+                                           ClassDecl *theClass) {
+  SILType selfType = getSelfType(theClass);
+  auto &selfTI = IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
+
+  auto &layout = selfTI.getClassLayout(IGM, selfType,
+                                       /*forBackwardDeployment=*/false);
+  return layout.doesMetadataRequireInitialization();
+}
+
 bool irgen::hasKnownSwiftMetadata(IRGenModule &IGM, CanType type) {
   // This needs to be kept up-to-date with getIsaEncodingForType.
 

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -161,6 +161,12 @@ namespace irgen {
   bool doesClassMetadataRequireInitialization(IRGenModule &IGM,
                                               ClassDecl *theClass);
 
+  /// Does the class require at least an in-place update on newer Objective-C
+  /// runtimes? If the class requires full initialization or relocation, this
+  /// also returns true.
+  bool doesClassMetadataRequireUpdate(IRGenModule &IGM,
+                                      ClassDecl *theClass);
+
   /// Load the instance size and alignment mask from a reference to
   /// class type metadata of the given type.
   std::pair<llvm::Value *, llvm::Value *>

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -155,7 +155,9 @@ namespace irgen {
   bool doesClassMetadataRequireRelocation(IRGenModule &IGM,
                                           ClassDecl *theClass);
 
-  /// Does the class have a non-fixed layout, or generic ancestry?
+  /// Does the class require at least in-place initialization because of
+  /// non-fixed size properties or generic ancestry? If the class requires
+  /// relocation, this also returns true.
   bool doesClassMetadataRequireInitialization(IRGenModule &IGM,
                                               ClassDecl *theClass);
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -589,7 +589,7 @@ static llvm::Value *emitSuperArgument(IRGenFunction &IGF,
   } else {
     searchClass = cast<MetatypeType>(searchClass).getInstanceType();
     ClassDecl *searchClassDecl = searchClass.getClassOrBoundGenericClass();
-    if (doesClassMetadataRequireInitialization(IGF.IGM, searchClassDecl)) {
+    if (doesClassMetadataRequireUpdate(IGF.IGM, searchClassDecl)) {
       searchValue = emitClassHeapMetadataRef(IGF, searchClass,
                                              MetadataValueType::ObjCClass,
                                              MetadataState::Complete,

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -407,20 +407,19 @@ llvm::Constant *irgen::tryEmitConstantHeapMetadataRef(IRGenModule &IGM,
   auto theDecl = type->getClassOrBoundGenericClass();
   assert(theDecl && "emitting constant heap metadata ref for non-class type?");
 
+  // If the class metadata is initialized from a pattern, we don't even have
+  // an uninitialized metadata symbol we could return, so just fail.
+  if (doesClassMetadataRequireRelocation(IGM, theDecl))
+    return nullptr;
+
   // If the class must not require dynamic initialization --- e.g. if it
   // is a super reference --- then respect everything that might impose that.
   if (!allowDynamicUninitialized) {
     if (doesClassMetadataRequireInitialization(IGM, theDecl))
       return nullptr;
-
-  // Otherwise, just respect genericity.
-  } else if (theDecl->isGenericContext() && !isTypeErasedGenericClass(theDecl)){
-    return nullptr;
   }
 
   // For imported classes, use the ObjC class symbol.
-  // This incidentally cannot coincide with most of the awkward cases, like
-  // having parent metadata.
   if (!hasKnownSwiftMetadata(IGM, theDecl))
     return IGM.getAddrOfObjCClass(theDecl, NotForDefinition);
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2586,6 +2586,36 @@ swift::swift_initClassMetadata(ClassMetadata *self,
 #endif
 }
 
+#if SWIFT_OBJC_INTEROP
+void
+swift::swift_updateClassMetadata(ClassMetadata *self,
+                                 ClassMetadata *super,
+                                 ClassLayoutFlags layoutFlags,
+                                 size_t numFields,
+                                 const TypeLayout * const *fieldTypes,
+                                 size_t *fieldOffsets) {
+  if (!super)
+    assert(self->Superclass == getRootSuperclass());
+  else
+    assert(self->Superclass == super);
+
+  // FIXME: Plumb this through
+#if 1
+  swift_getInitializedObjCClass((Class)self);
+#else
+  initClassFieldOffsetVector(self, numFields, fieldTypes, fieldOffsets);
+  initObjCClass(self, numFields, fieldTypes, fieldOffsets);
+
+  // Register this class with the runtime. This will also cause the
+  // runtime to slide the field offsets stored in the field offset
+  // globals. Note that the field offset vector is *not* updated;
+  // however we should not be using it for anything in a non-generic
+  // class.
+  swift_getInitializedObjCClassWithoutCallback(self);
+#endif
+}
+#endif
+
 #ifndef NDEBUG
 static bool isAncestorOf(const ClassMetadata *metadata,
                          ClassDescriptor *description) {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2238,12 +2238,16 @@ static void _swift_initializeSuperclass(ClassMetadata *theClass,
   }
 
 #if SWIFT_OBJC_INTEROP
-  // Set up the superclass of the metaclass, which is the metaclass of the
-  // superclass.
-  auto theMetaclass = (ClassMetadata *)object_getClass((id)theClass);
-  auto theSuperMetaclass
-    = (const ClassMetadata *)object_getClass(id_const_cast(theSuperclass));
-  theMetaclass->Superclass = theSuperMetaclass;
+  if (theClass->getDescription()->isGeneric() ||
+      (theSuperclass->isTypeMetadata() &&
+       theSuperclass->getDescription()->isGeneric())) {
+    // Set up the superclass of the metaclass, which is the metaclass of the
+    // superclass.
+    auto theMetaclass = (ClassMetadata *)object_getClass((id)theClass);
+    auto theSuperMetaclass
+      = (const ClassMetadata *)object_getClass(id_const_cast(theSuperclass));
+    theMetaclass->Superclass = theSuperMetaclass;
+  }
 #endif
 }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2016,6 +2016,95 @@ void swift::swift_initStructMetadata(StructMetadata *structType,
 /*** Classes ***************************************************************/
 /***************************************************************************/
 
+static MetadataAllocator &getResilientMetadataAllocator() {
+  // This should be constant-initialized, but this is safe.
+  static MetadataAllocator allocator;
+  return allocator;
+}
+
+ClassMetadata *
+swift::swift_relocateClassMetadata(ClassDescriptor *description,
+                                   ResilientClassMetadataPattern *pattern) {
+  auto bounds = description->getMetadataBounds();
+
+  auto metadata = reinterpret_cast<ClassMetadata *>(
+      (char*) getResilientMetadataAllocator().Allocate(
+        bounds.getTotalSizeInBytes(), sizeof(void*)) +
+        bounds.getAddressPointInBytes());
+
+  auto fullMetadata = asFullMetadata(metadata);
+  char *rawMetadata = reinterpret_cast<char*>(metadata);
+
+  // Zero out the entire immediate-members section.
+  void **immediateMembers =
+    reinterpret_cast<void**>(rawMetadata + bounds.ImmediateMembersOffset);
+  memset(immediateMembers, 0, description->getImmediateMembersSize());
+
+  // Initialize the header:
+
+  // Heap destructor.
+  fullMetadata->destroy = pattern->Destroy.get();
+
+  // Value witness table.
+#if SWIFT_OBJC_INTEROP
+  fullMetadata->ValueWitnesses =
+    (pattern->Flags & ClassFlags::UsesSwiftRefcounting)
+       ? &VALUE_WITNESS_SYM(Bo)
+       : &VALUE_WITNESS_SYM(BO);
+#else
+  fullMetadata->ValueWitnesses = &VALUE_WITNESS_SYM(Bo);
+#endif
+
+  // MetadataKind / isa.
+#if SWIFT_OBJC_INTEROP
+  metadata->setClassISA(pattern->Metaclass.get());
+#else
+  metadata->setKind(MetadataKind::Class);
+#endif
+
+  // Superclass.
+  metadata->Superclass = nullptr;
+
+#if SWIFT_OBJC_INTEROP
+  // Cache data.  Install the same initializer that the compiler is
+  // required to use.  We don't need to do this in non-ObjC-interop modes.
+  metadata->CacheData[0] = &_objc_empty_cache;
+  metadata->CacheData[1] = nullptr;
+#endif
+
+  // RO-data pointer.
+#if SWIFT_OBJC_INTEROP
+  auto classRO = pattern->Data.get();
+  metadata->Data =
+    reinterpret_cast<uintptr_t>(classRO) | SWIFT_CLASS_IS_SWIFT_MASK;
+#else
+  metadata->Data = SWIFT_CLASS_IS_SWIFT_MASK;
+#endif
+
+  // Class flags.
+  metadata->Flags = pattern->Flags;
+
+  // Instance layout.
+  metadata->InstanceAddressPoint = 0;
+  metadata->InstanceSize = 0;
+  metadata->InstanceAlignMask = 0;
+
+  // Reserved.
+  metadata->Reserved = 0;
+
+  // Class metadata layout.
+  metadata->ClassSize = bounds.getTotalSizeInBytes();
+  metadata->ClassAddressPoint = bounds.getAddressPointInBytes();
+
+  // Class descriptor.
+  metadata->setDescription(description);
+
+  // I-var destroyer.
+  metadata->IVarDestroyer = pattern->IVarDestroyer;
+
+  return metadata;
+}
+
 namespace {
   /// The structure of ObjC class ivars as emitted by compilers.
   struct ClassIvarEntry {
@@ -2156,95 +2245,6 @@ static void _swift_initializeSuperclass(ClassMetadata *theClass,
     = (const ClassMetadata *)object_getClass(id_const_cast(theSuperclass));
   theMetaclass->Superclass = theSuperMetaclass;
 #endif
-}
-
-#if SWIFT_OBJC_INTEROP
-static MetadataAllocator &getResilientMetadataAllocator() {
-  // This should be constant-initialized, but this is safe.
-  static MetadataAllocator allocator;
-  return allocator;
-}
-#endif
-
-ClassMetadata *
-swift::swift_relocateClassMetadata(ClassDescriptor *description,
-                                   ResilientClassMetadataPattern *pattern) {
-  auto bounds = description->getMetadataBounds();
-
-  auto metadata = reinterpret_cast<ClassMetadata *>(
-      (char*) malloc(bounds.getTotalSizeInBytes()) +
-      bounds.getAddressPointInBytes());
-  auto fullMetadata = asFullMetadata(metadata);
-  char *rawMetadata = reinterpret_cast<char*>(metadata);
-
-  // Zero out the entire immediate-members section.
-  void **immediateMembers =
-    reinterpret_cast<void**>(rawMetadata + bounds.ImmediateMembersOffset);
-  memset(immediateMembers, 0, description->getImmediateMembersSize());
-
-  // Initialize the header:
-
-  // Heap destructor.
-  fullMetadata->destroy = pattern->Destroy.get();
-
-  // Value witness table.
-#if SWIFT_OBJC_INTEROP
-  fullMetadata->ValueWitnesses =
-    (pattern->Flags & ClassFlags::UsesSwiftRefcounting)
-       ? &VALUE_WITNESS_SYM(Bo)
-       : &VALUE_WITNESS_SYM(BO);
-#else
-  fullMetadata->ValueWitnesses = &VALUE_WITNESS_SYM(Bo);
-#endif
-
-  // MetadataKind / isa.
-#if SWIFT_OBJC_INTEROP
-  metadata->setClassISA(pattern->Metaclass.get());
-#else
-  metadata->setKind(MetadataKind::Class);
-#endif
-
-  // Superclass.
-  metadata->Superclass = nullptr;
-
-#if SWIFT_OBJC_INTEROP
-  // Cache data.  Install the same initializer that the compiler is
-  // required to use.  We don't need to do this in non-ObjC-interop modes.
-  metadata->CacheData[0] = &_objc_empty_cache;
-  metadata->CacheData[1] = nullptr;
-#endif
-
-  // RO-data pointer.
-#if SWIFT_OBJC_INTEROP
-  auto classRO = pattern->Data.get();
-  metadata->Data =
-    reinterpret_cast<uintptr_t>(classRO) | SWIFT_CLASS_IS_SWIFT_MASK;
-#else
-  metadata->Data = SWIFT_CLASS_IS_SWIFT_MASK;
-#endif
-
-  // Class flags.
-  metadata->Flags = pattern->Flags;
-
-  // Instance layout.
-  metadata->InstanceAddressPoint = 0;
-  metadata->InstanceSize = 0;
-  metadata->InstanceAlignMask = 0;
-
-  // Reserved.
-  metadata->Reserved = 0;
-
-  // Class metadata layout.
-  metadata->ClassSize = bounds.getTotalSizeInBytes();
-  metadata->ClassAddressPoint = bounds.getAddressPointInBytes();
-
-  // Class descriptor.
-  metadata->setDescription(description);
-
-  // I-var destroyer.
-  metadata->IVarDestroyer = pattern->IVarDestroyer;
-
-  return metadata;
 }
 
 /// Initialize the field offset vector for a dependent-layout class, using the

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2161,7 +2161,7 @@ static inline ClassROData *getROData(ClassMetadata *theClass) {
   return (ClassROData*) (theClass->Data & ~uintptr_t(1));
 }
 
-static void _swift_initGenericClassObjCName(ClassMetadata *theClass) {
+static void initGenericClassObjCName(ClassMetadata *theClass) {
   // Use the remangler to generate a mangled name from the type metadata.
   Demangle::Demangler Dem;
   // Resolve symbolic references to a unique mangling that can be encoded in
@@ -2432,6 +2432,9 @@ static void initGenericObjCClass(ClassMetadata *self,
                                  size_t numFields,
                                  const TypeLayout * const *fieldTypes,
                                  size_t *fieldOffsets) {
+  // If the class is generic, we need to give it a name for Objective-C.
+  initGenericClassObjCName(self);
+
   ClassROData *rodata = getROData(self);
 
   // In ObjC interop mode, we have up to two places we need each correct
@@ -2554,10 +2557,6 @@ swift::swift_initClassMetadata(ClassMetadata *self,
     (void)unused;
     setUpObjCRuntimeGetImageNameFromClass();
   }, nullptr);
-
-  // If the class is generic, we need to give it a name for Objective-C.
-  if (self->getDescription()->isGeneric())
-    _swift_initGenericClassObjCName(self);
 #endif
 
   // Copy field offsets, generic arguments and (if necessary) vtable entries

--- a/test/IRGen/completely_fragile_class_layout.sil
+++ b/test/IRGen/completely_fragile_class_layout.sil
@@ -26,13 +26,29 @@ public class ClassWithResilientField {
 
 sil_vtable ClassWithResilientField {}
 
+public class SubclassOfClassWithResilientField : ClassWithResilientField {}
+
+sil_vtable SubclassOfClassWithResilientField {}
+
+
 // Field offsets are statically known:
 // CHECK-DAG: @"$s31completely_fragile_class_layout23ClassWithResilientFieldC5firstSivpWvd" = hidden constant i64 16, align 8
 // CHECK-DAG: @"$s31completely_fragile_class_layout23ClassWithResilientFieldC6second16resilient_struct4SizeVvpWvd" = hidden constant i64 24, align 8
 // CHECK-DAG: @"$s31completely_fragile_class_layout23ClassWithResilientFieldC5thirdSivpWvd" = hidden constant i64 40, align 8
 
+
 // Class has static metadata:
-// CHECK-LABEL: $s31completely_fragile_class_layout23ClassWithResilientFieldCMf
+// CHECK-LABEL: @"$s31completely_fragile_class_layout23ClassWithResilientFieldCMf"
+
+
+// Subclass also has static metadata:
+// CHECK-LABEL: @"$s31completely_fragile_class_layout33SubclassOfClassWithResilientFieldCMf" = internal global <{{.*}}> <{
+
+// Superclass field is filled in statically:
+// CHECK-SAME: @"$s31completely_fragile_class_layout23ClassWithResilientFieldCMf"
+
+// CHECK-SAME: }>
+
 
 // rdar://problem/41308521 -- enum lowering needs to pretend payloads are
 // resilient and not use spare bits, even when bypassing resilience while
@@ -108,10 +124,28 @@ bb0:
   return %result : $()
 }
 
-// Metadata accessor for ClassWithResilientField is trivial:
+
+// Metadata accessor for ClassWithResilientField uses singleton initialization:
+
 // CHECK-LABEL: define swiftcc %swift.metadata_response @"$s31completely_fragile_class_layout23ClassWithResilientFieldCMa
-// CHECK: call %objc_class* @swift_getInitializedObjCClass(%objc_class* {{.*}} @"$s31completely_fragile_class_layout23ClassWithResilientFieldCMf"
-// CHECK: ret
+
+// CHECK:      [[CACHE:%.*]] = load %swift.type*, %swift.type** getelementptr inbounds ({ %swift.type*, i8* }, { %swift.type*, i8* }* @"$s31completely_fragile_class_layout23ClassWithResilientFieldCMl", i32 0, i32 0)
+// CHECK-NEXT: [[COND:%.*]] = icmp eq %swift.type* [[CACHE]], null
+// CHECK-NEXT: br i1 [[COND]], label %cacheIsNull, label %cont
+
+// CHECK: cacheIsNull:
+// CHECK-NEXT: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @swift_getSingletonMetadata([[INT]] %0, %swift.type_descriptor* bitcast ({{.*}} @"$s31completely_fragile_class_layout23ClassWithResilientFieldCMn" to %swift.type_descriptor*))
+// CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+// CHECK-NEXT: [[STATUS:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 1
+// CHECK-NEXT: br label %cont
+
+// CHECK: cont:
+// CHECK-NEXT: [[NEW_METADATA:%.*]] = phi %swift.type* [ [[CACHE]], %entry ], [ [[METADATA]], %cacheIsNull ]
+// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 0, %entry ], [ [[STATUS]], %cacheIsNull ]
+// CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[NEW_METADATA]], 0
+// CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[NEW_STATUS]], 1
+// CHECK-NEXT: ret %swift.metadata_response [[T1]]
+
 
 // Accessing a field whose offset depends on resilient types should
 // use the field offset global.
@@ -135,7 +169,105 @@ bb0(%0 : @guaranteed $ClassWithResilientField):
   return %2 : $Int
 }
 
-// Metadata accessor for ClassWithResilientEnum is trivial:
+
+// Metadata initialization function for ClassWithResilientField calls swift_updateClassMetadata():
+
+// CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s31completely_fragile_class_layout23ClassWithResilientFieldCMr"(%swift.type*, i8*, i8**)
+
+// CHECK: entry:
+// CHECK-NEXT: [[FIELDS:%.*]] = alloca [3 x i8**]
+// CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* %0 to [[INT]]*
+// CHECK-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{11|14}}
+// CHECK-NEXT: [[FIELDS_ADDR:%.*]] = bitcast [3 x i8**]* [[FIELDS]] to i8*
+// CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 {{12|24}}, i8* [[FIELDS_ADDR]])
+// CHECK-NEXT: [[FIELDS_PTR:%.*]] = getelementptr inbounds [3 x i8**], [3 x i8**]* [[FIELDS]], i32 0, i32 0
+
+// CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct4SizeVMa"([[INT]] 319)
+// CHECK-NEXT: [[SIZE_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: [[STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[RESULT:%.*]] = icmp ule [[INT]] [[STATUS]], 63
+// CHECK-NEXT: br i1 [[RESULT]], label %dependency-satisfied, label %metadata-dependencies.cont
+
+// CHECK: dependency-satisfied:
+
+// -- ClassLayoutFlags = 0x100 (HasStaticVTable)
+// CHECK:      void @swift_updateClassMetadata(%swift.type* %0, %swift.type* null, [[INT]] 256, [[INT]] 3, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+
+// CHECK-native:      [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* {{.*}}
+// CHECK-native-NEXT: store [[INT]] [[FIELD_OFFSET]], [[INT]]* @"$s31completely_fragile_class_layout23ClassWithResilientFieldC1s16resilient_struct4SizeVvpWvd"
+
+// CHECK-native:      [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* {{.*}}
+// CHECK-native-NEXT: store [[INT]] [[FIELD_OFFSET]], [[INT]]* @"$s31completely_fragile_class_layout23ClassWithResilientFieldC5colors5Int32VvpWvd"
+
+// CHECK:      br label %metadata-dependencies.cont
+
+// CHECK: metadata-dependencies.cont:
+
+// CHECK-NEXT: [[PENDING_METADATA:%.*]] = phi %swift.type* [ [[SIZE_METADATA]], %entry ], [ null, %dependency-satisfied ]
+// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 63, %entry ], [ 0, %dependency-satisfied ]
+// CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[PENDING_METADATA]], 0
+// CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[NEW_STATUS]], 1
+// CHECK-NEXT: ret %swift.metadata_response [[T1]]
+
+
+// Metadata initialization function for SubclassOfClassWithResilientField:
+
+// CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s31completely_fragile_class_layout33SubclassOfClassWithResilientFieldCMr"(%swift.type*, i8*, i8**)
+
+// CHECK: entry:
+// CHECK-NEXT: [[FIELDS:%.*]] = alloca [0 x i8**]
+// CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* %0 to [[INT]]*
+// CHECK-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{11|14}}
+// CHECK-NEXT: [[FIELDS_ADDR:%.*]] = bitcast [0 x i8**]* [[FIELDS]] to i8*
+// CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 0, i8* [[FIELDS_ADDR]])
+// CHECK-NEXT: [[FIELDS_PTR:%.*]] = getelementptr inbounds [0 x i8**], [0 x i8**]* [[FIELDS]], i32 0, i32 0
+
+// CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s31completely_fragile_class_layout23ClassWithResilientFieldCMa"([[INT]] 257)
+// CHECK-NEXT: [[SUPER:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: [[STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[RESULT:%.*]] = icmp ule [[INT]] [[STATUS]], 1
+// CHECK-NEXT: br i1 [[RESULT]], label %dependency-satisfied, label %metadata-dependencies.cont
+
+// CHECK: dependency-satisfied:
+
+// -- ClassLayoutFlags = 0x100 (HasStaticVTable)
+// CHECK:      void @swift_updateClassMetadata(%swift.type* %0, %swift.type* [[SUPER]], [[INT]] 256, [[INT]] 0, i8*** [[FIELDS_PTR]], [[INT]]* [[FIELDS_DEST]])
+
+// CHECK-native:      [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* {{.*}}
+// CHECK-native-NEXT: store [[INT]] [[FIELD_OFFSET]], [[INT]]* @"$s31completely_fragile_class_layout23ClassWithResilientFieldC1s16resilient_struct4SizeVvpWvd"
+
+// CHECK-native:      [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* {{.*}}
+// CHECK-native-NEXT: store [[INT]] [[FIELD_OFFSET]], [[INT]]* @"$s31completely_fragile_class_layout23ClassWithResilientFieldC5colors5Int32VvpWvd"
+
+// CHECK:      br label %metadata-dependencies.cont
+
+// CHECK: metadata-dependencies.cont:
+
+// CHECK-NEXT: [[PENDING_METADATA:%.*]] = phi %swift.type* [ [[SUPER]], %entry ], [ null, %dependency-satisfied ]
+// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 1, %entry ], [ 0, %dependency-satisfied ]
+// CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[PENDING_METADATA]], 0
+// CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[NEW_STATUS]], 1
+// CHECK-NEXT: ret %swift.metadata_response [[T1]]
+
+
+// Metadata accessor for ClassWithResilientEnum looks like singleton initialization:
+
 // CHECK-LABEL: define swiftcc %swift.metadata_response @"$s31completely_fragile_class_layout22ClassWithResilientEnumCMa
-// CHECK: call %objc_class* @swift_getInitializedObjCClass(%objc_class* {{.*}} @"$s31completely_fragile_class_layout22ClassWithResilientEnumCMf"
-// CHECK: ret
+
+// CHECK:      [[CACHE:%.*]] = load %swift.type*, %swift.type** getelementptr inbounds ({ %swift.type*, i8* }, { %swift.type*, i8* }* @"$s31completely_fragile_class_layout22ClassWithResilientEnumCMl", i32 0, i32 0)
+// CHECK-NEXT: [[COND:%.*]] = icmp eq %swift.type* [[CACHE]], null
+// CHECK-NEXT: br i1 [[COND]], label %cacheIsNull, label %cont
+
+// CHECK: cacheIsNull:
+// CHECK-NEXT: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @swift_getSingletonMetadata([[INT]] %0, %swift.type_descriptor* bitcast ({{.*}} @"$s31completely_fragile_class_layout22ClassWithResilientEnumCMn" to %swift.type_descriptor*))
+// CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+// CHECK-NEXT: [[STATUS:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 1
+// CHECK-NEXT: br label %cont
+
+// CHECK: cont:
+// CHECK-NEXT: [[NEW_METADATA:%.*]] = phi %swift.type* [ [[CACHE]], %entry ], [ [[METADATA]], %cacheIsNull ]
+// CHECK-NEXT: [[NEW_STATUS:%.*]] = phi [[INT]] [ 0, %entry ], [ [[STATUS]], %cacheIsNull ]
+// CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[NEW_METADATA]], 0
+// CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[NEW_STATUS]], 1
+// CHECK-NEXT: ret %swift.metadata_response [[T1]]
+

--- a/test/IRGen/objc_dealloc.sil
+++ b/test/IRGen/objc_dealloc.sil
@@ -6,7 +6,7 @@
 // REQUIRES: objc_interop
 
 // CHECK: [[SGIZMO:%T12objc_dealloc10SwiftGizmoC]] = type
-// CHECK: [[GIZMO:%TSo5GizmoC]] = type opaque
+// CHECK: [[GIZMO:%TSo5GizmoC]] = type <{ %objc_class* }>
 
 sil_stage raw
 

--- a/test/IRGen/objc_subclass.swift
+++ b/test/IRGen/objc_subclass.swift
@@ -13,7 +13,7 @@
 // CHECK: [[OPAQUE:%swift.opaque]] = type
 // CHECK: [[INT:%TSi]] = type <{ [[LLVM_PTRSIZE_INT:i(32|64)]] }>
 // CHECK: [[TYPE:%swift.type]] = type
-// CHECK-DAG: [[GIZMO:%TSo5GizmoC]] = type opaque
+// CHECK-DAG: [[GIZMO:%TSo5GizmoC]] = type <{ %objc_class* }>
 // CHECK-DAG: [[OBJC:%objc_object]] = type opaque
 
 

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -6,7 +6,7 @@
 // RUN: %target-build-swift-dylib(%t/libresilient_class.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/libresilient_class.%target-dylib-extension
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xfrontend -enable-class-resilience -Xlinker -rpath -Xlinker %t
 // RUN: %target-codesign %t/main
 
 // RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_class.%target-dylib-extension
@@ -17,7 +17,7 @@
 // RUN: %target-build-swift-dylib(%t/libresilient_class_wmo.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
 // RUN: %target-codesign %t/libresilient_class_wmo.%target-dylib-extension
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_class_wmo -o %t/main2 -Xlinker -rpath -Xlinker %t -module-name main
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_class_wmo -Xfrontend -enable-class-resilience -o %t/main2 -Xlinker -rpath -Xlinker %t -module-name main
 // RUN: %target-codesign %t/main2
 
 // RUN: %target-run %t/main2 %t/libresilient_struct_wmo.%target-dylib-extension %t/libresilient_class_wmo.%target-dylib-extension


### PR DESCRIPTION
Progress on <rdar://problem/17528739>.

If a class has resiliently-sized fields, we continue to emit a fixed metadata layout using the compile-time sizes of those resilient types. However, we now emit a non-trivial metadata accessor function for the class metadata that instantiates field metadata and calls a new `swift_updateClassMetadata()` entrypoint. For now, this entry point simply runs the same idempotent initialization as before, but that will soon change.