### PR TITLE
[android] adb_push_build_products.py support for aarch64.

### DIFF
--- a/utils/android/adb_push_built_products/main.py
+++ b/utils/android/adb_push_built_products/main.py
@@ -44,6 +44,12 @@ def argument_parser():
         help='The path to an Android NDK. If specified, the libc++ library '
              'in that NDK will be pushed to the device.',
         default=os.getenv('ANDROID_NDK_HOME', None))
+    parser.add_argument(
+        '-a', '--destination-arch',
+        help='The architecture of the host device. Used to determine the '
+             'right library versions to send to the device.',
+        choices=['armv7', 'aarch64'],
+        default='armv7')
     return parser
 
 
@@ -75,7 +81,10 @@ def main():
                               'cxx-stl',
                               'llvm-libc++',
                               'libs',
-                              'armeabi-v7a',
+                              {
+                                  'armv7': 'armeabi-v7a',
+                                  'aarch64': 'arm64-v8a',
+                              }[args.destination_arch],
                               'libc++_shared.so')
         _push(libcpp, args.destination)
 


### PR DESCRIPTION
A new parameter for the adb_push_build_product.py script to allow
pushing the right libc++_shared.so for the host architecture.
