### PR TITLE
[ABI] Use mangled names for associated type witnesses. 

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -90,7 +90,7 @@ Globals
   global ::= protocol-conformance 'WI'   // generic protocol witness table instantiation function
   global ::= type protocol-conformance 'WL'   // lazy protocol witness table cache variable
 
-  global ::= protocol-conformance identifier 'Wt' // associated type metadata accessor
+  global ::= protocol-conformance identifier 'Wt' // associated type metadata accessor (HISTORICAL)
   global ::= protocol-conformance assoc-type-list nominal-type 'WT' // associated type witness table accessor
   global ::= type protocol-conformance 'Wl' // lazy protocol witness table accessor
 
@@ -138,7 +138,7 @@ types where the metadata itself has unknown layout.)
 
   global ::= protocol 'TL'               // protocol requirements base descriptor
   global ::= assoc-type-name 'Tl'        // associated type descriptor
-  global ::= assoc-type-name 'TM'        // default associated type witness accessor
+  global ::= assoc-type-name 'TM'        // default associated type witness accessor (HISTORICAL)
   global ::= type assoc-type-path protocol 'Tn' // associated conformance descriptor
   global ::= type assoc-type-path protocol 'TN' // default associated conformance witness accessor
 

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2245,8 +2245,7 @@ struct TargetProtocolConformanceDescriptor final
 public:
   using WitnessTableAccessorFn
     = const TargetWitnessTable<Runtime> *(const TargetMetadata<Runtime>*,
-                                          const TargetWitnessTable<Runtime> **,
-                                          size_t);
+                                          const TargetWitnessTable<Runtime> **);
 
   using GenericRequirementDescriptor =
     TargetGenericRequirementDescriptor<Runtime>;

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1700,11 +1700,6 @@ using TargetWitnessTablePointer =
 
 using WitnessTablePointer = TargetWitnessTablePointer<InProcess>;
 
-using AssociatedTypeAccessFunction =
-  SWIFT_CC(swift) MetadataResponse(MetadataRequest request,
-                                  const Metadata *self,
-                                  const WitnessTable *selfConformance);
-
 using AssociatedWitnessTableAccessFunction =
   SWIFT_CC(swift) WitnessTable *(const Metadata *associatedType,
                                  const Metadata *self,

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2008,7 +2008,10 @@ struct TargetGenericWitnessTable {
   /// The amount of private storage to allocate before the address point,
   /// in words. This memory is zeroed out in the instantiated witness table
   /// template.
-  uint16_t WitnessTablePrivateSizeInWords;
+  ///
+  /// The low bit is used to indicate whether this witness table is known
+  /// to require instantiation.
+  uint16_t WitnessTablePrivateSizeInWordsAndRequiresInstantiation;
 
   /// The protocol descriptor. Only used for resilient conformances.
   RelativeIndirectablePointer<ProtocolDescriptor,
@@ -2032,6 +2035,15 @@ struct TargetGenericWitnessTable {
   /// Private data for the instantiator.  Out-of-line so that the rest
   /// of this structure can be constant.
   RelativeDirectPointer<PrivateDataType> PrivateData;
+
+  uint16_t getWitnessTablePrivateSizeInWords() const {
+    return WitnessTablePrivateSizeInWordsAndRequiresInstantiation >> 1;
+  }
+
+  /// Whether the witness table is known to require instantiation.
+  uint16_t requiresInstantiation() const {
+    return WitnessTablePrivateSizeInWordsAndRequiresInstantiation & 0x01;
+  }
 };
 using GenericWitnessTable = TargetGenericWitnessTable<InProcess>;
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -580,6 +580,12 @@ public:
   bool isInstance() const { return Value & IsInstanceMask; }
 
   int_type getIntValue() const { return Value; }
+
+  enum : uintptr_t {
+    /// Bit used to indicate that an associated type witness is a pointer to
+    /// a mangled name (vs. a pointer to metadata).
+    AssociatedTypeMangledNameMask = 0x01
+  };
 };
 
 /// Flags that go in a TargetConformanceDescriptor structure.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -582,9 +582,17 @@ public:
   int_type getIntValue() const { return Value; }
 
   enum : uintptr_t {
+    /// Mask used to retrieve the mangled name from an associated type witness.
+    AssociatedTypeMangledNameMask = 0x03,
+
     /// Bit used to indicate that an associated type witness is a pointer to
     /// a mangled name (vs. a pointer to metadata).
-    AssociatedTypeMangledNameMask = 0x01
+    AssociatedTypeMangledNameBit = 0x01,
+
+    /// Bit used to indicate that the associated type mangled name is a
+    /// in the context of the protocol (based on Self) rather than in the
+    /// context of the conforming type.
+    AssociatedTypeProtocolContextBit = 0x02,
   };
 };
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -582,17 +582,16 @@ public:
   int_type getIntValue() const { return Value; }
 
   enum : uintptr_t {
-    /// Mask used to retrieve the mangled name from an associated type witness.
-    AssociatedTypeMangledNameMask = 0x03,
-
     /// Bit used to indicate that an associated type witness is a pointer to
     /// a mangled name (vs. a pointer to metadata).
     AssociatedTypeMangledNameBit = 0x01,
+  };
 
-    /// Bit used to indicate that the associated type mangled name is a
-    /// in the context of the protocol (based on Self) rather than in the
-    /// context of the conforming type.
-    AssociatedTypeProtocolContextBit = 0x02,
+  enum : uint8_t {
+    /// Prefix byte used to identify an associated type whose mangled name
+    /// is relative to the protocol's context rather than the conforming
+    /// type's context.
+    AssociatedTypeInProtocolContextByte = 0xFF
   };
 };
 

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -218,11 +218,6 @@ class LinkEntity {
     /// is stored in the data.
     DefaultAssociatedConformanceAccessor,
 
-    /// A function which returns the default type metadata for the associated
-    /// type of a protocol.  The secondary pointer is a ProtocolDecl*.
-    /// The index of the associated type declaration is stored in the data.
-    DefaultAssociatedTypeMetadataAccessFunction,
-
     /// A SIL function. The pointer is a SILFunction*.
     SILFunction,
 
@@ -262,11 +257,6 @@ class LinkEntity {
 
     /// A list of key/value pairs that resiliently specify a witness table.
     ResilientProtocolWitnessTable,
-
-    /// A function which returns the type metadata for the associated type
-    /// of a protocol.  The secondary pointer is a ProtocolConformance*.
-    /// The index of the associated type declaration is stored in the data.
-    AssociatedTypeMetadataAccessFunction,
 
     /// A function which returns the witness table for a protocol-constrained
     /// associated type of a protocol.  The secondary pointer is a
@@ -336,7 +326,7 @@ class LinkEntity {
   }
 
   static bool isDeclKind(Kind k) {
-    return k <= Kind::DefaultAssociatedTypeMetadataAccessFunction;
+    return k <= Kind::DefaultAssociatedConformanceAccessor;
   }
   static bool isTypeKind(Kind k) {
     return k >= Kind::ProtocolWitnessTableLazyAccessFunction;
@@ -811,24 +801,6 @@ public:
   }
 
   static LinkEntity
-  forAssociatedTypeMetadataAccessFunction(const ProtocolConformance *C,
-                                          AssociatedType association) {
-    LinkEntity entity;
-    entity.setForProtocolConformanceAndAssociatedType(
-                     Kind::AssociatedTypeMetadataAccessFunction, C,
-                     association.getAssociation());
-    return entity;
-  }
-
-  static LinkEntity
-  forDefaultAssociatedTypeMetadataAccessFunction(AssociatedType association) {
-    LinkEntity entity;
-    entity.setForDecl(Kind::DefaultAssociatedTypeMetadataAccessFunction,
-                      association.getAssociation());
-    return entity;
-  }
-
-  static LinkEntity
   forAssociatedTypeWitnessTableAccessFunction(const ProtocolConformance *C,
                                      const AssociatedConformance &association) {
     LinkEntity entity;
@@ -925,12 +897,7 @@ public:
   }
 
   AssociatedTypeDecl *getAssociatedType() const {
-    if (getKind() == Kind::AssociatedTypeMetadataAccessFunction)
-      return getAssociatedTypeByIndex(getProtocolConformance(),
-                              LINKENTITY_GET_FIELD(Data, AssociatedTypeIndex));
-
-    assert(getKind() == Kind::AssociatedTypeDescriptor ||
-           getKind() == Kind::DefaultAssociatedTypeMetadataAccessFunction);
+    assert(getKind() == Kind::AssociatedTypeDescriptor);
     return reinterpret_cast<AssociatedTypeDecl *>(Pointer);
   }
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -410,6 +410,20 @@ swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
                              const Metadata *type,
                              void **const *instantiationArgs);
 
+/// Retrieve an associated type witness from the given witness table.
+///
+/// \param wtable The witness table.
+/// \param conformingType Metadata for the conforming type.
+/// \param assocType Associated type descriptor.
+///
+/// \returns metadata for the associated type witness.
+SWIFT_RUNTIME_EXPORT
+MetadataResponse swift_getAssociatedTypeWitness(
+                                          MetadataRequest request,
+                                          WitnessTable *wtable,
+                                          const Metadata *conformingType,
+                                          const ProtocolRequirement *assocType);
+
 /// \brief Fetch a uniqued metadata for a function type.
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -656,7 +656,7 @@ FUNCTION(GetAssociatedTypeWitness, swift_getAssociatedTypeWitness, C_CC,
               WitnessTablePtrTy,
               TypeMetadataPtrTy,
               ProtocolRequirementStructTy->getPointerTo()),
-         ATTRS(NoUnwind))
+         ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getMetatypeMetadata(Metadata *instanceTy);
 FUNCTION(GetMetatypeMetadata, swift_getMetatypeMetadata, C_CC,

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -645,6 +645,19 @@ FUNCTION(GetGenericWitnessTable, swift_getGenericWitnessTable, C_CC,
               WitnessTablePtrPtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
+// MetadataResponse swift_getAssociatedTypeWitness(
+//                                            MetadataRequest request,
+//                                            WitnessTable *wtable,
+//                                            const Metadata *conformingType,
+//                                            ProtocolRequirement *assocType);
+FUNCTION(GetAssociatedTypeWitness, swift_getAssociatedTypeWitness, C_CC,
+         RETURNS(TypeMetadataResponseTy),
+         ARGS(SizeTy,
+              WitnessTablePtrTy,
+              TypeMetadataPtrTy,
+              ProtocolRequirementStructTy->getPointerTo()),
+         ATTRS(NoUnwind))
+
 // Metadata *swift_getMetatypeMetadata(Metadata *instanceTy);
 FUNCTION(GetMetatypeMetadata, swift_getMetatypeMetadata, C_CC,
          RETURNS(TypeMetadataPtrTy),

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3805,27 +3805,6 @@ IRGenModule::getAddrOfWitnessTablePattern(const NormalProtocolConformance *conf,
 }
 
 llvm::Function *
-IRGenModule::getAddrOfAssociatedTypeMetadataAccessFunction(
-                                  const NormalProtocolConformance *conformance,
-                                  AssociatedType association) {
-  auto forDefinition = ForDefinition;
-
-  LinkEntity entity =
-    LinkEntity::forAssociatedTypeMetadataAccessFunction(conformance,
-                                                        association);
-  llvm::Function *&entry = GlobalFuncs[entity];
-  if (entry) {
-    if (forDefinition) updateLinkageForDefinition(*this, entry, entity);
-    return entry;
-  }
-
-  auto signature = getAssociatedTypeMetadataAccessFunctionSignature();
-  LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
-  entry = createFunction(*this, link, signature);
-  return entry;
-}
-
-llvm::Function *
 IRGenModule::getAddrOfAssociatedTypeWitnessTableAccessFunction(
                                   const NormalProtocolConformance *conformance,
                                   const AssociatedConformance &association) {
@@ -3841,25 +3820,6 @@ IRGenModule::getAddrOfAssociatedTypeWitnessTableAccessFunction(
   }
 
   auto signature = getAssociatedTypeWitnessTableAccessFunctionSignature();
-  LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
-  entry = createFunction(*this, link, signature);
-  return entry;
-}
-
-llvm::Function *
-IRGenModule::getAddrOfDefaultAssociatedTypeMetadataAccessFunction(
-                                  AssociatedType association) {
-  auto forDefinition = ForDefinition;
-
-  LinkEntity entity =
-    LinkEntity::forDefaultAssociatedTypeMetadataAccessFunction(association);
-  llvm::Function *&entry = GlobalFuncs[entity];
-  if (entry) {
-    if (forDefinition) updateLinkageForDefinition(*this, entry, entity);
-    return entry;
-  }
-
-  auto signature = getAssociatedTypeMetadataAccessFunctionSignature();
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
   entry = createFunction(*this, link, signature);
   return entry;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3685,7 +3685,7 @@ llvm::StructType *IRGenModule::getGenericWitnessTableCacheTy() {
     {
       // WitnessTableSizeInWords
       Int16Ty,
-      // WitnessTablePrivateSizeInWords
+      // WitnessTablePrivateSizeInWords + RequiresInstantiation bit
       Int16Ty,
       // Protocol
       RelativeAddressTy,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -768,7 +768,8 @@ namespace {
         auto witness =
           entry.getAssociatedTypeWitness().Witness->mapTypeOutOfContext()
             ->getCanonicalType();
-        return IGM.getAssociatedTypeWitness(witness);
+        return IGM.getAssociatedTypeWitness(witness,
+                                            /*inProtocolContext=*/true);
       }
 
       return nullptr;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -765,49 +765,13 @@ namespace {
             entry.getAssociatedTypeWitness().Requirement != assocType)
           continue;
 
-        auto witness = entry.getAssociatedTypeWitness().Witness;
-        return getDefaultAssociatedTypeMetadataAccessFunction(
-                 AssociatedType(assocType), witness);
+        auto witness =
+          entry.getAssociatedTypeWitness().Witness->mapTypeOutOfContext()
+            ->getCanonicalType();
+        return IGM.getAssociatedTypeWitness(witness);
       }
 
       return nullptr;
-    }
-
-    /// Create an associated type metadata access function for the default
-    /// associated type witness.
-    llvm::Constant *getDefaultAssociatedTypeMetadataAccessFunction(
-                      AssociatedType requirement, CanType witness) {
-      auto accessor =
-        IGM.getAddrOfDefaultAssociatedTypeMetadataAccessFunction(requirement);
-
-      IRGenFunction IGF(IGM, accessor);
-      if (IGM.DebugInfo)
-        IGM.DebugInfo->emitArtificialFunction(IGF, accessor);
-
-      Explosion parameters = IGF.collectParameters();
-      auto request = DynamicMetadataRequest(parameters.claimNext());
-
-      llvm::Value *self = parameters.claimNext();
-      llvm::Value *wtable = parameters.claimNext();
-
-      CanType selfInContext =
-          Proto->mapTypeIntoContext(Proto->getProtocolSelfType())
-            ->getCanonicalType();
-
-      // Bind local Self type data from the metadata argument.
-      IGF.bindLocalTypeDataFromTypeMetadata(selfInContext, IsExact, self,
-                                            MetadataState::Abstract);
-      IGF.setUnscopedLocalTypeData(
-          selfInContext,
-          LocalTypeDataKind::forAbstractProtocolWitnessTable(Proto),
-          wtable);
-
-      // Emit a reference to the type metadata.
-      auto response = IGF.emitTypeMetadataRef(witness, request);
-      response.ensureDynamicState(IGF);
-      auto returnValue = response.combine(IGF);
-      IGF.Builder.CreateRet(returnValue);
-      return accessor;
     }
 
     llvm::Constant *findDefaultAssociatedConformanceWitness(

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -603,7 +603,6 @@ namespace {
       auto var = cast<llvm::GlobalVariable>(addr);
 
       var->setConstant(true);
-      disableAddressSanitizer(IGM, var);
       IGM.setTrueConstGlobal(var);
     }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -457,7 +457,8 @@ namespace {
     
     void addExtendedContext() {
       auto string = IGM.getTypeRef(
-          E->getSelfInterfaceType()->getCanonicalType());
+          E->getSelfInterfaceType()->getCanonicalType(),
+          MangledTypeRefRole::Metadata);
       B.addRelativeAddress(string);
     }
     
@@ -4202,7 +4203,8 @@ GenericRequirementsMetadata irgen::addGenericRequirements(
 
       auto flags = GenericRequirementFlags(abiKind, false, false);
       auto typeName =
-        IGM.getTypeRef(requirement.getSecondType()->getCanonicalType());
+        IGM.getTypeRef(requirement.getSecondType()->getCanonicalType(),
+                       MangledTypeRefRole::Metadata);
 
       addGenericRequirement(IGM, B, metadata, sig, flags,
                             requirement.getFirstType(),

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3563,7 +3563,8 @@ irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
                                        wtable,
                                        parentMetadata,
                                        assocTypeDescriptor });
-
+  call->setDoesNotThrow();
+  call->setDoesNotAccessMemory();
   return MetadataResponse::handle(IGF, request, call);
 }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1373,7 +1373,8 @@ llvm::Value *uniqueForeignWitnessTableRef(IRGenFunction &IGF,
           ->getCanonicalType();
       if (associate->hasTypeParameter())
         RequiresSpecialization = true;
-      llvm::Constant *witness = IGM.getAssociatedTypeWitness(associate);
+      llvm::Constant *witness =
+          IGM.getAssociatedTypeWitness(associate, /*inProtocolContext=*/false);
       Table.addBitCast(witness, IGM.Int8PtrTy);
     }
 
@@ -1502,19 +1503,23 @@ void WitnessTableBuilder::build() {
   TableSize = Table.size();
 }
 
-llvm::Constant *IRGenModule::getAssociatedTypeWitness(CanType type) {
+llvm::Constant *IRGenModule::getAssociatedTypeWitness(CanType type,
+                                                      bool inProtocolContext) {
   // FIXME: If we can directly reference constant type metadata, do so.
 
   // Form a reference to the mangled name for this type.
   assert(!type->hasArchetype() && "type cannot contain archetypes");
-  auto typeRef = getTypeRef(type, /*alignment=*/2);
+  auto typeRef = getTypeRef(type, /*alignment=*/4);
 
   // Set the low bit to indicate that this is a mangled name.
   auto witness = llvm::ConstantExpr::getPtrToInt(typeRef, IntPtrTy);
-  auto bit = llvm::ConstantInt::get(
-               IntPtrTy,
-               ProtocolRequirementFlags::AssociatedTypeMangledNameMask);
-  witness = llvm::ConstantExpr::getAdd(witness, bit);
+  unsigned bits = ProtocolRequirementFlags::AssociatedTypeMangledNameBit;
+  if (inProtocolContext) {
+    bits |= ProtocolRequirementFlags::AssociatedTypeProtocolContextBit;
+  }
+
+  auto bitsConstant = llvm::ConstantInt::get(IntPtrTy, bits);
+  witness = llvm::ConstantExpr::getAdd(witness, bitsConstant);
   return llvm::ConstantExpr::getIntToPtr(witness, Int8PtrTy);
 }
 
@@ -1828,7 +1833,8 @@ llvm::Constant *WitnessTableBuilder::emitResilientWitnessTable() {
       auto associate = Conformance.getTypeWitness(assocType, nullptr)
           ->getCanonicalType();
 
-      llvm::Constant *witness = IGM.getAssociatedTypeWitness(associate);
+      llvm::Constant *witness =
+          IGM.getAssociatedTypeWitness(associate, /*inProtocolContext=*/false);
       table.addRelativeAddress(witness);
       continue;
     }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2240,6 +2240,7 @@ void IRGenModule::emitProtocolConformance(
           getAddrOfProtocolConformanceDescriptor(conformance,
                                                  init.finishAndCreateFuture()));
   var->setConstant(true);
+  setTrueConstGlobal(var);
 }
 
 void IRGenModule::ensureRelativeSymbolCollocation(SILWitnessTable &wt) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3482,23 +3482,6 @@ irgen::emitWitnessMethodValue(IRGenFunction &IGF,
   return emitWitnessMethodValue(IGF, wtable, member);
 }
 
-Signature IRGenModule::getAssociatedTypeMetadataAccessFunctionSignature() {
-  auto &fnType = AssociatedTypeMetadataAccessFunctionTy;
-  if (!fnType) {
-    fnType = llvm::FunctionType::get(TypeMetadataResponseTy,
-                                     { SizeTy,
-                                       TypeMetadataPtrTy,
-                                       WitnessTablePtrTy },
-                                     /*varargs*/ false);
-  }
-
-  auto attrs = llvm::AttributeList::get(getLLVMContext(),
-                                        llvm::AttributeList::FunctionIndex,
-                                        llvm::Attribute::NoUnwind);
-
-  return Signature(fnType, attrs, SwiftCC);
-}
-
 llvm::Value *irgen::computeResilientWitnessTableIndex(
                                             IRGenFunction &IGF,
                                             ProtocolDecl *proto,

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -164,10 +164,10 @@ public:
   }
 };
 
-llvm::Constant *IRGenModule::getTypeRef(CanType type) {
+llvm::Constant *IRGenModule::getTypeRef(CanType type, unsigned alignment) {
   IRGenMangler Mangler;
   auto SymbolicName = Mangler.mangleTypeForReflection(*this, type);
-  return getAddrOfStringForTypeRef(SymbolicName);
+  return getAddrOfStringForTypeRef(SymbolicName, alignment);
 }
 
 class ReflectionMetadataBuilder {

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -163,11 +163,23 @@ mangleProtocolForLLVMTypeName(ProtocolCompositionType *type) {
 }
 
 std::string IRGenMangler::
-mangleSymbolNameForSymbolicMangling(const SymbolicMangling &mangling) {
+mangleSymbolNameForSymbolicMangling(const SymbolicMangling &mangling,
+                                    MangledTypeRefRole role) {
   beginManglingWithoutPrefix();
-  static const char prefix[] = "symbolic ";
+  const char *prefix;
+  switch (role) {
+  case MangledTypeRefRole::DefaultAssociatedTypeWitness:
+    prefix = "default assoc type ";
+    break;
+
+  case MangledTypeRefRole::Metadata:
+  case MangledTypeRefRole::Reflection:
+    prefix = "symbolic ";
+    break;
+  }
+  auto prefixLen = strlen(prefix);
+
   Buffer << prefix << mangling.String;
-  auto prefixLen = sizeof(prefix) - 1;
 
   for (auto &symbol : mangling.SymbolicReferences) {
     // Fill in the placeholder space with something printable.

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -25,6 +25,8 @@ class NormalProtocolConformance;
 
 namespace irgen {
 
+enum class MangledTypeRefRole;
+
 /// A mangling string that includes embedded symbolic references.
 struct SymbolicMangling {
   std::string String;
@@ -426,7 +428,8 @@ public:
   std::string mangleProtocolForLLVMTypeName(ProtocolCompositionType *type);
 
   std::string mangleSymbolNameForSymbolicMangling(
-                                              const SymbolicMangling &mangling);
+                                              const SymbolicMangling &mangling,
+                                              MangledTypeRefRole role);
 protected:
 
   std::string mangleTypeSymbol(Type type, const char *Op) {

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -277,31 +277,6 @@ public:
     return mangleConformanceSymbol(type, C, "WL");
   }
 
-  std::string mangleAssociatedTypeMetadataAccessFunction(
-                                      const ProtocolConformance *Conformance,
-                                      StringRef AssocTyName) {
-    beginMangling();
-    appendProtocolConformance(Conformance);
-    appendIdentifier(AssocTyName);
-    appendOperator("Wt");
-    return finalize();
-  }
-
-  std::string mangleDefaultAssociatedTypeMetadataAccessFunction(
-                                      const AssociatedTypeDecl *assocType) {
-    // Don't optimize away the protocol name, because we need it to distinguish
-    // among the type descriptors of different protocols.
-    llvm::SaveAndRestore<bool> optimizeProtocolNames(OptimizeProtocolNames,
-                                                     false);
-    beginMangling();
-    bool isAssocTypeAtDepth = false;
-    (void)appendAssocType(
-        assocType->getDeclaredInterfaceType()->castTo<DependentMemberType>(),
-        isAssocTypeAtDepth);
-    appendOperator("TM");
-    return finalize();
-  }
-
   std::string mangleAssociatedTypeWitnessTableAccessFunction(
                                       const ProtocolConformance *Conformance,
                                       CanType AssociatedType,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -436,6 +436,17 @@ public:
   llvm::Constant *getValue() const { return Value; }
 };
 
+/// Describes the role of a mangled type reference string.
+enum class MangledTypeRefRole {
+  /// The mangled type reference is used for normal metadata.
+  Metadata,
+  /// The mangled type reference is used for reflection metadata.
+  Reflection,
+  /// The mangled type reference is used for a default associated type
+  /// witness.
+  DefaultAssociatedTypeWitness,
+};
+
 /// IRGenModule - Primary class for emitting IR for global declarations.
 /// 
 class IRGenModule {
@@ -991,10 +1002,11 @@ public:
   /// reflection metadata.
   llvm::SetVector<const StructDecl *> ImportedStructs;
 
-  llvm::Constant *getTypeRef(CanType type, unsigned alignment = 1);
-  llvm::Constant *getAddrOfStringForTypeRef(StringRef mangling);
+  llvm::Constant *getTypeRef(CanType type, MangledTypeRefRole role);
+  llvm::Constant *getAddrOfStringForTypeRef(StringRef mangling,
+                                            MangledTypeRefRole role);
   llvm::Constant *getAddrOfStringForTypeRef(const SymbolicMangling &mangling,
-                                            unsigned alignment = 1);
+                                            MangledTypeRefRole role);
   llvm::Constant *getAddrOfFieldName(StringRef Name);
   llvm::Constant *getAddrOfCaptureDescriptor(SILFunction &caller,
                                              CanSILFunctionType origCalleeType,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -993,9 +993,10 @@ public:
   /// reflection metadata.
   llvm::SetVector<const StructDecl *> ImportedStructs;
 
-  llvm::Constant *getTypeRef(CanType type);
+  llvm::Constant *getTypeRef(CanType type, unsigned alignment = 1);
   llvm::Constant *getAddrOfStringForTypeRef(StringRef mangling);
-  llvm::Constant *getAddrOfStringForTypeRef(const SymbolicMangling &mangling);
+  llvm::Constant *getAddrOfStringForTypeRef(const SymbolicMangling &mangling,
+                                            unsigned alignment = 1);
   llvm::Constant *getAddrOfFieldName(StringRef Name);
   llvm::Constant *getAddrOfCaptureDescriptor(SILFunction &caller,
                                              CanSILFunctionType origCalleeType,
@@ -1003,6 +1004,9 @@ public:
                                              SubstitutionMap subs,
                                              const HeapLayout &layout);
   llvm::Constant *getAddrOfBoxDescriptor(CanType boxedType);
+
+  /// Produce an associated type witness that refers to the given type.
+  llvm::Constant *getAssociatedTypeWitness(CanType type);
 
   void emitAssociatedTypeMetadataRecord(const ProtocolConformance *Conformance);
   void emitFieldMetadataRecord(const NominalTypeDecl *Decl);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1004,7 +1004,8 @@ public:
   llvm::Constant *getAddrOfBoxDescriptor(CanType boxedType);
 
   /// Produce an associated type witness that refers to the given type.
-  llvm::Constant *getAssociatedTypeWitness(CanType type);
+  llvm::Constant *getAssociatedTypeWitness(CanType type,
+                                           bool inProtocolContext);
 
   void emitAssociatedTypeMetadataRecord(const ProtocolConformance *Conformance);
   void emitFieldMetadataRecord(const NominalTypeDecl *Decl);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -591,7 +591,6 @@ public:
   llvm::CallingConv::ID DefaultCC;     /// default calling convention
   llvm::CallingConv::ID SwiftCC;       /// swift calling convention
 
-  Signature getAssociatedTypeMetadataAccessFunctionSignature();
   Signature getAssociatedTypeWitnessTableAccessFunctionSignature();
   llvm::StructType *getGenericWitnessTableCacheTy();
 
@@ -697,7 +696,6 @@ private:
   llvm::Type *FixedBufferTy;          /// [N x i8], where N == 3 * sizeof(void*)
 
   llvm::Type *ValueWitnessTys[MaxNumValueWitnesses];
-  llvm::FunctionType *AssociatedTypeMetadataAccessFunctionTy = nullptr;
   llvm::FunctionType *AssociatedTypeWitnessTableAccessFunctionTy = nullptr;
   llvm::StructType *GenericWitnessTableCacheTy = nullptr;
   
@@ -1287,14 +1285,9 @@ public:
   llvm::Function *
   getAddrOfGenericWitnessTableInstantiationFunction(
                                     const NormalProtocolConformance *C);
-  llvm::Function *getAddrOfAssociatedTypeMetadataAccessFunction(
-                                           const NormalProtocolConformance *C,
-                                           AssociatedType association);
   llvm::Function *getAddrOfAssociatedTypeWitnessTableAccessFunction(
                                      const NormalProtocolConformance *C,
                                      const AssociatedConformance &association);
-  llvm::Function *getAddrOfDefaultAssociatedTypeMetadataAccessFunction(
-                                           AssociatedType association);
   llvm::Function *getAddrOfDefaultAssociatedConformanceAccessor(
                                            AssociatedConformance requirement);
 

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -234,14 +234,6 @@ std::string LinkEntity::mangleAsString() const {
     return mangler.mangleProtocolWitnessTableLazyCacheVariable(getType(),
                                                     getProtocolConformance());
 
-  case Kind::AssociatedTypeMetadataAccessFunction:
-    return mangler.mangleAssociatedTypeMetadataAccessFunction(
-                getProtocolConformance(), getAssociatedType()->getNameStr());
-
-  case Kind::DefaultAssociatedTypeMetadataAccessFunction:
-    return mangler.mangleDefaultAssociatedTypeMetadataAccessFunction(
-                getAssociatedType());
-
   case Kind::AssociatedTypeWitnessTableAccessFunction: {
     auto assocConf = getAssociatedConformance();
     return mangler.mangleAssociatedTypeWitnessTableAccessFunction(
@@ -503,8 +495,6 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     }
   }
 
-  case Kind::AssociatedTypeMetadataAccessFunction:
-  case Kind::DefaultAssociatedTypeMetadataAccessFunction:
   case Kind::AssociatedTypeWitnessTableAccessFunction:
   case Kind::DefaultAssociatedConformanceAccessor:
   case Kind::GenericProtocolWitnessTableCache:
@@ -637,7 +627,6 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
   case Kind::TypeMetadataSingletonInitializationCache:
   case Kind::TypeMetadataCompletionFunction:
   case Kind::TypeMetadataPattern:
-  case Kind::DefaultAssociatedTypeMetadataAccessFunction:
   case Kind::DefaultAssociatedConformanceAccessor:
     return false;
 
@@ -648,7 +637,6 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
   case Kind::ProtocolWitnessTableAccessFunction:
   case Kind::ProtocolWitnessTableLazyAccessFunction:
   case Kind::ProtocolWitnessTableLazyCacheVariable:
-  case Kind::AssociatedTypeMetadataAccessFunction:
   case Kind::AssociatedTypeWitnessTableAccessFunction:
   case Kind::GenericProtocolWitnessTableCache:
   case Kind::GenericProtocolWitnessTableInstantiationFunction:

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -217,31 +217,42 @@ MetadataDependency MetadataDependencyCollector::finish(IRGenFunction &IGF) {
 }
 
 
-llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(StringRef str) {
-  return getAddrOfStringForTypeRef(SymbolicMangling{str,{}});
+llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(StringRef str,
+                                                       MangledTypeRefRole role){
+  return getAddrOfStringForTypeRef(SymbolicMangling{str, {}}, role);
 }
 
 llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(
                                              const SymbolicMangling &mangling,
-                                             unsigned alignment) {
+                                             MangledTypeRefRole role) {
   // Create a symbol name for the symbolic mangling. This is used as the
   // uniquing key both for ODR coalescing and within this TU.
   IRGenMangler mangler;
   std::string symbolName =
-    mangler.mangleSymbolNameForSymbolicMangling(mangling);
+    mangler.mangleSymbolNameForSymbolicMangling(mangling, role);
 
   // See if we emitted the constant already.
-  // FIXME: Make sure the existing variable has enough alignment. Otherwise,
-  // replace it.
   auto &entry = StringsForTypeRef[symbolName];
-  if (entry.second && entry.first->getAlignment() >= alignment) {
+  if (entry.second) {
     return entry.second;
   }
   
   ConstantInitBuilder B(*this);
   auto S = B.beginStruct();
   S.setPacked(true);
-  
+
+  switch (role) {
+  case MangledTypeRefRole::DefaultAssociatedTypeWitness:
+    // The 0xFF prefix identifies a default associated type witness.
+    S.addInt(Int8Ty,
+             ProtocolRequirementFlags::AssociatedTypeInProtocolContextByte);
+    break;
+
+  case MangledTypeRefRole::Metadata:
+  case MangledTypeRefRole::Reflection:
+    break;
+  }
+
   unsigned pos = 0;
   for (auto &symbolic : mangling.SymbolicReferences) {
     assert(symbolic.second >= pos
@@ -288,7 +299,7 @@ llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(
                                       nullptr,
                                       symbolName);
   var->setVisibility(llvm::GlobalValue::HiddenVisibility);
-  var->setAlignment(alignment);
+  var->setAlignment(2);
   setTrueConstGlobal(var);
   var->setSection(getReflectionTypeRefSectionName());
   

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -88,16 +88,8 @@ static const Metadata *findHashableBaseTypeImpl(const Metadata *type) {
   }
   // By this point, `type` is known to conform to `Hashable`.
 
-  const Metadata *baseTypeThatConformsToHashable = type;
-  while (true) {
-    const Metadata *superclass =
-        _swift_class_getSuperclass(baseTypeThatConformsToHashable);
-    if (!superclass)
-      break;
-    if (!swift_conformsToProtocol(superclass, &HashableProtocolDescriptor))
-      break;
-    baseTypeThatConformsToHashable = superclass;
-  }
+  const Metadata *baseTypeThatConformsToHashable =
+    findConformingSuperclass(type, &HashableProtocolDescriptor);
   HashableConformances.getOrInsert(HashableConformanceKey{type},
                                    baseTypeThatConformsToHashable);
   return baseTypeThatConformsToHashable;

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2502,19 +2502,12 @@ static inline bool swift_isClassOrObjCExistentialTypeImpl(const Metadata *T) {
 namespace {
 
 // protocol _ObjectiveCBridgeable {
-struct _ObjectiveCBridgeableWitnessTable {
-  /// The protocol conformance descriptor.
-  const void *protocolConformanceDescriptor;
-
+struct _ObjectiveCBridgeableWitnessTable : WitnessTable {
   static_assert(WitnessTableFirstRequirementOffset == 1,
                 "Witness table layout changed");
 
   // associatedtype _ObjectiveCType : class
-  SWIFT_CC(swift)
-  MetadataResponse (*ObjectiveCType)(
-                     MetadataRequest request,
-                     const Metadata *parentMetadata,
-                     const _ObjectiveCBridgeableWitnessTable *witnessTable);
+  void *_ObjectiveCType;
 
   // func _bridgeToObjectiveC() -> _ObjectiveCType
   SWIFT_CC(swift)
@@ -2544,6 +2537,23 @@ struct _ObjectiveCBridgeableWitnessTable {
 };
 // }
 
+/// Retrieve the bridged Objective-C type for the given type that
+/// conforms to \c _ObjectiveCBridgeable.
+MetadataResponse _getBridgedObjectiveCType(
+                             MetadataRequest request,
+                             const Metadata *conformingType,
+                             const _ObjectiveCBridgeableWitnessTable *wtable) {
+  // FIXME: Can we directly reference the descriptor somehow?
+  const ProtocolConformanceDescriptor *conformance = wtable->Description;
+  const ProtocolDescriptor *protocol = conformance->getProtocol();
+  auto assocTypeRequirement = protocol->getRequirements().begin();
+  assert(assocTypeRequirement->Flags.getKind() ==
+         ProtocolRequirementFlags::Kind::AssociatedTypeAccessFunction);
+  auto mutableWTable = (WitnessTable *)wtable;
+  return swift_getAssociatedTypeWitness(request, mutableWTable, conformingType,
+                                        assocTypeRequirement);
+}
+  
 } // unnamed namespace
 
 extern "C" const ProtocolDescriptor PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable);
@@ -2634,8 +2644,8 @@ static bool _dynamicCastClassToValueViaObjCBridgeable(
                DynamicCastFlags flags) {
   // Determine the class type to which the target value type is bridged.
   auto targetBridgedClass =
-    targetBridgeWitness->ObjectiveCType(MetadataState::Complete, targetType,
-                                        targetBridgeWitness).Value;
+      _getBridgedObjectiveCType(MetadataState::Complete, targetType,
+                                targetBridgeWitness).Value;
 
   // Dynamic cast the source object to the class type to which the target value
   // type is bridged. If we succeed, we can bridge from there; if we fail,
@@ -2888,8 +2898,8 @@ const Metadata *_getBridgedNonVerbatimObjectiveCType(
   // Check if the type conforms to _BridgedToObjectiveC, in which case
   // we'll extract its associated type.
   if (const auto *bridgeWitness = findBridgeWitness(T)) {
-    return bridgeWitness->ObjectiveCType(MetadataState::Complete, T,
-                                         bridgeWitness).Value;
+    return _getBridgedObjectiveCType(MetadataState::Complete, T,
+                                     bridgeWitness).Value;
   }
   
   return nullptr;
@@ -2980,8 +2990,8 @@ _bridgeNonVerbatimFromObjectiveC(
     // Check if sourceValue has the _ObjectiveCType type required by the
     // protocol.
     const Metadata *objectiveCType =
-        bridgeWitness->ObjectiveCType(MetadataState::Complete, nativeType,
-                                      bridgeWitness).Value;
+        _getBridgedObjectiveCType(MetadataState::Complete, nativeType,
+                                  bridgeWitness).Value;
       
     auto sourceValueAsObjectiveCType =
         const_cast<void*>(swift_dynamicCastUnknownClass(sourceValue,
@@ -3031,8 +3041,8 @@ _bridgeNonVerbatimFromObjectiveCConditional(
   // Dig out the Objective-C class type through which the native type
   // is bridged.
   const Metadata *objectiveCType =
-    bridgeWitness->ObjectiveCType(MetadataState::Complete, nativeType,
-                                  bridgeWitness).Value;
+    _getBridgedObjectiveCType(MetadataState::Complete, nativeType,
+                              bridgeWitness).Value;
         
   // Check whether we can downcast the source value to the Objective-C
   // type.

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3977,7 +3977,7 @@ swift::swift_getAssociatedTypeWitness(MetadataRequest request,
     WitnessTableFirstRequirementOffset;
   auto witness = ((const void* const *)wtable)[witnessIndex];
   if ((uintptr_t(witness) &
-         ProtocolRequirementFlags::AssociatedTypeMangledNameMask) == 0) {
+         ProtocolRequirementFlags::AssociatedTypeMangledNameBit) == 0) {
     return swift_checkMetadataState(request, (const Metadata *)witness);
   }
 
@@ -3988,7 +3988,8 @@ swift::swift_getAssociatedTypeWitness(MetadataRequest request,
                      ~ProtocolRequirementFlags::AssociatedTypeMangledNameMask));
 
   const Metadata *assocTypeMetadata;
-  if (witness == req.DefaultImplementation) {
+  if ((uintptr_t(witness) &
+         ProtocolRequirementFlags::AssociatedTypeProtocolContextBit)) {
     // The protocol's Self is the only generic parameter that can occur in the
     // type.
     assocTypeMetadata =
@@ -4027,7 +4028,7 @@ swift::swift_getAssociatedTypeWitness(MetadataRequest request,
 
   // Update the witness table.
   assert((uintptr_t(assocTypeMetadata) &
-            ProtocolRequirementFlags::AssociatedTypeMangledNameMask) == 0);
+            ProtocolRequirementFlags::AssociatedTypeMangledNameBit) == 0);
   reinterpret_cast<const void**>(wtable)[witnessIndex] = assocTypeMetadata;
   return swift_checkMetadataState(request, assocTypeMetadata);
 }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4002,7 +4002,12 @@ swift::swift_getAssociatedTypeWitness(MetadataRequest request,
   } else {
     // The generic parameters in the associated type name are those of the
     // conforming type.
-    SubstGenericParametersFromMetadata substitutions(conformingType);
+
+    // For a class, chase the superclass chain up until we hit the
+    // type that specified the conformance.
+    auto originalConformingType = findConformingSuperclass(conformingType,
+                                                           protocol);
+    SubstGenericParametersFromMetadata substitutions(originalConformingType);
     assocTypeMetadata = _getTypeByMangledName(mangledName, substitutions);
   }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3956,9 +3956,11 @@ swift::swift_getAssociatedTypeWitness(MetadataRequest request,
   }
 
   // Demangle the associated type name.
-  const char *mangledName =
-    (const char *)(uintptr_t(witness) &
-                   ~ProtocolRequirementFlags::AssociatedTypeMangledNameMask);
+  StringRef mangledName =
+    Demangle::makeSymbolicMangledNameStringRef(
+      (const char *)(uintptr_t(witness) &
+                     ~ProtocolRequirementFlags::AssociatedTypeMangledNameMask));
+
   const Metadata *assocTypeMetadata;
   if (witness == req.DefaultImplementation) {
     // The protocol's Self is the only generic parameter that can occur in the

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -428,6 +428,11 @@ public:
                            ProtocolDescriptorRef protocol,
                            const WitnessTable **conformance);
 
+  /// Given a type that we know conforms to the given protocol, find the
+  /// superclass that introduced the conformance.
+  const Metadata *findConformingSuperclass(const Metadata *type,
+                                           const ProtocolDescriptor *protocol);
+
 } // end namespace swift
 
 #endif /* SWIFT_RUNTIME_PRIVATE_H */

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -667,17 +667,12 @@ static const Metadata *resolveGenericParamRef(
       swift_conformsToProtocol(current, assocTypeRef.Protocol);
     if (!witnessTable) return nullptr;
 
-    // Determine the index of the associated type based on its offset
-    // from the beginning of the protocol's requirements.
-    auto protocolDescriptor = witnessTable->Description->getProtocol();
-    unsigned index = assocTypeRef.Requirement.get() -
-        protocolDescriptor->getRequirements().data();
-
-    // Call the associated type access function.
-    unsigned adjustedIndex = index + WitnessTableFirstRequirementOffset;
-    current =
-      ((AssociatedTypeAccessFunction * const *)witnessTable)[adjustedIndex]
-        (MetadataState::Abstract, current, witnessTable).Value;
+    // Retrieve the associated type.
+    auto assocTypeReq = assocTypeRef.Requirement.get();
+    current = swift_getAssociatedTypeWitness(
+                                    MetadataState::Abstract,
+                                    const_cast<WitnessTable *>(witnessTable),
+                                    current, assocTypeReq).Value;
     if (!current) return nullptr;
   }
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -765,5 +765,21 @@ bool swift::_checkGenericRequirements(
   return false;
 }
 
+const Metadata *swift::findConformingSuperclass(
+                                          const Metadata *type,
+                                          const ProtocolDescriptor *protocol) {
+  const Metadata *conformingType = type;
+  while (true) {
+    const Metadata *superclass = _swift_class_getSuperclass(conformingType);
+    if (!superclass)
+      break;
+    if (!swift_conformsToProtocol(superclass, protocol))
+      break;
+    conformingType = superclass;
+  }
+
+  return conformingType;
+}
+
 #define OVERRIDE_PROTOCOLCONFORMANCE COMPATIBILITY_OVERRIDE
 #include "CompatibilityOverride.def"

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -173,7 +173,7 @@ ProtocolConformanceDescriptor::getWitnessTable(const Metadata *type) const {
     return getStaticWitnessTable();
 
   case ConformanceFlags::ConformanceKind::WitnessTableAccessor:
-    return getWitnessTableAccessor()(type, nullptr, 0);
+    return getWitnessTableAccessor()(type, nullptr);
 
   case ConformanceFlags::ConformanceKind::ConditionalWitnessTableAccessor: {
     // Check the conditional requirements.
@@ -186,8 +186,7 @@ ProtocolConformanceDescriptor::getWitnessTable(const Metadata *type) const {
 
     return getWitnessTableAccessor()(
                            type,
-                           (const swift::WitnessTable**)conditionalArgs.data(),
-                           conditionalArgs.size());
+                           (const swift::WitnessTable**)conditionalArgs.data());
   }
   }
   return nullptr;

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -29,22 +29,22 @@ protocol HasThreeAssocTypes {
 // CHECK:         ret i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s23associated_type_witness9UniversalVAA1QAAWP", i32 0, i32 0)
 
 //   Witness table for WithUniversal : Assocked.
-// GLOBAL-LABEL: @"$s23associated_type_witness13WithUniversalVAA8AssockedAAWP" = hidden constant [4 x i8*] [
+// GLOBAL-LABEL: @"$s23associated_type_witness13WithUniversalVAA8AssockedAAWP" = hidden global [4 x i8*] [
 // GLOBAL-SAME:    @"$s23associated_type_witness13WithUniversalVAA8AssockedAAMc"
 // GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAA1PAAWa" to i8*)
 // GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAA1QAAWa" to i8*)  
-// GLOBAL-SAME:    i8* bitcast (%swift.metadata_response (i64)* @"$s23associated_type_witness9UniversalVMa" to i8*)
+// GLOBAL-SAME:    i64 add (i64 ptrtoint (<{ [36 x i8], i8 }>* @"symbolic 23associated_type_witness9UniversalV" to i64), i64 1) to i8*)
 // GLOBAL-SAME:  ]
 struct WithUniversal : Assocked {
   typealias Assoc = Universal
 }
 
 //   Witness table for GenericWithUniversal : Assocked.
-// GLOBAL-LABEL: @"$s23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAAWP" = hidden constant [4 x i8*] [
+// GLOBAL-LABEL: @"$s23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAAWP" = hidden global [4 x i8*] [
 // GLOBAL-SAME:    @"$s23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAAMc"
 // GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAA1PAAWa" to i8*)
 // GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAA1QAAWa" to i8*)  
-// GLOBAL-SAME:    i8* bitcast (%swift.metadata_response (i64)* @"$s23associated_type_witness9UniversalVMa" to i8*)
+// GLOBAL-SAME:    @"symbolic 23associated_type_witness9UniversalV"
 // GLOBAL-SAME:  ]
 struct GenericWithUniversal<T> : Assocked {
   typealias Assoc = Universal
@@ -55,7 +55,7 @@ struct GenericWithUniversal<T> : Assocked {
 // GLOBAL-SAME:    @"$s23associated_type_witness9FulfilledVyxGAA8AssockedAAMc"
 // GLOBAL-SAME:    i8* bitcast (i8** (%swift.type*, %swift.type*, i8**)* @"$s23associated_type_witness9FulfilledVyxGAA8AssockedAA5AssocAaEP_AA1PPWT" to i8*)
 // GLOBAL-SAME:    i8* bitcast (i8** (%swift.type*, %swift.type*, i8**)* @"$s23associated_type_witness9FulfilledVyxGAA8AssockedAA5AssocAaEP_AA1QPWT" to i8*)
-// GLOBAL-SAME:    i8* bitcast (%swift.metadata_response (i64, %swift.type*, i8**)* @"$s23associated_type_witness9FulfilledVyxGAA8AssockedAA5AssocWt" to i8*)
+// GLOBAL-SAME:    @"symbolic x"
 // GLOBAL-SAME:  ]
 struct Fulfilled<T : P & Q> : Assocked {
   typealias Assoc = T
@@ -75,18 +75,6 @@ struct Fulfilled<T : P & Q> : Assocked {
 // CHECK-NEXT:    [[T2:%.*]] = load i8**, i8*** [[T1]], align 8, !invariant.load
 // CHECK-NEXT:    ret i8** [[T2]]
 
-//   Associated type metadata access function for Fulfilled.Assoc.
-// CHECK-LABEL:  define internal swiftcc %swift.metadata_response @"$s23associated_type_witness9FulfilledVyxGAA8AssockedAA5AssocWt"(i64, %swift.type* %"Fulfilled<T>", i8** %"Fulfilled<T>.Assocked")
-// CHECK:         [[T0:%.*]] = bitcast %swift.type* %"Fulfilled<T>" to %swift.type**
-// CHECK-NEXT:    [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 2
-// CHECK-NEXT:    [[T2:%.*]] = load %swift.type*, %swift.type** [[T1]], align 8, !invariant.load
-// CHECK-NEXT:    [[T3:%.*]] = call swiftcc %swift.metadata_response @swift_checkMetadataState(i64 %0, %swift.type* [[T2]])
-// CHECK-NEXT:    [[CHECKED:%.*]] = extractvalue %swift.metadata_response [[T3]], 0
-// CHECK-NEXT:    [[STATE:%.*]] = extractvalue %swift.metadata_response [[T3]], 1
-// CHECK:         [[T3:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[CHECKED]], 0
-// CHECK-NEXT:    [[T4:%.*]] = insertvalue %swift.metadata_response [[T3]], i64 [[STATE]], 1
-// CHECK-NEXT:    ret %swift.metadata_response [[T4]]
-
 struct Pair<T, U> : P, Q {}
 
 //   Generic witness table pattern for Computed : Assocked.
@@ -94,7 +82,7 @@ struct Pair<T, U> : P, Q {}
 // GLOBAL-SAME:    @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAMc"
 // GLOBAL-SAME:    i8* bitcast (i8** (%swift.type*, %swift.type*, i8**)* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAA5Assoc_AA1PPWT" to i8*)
 // GLOBAL-SAME:    i8* bitcast (i8** (%swift.type*, %swift.type*, i8**)* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAA5Assoc_AA1QPWT" to i8*)
-// GLOBAL-SAME:    i8* bitcast (%swift.metadata_response (i64, %swift.type*, i8**)* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAA5AssocWt" to i8*)
+// GLOBAL-SAME:    @"symbolic 23associated_type_witness4PairVyxq_G"
 // GLOBAL-SAME:  ]
 //   Generic witness table cache for Computed : Assocked.
 // GLOBAL-LABEL: @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWG" = internal constant %swift.generic_witness_table_cache {
@@ -120,37 +108,6 @@ struct Computed<T, U> : Assocked {
   typealias Assoc = Pair<T, U>
 }
 
-//   Associated type metadata access function for Computed.Assoc.
-// CHECK-LABEL:  define internal swiftcc %swift.metadata_response @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAA5AssocWt"(i64, %swift.type* %"Computed<T, U>", i8** %"Computed<T, U>.Assocked")
-// CHECK:         entry:
-// CHECK:          [[T0:%.*]] = getelementptr inbounds i8*, i8** %"Computed<T, U>.Assocked", i32 -1
-// CHECK-NEXT:     [[CACHE:%.*]] = bitcast i8** [[T0]] to %swift.type**
-// CHECK-NEXT:     [[CACHE_RESULT:%.*]] = load %swift.type*, %swift.type** [[CACHE]], align 8
-// CHECK-NEXT:     [[T1:%.*]] = icmp eq %swift.type* [[CACHE_RESULT]], null
-// CHECK-NEXT:     br i1 [[T1]], label %fetch, label %cont
-// CHECK:        cont:
-// CHECK-NEXT:     [[T0:%.*]] = phi %swift.type* [ [[CACHE_RESULT]], %entry ], [ [[FETCH_RESULT:%.*]], %fetch ],
-// CHECK-SAME:        [ [[FETCH_RESULT]], %is_complete ]
-// CHECK-NEXT:     [[T1:%.*]] = phi i64 [ 0, %entry ], [ [[FETCH_STATE:%.*]], %fetch ], [ 0, %is_complete ]
-// CHECK-NEXT:     [[T2:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[T0]], 0
-// CHECK-NEXT:     [[T3:%.*]] = insertvalue %swift.metadata_response [[T2]], i64 [[T1]], 1
-// CHECK-NEXT:     ret %swift.metadata_response [[T3]]
-// CHECK:        fetch:
-// CHECK-NEXT:    [[T0:%.*]] = bitcast %swift.type* %"Computed<T, U>" to %swift.type**
-// CHECK-NEXT:    [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 2
-// CHECK-NEXT:    [[T:%.*]] = load %swift.type*, %swift.type** [[T1]], align 8, !invariant.load
-// CHECK:         [[T0:%.*]] = bitcast %swift.type* %"Computed<T, U>" to %swift.type**
-// CHECK-NEXT:    [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 3
-// CHECK-NEXT:    [[U:%.*]] = load %swift.type*, %swift.type** [[T1]], align 8, !invariant.load
-// CHECK:         [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s23associated_type_witness4PairVMa"(i64 %0, %swift.type* [[T]], %swift.type* [[U]])
-// CHECK-NEXT:    [[FETCH_RESULT]] = extractvalue %swift.metadata_response [[T0]], 0
-// CHECK-NEXT:    [[FETCH_STATE]] = extractvalue %swift.metadata_response [[T0]], 1
-// CHECK-NEXT:    [[COMPLETE:%.*]] = icmp eq i64 [[FETCH_STATE]], 0
-// CHECK-NEXT:    br i1 [[COMPLETE]], label %is_complete, label %cont
-// CHECK:       is_complete:
-// CHECK-NEXT:    store atomic %swift.type* [[FETCH_RESULT]], %swift.type** [[CACHE]] release, align 8
-// CHECK-NEXT:    br label %cont
-
 //   Witness table accessor function for Computed : Assocked.
 // CHECK-LABEL: define hidden i8** @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
@@ -173,7 +130,7 @@ protocol DerivedFromSimpleAssoc : HasSimpleAssoc {}
 //   Generic witness table cache for GenericComputed : DerivedFromSimpleAssoc.
 // GLOBAL-LABEL: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG" = internal constant %swift.generic_witness_table_cache {
 // GLOBAL-SAME:    i16 2,
-// GLOBAL-SAME:    i16 0,
+// GLOBAL-SAME:    i16 1,
 
 //   Relative reference to protocol
 // GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ({{.*}} @"$s23associated_type_witness22DerivedFromSimpleAssocMp" to i64
@@ -188,8 +145,6 @@ protocol DerivedFromSimpleAssoc : HasSimpleAssoc {}
 // GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint (void (i8**, %swift.type*, i8**)* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI" to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", i32 0, i32 5) to i64)) to i32)
 
 //   Relative reference to private data
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* @1 to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", i32 0, i32 6) to i64)) to i32)
-// GLOBAL-SAME:  }
 struct GenericComputed<T: P> : DerivedFromSimpleAssoc {
   typealias Assoc = PBox<T>
 }

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -85,7 +85,7 @@ func testFastRuncible<T: Runcible, U: FastRuncible>(_ t: T, u: U)
 // CHECK-NEXT: [[T2:%.*]] = bitcast i8* [[T1]] to i8** (%swift.type*, %swift.type*, i8**)*
 // CHECK-NEXT: %T.RuncerType.FastRuncer = call swiftcc i8** [[T2]](%swift.type* %T.RuncerType, %swift.type* %U, i8** %U.FastRuncible)
 //     1c. Get the type metadata for U.RuncerType.Runcee.
-// CHECK-NEXT: [[T2:%.*]] = call %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %T.RuncerType.FastRuncer, %swift.type* %T.RuncerType, %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types10FastRuncerMp", i32 0, i32 10))
+// CHECK-NEXT: [[T2:%.*]] = call %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 0, i8** %T.RuncerType.FastRuncer, %swift.type* %T.RuncerType, %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types10FastRuncerMp", i32 0, i32 10))
 // CHECK-NEXT: %T.RuncerType.Runcee = extractvalue %swift.metadata_response [[T2]], 0
 // CHECK-NEXT: store %swift.type*
 //     2b. Get the witness table for U.RuncerType.Runcee : Speedy.

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -75,7 +75,7 @@ func testFastRuncible<T: Runcible, U: FastRuncible>(_ t: T, u: U)
 //   1. Get the type metadata for U.RuncerType.Runcee.
 //     1a. Get the type metadata for U.RuncerType.
 //         Note that we actually look things up in T, which is going to prove unfortunate.
-// CHECK: [[T2:%.*]] = call %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 0, i8** %T.Runcible, %swift.type* %T, %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types8RuncibleMp", i32 0, i32 14))
+// CHECK: [[T2:%.*]] = call %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 0, i8** %T.Runcible, %swift.type* %T, %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types8RuncibleMp", i32 0, i32 14)) [[NOUNWIND_READNONE:#.*]]
 // CHECK-NEXT: %T.RuncerType = extractvalue %swift.metadata_response [[T2]], 0
 // CHECK-NEXT: store %swift.type*
 //   2. Get the witness table for U.RuncerType.Runcee : Speedy
@@ -98,4 +98,6 @@ func testFastRuncible<T: Runcible, U: FastRuncible>(_ t: T, u: U)
 // CHECK-NEXT: [[T0:%.*]] = load i8*, i8** [[T0_GEP]]
 // CHECK-NEXT: [[T1:%.*]] = bitcast i8* [[T0]] to void (%swift.type*, %swift.type*, i8**)*
 // CHECK-NEXT: call swiftcc void [[T1]](%swift.type* swiftself %T.RuncerType.Runcee, %swift.type* %T.RuncerType.Runcee, i8** %T.RuncerType.Runcee.Speedy)
+
+// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
 

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -75,10 +75,7 @@ func testFastRuncible<T: Runcible, U: FastRuncible>(_ t: T, u: U)
 //   1. Get the type metadata for U.RuncerType.Runcee.
 //     1a. Get the type metadata for U.RuncerType.
 //         Note that we actually look things up in T, which is going to prove unfortunate.
-// CHECK:      [[T0_GEP:%.*]] = getelementptr inbounds i8*, i8** %T.Runcible, i32 3
-// CHECK:      [[T0:%.*]] = load i8*, i8** [[T0_GEP]]
-// CHECK-NEXT: [[T1:%.*]] = bitcast i8* [[T0]] to %swift.metadata_response ([[INT]], %swift.type*, i8**)*
-// CHECK-NEXT: [[T2:%.*]] = call swiftcc %swift.metadata_response [[T1]]([[INT]] 0, %swift.type* %T, i8** %T.Runcible)
+// CHECK: [[T2:%.*]] = call %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 0, i8** %T.Runcible, %swift.type* %T, %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types8RuncibleMp", i32 0, i32 14))
 // CHECK-NEXT: %T.RuncerType = extractvalue %swift.metadata_response [[T2]], 0
 // CHECK-NEXT: store %swift.type*
 //   2. Get the witness table for U.RuncerType.Runcee : Speedy
@@ -88,10 +85,7 @@ func testFastRuncible<T: Runcible, U: FastRuncible>(_ t: T, u: U)
 // CHECK-NEXT: [[T2:%.*]] = bitcast i8* [[T1]] to i8** (%swift.type*, %swift.type*, i8**)*
 // CHECK-NEXT: %T.RuncerType.FastRuncer = call swiftcc i8** [[T2]](%swift.type* %T.RuncerType, %swift.type* %U, i8** %U.FastRuncible)
 //     1c. Get the type metadata for U.RuncerType.Runcee.
-// CHECK-NEXT: [[T0_GEP:%.*]] = getelementptr inbounds i8*, i8** %T.RuncerType.FastRuncer, i32 2
-// CHECK-NEXT: [[T0:%.*]] = load i8*, i8** [[T0_GEP]]
-// CHECK-NEXT: [[T1:%.*]] = bitcast i8* [[T0]] to %swift.metadata_response ([[INT]], %swift.type*, i8**)*
-// CHECK-NEXT: [[T2:%.*]] = call swiftcc %swift.metadata_response [[T1]]([[INT]] 0, %swift.type* %T.RuncerType, i8** %T.RuncerType.FastRuncer)
+// CHECK-NEXT: [[T2:%.*]] = call %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %T.RuncerType.FastRuncer, %swift.type* %T.RuncerType, %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types10FastRuncerMp", i32 0, i32 10))
 // CHECK-NEXT: %T.RuncerType.Runcee = extractvalue %swift.metadata_response [[T2]], 0
 // CHECK-NEXT: store %swift.type*
 //     2b. Get the witness table for U.RuncerType.Runcee : Speedy.

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -256,10 +256,8 @@ struct GenericLayoutWithAssocType<T: ParentHasAssociatedType> {
 // CHECK: [[T0_GEP:%.*]] = getelementptr inbounds i8*, i8** %T.ParentHasAssociatedType, i32 1
 // CHECK: [[T0:%.*]] = load i8*, i8** [[T0_GEP]]
 // CHECK: [[T1:%.*]] = bitcast i8* [[T0]] to i8**
-// CHECK: [[T2_GEP:%.*]] = getelementptr inbounds i8*, i8** [[T1]], i32 1
-// CHECK: [[T2:%.*]] = load i8*, i8** [[T2_GEP]], align 8, !invariant.load
-// CHECK: [[T3:%.*]] = bitcast i8* [[T2]] to %swift.metadata_response (
-// CHECK: [[T4:%.*]] = call swiftcc %swift.metadata_response [[T3]](i64 0, %swift.type* %T, i8** [[T1]])
+// CHECK: [[T4:%.*]] = call %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %T.HasAssociatedType, %swift.type* %T, %swift.protocol_requirement* @"$s5Assoc15generic_structs17HasAssociatedTypePTl")
+
 // CHECK: %T.Assoc = extractvalue %swift.metadata_response [[T4]], 0
 
 // CHECK:   [[T0:%.*]] = getelementptr inbounds i8*, i8** %T.ParentHasAssociatedType, i32 2
@@ -267,8 +265,5 @@ struct GenericLayoutWithAssocType<T: ParentHasAssociatedType> {
 // CHECK:   [[T2:%.*]] = bitcast i8* [[T1]] to i8** (%swift.type*, %swift.type*, i8**)*
 // CHECK:   %T.Assoc.HasAssociatedType = call swiftcc i8** [[T2]](%swift.type* %T.Assoc, %swift.type* %T, i8** %T.ParentHasAssociatedType)
 
-// CHECK:   [[T0_GEP:%.*]] = getelementptr inbounds i8*, i8** %T.Assoc.HasAssociatedType, i32 1
-// CHECK:   [[T0:%.*]] = load i8*, i8** [[T0_GEP]]
-// CHECK:   [[T1:%.*]] = bitcast i8* [[T0]] to %swift.metadata_response (i64, %swift.type*, i8**)*
-// CHECK:   [[T2:%.*]] = call swiftcc %swift.metadata_response [[T1]](i64 0, %swift.type* %T.Assoc, i8** %T.Assoc.HasAssociatedType)
+// CHECK:   [[T2:%.*]] = call %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %T.Assoc.HasAssociatedType, %swift.type* %T.Assoc, %swift.protocol_requirement* @"$s5Assoc15generic_structs17HasAssociatedTypePTl")
 // CHECK:   %T.Assoc.Assoc = extractvalue %swift.metadata_response [[T2]], 0

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -21,8 +21,8 @@ import resilient_protocol
 // -- number of witness table entries
 // CHECK-SAME:   i16 1,
 
-// -- size of private area
-// CHECK-SAME:   i16 0,
+// -- size of private area + 'needs instantiation' bit
+// CHECK-SAME:   i16 1,
 
 // -- the protocol descriptor
 // CHECK-SAME:   @"{{got.|__imp_}}$s18resilient_protocol22OtherResilientProtocolMp"
@@ -123,8 +123,8 @@ protocol InternalProtocol {
 // -- number of witness table entries
 // CHECK-SAME:   i16 1,
 
-// -- size of private area
-// CHECK-SAME:   i16 0,
+// -- size of private area + 'needs instantiation' bit
+// CHECK-SAME:   i16 1,
 
 // -- the protocol descriptor
 // CHECK-SAME:   @"{{got.|__imp_}}$s18resilient_protocol24ProtocolWithRequirementsMp"
@@ -147,7 +147,7 @@ protocol InternalProtocol {
 
 // -- type metadata for associated type
 // CHECK-SAME: @"{{got.|__imp_}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl"
-// CHECK-SAME: @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AA1TWt"
+// CHECK-SAME: @"symbolic Si"
 
 // CHECK-SAME: @"{{got.|__imp_}}$s18resilient_protocol24ProtocolWithRequirementsP5firstyyFTq"
 // CHECK-SAME: @firstWitness
@@ -160,9 +160,9 @@ protocol InternalProtocol {
 
 // Witness table for conformance with resilient associated type
 
-// CHECK: @"$s19protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWP" = {{(protected )?}}hidden constant [3 x i8*] [
+// CHECK: @"$s19protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWP" = {{(protected )?}}hidden global [3 x i8*] [
 // CHECK-SAME:   i8* bitcast (i8** ()* @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa" to i8*)
-// CHECK-SAME:   i8* bitcast (%swift.metadata_response ([[INT]])* @"$s19protocol_resilience23ResilientConformingTypeVMa" to i8*)
+// CHECK-SAME:   @"symbolic 19protocol_resilience23ResilientConformingTypeV"
 // CHECK-SAME: ]
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultC(%swift.opaque* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -12,14 +12,19 @@
 // Resilient protocol definition
 // ----------------------------------------------------------------------------
 
+// CHECK: @"default assoc type x" = linkonce_odr hidden constant
+// CHECK-SAME: i8 -1, [1 x i8] c"x", i8 0
+
+// CHECK: @"default assoc type \01____y2T118resilient_protocol29ProtocolWithAssocTypeDefaultsPQzG 18resilient_protocol7WrapperV" =
+
 // Protocol descriptor
 // CHECK-DEFINITION-LABEL: @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsMp" ={{( protected)?}} constant
 // CHECK-DEFINITION-SAME: @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0TN"
 
 // Associated type default + flags
 // CHECK-DEFINITION-SAME: [[INT]] add
-// CHECK-DEFINITION-SAME: @"symbolic \01____y2T118resilient_protocol29ProtocolWithAssocTypeDefaultsPQzG 18resilient_protocol7WrapperV"
-// CHECK-DEFINITION-SAME: [[INT]] 3
+// CHECK-DEFINITION-SAME: @"default assoc type \01____y2T118resilient_protocol29ProtocolWithAssocTypeDefaultsPQzG 18resilient_protocol7WrapperV"
+// CHECK-DEFINITION-SAME: [[INT]] 1
 
 // Protocol requirements base descriptor
 // CHECK-DEFINITION: @"$s18resilient_protocol21ResilientBaseProtocolTL" ={{( dllexport)?}}{{( protected)?}} alias %swift.protocol_requirement, getelementptr (%swift.protocol_requirement, %swift.protocol_requirement* getelementptr inbounds (<{ i32, i32, i32, i32, i32, i32, %swift.protocol_requirement }>, <{ i32, i32, i32, i32, i32, i32, %swift.protocol_requirement }>* @"$s18resilient_protocol21ResilientBaseProtocolMp", i32 0, i32 6), i32 -1)

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // Resilient protocol definition
-// RUN: %target-swift-frontend -emit-ir -enable-resilience -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift | %FileCheck -check-prefix=CHECK-DEFINITION %s
+// RUN: %target-swift-frontend -emit-ir -enable-resilience -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift | %FileCheck -DINT=i%target-ptrsize -check-prefix=CHECK-DEFINITION %s
 
 // Resilient protocol usage
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
@@ -15,6 +15,11 @@
 // Protocol descriptor
 // CHECK-DEFINITION-LABEL: @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsMp" ={{( protected)?}} constant
 // CHECK-DEFINITION-SAME: @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0TN"
+
+// Associated type default + flags
+// CHECK-DEFINITION-SAME: [[INT]] add
+// CHECK-DEFINITION-SAME: @"symbolic \01____y2T118resilient_protocol29ProtocolWithAssocTypeDefaultsPQzG 18resilient_protocol7WrapperV"
+// CHECK-DEFINITION-SAME: [[INT]] 3
 
 // Protocol requirements base descriptor
 // CHECK-DEFINITION: @"$s18resilient_protocol21ResilientBaseProtocolTL" ={{( dllexport)?}}{{( protected)?}} alias %swift.protocol_requirement, getelementptr (%swift.protocol_requirement, %swift.protocol_requirement* getelementptr inbounds (<{ i32, i32, i32, i32, i32, i32, %swift.protocol_requirement }>, <{ i32, i32, i32, i32, i32, i32, %swift.protocol_requirement }>* @"$s18resilient_protocol21ResilientBaseProtocolMp", i32 0, i32 6), i32 -1)

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -82,7 +82,7 @@ where Element: ProtocolWithRequirements, Element.T == Y {
 
 // CHECK-USAGE: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @"$s31protocol_resilience_descriptors17assocTypeMetadatay1TQzmxm010resilient_A024ProtocolWithRequirementsRzlF"(%swift.type*, %swift.type* [[PWD:%.*]], i8** [[WTABLE:%.*]])
 public func assocTypeMetadata<PWR: ProtocolWithRequirements>(_: PWR.Type) -> PWR.T.Type {
-  // CHECK-USAGE: call %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %PWR.ProtocolWithRequirements, %swift.type* %PWR, %swift.protocol_requirement* @"$s1T18resilient_protocol24ProtocolWithRequirementsPTl")
+  // CHECK-USAGE: call %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 0, i8** %PWR.ProtocolWithRequirements, %swift.type* %PWR, %swift.protocol_requirement* @"$s1T18resilient_protocol24ProtocolWithRequirementsPTl")
   return PWR.T.self
 }
 
@@ -90,7 +90,7 @@ func useOtherResilientProtocol<T: OtherResilientProtocol>(_: T.Type) { }
 
 // CHECK-USAGE: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s31protocol_resilience_descriptors23extractAssocConformanceyyx010resilient_A0012ProtocolWithE12TypeDefaultsRzlF"
 public func extractAssocConformance<T: ProtocolWithAssocTypeDefaults>(_: T) {
-  // CHECK-USAGE: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.ProtocolWithAssocTypeDefaults, i64 udiv (i64 sub (i64 ptrtoint (%swift.protocol_requirement* @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0Tn" to i64), i64 ptrtoint (%swift.protocol_requirement* @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsTL" to i64)), i64 8)
+  // CHECK-USAGE: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.ProtocolWithAssocTypeDefaults, [[INT]] udiv ([[INT]] sub ([[INT]] ptrtoint (%swift.protocol_requirement* @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0Tn" to [[INT]]), [[INT]] ptrtoint (%swift.protocol_requirement* @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsTL" to [[INT]])), [[INT]] 8)
   // CHECK-USAGE: load i8*, i8** [[WITNESS_ADDR]]
   useOtherResilientProtocol(T.T2.self)
 }

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -15,8 +15,6 @@
 // Protocol descriptor
 // CHECK-DEFINITION-LABEL: @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsMp" ={{( protected)?}} constant
 // CHECK-DEFINITION-SAME: @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0TN"
-// CHECK-DEFINITION-SAME: $s2T118resilient_protocol29ProtocolWithAssocTypeDefaultsPTM
-// CHECK-DEFINITION-SAME: $s2T218resilient_protocol29ProtocolWithAssocTypeDefaultsPTM
 
 // Protocol requirements base descriptor
 // CHECK-DEFINITION: @"$s18resilient_protocol21ResilientBaseProtocolTL" ={{( dllexport)?}}{{( protected)?}} alias %swift.protocol_requirement, getelementptr (%swift.protocol_requirement, %swift.protocol_requirement* getelementptr inbounds (<{ i32, i32, i32, i32, i32, i32, %swift.protocol_requirement }>, <{ i32, i32, i32, i32, i32, i32, %swift.protocol_requirement }>* @"$s18resilient_protocol21ResilientBaseProtocolMp", i32 0, i32 6), i32 -1)
@@ -29,15 +27,6 @@
 // Default associated conformance witnesses
 // CHECK-DEFINITION-LABEL: define internal swiftcc i8** @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0TN"
 
-// Default associated type witnesses
-// CHECK-DEFINITION-LABEL: define internal swiftcc %swift.metadata_response @"$s2T118resilient_protocol29ProtocolWithAssocTypeDefaultsPTM"
-
-// CHECK-DEFINITION-LABEL: define internal swiftcc %swift.metadata_response @"$s2T218resilient_protocol29ProtocolWithAssocTypeDefaultsPTM"
-// CHECK-DEFINITION: getelementptr inbounds i8*, i8** [[WTABLE:%.*]], i32 2
-// CHECK-DEFINITION: call{{.*}}s18resilient_protocol7WrapperVMa
-
-// CHECK-DEFINITION-LABEL: define internal swiftcc %swift.metadata_response @"$s9AssocType18resilient_protocol20ResilientSelfDefaultPTM
-
 import resilient_protocol
 
 // ----------------------------------------------------------------------------
@@ -45,7 +34,7 @@ import resilient_protocol
 // ----------------------------------------------------------------------------
 // CHECK-USAGE-LABEL: $s31protocol_resilience_descriptors34ConformsToProtocolWithRequirementsVyxG010resilient_A00fgH0AAWr" = internal
 // CHECK-USAGE-SAME: {{got.|__imp_}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl
-// CHECK-USAGE-SAME: $s31protocol_resilience_descriptors34ConformsToProtocolWithRequirementsVyxG010resilient_A00fgH0AA1TWt
+// CHECK-USAGE-SAME: @"symbolic x"
 public struct ConformsToProtocolWithRequirements<Element>
     : ProtocolWithRequirements {
   public typealias T = Element
@@ -83,8 +72,7 @@ where Element: ProtocolWithRequirements, Element.T == Y {
 
 // CHECK-USAGE: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @"$s31protocol_resilience_descriptors17assocTypeMetadatay1TQzmxm010resilient_A024ProtocolWithRequirementsRzlF"(%swift.type*, %swift.type* [[PWD:%.*]], i8** [[WTABLE:%.*]])
 public func assocTypeMetadata<PWR: ProtocolWithRequirements>(_: PWR.Type) -> PWR.T.Type {
-  // CHECK-USAGE: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %PWR.ProtocolWithRequirements, [[INT]] udiv ([[INT]] sub ([[INT]] ptrtoint (%swift.protocol_requirement* @"$s1T18resilient_protocol24ProtocolWithRequirementsPTl" to [[INT]]), [[INT]] ptrtoint (%swift.protocol_requirement* @"$s18resilient_protocol24ProtocolWithRequirementsTL" to [[INT]])), [[INT]] 8
-  // CHECK-USAGE: load i8*, i8** [[WITNESS_ADDR]], align {{(4|8)}}
+  // CHECK-USAGE: call %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %PWR.ProtocolWithRequirements, %swift.type* %PWR, %swift.protocol_requirement* @"$s1T18resilient_protocol24ProtocolWithRequirementsPTl")
   return PWR.T.self
 }
 
@@ -92,7 +80,7 @@ func useOtherResilientProtocol<T: OtherResilientProtocol>(_: T.Type) { }
 
 // CHECK-USAGE: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s31protocol_resilience_descriptors23extractAssocConformanceyyx010resilient_A0012ProtocolWithE12TypeDefaultsRzlF"
 public func extractAssocConformance<T: ProtocolWithAssocTypeDefaults>(_: T) {
-  // CHECK-USAGE: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.ProtocolWithAssocTypeDefaults, [[INT]] udiv ([[INT]] sub ([[INT]] ptrtoint (%swift.protocol_requirement* @"$s2T218resilient_protocol29ProtocolWithAssocTypeDefaultsPTl" to [[INT]]), [[INT]] ptrtoint (%swift.protocol_requirement* @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsTL" to [[INT]])), [[INT]] 8)
+  // CHECK-USAGE: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.ProtocolWithAssocTypeDefaults, i64 udiv (i64 sub (i64 ptrtoint (%swift.protocol_requirement* @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0Tn" to i64), i64 ptrtoint (%swift.protocol_requirement* @"$s18resilient_protocol29ProtocolWithAssocTypeDefaultsTL" to i64)), i64 8)
   // CHECK-USAGE: load i8*, i8** [[WITNESS_ADDR]]
   useOtherResilientProtocol(T.T2.self)
 }

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -16,7 +16,6 @@
 // STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_fieldmd|.sw5flmd\$B}}
 // STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_assocty|.sw5asty\$B}}
 // STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_capture|.sw5cptr\$B}}
-// STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_typeref|.sw5tyrf\$B}}
 // STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_reflstr|.sw5rfst\$B}}
 // STRIP_REFLECTION_METADATA-NOT: section "{{[^"]*swift5_builtin|.sw5bltn\$B}}
 

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -41,13 +41,13 @@ struct Conformer: Q, QQ {
 // CHECK:   i8* bitcast ([5 x i8*]* [[CONFORMER_P_WITNESS_TABLE:@"\$s18sil_witness_tables9ConformerVAA1PAAWP"]] to i8*),
 // CHECK:   i8* bitcast (void (%T18sil_witness_tables9ConformerV*, %swift.type*, i8**)* @"$s18sil_witness_tables9ConformerVAA1QA2aDP7qMethod{{[_0-9a-zA-Z]*}}FTW" to i8*)
 // CHECK: ]
-// CHECK: [[CONFORMER_P_WITNESS_TABLE]] = hidden constant [5 x i8*] [
+// CHECK: [[CONFORMER_P_WITNESS_TABLE]] = hidden global [5 x i8*] [
 // CHECK:   i8* bitcast (i8** ()* @"$s18sil_witness_tables14AssocConformerVAA1AAAWa" to i8*)
-// CHECK:   i8* bitcast (%swift.metadata_response (i64)* @"$s18sil_witness_tables14AssocConformerVMa" to i8*)
+// CHECK:   "symbolic 18sil_witness_tables14AssocConformerV"
 // CHECK:   i8* bitcast (void (%swift.type*, %swift.type*, i8**)* @"$s18sil_witness_tables9ConformerVAA1PA2aDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW" to i8*),
 // CHECK:   i8* bitcast (void (%T18sil_witness_tables9ConformerV*, %swift.type*, i8**)* @"$s18sil_witness_tables9ConformerVAA1PA2aDP14instanceMethod{{[_0-9a-zA-Z]*}}FTW" to i8*)
 // CHECK: ]
-// CHECK: [[CONFORMER2_P_WITNESS_TABLE:@"\$s18sil_witness_tables10Conformer2VAA1PAAWP"]] = hidden constant [5 x i8*]
+// CHECK: [[CONFORMER2_P_WITNESS_TABLE:@"\$s18sil_witness_tables10Conformer2VAA1PAAWP"]] = hidden global [5 x i8*]
 
 struct Conformer2: Q {
   typealias Assoc = AssocConformer
@@ -75,6 +75,3 @@ func externalErasure(c: ExternalConformer) -> ExternalP {
 
 // CHECK-LABEL: define hidden swiftcc %swift.metadata_response @"$s18sil_witness_tables14AssocConformerVMa"(i64)
 // CHECK:         ret %swift.metadata_response { %swift.type* bitcast (i64* getelementptr inbounds {{.*}} @"$s18sil_witness_tables14AssocConformerVMf", i32 0, i32 1) to %swift.type*), i64 0 }
-
-// CHECK-LABEL: define hidden i8** @"$s18sil_witness_tables9ConformerVAA1PAAWa"()
-// CHECK:         ret i8** getelementptr inbounds ([5 x i8*], [5 x i8*]* @"$s18sil_witness_tables9ConformerVAA1PAAWP", i32 0, i32 0)

--- a/test/IRGen/witness_table_indirect_conformances.swift
+++ b/test/IRGen/witness_table_indirect_conformances.swift
@@ -30,10 +30,10 @@ struct Z: P2 {
 	func getAssocP2() -> Y { return Y() }
 }
 
-// CHECK: @"$s35witness_table_indirect_conformances1WVAA2P3AAWP" = hidden constant [5 x i8*] [
+// CHECK: @"$s35witness_table_indirect_conformances1WVAA2P3AAWP" = hidden global [5 x i8*] [
 // CHECK-SAME: @"$s35witness_table_indirect_conformances1WVAA2P3AAMc"
 // CHECK-SAME: i8* bitcast (i8** ()* @"$s35witness_table_indirect_conformances1YVAA1QAAWa" to i8*),
-// CHECK-SAME: i8* bitcast (%swift.metadata_response ([[INT]])* @"$s35witness_table_indirect_conformances1ZVMa" to i8*),
+// CHECK-SAME: @"symbolic 35witness_table_indirect_conformances1ZV"
 // CHECK-SAME: i8* bitcast (void (%T35witness_table_indirect_conformances1ZV*, %T35witness_table_indirect_conformances1WV*, %swift.type*, i8**)* @"$s35witness_table_indirect_conformances1WVAA2P3A2aDP08getAssocE00gE0QzyFTW" to i8*)]
 struct W: P3 {
 	typealias AssocP3 = Z

--- a/test/IRGen/witness_table_objc_associated_type.swift
+++ b/test/IRGen/witness_table_objc_associated_type.swift
@@ -19,9 +19,9 @@ struct SB: B {
   typealias AA = SA
   func foo() {}
 }
-// CHECK-LABEL: @"$s34witness_table_objc_associated_type2SBVAA1BAAWP" = hidden constant [4 x i8*] [
+// CHECK-LABEL: @"$s34witness_table_objc_associated_type2SBVAA1BAAWP" = hidden global [4 x i8*] [
 // CHECK:         i8* bitcast (i8** ()* @"$s34witness_table_objc_associated_type2SAVAA1AAAWa" to i8*)
-// CHECK:         i8* bitcast (%swift.metadata_response ([[INT]])* @"$s34witness_table_objc_associated_type2SAVMa" to i8*)
+// CHECK:         @"symbolic 34witness_table_objc_associated_type2SAV"
 // CHECK:         i8* bitcast {{.*}} @"$s34witness_table_objc_associated_type2SBVAA1BA2aDP3fooyyFTW"
 // CHECK:       ]
 
@@ -30,8 +30,8 @@ struct SO: C {
   typealias OO = CO
   func foo() {}
 }
-// CHECK-LABEL: @"$s34witness_table_objc_associated_type2SOVAA1CAAWP" = hidden constant [3 x i8*] [
-// CHECK:         i8* bitcast (%swift.metadata_response ([[INT]])* @"$s34witness_table_objc_associated_type2COCMa" to i8*)
+// CHECK-LABEL: @"$s34witness_table_objc_associated_type2SOVAA1CAAWP" = hidden global [3 x i8*] [
+// CHECK:         @"symbolic 34witness_table_objc_associated_type2COC"
 // CHECK:         i8* bitcast {{.*}} @"$s34witness_table_objc_associated_type2SOVAA1CA2aDP3fooyyFTW"
 // CHECK:       ]
 

--- a/test/Inputs/conditional_conformance_recursive.swift
+++ b/test/Inputs/conditional_conformance_recursive.swift
@@ -28,24 +28,3 @@ extension Wrapper: P3 where T: P3 { }
 // CHECK: [[CONDITIONAL_REQ_BUFFER:%.*]] = alloca [1 x i8**]
 // CHECK: [[FIRST_REQ:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* [[CONDITIONAL_REQ_BUFFER]]
 // CHECK: call i8** @"$s33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrlWa"(%swift.type* [[WRAPPER_TO_A:%.*]], i8*** [[FIRST_REQ]])
-
-// associated type metadata accessor for B in Wrapper<T>: P2
-// CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrl1BWt"
-// CHECK:   [[T_TO_P2_PTR:%.*]] = getelementptr inbounds i8*, i8** [[WRAPPER_T_TO_P2:%.*]], i32 -1
-// CHECK:   [[T_TO_P2_VAL:%.*]] = load i8*, i8** [[T_TO_P2_PTR]]
-// CHECK:   [[T_TO_P2:%.*]] = bitcast i8* [[T_TO_P2_VAL]] to i8**
-// CHECK:   [[T_TO_P1_VAL_GEP:%.*]] = getelementptr inbounds i8*, i8** [[T_TO_P2]], i32 1
-// CHECK:   [[T_TO_P1_VAL:%.*]] = load i8*, i8** [[T_TO_P1_VAL_GEP]]
-// CHECK:   [[T_TO_P1:%.*]] = bitcast i8* [[T_TO_P1_VAL]] to i8**
-// CHECK:   [[WRAPPER_T_TYPE:%.*]] = bitcast %swift.type* [[WRAPPER_T:%.*]] to %swift.type**
-// CHECK:   [[T_TYPE_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[WRAPPER_T_TYPE]], i64 2
-// CHECK:   [[T_TYPE:%.*]] = load %swift.type*, %swift.type** [[T_TYPE_PTR]]
-// CHECK:   [[T_B_TYPE_ACCESSOR_PTR_GEP:%.*]] = getelementptr inbounds i8*, i8** [[T_TO_P1]], i32 2
-// CHECK:   [[T_B_TYPE_ACCESSOR_PTR:%.*]] = load i8*, i8** [[T_B_TYPE_ACCESSOR_PTR_GEP]], align 8
-// CHECK:   [[T_B_TYPE_ACCESSOR:%.*]] = bitcast i8* [[T_B_TYPE_ACCESSOR_PTR]] to %swift.metadata_response (i64, %swift.type*, i8**)*
-// CHECK:   [[T_A_TYPE:%.*]] = call swiftcc %swift.metadata_response [[T_B_TYPE_ACCESSOR]](i64 %0, %swift.type* [[T_TYPE]], i8** [[T_TO_P1]])
-// CHECK:   [[T0:%.*]] = extractvalue %swift.metadata_response [[T_A_TYPE]], 0
-// CHECK:   [[T1:%.*]] = extractvalue %swift.metadata_response [[T_A_TYPE]], 1
-// CHECK:   [[T2:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[T0]], 0
-// CHECK:   [[T3:%.*]] = insertvalue %swift.metadata_response [[T2]], i64 [[T1]], 1
-// CHECK:   ret %swift.metadata_response [[T3]]

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -818,7 +818,7 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
   // and an initializer, so we must instantiate.
   {
     tableStorage2.WitnessTableSizeInWords = 7;
-    tableStorage2.WitnessTablePrivateSizeInWords = 1 + 1;
+    tableStorage2.WitnessTablePrivateSizeInWords = (1 + 1) << 1;
     initializeRelativePointer(&tableStorage2.Protocol, &testProtocol.descriptor);
     initializeRelativePointer(&tableStorage2.Pattern, witnesses);
     initializeRelativePointer(&tableStorage2.Instantiator,


### PR DESCRIPTION
Rather than storing associated type metadata access functions in
witness tables, initially store a pointer to a mangled type name.
On first access, demangle that type name and replace the witness
table entry with the resulting type metadata.

This reduces the code size of protocol conformances, because we no
longer need to create associated type metadata access functions for
every associated type, and the mangled names are much smaller (and
sharable). The same code size improvements apply to defaulted
associated types for resilient protocols, although those are more
rare. Witness tables themselves are slightly smaller, because we
don’t need separate private entries in them to act as caches.

On the caller side, associated type metadata is always produced via
a call to swift_getAssociatedTypeWitness(), which handles the demangling
and caching behavior.

In all, this reduces the size of the standard library by ~70k. There
are additional code-size wins that are possible with follow-on work:

* We can stop emitting type metadata access functions for non-resilient
types that have constant metadata (like `Int`), because they’re only
currently used as associated type metadata access functions.
* We can stop emitting separate associated type reflection metadata,
because the reflection infrastructure can use these mangled names
directly.