### PR TITLE
[WIP] [android] Duplicate arm64 checks for aarch64.

### DIFF
--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -52,3 +52,13 @@ public func use_global() -> Int {
 // arm64-NEXT:    bl _swift_beginAccess
 // arm64-NEXT:    ldr [[REG2:x[0-9]+]], {{\[}}sp, #16{{\]}}
 // arm64-NEXT:    ldr {{x[0-9]+}}, {{\[}}[[REG2]]{{\]}}
+
+// aarch64-LABEL: {{_?}}$s4main10use_globalSiyF:
+// aarch64:         adrp [[REG1:x[0-9]+]], _$s4main6globalSivp@PAGE
+// aarch64:         add [[REG1]], [[REG1]], _$s4main6globalSivp@PAGEOFF
+// This is a spill around beginAccess that is not strictly necessary.
+// aarch64:         str [[REG1]], {{\[}}sp, #16{{\]}}
+// aarch64-NEXT:    str
+// aarch64-NEXT:    bl _swift_beginAccess
+// aarch64-NEXT:    ldr [[REG2:x[0-9]+]], {{\[}}sp, #16{{\]}}
+// aarch64-NEXT:    ldr {{x[0-9]+}}, {{\[}}[[REG2]]{{\]}}


### PR DESCRIPTION
This test still fails. The adrp instructions generated are not the ones
that are expected.

This is the output and the differences with the expected results:

```
	adrp	x8, ($s4main6globalSivp) // EXPECTED: adrp x8, _$s4main6globalSivp@PAGE
	add	x8, x8, :lo12:($s4main6globalSivp) // EXPECTED: add x8, x8, _$s4main6globalSivp@PAGEOFF
	mov	x0, x8
	orr	x2, xzr, #0x20
	mov	x9, #0
	add	x10, sp, #24
	mov	x1, x10
	mov	x3, x9
	str	x8, [sp, #16]
	str	x10, [sp, #8]
	bl	swift_beginAccess // EXPECTED: bl _swift_beginAccess
	ldr	x8, [sp, #16]
	ldr	x0, [x8]
```