### PR TITLE
stdlib: fix ThreadLocalStorage builds for Windows

### DIFF
--- a/stdlib/public/stubs/ThreadLocalStorage.cpp
+++ b/stdlib/public/stubs/ThreadLocalStorage.cpp
@@ -23,15 +23,13 @@ void _stdlib_destroyTLS(void *);
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 void *_stdlib_createTLS(void);
 
-#ifndef SWIFT_THREAD_GETSPECIFIC
+#if defined(_WIN32) && !defined(__CYGWIN__)
 
-# if defined(_WIN32) && !defined(__CYGWIN__)
-
-#  if defined(_M_IX86)
-typedef __stdcall void (*__swift_thread_key_destructor)(void *);
-#  else
-typedef void (*__swift_thread_key_destructor)(void *);
-#  endif
+typedef
+#if defined(_M_IX86)
+__stdcall
+#endif
+void (*__swift_thread_key_destructor)(void *);
 
 static void
 #if defined(_M_IX86)
@@ -47,8 +45,6 @@ _stdlib_thread_key_create(__swift_thread_key_t * _Nonnull key,
   *key = FlsAlloc(destroyTLS_CCAdjustmentThunk);
   return *key != FLS_OUT_OF_INDEXES;
 }
-
-# endif
 
 #endif
 


### PR DESCRIPTION
Due to the build ordering, I didn't notice this earlier.  The inclusion
of the header would define the guard, preventing the needed definitions.
Unconditionally define the functions to ensure that they are available.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
