### PR TITLE
[ConstraintSystem] [NFC] Clean up type variables for closure parameters.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -629,20 +629,6 @@ namespace {
                               /*isDynamic=*/false);
       }
 
-      auto type = solution.simplifyType(openedType);
-
-      // If we've ended up trying to assign an inout type here, it means we're
-      // missing an ampersand in front of the ref.
-      //
-      // FIXME: This is the wrong place for this diagnostic.
-      if (auto inoutType = type->getAs<InOutType>()) {
-        auto &tc = cs.getTypeChecker();
-        tc.diagnose(loc.getBaseNameLoc(), diag::missing_address_of,
-                    inoutType->getInOutObjectType())
-          .fixItInsert(loc.getBaseNameLoc(), "&");
-        return nullptr;
-      }
-
       SubstitutionMap substitutions;
 
       // Due to a SILGen quirk, unqualified property references do not
@@ -654,6 +640,7 @@ namespace {
             locator);
       }
 
+      auto type = solution.simplifyType(openedType);
       auto declRefExpr =
         new (ctx) DeclRefExpr(ConcreteDeclRef(decl, substitutions),
                               loc, implicit, semantics, type);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -366,6 +366,11 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
       return None;
   }
 
+  if (type->is<InOutType>() && !typeVar->getImpl().canBindToInOut())
+    type = LValueType::get(type->getInOutObjectType());
+  if (type->is<LValueType>() && !typeVar->getImpl().canBindToLValue())
+    type = type->getRValueType();
+
   // BindParam constraints are not reflexive and must be treated specially.
   if (constraint->getKind() == ConstraintKind::BindParam) {
     if (kind == AllowedBindingKind::Subtypes) {
@@ -869,8 +874,6 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
 
     type = cs.openUnboundGenericType(UGT, locator);
     type = type->reconstituteSugar(/*recursive=*/false);
-  } else if (type->is<InOutType>() && !TypeVar->getImpl().canBindToInOut()) {
-    type = LValueType::get(type->getInOutObjectType());
   }
 
   // FIXME: We want the locator that indicates where the binding came

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -869,6 +869,8 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
 
     type = cs.openUnboundGenericType(UGT, locator);
     type = type->reconstituteSugar(/*recursive=*/false);
+  } else if (type->is<InOutType>() && !TypeVar->getImpl().canBindToInOut()) {
+    type = LValueType::get(type->getInOutObjectType());
   }
 
   // FIXME: We want the locator that indicates where the binding came

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6308,20 +6308,6 @@ bool FailureDiagnosis::diagnoseClosureExpr(
     // Coerce parameter types here only if there are no unresolved
     if (CS.TC.coerceParameterListToType(params, CE, fnType))
       return true;
-
-    for (auto param : *params) {
-      auto paramType = param->getType();
-      // If this is unresolved 'inout' parameter, it's better to drop
-      // 'inout' from type because that might help to diagnose actual problem
-      // e.g. type inference doesn't give us much information anyway.
-      if (param->isInOut() && paramType->hasUnresolvedType()) {
-        assert(!param->isImmutable() || !paramType->is<InOutType>());
-        param->setType(CS.getASTContext().TheUnresolvedType);
-        param->setInterfaceType(paramType->getInOutObjectType());
-        param->setSpecifier(swift::VarDecl::Specifier::Default);
-      }
-    }
-
     expectedResultType = fnType->getResult();
   }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2054,8 +2054,6 @@ namespace {
           // FIXME: Need a better locator for a pattern as a base.
           paramType = CS.openUnboundGenericType(type, locator);
           internalType = paramType;
-          if (param->isInOut())
-            internalType = LValueType::get(internalType);
         } else {
           // Otherwise, create fresh type variables.
           paramType = CS.createTypeVariable(locator, TVO_CanBindToInOut);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -977,26 +977,6 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
 
   assert(!valueType->hasUnboundGenericType() &&
          !valueType->hasTypeParameter());
-
-  // If this is a let-param whose type is a type variable, this is an untyped
-  // closure param that may be bound to an inout type later. References to the
-  // param should have lvalue type instead. Express the relationship with a new
-  // constraint.
-  if (auto *param = dyn_cast<ParamDecl>(varDecl)) {
-    if (param->isLet() && valueType->is<TypeVariableType>()) {
-      auto found = OpenedParameterTypes.find(param);
-      if (found != OpenedParameterTypes.end())
-        return { found->second, found->second };
-
-      auto typeVar = createTypeVariable(getConstraintLocator(locator),
-                                        TVO_CanBindToLValue);
-      addConstraint(ConstraintKind::BindParam, valueType, typeVar,
-                    getConstraintLocator(locator));
-      OpenedParameterTypes.insert(std::make_pair(param, typeVar));
-      return { typeVar, typeVar };
-    }
-  }
-
   return { valueType, valueType };
 }
 


### PR DESCRIPTION
Previously we were sharing a single type variable for a param of a closure's function type and the paramDecl's type inside the closure itself. With inout parameters this caused vardecls of inout type and then several hacks to deal with them.

Instead, create two TVs and constrain them appropriately.
