### PR TITLE
[stdlib] Finalize one-shot hashing interface

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2378,7 +2378,7 @@ public func checkHashable<Instances: Collection>(
           """,
           stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
         expectEqual(
-          x._rawHashValue(seed: (0, 0)), y._rawHashValue(seed: (0, 0)),
+          x._rawHashValue(seed: 0), y._rawHashValue(seed: 0),
           """
           _rawHashValue expected to match, found to differ
           lhs (at index \(i)): \(x)
@@ -2399,8 +2399,8 @@ public func checkHashable<Instances: Collection>(
           """,
           stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
         expectTrue(
-          (0..<10 as Range<UInt64>).contains { i in
-            x._rawHashValue(seed: (0, i)) != y._rawHashValue(seed: (0, i))
+          (0..<10).contains { i in
+            x._rawHashValue(seed: i) != y._rawHashValue(seed: i)
           },
           """
           _rawHashValue(seed:) expected to differ, found to match

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -240,7 +240,7 @@ extension NSObject : Equatable, Hashable {
     hasher.combine(hashValue)
   }
 
-  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  public func _rawHashValue(seed: Int) -> Int {
     // FIXME: We should use self.hash here, but hashValue is currently
     // overridable.
     return self.hashValue._rawHashValue(seed: seed)

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -44,8 +44,7 @@ struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
   __swift_intptr_t scale;
-  __swift_uint64_t seed0;
-  __swift_uint64_t seed1;
+  __swift_intptr_t seed;
   void *rawKeys;
   void *rawValues;
 };
@@ -54,8 +53,7 @@ struct _SwiftSetBodyStorage {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
   __swift_intptr_t scale;
-  __swift_uint64_t seed0;
-  __swift_uint64_t seed1;
+  __swift_intptr_t seed;
   void *rawElements;
 };
 

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -49,7 +49,7 @@ internal protocol _AnyHashableBox {
   func _isEqual(to box: _AnyHashableBox) -> Bool?
   var _hashValue: Int { get }
   func _hash(into hasher: inout Hasher)
-  func _rawHashValue(_seed: (UInt64, UInt64)) -> Int
+  func _rawHashValue(_seed: Int) -> Int
 
   var _base: Any { get }
   func _unbox<T: Hashable>() -> T?
@@ -97,7 +97,7 @@ internal struct _ConcreteHashableBox<Base : Hashable> : _AnyHashableBox {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  func _rawHashValue(_seed: (UInt64, UInt64)) -> Int {
+  func _rawHashValue(_seed: Int) -> Int {
     return _baseHashable._rawHashValue(seed: _seed)
   }
 
@@ -269,7 +269,7 @@ extension AnyHashable : Hashable {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  public func _rawHashValue(seed: Int) -> Int {
     return _box._canonicalBox._rawHashValue(_seed: seed)
   }
 }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1836,7 +1836,7 @@ internal struct _ArrayAnyHashableBox<Element: Hashable>
     }
   }
 
-  func _rawHashValue(_seed: (UInt64, UInt64)) -> Int {
+  func _rawHashValue(_seed: Int) -> Int {
     var hasher = Hasher(_seed: _seed)
     self._hash(into: &hasher)
     return hasher._finalize()

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1584,7 +1584,7 @@ internal struct _DictionaryAnyHashableBox<Key: Hashable, Value: Hashable>
     _canonical.hash(into: &hasher)
   }
 
-  internal func _rawHashValue(_seed: Hasher._Seed) -> Int {
+  internal func _rawHashValue(_seed: Int) -> Int {
     return _canonical._rawHashValue(seed: _seed)
   }
 

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -44,7 +44,7 @@ internal class _RawDictionaryStorage: _SwiftNativeNSDictionary {
   internal final var _scale: Int
 
   @usableFromInline
-  internal final var _seed: Hasher._Seed
+  internal final var _seed: Int
 
   @usableFromInline
   @nonobjc
@@ -287,9 +287,8 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
     // FIXME: Use true per-instance seeding instead. Per-capacity seeding still
     // leaves hash values the same in same-sized tables, which may affect
     // operations on two tables at once. (E.g., union.)
-    storage._seed = (
-      Hasher._seed.0 ^ UInt64(truncatingIfNeeded: scale),
-      Hasher._seed.1)
+    storage._seed = scale
+
     // Initialize hash table metadata.
     storage._hashTable.clear()
     return storage

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1519,7 +1519,7 @@ extension ${Self} : Hashable {
   }
 
   @inlinable
-  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  public func _rawHashValue(seed: Int) -> Int {
     // To satisfy the axiom that equality implies hash equality, we need to
     // finesse the hash value of -0.0 to match +0.0.
     let v = isZero ? 0 : self
@@ -1839,7 +1839,7 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
   }
 
   internal var _hashValue: Int {
-    return _rawHashValue(_seed: Hasher._seed)
+    return _rawHashValue(_seed: 0)
   }
 
   internal func _hash(into hasher: inout Hasher) {
@@ -1848,7 +1848,7 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
     hasher.combine(_value)
   }
 
-  internal func _rawHashValue(_seed: (UInt64, UInt64)) -> Int {
+  internal func _rawHashValue(_seed: Int) -> Int {
     var hasher = Hasher(_seed: _seed)
     _hash(into: &hasher)
     return hasher.finalize()

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -126,17 +126,13 @@ public protocol Hashable : Equatable {
   // Raw top-level hashing interface. Some standard library types (mostly
   // primitives) specialize this to eliminate small resiliency overheads. (This
   // only matters for tiny keys.)
-  //
-  // FIXME(hasher): Change to take a Hasher instead. To achieve the same
-  // performance, this requires Set and Dictionary to store their fully
-  // initialized local hashers, not just their seeds.
-  func _rawHashValue(seed: (UInt64, UInt64)) -> Int
+  func _rawHashValue(seed: Int) -> Int
 }
 
 extension Hashable {
   @inlinable
   @inline(__always)
-  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  public func _rawHashValue(seed: Int) -> Int {
     var hasher = Hasher(_seed: seed)
     hasher.combine(self)
     return hasher._finalize()
@@ -147,7 +143,7 @@ extension Hashable {
 @inlinable
 @inline(__always)
 public func _hashValue<H: Hashable>(for value: H) -> Int {
-  return value._rawHashValue(seed: Hasher._seed)
+  return value._rawHashValue(seed: 0)
 }
 
 // Called by the SwiftValue implementation.

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -20,20 +20,27 @@ import SwiftShims
 // rdar://problem/38549901
 @usableFromInline
 internal protocol _HasherCore {
-  init(seed: Hasher._Seed)
+  init(rawSeed: (UInt64, UInt64))
   mutating func compress(_ value: UInt64)
   mutating func finalize(tailAndByteCount: UInt64) -> UInt64
+}
 
-  // FIXME(hasher): Remove once one-shot hashing has a hasher parameter.
-  /// Generate a seed value from the current state of this hasher.
-  ///
-  /// Note that the returned value is not same as the seed that was used to
-  /// initialize the hasher.
-  ///
-  /// This comes handy when type's _hash(into:) implementation needs to perform
-  /// one-shot hashing for some of its components. (E.g., for commutative
-  /// hashing.)
-  func _generateSeed() -> Hasher._Seed
+extension _HasherCore {
+  @inline(__always)
+  internal init() {
+    self.init(rawSeed: Hasher._executionSeed)
+  }
+
+  @inline(__always)
+  internal init(seed: Int) {
+    let executionSeed = Hasher._executionSeed
+    // Prevent sign-extending the supplied seed; this makes testing slightly
+    // easier.
+    let seed = UInt(bitPattern: seed)
+    self.init(rawSeed: (
+      executionSeed.0 ^ UInt64(truncatingIfNeeded: seed),
+      executionSeed.1))
+  }
 }
 
 @inline(__always)
@@ -155,14 +162,24 @@ internal struct _HasherTailBuffer {
 // FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
 // rdar://problem/38549901
 @usableFromInline @_fixed_layout
-internal struct _BufferingHasher<Core: _HasherCore> {
+internal struct _BufferingHasher<RawCore: _HasherCore> {
   private var _buffer: _HasherTailBuffer
-  private var _core: Core
+  private var _core: RawCore
 
   @inline(__always)
-  internal init(seed: Hasher._Seed) {
+  internal init(core: RawCore) {
     self._buffer = _HasherTailBuffer()
-    self._core = Core(seed: seed)
+    self._core = core
+  }
+
+  @inline(__always)
+  internal init() {
+    self.init(core: RawCore())
+  }
+
+  @inline(__always)
+  internal init(seed: Int) {
+    self.init(core: RawCore(seed: seed))
   }
 
   @inline(__always)
@@ -249,13 +266,6 @@ internal struct _BufferingHasher<Core: _HasherCore> {
     }
   }
 
-  // Generate a seed value from the current state of this hasher.
-  // FIXME(hasher): Remove
-  @inline(__always)
-  internal func _generateSeed() -> Hasher._Seed {
-    return _core._generateSeed()
-  }
-
   @inline(__always)
   internal mutating func finalize() -> UInt64 {
     return _core.finalize(tailAndByteCount: _buffer.value)
@@ -296,9 +306,6 @@ public struct Hasher {
   @usableFromInline
   internal typealias Core = _BufferingHasher<RawCore>
 
-  @usableFromInline
-  internal typealias _Seed = (UInt64, UInt64)
-
   internal var _core: Core
 
   /// Creates a new hasher.
@@ -307,14 +314,22 @@ public struct Hasher {
   /// startup, usually from a high-quality random source.
   @_effects(releasenone)
   public init() {
-    self._core = Core(seed: Hasher._seed)
+    self._core = Core()
   }
 
   /// Initialize a new hasher using the specified seed value.
+  /// The provided seed is mixed in with the global execution seed.
   @usableFromInline
   @_effects(releasenone)
-  internal init(_seed seed: _Seed) {
-    self._core = Core(seed: seed)
+  internal init(_seed: Int) {
+    self._core = Core(seed: _seed)
+  }
+
+  /// Initialize a new hasher using the specified seed value.
+  @usableFromInline // @testable
+  @_effects(releasenone)
+  internal init(_rawSeed: (UInt64, UInt64)) {
+    self._core = Core(core: RawCore(rawSeed: _rawSeed))
   }
 
   /// Indicates whether we're running in an environment where hashing needs to
@@ -333,8 +348,8 @@ public struct Hasher {
 
   /// The 128-bit hash seed used to initialize the hasher state. Initialized
   /// once during process startup.
-  @inlinable
-  internal static var _seed: _Seed {
+  @inlinable // @testable
+  internal static var _executionSeed: (UInt64, UInt64) {
     @inline(__always)
     get {
       // The seed itself is defined in C++ code so that it is initialized during
@@ -427,17 +442,9 @@ public struct Hasher {
     return Int(truncatingIfNeeded: core.finalize())
   }
 
-  // Generate a seed value from the current state of this hasher.
-  // FIXME(hasher): Remove
   @_effects(readnone)
   @usableFromInline
-  internal func _generateSeed() -> Hasher._Seed {
-    return _core._generateSeed()
-  }
-
-  @_effects(readnone)
-  @usableFromInline
-  internal static func _hash(seed: _Seed, _ value: UInt64) -> Int {
+  internal static func _hash(seed: Int, _ value: UInt64) -> Int {
     var core = RawCore(seed: seed)
     core.compress(value)
     let tbc = _HasherTailBuffer(tail: 0, byteCount: 8)
@@ -446,7 +453,7 @@ public struct Hasher {
 
   @_effects(readnone)
   @usableFromInline
-  internal static func _hash(seed: _Seed, _ value: UInt) -> Int {
+  internal static func _hash(seed: Int, _ value: UInt) -> Int {
     var core = RawCore(seed: seed)
 #if arch(i386) || arch(arm)
     _sanityCheck(UInt.bitWidth < UInt64.bitWidth)
@@ -464,7 +471,7 @@ public struct Hasher {
   @_effects(readnone)
   @usableFromInline
   internal static func _hash(
-    seed: _Seed,
+    seed: Int,
     bytes value: UInt64,
     count: Int) -> Int {
     _sanityCheck(count >= 0 && count < 8)
@@ -476,7 +483,7 @@ public struct Hasher {
   @_effects(readnone)
   @usableFromInline
   internal static func _hash(
-    seed: _Seed,
+    seed: Int,
     bytes: UnsafeRawBufferPointer) -> Int {
     var core = Core(seed: seed)
     core.combine(bytes: bytes)

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1673,7 +1673,7 @@ extension ${Self} : Hashable {
   }
 
   @inlinable
-  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  public func _rawHashValue(seed: Int) -> Int {
     % if bits == 64:
     return Hasher._hash(seed: seed, UInt64(_value))
     % elif bits == word_bits:
@@ -1905,7 +1905,7 @@ internal struct _IntegerAnyHashableBox<
     _value.hash(into: &hasher)
   }
 
-  internal func _rawHashValue(_seed: (UInt64, UInt64)) -> Int {
+  internal func _rawHashValue(_seed: Int) -> Int {
     _sanityCheck(Base.self == UInt64.self || Base.self == Int64.self,
       "self isn't canonical")
     return _value._rawHashValue(seed: _seed)

--- a/stdlib/public/core/NewtypeWrapper.swift
+++ b/stdlib/public/core/NewtypeWrapper.swift
@@ -34,7 +34,7 @@ extension _SwiftNewtypeWrapper where Self: Hashable, Self.RawValue: Hashable {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  public func _rawHashValue(seed: Int) -> Int {
     return rawValue._rawHashValue(seed: seed)
   }
 }
@@ -75,7 +75,7 @@ where Base: _SwiftNewtypeWrapper & Hashable, Base.RawValue: Hashable {
     _preconditionFailure("_hash(into:) called on non-canonical AnyHashable box")
   }
 
-  func _rawHashValue(_seed: (UInt64, UInt64)) -> Int {
+  func _rawHashValue(_seed: Int) -> Int {
     _preconditionFailure("_rawHashValue(_seed:) called on non-canonical AnyHashable box")
   }
 

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -236,7 +236,7 @@ extension _Pointer /*: Hashable */ {
   }
 
   @inlinable
-  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  public func _rawHashValue(seed: Int) -> Int {
     return Hasher._hash(seed: seed, UInt(bitPattern: self))
   }
 }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -464,8 +464,15 @@ extension Set: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
     // FIXME(ABI)#177: <rdar://problem/18915294> Cache Set<T> hashValue
+
+    // Generate a seed from a snapshot of the hasher.  This makes members' hash
+    // values depend on the state of the hasher, which improves hashing
+    // quality. (E.g., it makes it possible to resolve collisions by passing in
+    // a different hasher.)
+    var copy = hasher
+    let seed = copy._finalize()
+
     var hash = 0
-    let seed = hasher._generateSeed()
     for member in self {
       hash ^= member._rawHashValue(seed: seed)
     }
@@ -511,7 +518,7 @@ internal struct _SetAnyHashableBox<Element: Hashable>: _AnyHashableBox {
     _canonical.hash(into: &hasher)
   }
 
-  internal func _rawHashValue(_seed: Hasher._Seed) -> Int {
+  internal func _rawHashValue(_seed: Int) -> Int {
     return _canonical._rawHashValue(seed: _seed)
   }
 

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -44,7 +44,7 @@ internal class _RawSetStorage: _SwiftNativeNSSet {
   internal final var _scale: Int
 
   @usableFromInline
-  internal final var _seed: Hasher._Seed
+  internal final var _seed: Int
 
   @usableFromInline
   @nonobjc
@@ -311,9 +311,7 @@ extension _SetStorage {
     // FIXME: Use true per-instance seeding instead. Per-capacity seeding still
     // leaves hash values the same in same-sized tables, which may affect
     // operations on two tables at once. (E.g., union.)
-    storage._seed = (
-      Hasher._seed.0 ^ UInt64(truncatingIfNeeded: scale),
-      Hasher._seed.1)
+    storage._seed = scale
 
     // Initialize hash table metadata.
     storage._hashTable.clear()

--- a/stdlib/public/core/SipHash.swift
+++ b/stdlib/public/core/SipHash.swift
@@ -30,11 +30,11 @@ internal struct _SipHashState {
   fileprivate var v3: UInt64 = 0x7465646279746573
 
   @inline(__always)
-  fileprivate init(seed: (UInt64, UInt64)) {
-    v3 ^= seed.1
-    v2 ^= seed.0
-    v1 ^= seed.1
-    v0 ^= seed.0
+  fileprivate init(rawSeed: (UInt64, UInt64)) {
+    v3 ^= rawSeed.1
+    v2 ^= rawSeed.0
+    v1 ^= rawSeed.1
+    v0 ^= rawSeed.0
   }
 
   @inline(__always)
@@ -65,11 +65,6 @@ internal struct _SipHashState {
   fileprivate func _extract() -> UInt64 {
     return v0 ^ v1 ^ v2 ^ v3
   }
-
-  @inline(__always)
-  fileprivate func _generateSeed() -> (UInt64, UInt64) {
-    return (v0 &+ v1, v2 ^ v3)
-  }
 }
 
 // FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
@@ -79,8 +74,8 @@ internal struct _SipHash13Core: _HasherCore {
   private var _state: _SipHashState
 
   @inline(__always)
-  internal init(seed: (UInt64, UInt64)) {
-    _state = _SipHashState(seed: seed)
+  internal init(rawSeed: (UInt64, UInt64)) {
+    _state = _SipHashState(rawSeed: rawSeed)
   }
 
   @inline(__always)
@@ -99,19 +94,14 @@ internal struct _SipHash13Core: _HasherCore {
     }
     return _state._extract()
   }
-
-  @inline(__always)
-  internal func _generateSeed() -> (UInt64, UInt64) {
-    return _state._generateSeed()
-  }
 }
 
 internal struct _SipHash24Core: _HasherCore {
   private var _state: _SipHashState
 
   @inline(__always)
-  internal init(seed: (UInt64, UInt64)) {
-    _state = _SipHashState(seed: seed)
+  internal init(rawSeed: (UInt64, UInt64)) {
+    _state = _SipHashState(rawSeed: rawSeed)
   }
 
   @inline(__always)
@@ -132,23 +122,20 @@ internal struct _SipHash24Core: _HasherCore {
     }
     return _state._extract()
   }
-
-  @inline(__always)
-  internal func _generateSeed() -> (UInt64, UInt64) {
-    return _state._generateSeed()
-  }
 }
 
 // FIXME: This type only exists to facilitate testing, and should not exist in
 // production builds.
 @usableFromInline // @testable
 internal struct _SipHash13 {
-  internal typealias Core = _BufferingHasher<_SipHash13Core>
+  internal typealias Core = _SipHash13Core
 
-  internal var _core: Core
+  internal var _core: _BufferingHasher<Core>
 
   @usableFromInline // @testable
-  internal init(_seed: (UInt64, UInt64)) { _core = Core(seed: _seed) }
+  internal init(_rawSeed: (UInt64, UInt64)) {
+    _core = _BufferingHasher(core: Core(rawSeed: _rawSeed))
+  }
   @usableFromInline // @testable
   internal mutating func _combine(_ v: UInt) { _core.combine(v) }
   @usableFromInline // @testable
@@ -178,12 +165,14 @@ internal struct _SipHash13 {
 // production builds.
 @usableFromInline // @testable
 internal struct _SipHash24 {
-  internal typealias Core = _BufferingHasher<_SipHash24Core>
+  internal typealias Core = _SipHash24Core
 
-  internal var _core: Core
+  internal var _core: _BufferingHasher<Core>
 
   @usableFromInline // @testable
-  internal init(_seed: (UInt64, UInt64)) { _core = Core(seed: _seed) }
+  internal init(_rawSeed: (UInt64, UInt64)) {
+    _core = _BufferingHasher(core: Core(rawSeed: _rawSeed))
+  }
   @usableFromInline // @testable
   internal mutating func _combine(_ v: UInt) { _core.combine(v) }
   @usableFromInline // @testable

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -50,7 +50,7 @@ extension _UnmanagedString where CodeUnit == UInt8 {
     hasher._core.combine(0xFF as UInt8) // terminator
   }
 
-  internal func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  internal func _rawHashValue(seed: Int) -> Int {
     return Hasher._hash(seed: seed, bytes: rawBuffer)
   }
 }
@@ -61,7 +61,7 @@ extension _UnmanagedString where CodeUnit == UInt16 {
     hasher._core.combine(0xFF as UInt8) // terminator
   }
 
-  internal func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  internal func _rawHashValue(seed: Int) -> Int {
     var core = Hasher.Core(seed: seed)
     self.hashUTF16(into: &core)
     return Int(truncatingIfNeeded: core.finalize())
@@ -74,7 +74,7 @@ extension _UnmanagedOpaqueString {
     hasher._core.combine(0xFF as UInt8) // terminator
   }
 
-  internal func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  internal func _rawHashValue(seed: Int) -> Int {
     var core = Hasher.Core(seed: seed)
     self.hashUTF16(into: &core)
     return Int(truncatingIfNeeded: core.finalize())
@@ -94,7 +94,7 @@ extension _SmallUTF8String {
 #endif // 64-bit
   }
 
-  internal func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  internal func _rawHashValue(seed: Int) -> Int {
 #if arch(i386) || arch(arm)
     unsupportedOn32bit()
 #else
@@ -149,7 +149,7 @@ extension _StringGuts {
 
   @_effects(releasenone) // FIXME: Is this valid in the opaque case?
   @usableFromInline
-  internal func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  internal func _rawHashValue(seed: Int) -> Int {
     if _isSmall {
       return _smallUTF8String._rawHashValue(seed: seed)
     }
@@ -166,10 +166,7 @@ extension _StringGuts {
 
   @_effects(releasenone) // FIXME: Is this valid in the opaque case?
   @usableFromInline
-  internal func _rawHashValue(
-    _ range: Range<Int>,
-    seed: (UInt64, UInt64)
-  ) -> Int {
+  internal func _rawHashValue(_ range: Range<Int>, seed: Int) -> Int {
     if _isSmall {
       return _smallUTF8String[range]._rawHashValue(seed: seed)
     }
@@ -197,7 +194,7 @@ extension String : Hashable {
   }
 
   @inlinable
-  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  public func _rawHashValue(seed: Int) -> Int {
     return _guts._rawHashValue(seed: seed)
   }
 }
@@ -214,7 +211,7 @@ extension StringProtocol {
   }
 
   @inlinable
-  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+  public func _rawHashValue(seed: Int) -> Int {
     return _wholeString._guts._rawHashValue(_encodedOffsetRange, seed: seed)
   }
 }

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -66,8 +66,7 @@ swift::_SwiftEmptyDictionarySingleton swift::_swiftEmptyDictionarySingleton = {
     0, // int count;
     0, // int capacity;                                    
     0, // int scale;
-    0, // uint64 seed0;
-    0, // uint64 seed1;
+    0, // int seed;
     (void *)1, // void* keys; (non-null garbage)
     (void *)1  // void* values; (non-null garbage)
   },
@@ -91,8 +90,7 @@ swift::_SwiftEmptySetSingleton swift::_swiftEmptySetSingleton = {
     0, // int count;
     0, // int capacity;                                    
     0, // int scale;
-    0, // uint64 seed0;
-    0, // uint64 seed1;
+    0, // int seed;
     (void *)1, // void *rawElements; (non-null garbage)
   },
 

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -27,7 +27,7 @@ enum E {
 
 // CHECK-NORMAL-LABEL:define hidden swiftcc i{{.*}} @"$s12enum_derived1EO9hashValueSivg"(i8)
 // CHECK-TESTABLE-LABEL:define{{( dllexport)?}}{{( protected)?}} swiftcc i{{.*}} @"$s12enum_derived1EO9hashValueSivg"(i8)
-// CHECK: call swiftcc void @"$ss6HasherV5_seedABs6UInt64V_AEt_tcfC"(%Ts6HasherV* {{.*}})
+// CHECK: call swiftcc void @"$ss6HasherV5_seedABSi_tcfC"(%Ts6HasherV* {{.*}})
 // CHECK: call swiftcc i{{[0-9]+}} @"$ss6HasherV9_finalizeSiyF"(%Ts6HasherV* {{.*}})
 // CHECK: ret i{{[0-9]+}} %{{[0-9]+}}
 

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -698,5 +698,5 @@ class SwiftAnyEnjoyer: NSIdLover, NSIdLoving {
 // CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics
 // CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @$sSo13GenericOptionaSHSCSH9hashValueSivgTW
 // CHECK-NEXT: method #Hashable.hash!1: {{.*}} : @$sSo13GenericOptionaSHSCSH4hash4intoys6HasherVz_tFTW
-// CHECK-NEXT: method #Hashable._rawHashValue!1: {{.*}} : @$sSo13GenericOptionaSHSCSH13_rawHashValue4seedSis6UInt64V_AFt_tFTW
+// CHECK-NEXT: method #Hashable._rawHashValue!1: {{.*}} : @$sSo13GenericOptionaSHSCSH13_rawHashValue4seedS2i_tFTW
 // CHECK-NEXT: }

--- a/test/SILGen/synthesized_conformance_enum.swift
+++ b/test/SILGen/synthesized_conformance_enum.swift
@@ -63,7 +63,7 @@ extension NoValues: CaseIterable {}
 // CHECK-NEXT:   base_protocol Equatable: <T where T : Equatable> Enum<T>: Equatable module synthesized_conformance_enum
 // CHECK-NEXT:   method #Hashable.hashValue!getter.1: <Self where Self : Hashable> (Self) -> () -> Int : @$s28synthesized_conformance_enum4EnumOyxGSHAASHRzlSH9hashValueSivgTW	// protocol witness for Hashable.hashValue.getter in conformance <A> Enum<A>
 // CHECK-NEXT:   method #Hashable.hash!1: <Self where Self : Hashable> (Self) -> (inout Hasher) -> () : @$s28synthesized_conformance_enum4EnumOyxGSHAASHRzlSH4hash4intoys6HasherVz_tFTW	// protocol witness for Hashable.hash(into:) in conformance <A> Enum<A>
-// CHECK-NEXT:   method #Hashable._rawHashValue!1: <Self where Self : Hashable> (Self) -> ((UInt64, UInt64)) -> Int : @$s28synthesized_conformance_enum4EnumOyxGSHAASHRzlSH13_rawHashValue4seedSis6UInt64V_AHt_tFTW	// protocol witness for Hashable._rawHashValue(seed:) in conformance <A> Enum<A>
+// CHECK-NEXT:   method #Hashable._rawHashValue!1: <Self where Self : Hashable> (Self) -> (Int) -> Int : @$s28synthesized_conformance_enum4EnumOyxGSHAASHRzlSH13_rawHashValue4seedS2i_tFTW // protocol witness for Hashable._rawHashValue(seed:) in conformance <A> Enum<A>
 // CHECK-NEXT:   conditional_conformance (T: Hashable): dependent
 // CHECK-NEXT: }
 

--- a/test/SILGen/synthesized_conformance_struct.swift
+++ b/test/SILGen/synthesized_conformance_struct.swift
@@ -65,7 +65,7 @@ extension Struct: Codable where T: Codable {}
 // CHECK-NEXT:   base_protocol Equatable: <T where T : Equatable> Struct<T>: Equatable module synthesized_conformance_struct
 // CHECK-NEXT:   method #Hashable.hashValue!getter.1: <Self where Self : Hashable> (Self) -> () -> Int : @$s30synthesized_conformance_struct6StructVyxGSHAASHRzlSH9hashValueSivgTW	// protocol witness for Hashable.hashValue.getter in conformance <A> Struct<A>
 // CHECK-NEXT:   method #Hashable.hash!1: <Self where Self : Hashable> (Self) -> (inout Hasher) -> () : @$s30synthesized_conformance_struct6StructVyxGSHAASHRzlSH4hash4intoys6HasherVz_tFTW	// protocol witness for Hashable.hash(into:) in conformance <A> Struct<A>
-// CHECK-NEXT:   method #Hashable._rawHashValue!1: <Self where Self : Hashable> (Self) -> ((UInt64, UInt64)) -> Int : @$s30synthesized_conformance_struct6StructVyxGSHAASHRzlSH13_rawHashValue4seedSis6UInt64V_AHt_tFTW	// protocol witness for Hashable._rawHashValue(seed:) in conformance <A> Struct<A>
+// CHECK-NEXT:   method #Hashable._rawHashValue!1: <Self where Self : Hashable> (Self) -> (Int) -> Int : @$s30synthesized_conformance_struct6StructVyxGSHAASHRzlSH13_rawHashValue4seedS2i_tFTW // protocol witness for Hashable._rawHashValue(seed:) in conformance <A> Struct<A>
 // CHECK-NEXT:   conditional_conformance (T: Hashable): dependent
 // CHECK-NEXT: }
 

--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -246,12 +246,9 @@ FixedPoint.test("${Self}.hash(into:)") {
 
 %     reference = prepare_bit_pattern(bit_pattern, self_ty.bits, False)
 %     if self_ty.bits == 64:
-    let expected = Hasher._hash(seed: Hasher._seed, ${reference} as UInt64)
+    let expected = Hasher._hash(seed: 0, ${reference} as UInt64)
 %     else:
-    let expected = Hasher._hash(
-      seed: Hasher._seed,
-      bytes: ${reference},
-      count: ${self_ty.bits / 8})
+    let expected = Hasher._hash(seed: 0, bytes: ${reference}, count: ${self_ty.bits / 8})
 %     end
     expectEqual(expected, output, "input: \(input)")
   }

--- a/validation-test/stdlib/Hashing.swift
+++ b/validation-test/stdlib/Hashing.swift
@@ -10,11 +10,11 @@ var HashingTestSuite = TestSuite("Hashing")
 
 func checkHash(
   for value: UInt64,
-  withSeed seed: (UInt64, UInt64),
+  withSeed seed: UInt,
   expected: UInt64,
   file: String = #file, line: UInt = #line
 ) {
-  var hasher = Hasher(_seed: seed)
+  var hasher = Hasher(_seed: Int(bitPattern: seed))
   hasher._combine(value)
   let hash = hasher.finalize()
   expectEqual(
@@ -23,24 +23,26 @@ func checkHash(
 }
 
 HashingTestSuite.test("Hasher/CustomKeys") {
-  // This assumes Hasher implements SipHash-1-3.
-  checkHash(for: 0, withSeed: (0, 0), expected: 0xbd60acb658c79e45)
-  checkHash(for: 0, withSeed: (0, 1), expected: 0x1ce32b0b44e61175)
-  checkHash(for: 0, withSeed: (1, 0), expected: 0x9c44b7c8df2ca74b)
-  checkHash(for: 0, withSeed: (1, 1), expected: 0x9653ca0a3b455506)
-  checkHash(for: 0, withSeed: (.max, .max), expected: 0x3ab336a4895e4d36)
+  // This assumes Hasher implements SipHash-1-3 and hashing is deterministic.
+  expectTrue(Hasher._isDeterministic)
 
-  checkHash(for: 1, withSeed: (0, 0), expected: 0x1e9f734161d62dd9)
-  checkHash(for: 1, withSeed: (0, 1), expected: 0xb6fcf32d09f76cba)
-  checkHash(for: 1, withSeed: (1, 0), expected: 0xacb556b13007504a)
-  checkHash(for: 1, withSeed: (1, 1), expected: 0x7defec680db51d24)
-  checkHash(for: 1, withSeed: (.max, .max), expected: 0x212798441870ef6b)
+  checkHash(for: 0, withSeed: 0, expected: 0xbd60acb658c79e45)
+  checkHash(for: 1, withSeed: 0, expected: 0x1e9f734161d62dd9)
+  checkHash(for: .max, withSeed: 0, expected: 0x2f205be2fec8e38d)
 
-  checkHash(for: .max, withSeed: (0, 0), expected: 0x2f205be2fec8e38d)
-  checkHash(for: .max, withSeed: (0, 1), expected: 0x3ff7fa33381ecf7b)
-  checkHash(for: .max, withSeed: (1, 0), expected: 0x404afd8eb2c4b22a)
-  checkHash(for: .max, withSeed: (1, 1), expected: 0x855642d657c1bd46)
-  checkHash(for: .max, withSeed: (.max, .max), expected: 0x5b16b7a8181980c2)
+  checkHash(for: 0, withSeed: 1, expected: 0x9c44b7c8df2ca74b)
+  checkHash(for: 1, withSeed: 1, expected: 0xacb556b13007504a)
+  checkHash(for: .max, withSeed: 1, expected: 0x404afd8eb2c4b22a)
+
+  checkHash(for: 0, withSeed: 0xFFFFFFFF, expected: 0x47329159fe988221)
+  checkHash(for: 1, withSeed: 0xFFFFFFFF, expected: 0xd7da861471fc35dc)
+  checkHash(for: .max, withSeed: 0xFFFFFFFF, expected: 0xf6e3047fc114dbc0)
+
+#if !(arch(i386) || arch(arm))
+  checkHash(for: 0, withSeed: 0xFFFFFFFF_FFFFFFFF, expected: 0x8d0ea5ad8d6a55c7)
+  checkHash(for: 1, withSeed: 0xFFFFFFFF_FFFFFFFF, expected: 0x2899f60d6b5bc847)
+  checkHash(for: .max, withSeed: 0xFFFFFFFF_FFFFFFFF, expected: 0xc4d7726fff5e65a0)
+#endif
 }
 
 HashingTestSuite.test("Hasher/DefaultKey") {
@@ -48,17 +50,17 @@ HashingTestSuite.test("Hasher/DefaultKey") {
 
   let defaultHash = _hashValue(for: value)
 
-  let rawHash = value._rawHashValue(seed: Hasher._seed)
+  let rawHash = value._rawHashValue(seed: 0)
   expectEqual(rawHash, defaultHash)
 
-  let oneShotHash = Hasher._hash(seed: Hasher._seed, value)
+  let oneShotHash = Hasher._hash(seed: 0, value)
   expectEqual(oneShotHash, defaultHash)
 
   var defaultHasher = Hasher()
   defaultHasher._combine(value)
   expectEqual(defaultHasher.finalize(), defaultHash)
 
-  var customHasher = Hasher(_seed: Hasher._seed)
+  var customHasher = Hasher(_seed: 0)
   customHasher._combine(value)
   expectEqual(customHasher.finalize(), defaultHash)
 }
@@ -66,7 +68,7 @@ HashingTestSuite.test("Hasher/DefaultKey") {
 HashingTestSuite.test("Hashing/TopLevelHashing/UInt64") {
   func checkTopLevelHash(
     for value: UInt64,
-    seed: (UInt64, UInt64),
+    seed: Int,
     file: String = #file,
     line: UInt = #line) {
     var hasher = Hasher(_seed: seed)
@@ -75,22 +77,20 @@ HashingTestSuite.test("Hashing/TopLevelHashing/UInt64") {
     let actual = Hasher._hash(seed: seed, value)
     expectEqual(actual, expected, file: file, line: line)
   }
-  checkTopLevelHash(for: 0, seed: (0, 0))
-  checkTopLevelHash(for: 1, seed: (0, 0))
-  checkTopLevelHash(for: 1, seed: (1, 0))
-  checkTopLevelHash(for: 1, seed: (1, 1))
-  checkTopLevelHash(for: 0x0102030405060708, seed: (1, 1))
-  checkTopLevelHash(
-    for: 0x0102030405060708,
-    seed: (0x0807060504030201, 0x090a0b0c0d0e0f))
-  checkTopLevelHash(for: UInt64.max, seed: (1, 1))
-  checkTopLevelHash(for: UInt64.max, seed: (UInt64.max, UInt64.max))
+  checkTopLevelHash(for: 0, seed: 0)
+  checkTopLevelHash(for: 1, seed: 0)
+  checkTopLevelHash(for: 0, seed: 1)
+  checkTopLevelHash(for: 1, seed: 1)
+  checkTopLevelHash(for: 0x0102030405060708, seed: 1)
+  checkTopLevelHash(for: 0x0102030405060708, seed: Int.max)
+  checkTopLevelHash(for: UInt64.max, seed: 1)
+  checkTopLevelHash(for: UInt64.max, seed: Int.max)
 }
 
 HashingTestSuite.test("Hashing/TopLevelHashing/UInt") {
   func checkTopLevelHash(
     for value: UInt,
-    seed: (UInt64, UInt64),
+    seed: Int,
     file: String = #file,
     line: UInt = #line) {
     var hasher = Hasher(_seed: seed)
@@ -99,25 +99,25 @@ HashingTestSuite.test("Hashing/TopLevelHashing/UInt") {
     let actual = Hasher._hash(seed: seed, value)
     expectEqual(actual, expected, file: file, line: line)
   }
-  checkTopLevelHash(for: 0, seed: (0, 0))
-  checkTopLevelHash(for: 1, seed: (0, 0))
-  checkTopLevelHash(for: 1, seed: (1, 0))
-  checkTopLevelHash(for: 1, seed: (1, 1))
+  checkTopLevelHash(for: 0, seed: 0)
+  checkTopLevelHash(for: 1, seed: 0)
+  checkTopLevelHash(for: 0, seed: 1)
+  checkTopLevelHash(for: 1, seed: 1)
   checkTopLevelHash(
     for: UInt(truncatingIfNeeded: 0x0102030405060708 as UInt64),
-    seed: (1, 1))
+    seed: 1)
   checkTopLevelHash(
     for: UInt(truncatingIfNeeded: 0x0102030405060708 as UInt64),
-    seed: (0x8877665544332211, 0x1122334455667788))
-  checkTopLevelHash(for: UInt.max, seed: (1, 1))
-  checkTopLevelHash(for: UInt.max, seed: (UInt64.max, UInt64.max))
+    seed: Int(truncatingIfNeeded: 0x8877665544332211 as UInt64))
+  checkTopLevelHash(for: UInt.max, seed: 1)
+  checkTopLevelHash(for: UInt.max, seed: Int.max)
 }
 
 HashingTestSuite.test("Hashing/TopLevelHashing/PartialUInt64") {
   func checkTopLevelHash(
     for value: UInt64,
     count: Int,
-    seed: (UInt64, UInt64),
+    seed: Int,
     file: String = #file,
     line: UInt = #line) {
     var hasher = Hasher(_seed: seed)
@@ -131,11 +131,12 @@ HashingTestSuite.test("Hashing/TopLevelHashing/PartialUInt64") {
       file: file,
       line: line)
   }
-  for seed: (UInt64, UInt64) in [
-    (0, 0),
-    (1, 0),
-    (1, 1),
-    (0x1827364554637281, 0xf9e8d7c6b5a49382)
+  for seed: Int in [
+    0,
+    1,
+    2,
+    Int(truncatingIfNeeded: 0x1827364554637281 as UInt64),
+    Int(truncatingIfNeeded: 0xf9e8d7c6b5a49382 as UInt64)
   ] {
     for count in 1 ..< 8 {
       checkTopLevelHash(for: 0, count: count, seed: seed)
@@ -153,7 +154,7 @@ HashingTestSuite.test("Hashing/TopLevelHashing/PartialUInt64") {
 HashingTestSuite.test("Hashing/TopLevelHashing/UnsafeRawBufferPointer") {
   func checkTopLevelHash(
     for buffer: [UInt8],
-    seed: (UInt64, UInt64),
+    seed: Int,
     file: String = #file,
     line: UInt = #line) {
     var hasher = Hasher(_seed: seed)
@@ -171,11 +172,12 @@ HashingTestSuite.test("Hashing/TopLevelHashing/UnsafeRawBufferPointer") {
       file: file,
       line: line)
   }
-  for seed: (UInt64, UInt64) in [
-    (0, 0),
-    (1, 0),
-    (1, 1),
-    (0x1827364554637281, 0xf9e8d7c6b5a49382)
+  for seed: Int in [
+    0,
+    1,
+    2,
+    Int(truncatingIfNeeded: 0x1827364554637281 as UInt64),
+    Int(truncatingIfNeeded: 0xf9e8d7c6b5a49382 as UInt64)
   ] {
     var zeros: [UInt8] = []
     var integers: [UInt8] = []

--- a/validation-test/stdlib/HashingRandomization.swift
+++ b/validation-test/stdlib/HashingRandomization.swift
@@ -11,7 +11,7 @@
 // environment variable is set.
 
 print("Deterministic: \(Hasher._isDeterministic)")
-print("Seed: \(Hasher._seed)")
+print("Seed: \(Hasher._executionSeed)")
 print("Hash values: <\(0.hashValue), \(1.hashValue)>")
 
 // With randomized hashing, we get a new seed and a new set of hash values on

--- a/validation-test/stdlib/SipHash.swift
+++ b/validation-test/stdlib/SipHash.swift
@@ -245,7 +245,7 @@ struct Loop<C: Collection>: Sequence, IteratorProtocol {
 
 SipHashTests.test("${Self}/combine(UnsafeRawBufferPointer)")
   .forEach(in: ${tests}) { test in
-  var hasher = ${Self}(_seed: test.seed)
+  var hasher = ${Self}(_rawSeed: test.seed)
   test.input.withUnsafeBytes { hasher.combine(bytes: $0) }
   let hash = hasher.finalize()
   expectEqual(${Self}.HashValue(truncatingIfNeeded: test.output), hash)
@@ -255,7 +255,7 @@ SipHashTests.test("${Self}/combine(UnsafeRawBufferPointer)/pattern")
   .forEach(in: cartesianProduct(${tests}, incrementalPatterns)) { test_ in
   let (test, pattern) = test_
 
-  var hasher = ${Self}(_seed: test.seed)
+  var hasher = ${Self}(_rawSeed: test.seed)
   var chunkSizes = Loop(pattern).makeIterator()
   var startIndex = 0
   while startIndex != test.input.endIndex {
@@ -274,7 +274,7 @@ SipHashTests.test("${Self}/combine(UnsafeRawBufferPointer)/pattern")
 SipHashTests.test("${Self}._combine(${data_type})")
   .forEach(in: ${tests}) { test in
 
-  var hasher = ${Self}(_seed: test.seed)
+  var hasher = ${Self}(_rawSeed: test.seed)
 
   // Load little-endian chunks and combine them into the hasher.
   let bitWidth = ${data_type}.bitWidth
@@ -303,7 +303,7 @@ SipHashTests.test("${Self}._combine(${data_type})")
 
 SipHashTests.test("${Self}/OperationsAfterFinalize") {
   // Verify that finalize is nonmutating.
-  var hasher1 = ${Self}(_seed: (0, 0))
+  var hasher1 = ${Self}(_rawSeed: (0, 0))
   hasher1._combine(1 as UInt8)
   _ = hasher1.finalize()
   // Hasher is now consumed. The operations below are illegal, but this isn't
@@ -314,7 +314,7 @@ SipHashTests.test("${Self}/OperationsAfterFinalize") {
   let hash1b = hasher1.finalize()
   expectEqual(hash1a, hash1b)
 
-  var hasher2 = ${Self}(_seed: (0, 0))
+  var hasher2 = ${Self}(_rawSeed: (0, 0))
   hasher2._combine(1 as UInt8)
   hasher2._combine(2 as UInt16)
   let hash2 = hasher2.finalize()


### PR DESCRIPTION
`_rawHashValue(seed:)` is an underscored `Hashable` requirement with a default implementation, introduced earlier for 5.0. It speeds up hashing of small-sized keys by eliminating some resiliency overhead.

- Don’t expose the raw execution seed to `_rawHashValue`.
- Change the type of `_rawHashValue`’s seed from `(UInt64,UInt64)` to a single `Int`. Working with a pair of `UInt64`s is unwieldy, and overkill in practice. `Int` as a seed also integrates nicely with `Int` as a hash value.
- Remove `_HasherCore._generateSeed()`. Instead, simply call `finalize()` on a copy of the hasher to get a seed suitable for `_rawHashValue`.
- Update `Set` and `Dictionary` to store a single Int as the seed value.

Note that this doesn’t affect the core hasher, which still mixes in the actual 128-bit execution seed during its initialization. To reduce the potential of confusion, use the name `rawSeed` to refer to an actual 128-bit seed value.

rdar://problem/44724660