### PR TITLE
[stdlib] Dictionary.values: Replace setter with _modify

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1289,8 +1289,11 @@ extension Dictionary {
     get {
       return Values(_dictionary: self)
     }
-    set {
-      self._variant = newValue._variant
+    _modify {
+      var values = Values(_variant: _variant)
+      _variant = .native(_NativeDictionary())
+      yield &values
+      self._variant = values._variant
     }
   }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1290,7 +1290,7 @@ extension Dictionary {
       return Values(_dictionary: self)
     }
     _modify {
-      var values = Values(_variant: _variant)
+      var values = Values(_dictionary: self)
       _variant = .native(_NativeDictionary())
       yield &values
       self._variant = values._variant


### PR DESCRIPTION
This should enable in-place modification of the `Values` view, which should greatly improve the performance of code like this:

```swift
dictionary.values[index] = newValue
```

https://bugs.swift.org/browse/SR-5258 / rdar://problem/44725826