### PR TITLE
[string] Fix small string implementation for big endian platforms

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -365,7 +365,7 @@ extension _StringGuts {
       unsupportedOn32bit()
 #else
       return _SmallUTF8String(
-        _rawBits: (_otherBits, _object.asSmallUTF8SecondWord))
+        _rawBits: (low: _otherBits, high: _object.asSmallUTF8SecondWord))
 #endif
     }
   }


### PR DESCRIPTION
Exclusively store small strings in little-endian byte order. This
will insert byte swaps when accessing small strings on big endian
platforms, however these are usually extremely cheap.

This approach means that the layout of the code points and count
in memory will be the same on both big and little endian machines
simplifying future development. Prior to this change this code
was broken on big endian machines because the memory layout was
different (the count ending up in the middle of the string).