### PR TITLE
Fix 'operator ==' is ambiguous with MSVC

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -592,6 +592,10 @@ public:
   GenericSignature *getPointer() const {
     return Signature;
   }
+
+  bool operator==(const swift::CanGenericSignature& other) {
+    return Signature == other.Signature;
+  }
 };
 
 template <typename T>

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -134,6 +134,10 @@ struct ValueOwnershipKind {
 
   operator innerty() const { return Value; }
 
+  bool operator==(const swift::ValueOwnershipKind::innerty& b) {
+    return Value == b;
+  }
+
   Optional<ValueOwnershipKind> merge(ValueOwnershipKind RHS) const;
 
   bool isTrivialOr(ValueOwnershipKind Kind) const {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4558,7 +4558,7 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
   }
 
   // Emit the raw application.
-  auto genericSig =
+  GenericSignature *genericSig =
     fn.getType().castTo<SILFunctionType>()->getGenericSignature();
 
   // When calling a closure that's defined in a generic context but does not


### PR DESCRIPTION
When compiling with MSVC 19.15.26726 on Windows, this error among a few other similar
conflicts with AnyValue occur:

```
c:\users\jmittertreiner\localswift\swift\lib\silgen\ManagedValue.h(257):
error C2593: 'operator ==' is ambiguous
C:\Users\jmittertreiner\LocalSwift\swift\include\swift/Basic/AnyValue.h(128):
note: could be 'bool swift::operator ==(const swift::AnyValue &,const
swift::AnyValue &)' [found using argument-dependent lookup]
c:\users\jmittertreiner\localswift\swift\lib\silgen\ManagedValue.h(257):
note: or       'built-in C++
operator==(swift::ValueOwnershipKind::innerty,
swift::ValueOwnershipKind::innerty)'
c:\users\jmittertreiner\localswift\swift\lib\silgen\ManagedValue.h(257):
note: while trying to match the argument list '(swift::ValueOwnershipKind,
swift::ValueOwnershipKind)'
```
Defined the overloads so it selects the correct one.

