### PR TITLE
[stdlib] Make KeyValuePairs fully inlinable

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1302,14 +1302,14 @@ extension Array: CustomReflectable {
 extension Array: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the array and its elements.
   public var description: String {
-    return _makeCollectionDescription(for: self, withTypeName: nil)
+    return _makeCollectionDescription()
   }
 
   /// A textual representation of the array and its elements, suitable for
   /// debugging.
   public var debugDescription: String {
     // Always show sugared representation for Arrays.
-    return _makeCollectionDescription(for: self, withTypeName: nil)
+    return _makeCollectionDescription()
   }
 }
 

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -57,29 +57,32 @@ func _deallocateUninitializedArray<Element>(
 }
 
 
-
-// Utility method for collections that wish to implement CustomStringConvertible
-// and CustomDebugStringConvertible using a bracketed list of elements,
-// like an array.
-internal func _makeCollectionDescription<C: Collection>
-  (for items: C, withTypeName type: String?) -> String {
-  var result = ""
-  if let type = type {
-    result += "\(type)(["
-  } else {
-    result += "["
-  }
-  var first = true
-  for item in items {
-    if first {
-      first = false
+extension Collection {  
+  // Utility method for collections that wish to implement
+  // CustomStringConvertible and CustomDebugStringConvertible using a bracketed
+  // list of elements, like an array.
+  internal func _makeCollectionDescription(
+    withTypeName type: String? = nil
+  ) -> String {
+    var result = ""
+    if let type = type {
+      result += "\(type)(["
     } else {
-      result += ", "
+      result += "["
     }
-    debugPrint(item, terminator: "", to: &result)
+
+    var first = true
+    for item in self {
+      if first {
+        first = false
+      } else {
+        result += ", "
+      }
+      debugPrint(item, terminator: "", to: &result)
+    }
+    result += type != nil ? "])" : "]"
+    return result
   }
-  result += type != nil ? "])" : "]"
-  return result
 }
 
 extension _ArrayBufferProtocol {

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1121,13 +1121,13 @@ extension ArraySlice: CustomReflectable {
 extension ArraySlice: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the array and its elements.
   public var description: String {
-    return _makeCollectionDescription(for: self, withTypeName: nil)
+    return _makeCollectionDescription()
   }
 
   /// A textual representation of the array and its elements, suitable for
   /// debugging.
   public var debugDescription: String {
-    return _makeCollectionDescription(for: self, withTypeName: "ArraySlice")
+    return _makeCollectionDescription(withTypeName: "ArraySlice")
   }
 }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -86,6 +86,7 @@ set(SWIFTLIB_ESSENTIAL
   IntegerTypes.swift.gyb
   Join.swift
   KeyPath.swift
+  KeyValuePairs.swift
   LazyCollection.swift
   LazySequence.swift
   LifetimeManager.swift

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -947,13 +947,13 @@ extension ContiguousArray: CustomReflectable {
 extension ContiguousArray: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the array and its elements.
   public var description: String {
-    return _makeCollectionDescription(for: self, withTypeName: nil)
+    return _makeCollectionDescription()
   }
 
   /// A textual representation of the array and its elements, suitable for
   /// debugging.
   public var debugDescription: String {
-    return _makeCollectionDescription(for: self, withTypeName: "ContiguousArray")
+    return _makeCollectionDescription(withTypeName: "ContiguousArray")
   }
 }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1388,13 +1388,11 @@ extension Dictionary {
     }
 
     public var description: String {
-      return _makeCollectionDescription(for: self, withTypeName: nil)
+      return _makeCollectionDescription()
     }
 
     public var debugDescription: String {
-      return _makeCollectionDescription(
-        for: self,
-        withTypeName: "Dictionary.Keys")
+      return _makeCollectionDescription(withTypeName: "Dictionary.Keys")
     }
   }
 
@@ -1460,13 +1458,11 @@ extension Dictionary {
     }
 
     public var description: String {
-      return _makeCollectionDescription(for: self, withTypeName: nil)
+      return _makeCollectionDescription()
     }
 
     public var debugDescription: String {
-      return _makeCollectionDescription(
-        for: self,
-        withTypeName: "Dictionary.Values")
+      return _makeCollectionDescription(withTypeName: "Dictionary.Values")
     }
   }
 }
@@ -1601,12 +1597,18 @@ internal struct _DictionaryAnyHashableBox<Key: Hashable, Value: Hashable>
   }
 }
 
-extension Dictionary: CustomStringConvertible, CustomDebugStringConvertible {
-  internal func _makeDescription() -> String {
-    if count == 0 {
+extension Collection {
+  // Utility method for KV collections that wish to implement
+  // CustomStringConvertible and CustomDebugStringConvertible using a bracketed
+  // list of elements.
+  // FIXME: Doesn't use the withTypeName argument yet
+  internal func _makeKeyValuePairDescription<K, V>(
+    withTypeName type: String? = nil
+  ) -> String where Element == (key: K, value: V) {
+    if self.count == 0 {
       return "[:]"
     }
-
+    
     var result = "["
     var first = true
     for (k, v) in self {
@@ -1622,16 +1624,18 @@ extension Dictionary: CustomStringConvertible, CustomDebugStringConvertible {
     result += "]"
     return result
   }
+}
 
+extension Dictionary: CustomStringConvertible, CustomDebugStringConvertible {
   /// A string that represents the contents of the dictionary.
   public var description: String {
-    return _makeDescription()
+    return _makeKeyValuePairDescription()
   }
 
   /// A string that represents the contents of the dictionary, suitable for
   /// debugging.
   public var debugDescription: String {
-    return _makeDescription()
+    return _makeKeyValuePairDescription()
   }
 }
 

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -76,6 +76,7 @@
     "WriteBackMutableSlice.swift",
     "UnfoldSequence.swift",
     "UIntBuffer.swift",
+    "KeyValuePairs.swift",
     {
       "Type-erased": [
         "ExistentialCollection.swift"

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -44,8 +44,8 @@
 ///     }
 ///     // Prints "Marlies Gohr set a 100m record of 10.81 seconds."
 ///
-/// Dictionary Literals as Function Parameters
-/// ------------------------------------------
+/// Key-Value Pairs as a Function Parameter
+/// ---------------------------------------
 ///
 /// When calling a function with a `KeyValuePairs` parameter, you can pass
 /// a Swift dictionary literal without causing a `Dictionary` to be created.

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -1,0 +1,141 @@
+//===--- KeyValuePairs.swift ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A lightweight collection of key-value pairs.
+///
+/// Use a `KeyValuePairs` instance when you need an ordered collection of
+/// key-value pairs and don't require the fast key lookup that the
+/// `Dictionary` type provides. Unlike key-value pairs in a true dictionary,
+/// neither the key nor the value of a `KeyValuePairs` instance must
+/// conform to the `Hashable` protocol.
+///
+/// You initialize a `KeyValuePairs` instance using a Swift dictionary
+/// literal. Besides maintaining the order of the original dictionary literal,
+/// `KeyValuePairs` also allows duplicates keys. For example:
+///
+///     let recordTimes: KeyValuePairs = ["Florence Griffith-Joyner": 10.49,
+///                                           "Evelyn Ashford": 10.76,
+///                                           "Evelyn Ashford": 10.79,
+///                                           "Marlies Gohr": 10.81]
+///     print(recordTimes.first!)
+///     // Prints "("Florence Griffith-Joyner", 10.49)"
+///
+/// Some operations that are efficient on a dictionary are slower when using
+/// `KeyValuePairs`. In particular, to find the value matching a key, you
+/// must search through every element of the collection. The call to
+/// `firstIndex(where:)` in the following example must traverse the whole
+/// collection to find the element that matches the predicate:
+///
+///     let runner = "Marlies Gohr"
+///     if let index = recordTimes.firstIndex(where: { $0.0 == runner }) {
+///         let time = recordTimes[index].1
+///         print("\(runner) set a 100m record of \(time) seconds.")
+///     } else {
+///         print("\(runner) couldn't be found in the records.")
+///     }
+///     // Prints "Marlies Gohr set a 100m record of 10.81 seconds."
+///
+/// Dictionary Literals as Function Parameters
+/// ------------------------------------------
+///
+/// When calling a function with a `KeyValuePairs` parameter, you can pass
+/// a Swift dictionary literal without causing a `Dictionary` to be created.
+/// This capability can be especially important when the order of elements in
+/// the literal is significant.
+///
+/// For example, you could create an `IntPairs` structure that holds a list of
+/// two-integer tuples and use an initializer that accepts a
+/// `KeyValuePairs` instance.
+///
+///     struct IntPairs {
+///         var elements: [(Int, Int)]
+///
+///         init(_ elements: KeyValuePairs<Int, Int>) {
+///             self.elements = Array(elements)
+///         }
+///     }
+///
+/// When you're ready to create a new `IntPairs` instance, use a dictionary
+/// literal as the parameter to the `IntPairs` initializer. The
+/// `KeyValuePairs` instance preserves the order of the elements as
+/// passed.
+///
+///     let pairs = IntPairs([1: 2, 1: 1, 3: 4, 2: 1])
+///     print(pairs.elements)
+///     // Prints "[(1, 2), (1, 1), (3, 4), (2, 1)]"
+@_fixed_layout // trivial-implementation
+public struct KeyValuePairs<Key, Value> : ExpressibleByDictionaryLiteral {
+  @usableFromInline // trivial-implementation
+  internal let _elements: [(Key, Value)]
+
+  /// Creates a new `KeyValuePairs` instance from the given dictionary
+  /// literal.
+  ///
+  /// The order of the key-value pairs is kept intact in the resulting
+  /// `KeyValuePairs` instance.
+  @inlinable // trivial-implementation
+  public init(dictionaryLiteral elements: (Key, Value)...) {
+    self._elements = elements
+  }
+}
+
+/// `Collection` conformance that allows `KeyValuePairs` to
+/// interoperate with the rest of the standard library.
+extension KeyValuePairs : RandomAccessCollection {
+  /// The element type of a `KeyValuePairs`: a tuple containing an
+  /// individual key-value pair.
+  public typealias Element = (key: Key, value: Value)
+  public typealias Index = Int
+  public typealias Indices = Range<Int>
+  public typealias SubSequence = Slice<KeyValuePairs>
+  
+  /// The position of the first element in a nonempty collection.
+  ///
+  /// If the `KeyValuePairs` instance is empty, `startIndex` is equal to
+  /// `endIndex`.
+  @inlinable // trivial-implementation
+  public var startIndex: Index { return 0 }
+
+  /// The collection's "past the end" position---that is, the position one
+  /// greater than the last valid subscript argument.
+  ///
+  /// If the `KeyValuePairs` instance is empty, `endIndex` is equal to
+  /// `startIndex`.
+  @inlinable // trivial-implementation
+  public var endIndex: Index { return _elements.endIndex }
+
+  /// Accesses the element at the specified position.
+  ///
+  /// - Parameter position: The position of the element to access. `position`
+  ///   must be a valid index of the collection that is not equal to the
+  ///   `endIndex` property.
+  /// - Returns: The key-value pair at position `position`.
+  @inlinable // trivial-implementation
+  public subscript(position: Index) -> Element {
+    return _elements[position]
+  }
+}
+
+extension KeyValuePairs: CustomStringConvertible {
+  /// A string that represents the contents of the dictionary.
+  public var description: String {
+    return _makeKeyValuePairDescription()
+  }
+}
+
+extension KeyValuePairs: CustomDebugStringConvertible {
+  /// A string that represents the contents of the dictionary, suitable for
+  /// debugging.
+  public var debugDescription: String {
+    return _makeKeyValuePairDescription()
+  }
+}

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -217,8 +217,7 @@ public struct Mirror {
     children: C,
     displayStyle: DisplayStyle? = nil,
     ancestorRepresentation: AncestorRepresentation = .generated
-  ) where C.Element == Child 
-  {
+  ) where C.Element == Child {
 
     self.subjectType = Subject.self
     self._makeSuperclassMirror = Mirror._superclassIterator(
@@ -262,9 +261,7 @@ public struct Mirror {
     unlabeledChildren: C,
     displayStyle: DisplayStyle? = nil,
     ancestorRepresentation: AncestorRepresentation = .generated
-  ) 
-  {
-
+  ) {
     self.subjectType = Subject.self
     self._makeSuperclassMirror = Mirror._superclassIterator(
       subject, ancestorRepresentation)
@@ -460,115 +457,6 @@ extension Mirror {
 }
 
 //===--- General Utilities ------------------------------------------------===//
-// This component could stand alone, but is used in Mirror's public interface.
-
-/// A lightweight collection of key-value pairs.
-///
-/// Use a `KeyValuePairs` instance when you need an ordered collection of
-/// key-value pairs and don't require the fast key lookup that the
-/// `Dictionary` type provides. Unlike key-value pairs in a true dictionary,
-/// neither the key nor the value of a `KeyValuePairs` instance must
-/// conform to the `Hashable` protocol.
-///
-/// You initialize a `KeyValuePairs` instance using a Swift dictionary
-/// literal. Besides maintaining the order of the original dictionary literal,
-/// `KeyValuePairs` also allows duplicates keys. For example:
-///
-///     let recordTimes: KeyValuePairs = ["Florence Griffith-Joyner": 10.49,
-///                                           "Evelyn Ashford": 10.76,
-///                                           "Evelyn Ashford": 10.79,
-///                                           "Marlies Gohr": 10.81]
-///     print(recordTimes.first!)
-///     // Prints "("Florence Griffith-Joyner", 10.49)"
-///
-/// Some operations that are efficient on a dictionary are slower when using
-/// `KeyValuePairs`. In particular, to find the value matching a key, you
-/// must search through every element of the collection. The call to
-/// `firstIndex(where:)` in the following example must traverse the whole
-/// collection to find the element that matches the predicate:
-///
-///     let runner = "Marlies Gohr"
-///     if let index = recordTimes.firstIndex(where: { $0.0 == runner }) {
-///         let time = recordTimes[index].1
-///         print("\(runner) set a 100m record of \(time) seconds.")
-///     } else {
-///         print("\(runner) couldn't be found in the records.")
-///     }
-///     // Prints "Marlies Gohr set a 100m record of 10.81 seconds."
-///
-/// Dictionary Literals as Function Parameters
-/// ------------------------------------------
-///
-/// When calling a function with a `KeyValuePairs` parameter, you can pass
-/// a Swift dictionary literal without causing a `Dictionary` to be created.
-/// This capability can be especially important when the order of elements in
-/// the literal is significant.
-///
-/// For example, you could create an `IntPairs` structure that holds a list of
-/// two-integer tuples and use an initializer that accepts a
-/// `KeyValuePairs` instance.
-///
-///     struct IntPairs {
-///         var elements: [(Int, Int)]
-///
-///         init(_ elements: KeyValuePairs<Int, Int>) {
-///             self.elements = Array(elements)
-///         }
-///     }
-///
-/// When you're ready to create a new `IntPairs` instance, use a dictionary
-/// literal as the parameter to the `IntPairs` initializer. The
-/// `KeyValuePairs` instance preserves the order of the elements as
-/// passed.
-///
-///     let pairs = IntPairs([1: 2, 1: 1, 3: 4, 2: 1])
-///     print(pairs.elements)
-///     // Prints "[(1, 2), (1, 1), (3, 4), (2, 1)]"
-public struct KeyValuePairs<Key, Value> : ExpressibleByDictionaryLiteral {
-  /// Creates a new `KeyValuePairs` instance from the given dictionary
-  /// literal.
-  ///
-  /// The order of the key-value pairs is kept intact in the resulting
-  /// `KeyValuePairs` instance.
-  public init(dictionaryLiteral elements: (Key, Value)...) {
-    self._elements = elements
-  }
-  internal let _elements: [(Key, Value)]
-}
-
-/// `Collection` conformance that allows `KeyValuePairs` to
-/// interoperate with the rest of the standard library.
-extension KeyValuePairs : RandomAccessCollection {
-  public typealias Indices = Range<Int>
-  
-  /// The position of the first element in a nonempty collection.
-  ///
-  /// If the `KeyValuePairs` instance is empty, `startIndex` is equal to
-  /// `endIndex`.
-  public var startIndex: Int { return 0 }
-
-  /// The collection's "past the end" position---that is, the position one
-  /// greater than the last valid subscript argument.
-  ///
-  /// If the `KeyValuePairs` instance is empty, `endIndex` is equal to
-  /// `startIndex`.
-  public var endIndex: Int { return _elements.endIndex }
-
-  // FIXME(ABI)#174 (Type checker): a typealias is needed to prevent <rdar://20248032>
-  /// The element type of a `KeyValuePairs`: a tuple containing an
-  /// individual key-value pair.
-  public typealias Element = (key: Key, value: Value)
-
-  /// Accesses the element at the specified position.
-  ///
-  /// - Parameter position: The position of the element to access. `position`
-  ///   must be a valid index of the collection that is not equal to the
-  ///   `endIndex` property.
-  /// - Returns: The key-value pair at position `position`.
-  public subscript(position: Int) -> Element {
-    return _elements[position]
-  }
-}
 
 extension String {
   /// Creates a string representing the given value.

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1051,12 +1051,12 @@ extension Set: SetAlgebra {
 extension Set: CustomStringConvertible, CustomDebugStringConvertible {
   /// A string that represents the contents of the set.
   public var description: String {
-    return _makeCollectionDescription(for: self, withTypeName: nil)
+    return _makeCollectionDescription()
   }
 
   /// A string that represents the contents of the set, suitable for debugging.
   public var debugDescription: String {
-    return _makeCollectionDescription(for: self, withTypeName: "Set")
+    return _makeCollectionDescription(withTypeName: "Set")
   }
 }
 


### PR DESCRIPTION
The implementation is trivial and it has a significant benefit on performance.

Also gives KVP custom string conversions, factoring out the code used in `Dictionary`. And makes `_makeCollectionDescription` an extension method, cos it should be.