### PR TITLE
SIL optimizer: consider non-branch terminators with a single successor for critical edges.

### DIFF
--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -405,7 +405,11 @@ bool swift::isCriticalEdge(TermInst *T, unsigned EdgeIdx) {
   assert(T->getSuccessors().size() > EdgeIdx && "Not enough successors");
 
   auto SrcSuccs = T->getSuccessors();
-  if (SrcSuccs.size() <= 1)
+  
+  if (SrcSuccs.size() <= 1 &&
+      // Also consider non-branch instructions with a single successor for
+      // critical edges, for example: a switch_enum of a single-case enum.
+      (isa<BranchInst>(T) || isa<CondBranchInst>(T)))
     return false;
 
   SILBasicBlock *DestBB = SrcSuccs[EdgeIdx];

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1684,6 +1684,32 @@ exit:
   return %9999 : $()
 }
 
+// CHECK-LABEL: sil @dont_crash_jump_threading_single_case_switch_enums
+// CHECK-NOT: switch_enum
+// CHECK: } // end sil function
+sil @dont_crash_jump_threading_single_case_switch_enums : $@convention(thin) () -> () {
+bb0:
+  br bb1(undef : $OneCase)
+
+bb1(%19 : $OneCase):
+  switch_enum %19 : $OneCase, case #OneCase.First!enumelt.1: bb2
+
+bb2:
+  switch_enum %19 : $OneCase, case #OneCase.First!enumelt.1: bb3
+
+bb3:
+  %48 = enum $OneCase, #OneCase.First!enumelt.1
+  cond_br undef, bb6, bb7
+
+bb6:
+  %72 = tuple ()
+  return %72 : $()
+
+bb7:
+  br bb1(%48 : $OneCase)
+}
+
+
 enum IntEnum : Int32 {
   case E0
   case E1


### PR DESCRIPTION
For example: a switch_enum for a single-case enum. It has only a single successor edge, but needs to be split as well (if the destination block has multiple predecessors).

Fixes a crash in SimplifyCFG.
rdar://problem/44675677
