### PR TITLE
[sourcekit] Fix a lock inversion in editorReplaceText found by TSan

### DIFF
--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -266,8 +266,7 @@ void EditTest::doubleOpenWithDelay(useconds_t delay, bool closeDoc) {
   close(DocName);
 }
 
-// This test is failing occassionally in CI: rdar://42483323
-TEST_F(EditTest, DISABLED_DiagsAfterCloseAndReopen) {
+TEST_F(EditTest, DiagsAfterCloseAndReopen) {
   // Attempt to open the same file twice in a row. This tests (subject to
   // timing) cases where:
   // * the 2nd open happens before the first AST starts building


### PR DESCRIPTION
When triggering `replaceText` we were locking the `EditorDocument` then the `ASTProducer`, but during AST building we do the reverse. This would cause a deadlock if these two bits of code raced. Break the cycle by dropping the editor lock when calling into the `ASTManager`.

Also, since this seems like the most likely cause of the timeouts in the `CloseAndReopen` test, re-enable it.

Thank you TSan!