### PR TITLE
Hoist CFGState and BBState out of function scope

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4419,12 +4419,7 @@ public:
             "have at least one argument for self.");
   }
 
-  /// Verify the various control-flow-sensitive rules of SIL:
-  ///
-  /// - stack allocations and deallocations must obey a stack discipline
-  /// - accesses must be uniquely ended
-  /// - flow-sensitive states must be equivalent on all paths into a block
-  void verifyFlowSensitiveRules(SILFunction *F) {
+  struct VerifyFlowSensitiveRulesDetails {
     enum CFGState {
       /// No special rules are in play.
       Normal,
@@ -4433,6 +4428,7 @@ public:
       /// We've followed the unwind edge of a yield.
       YieldUnwind
     };
+
     struct BBState {
       std::vector<SingleValueInstruction*> Stack;
 
@@ -4441,17 +4437,24 @@ public:
 
       CFGState CFG = Normal;
     };
+  };
 
+  /// Verify the various control-flow-sensitive rules of SIL:
+  ///
+  /// - stack allocations and deallocations must obey a stack discipline
+  /// - accesses must be uniquely ended
+  /// - flow-sensitive states must be equivalent on all paths into a block
+  void verifyFlowSensitiveRules(SILFunction *F) {
     // Do a breath-first search through the basic blocks.
     // Note that we intentionally don't verify these properties in blocks
     // that can't be reached from the entry block.
-    llvm::DenseMap<SILBasicBlock*, BBState> visitedBBs;
+    llvm::DenseMap<SILBasicBlock*, VerifyFlowSensitiveRulesDetails::BBState> visitedBBs;
     SmallVector<SILBasicBlock*, 16> Worklist;
     visitedBBs.try_emplace(&*F->begin());
     Worklist.push_back(&*F->begin());
     while (!Worklist.empty()) {
       SILBasicBlock *BB = Worklist.pop_back_val();
-      BBState state = visitedBBs[BB];
+      VerifyFlowSensitiveRulesDetails::BBState state = visitedBBs[BB];
       for (SILInstruction &i : *BB) {
         CurInstruction = &i;
 
@@ -4486,16 +4489,16 @@ public:
                     "return with operations still active");
 
             if (isa<UnwindInst>(term)) {
-              require(state.CFG == YieldUnwind,
+              require(state.CFG == VerifyFlowSensitiveRulesDetails::YieldUnwind,
                       "encountered 'unwind' when not on unwind path");
             } else {
-              require(state.CFG != YieldUnwind,
+              require(state.CFG != VerifyFlowSensitiveRulesDetails::YieldUnwind,
                       "encountered 'return' or 'throw' when on unwind path");
               if (isa<ReturnInst>(term) &&
                   F->getLoweredFunctionType()->getCoroutineKind() ==
                     SILCoroutineKind::YieldOnce &&
                   F->getModule().getStage() != SILStage::Raw) {
-                require(state.CFG == YieldOnceResume,
+                require(state.CFG == VerifyFlowSensitiveRulesDetails::YieldOnceResume,
                         "encountered 'return' before yielding a value in "
                         "yield_once coroutine");
               }
@@ -4503,9 +4506,9 @@ public:
           }
 
           if (isa<YieldInst>(term)) {
-            require(state.CFG != YieldOnceResume,
+            require(state.CFG != VerifyFlowSensitiveRulesDetails::YieldOnceResume,
                     "encountered multiple 'yield's along single path");
-            require(state.CFG == Normal,
+            require(state.CFG == VerifyFlowSensitiveRulesDetails::Normal,
                     "encountered 'yield' on abnormal CFG path");
           }
 
@@ -4532,14 +4535,14 @@ public:
               if (isa<YieldInst>(term)) {
                 // Enforce that the unwind logic is segregated in all stages.
                 if (i == 1) {
-                  insertResult.first->second.CFG = YieldUnwind;
+                  insertResult.first->second.CFG = VerifyFlowSensitiveRulesDetails::YieldUnwind;
 
                 // We check the yield_once rule in the mandatory analyses,
                 // so we can't assert it yet in the raw stage.
                 } else if (F->getLoweredFunctionType()->getCoroutineKind()
                              == SILCoroutineKind::YieldOnce && 
                            F->getModule().getStage() != SILStage::Raw) {
-                  insertResult.first->second.CFG = YieldOnceResume;
+                  insertResult.first->second.CFG = VerifyFlowSensitiveRulesDetails::YieldOnceResume;
                 }
               }
 


### PR DESCRIPTION
MSVC (Version 19.15.26726) has some really wonky behaviour with enums and
structs in function scopes. Hoisting them outside seems to work around
it.

Here's the error message, I don't at all understand why it would cause this specific error.
```
C:\PROGRA~2\MIB055~1\2017\PROFES~1\VC\Tools\MSVC\1415~1.267\bin\Hostx64\x64\cl.exe  /nologo /TP -DCMARK_STATIC_DEFINE -DGTEST_HAS_RTTI=0 -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Ilib\SIL -Iswift\lib\SIL -Iinclude -Iswift\include -Illvm\include -Ibuild\Ninja-DebugAssert\llvm-windows-amd64\include -Ibuild\Ninja-DebugAssert\llvm-windows-amd64\tools\clang\include -Illvm\tools\clang\include -Icmark\src -Ibuild\Ninja-DebugAssert\cmark-windows-amd64\src -I"C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.15.26726\\include" -I"C:\Program Files (x86)\Windows Kits\10\\Include\10.0.17134.0\ucrt" -I"C:\Program Files (x86)\Windows Kits\10\\Include\10.0.17134.0\shared" -I"C:\Program Files (x86)\Windows Kits\10\\Include\10.0.17134.0\um" /DWIN32 /D_WINDOWS   /Zc:inline /Zc:strictStrings /Oi /Zc:rvalueCast /W4 -wd4141 -wd4146 -wd4180 -wd4244 -wd4258 -wd4267 -wd4291 -wd4345 -wd4351 -wd4355 -wd4456 -wd4457 -wd4458 -wd4459 -wd4503 -wd4624 -wd4722 -wd4800 -wd4100 -wd4127 -wd4512 -wd4505 -wd4610 -wd4510 -wd4702 -wd4245 -wd4706 -wd4310 -wd4701 -wd4703 -wd4389 -wd4611 -wd4805 -wd4204 -wd4577 -wd4091 -wd4592 -wd4319 -wd4324 -w14062 -we4238 /we4062 /wd4068 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 /MDd /Zi /Ob0 /Od /RTC1    /EHs-c- /GR- /Od -DLLVM_ON_WIN32 -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_USE_WINAPI_FAMILY_DESKTOP_APP -D_DLL -D_ENABLE_ATOMIC_ALIGNMENT_FIX -D_HAS_STATIC_RTTI=0 -UNDEBUG -std:c++14 /Folib\SIL\CMakeFiles\swiftSIL.dir\SILVerifier.cpp.obj /Fdlib\SIL\CMakeFiles\swiftSIL.dir\swiftSIL.pdb /FS -c swift\lib\SIL\SILVerifier.cpp
swift\lib\SIL\SILVerifier.cpp(4831): error C2888: 'void swift::SILFunction::verify(bool) const': symbol cannot be defined within namespace 'std'
swift\lib\SIL\SILVerifier.cpp(4842): error C2888: 'void swift::SILFunction::verifyCriticalEdges(void) const': symbol cannot be defined within namespace 'std'
swift\lib\SIL\SILVerifier.cpp(4851): error C2888: 'void swift::SILProperty::verify(const swift::SILModule &) const': symbol cannot be defined within namespace 'std'
swift\lib\SIL\SILVerifier.cpp(4906): error C2888: 'void swift::SILVTable::verify(const swift::SILModule &) const': symbol cannot be defined within namespace 'std'
swift\lib\SIL\SILVerifier.cpp(4963): error C2888: 'void swift::SILWitnessTable::verify(const swift::SILModule &) const': symbol cannot be defined within namespace 'std'
swift\lib\SIL\SILVerifier.cpp(5003): error C2888: 'void swift::SILDefaultWitnessTable::verify(const swift::SILModule &) const': symbol cannot be defined within namespace 'std'
swift\lib\SIL\SILVerifier.cpp(5033): error C2888: 'void swift::SILGlobalVariable::verify(void) const': symbol cannot be defined within namespace 'std'
swift\lib\SIL\SILVerifier.cpp(5058): error C2888: 'void swift::SILModule::verify(void) const': symbol cannot be defined within namespace 'std'
swift\lib\SIL\SILVerifier.cpp(5149): error C2888: 'bool swift::maybeScopeless(swift::SILInstruction &)': symbol cannot be defined within namespace 'std'
```
Very oddly, commenting out all the `insertResult.first->second` lines (Lines 4536, 4543, 4565) also makes the error message go away.

I also see the error in https://github.com/apple/swift/pull/19303, but since hoisting out BBState is what fixed it, I also had to hoist out CFGState as in that PR.

Also, with this change, Swift successfully now compiles and links (but immediately crashes when run) on Windows building with MSVC on my machine.