### PR TITLE
build-script: always rebuild XCTest on non-Darwin

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2487,6 +2487,11 @@ for host in "${ALL_HOSTS[@]}"; do
                   continue
                 ;;
                 *)
+                  # FIXME: Always re-build XCTest on non-darwin platforms.
+                  # Remove this when products build in the CMake system.
+                  echo "Cleaning the XCTest build directory"
+                  call rm -rf "${XCTEST_BUILD_DIR}"
+
                   cmake_options=(
                     ${cmake_options[@]}
                     -DCMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"


### PR DESCRIPTION
This should resolve SR-8826!  Ideally, we would be using CMake to tie together
all the dependent packages and get proper dependency tracking.  Currently,
change to the swift runtime do not get tracked properly, and can result in
undefined references to symbols.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
