### PR TITLE
[Build System: CMake] make add_swift_library a wrapper to add_llvm_library

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1326,7 +1326,6 @@ endfunction()
 #     [INTERFACE_LINK_LIBRARIES dep1 ...]
 #     [SWIFT_MODULE_DEPENDS dep1 ...]
 #     [LLVM_COMPONENT_DEPENDS comp1 ...]
-#     [C_COMPILE_FLAGS flag1...]
 #     [LINK_FLAGS flag1...]
 #     [INSTALL]
 #     INSTALL_IN_COMPONENT comp
@@ -1350,9 +1349,6 @@ endfunction()
 # LLVM_COMPONENT_DEPENDS
 #   LLVM components this library depends on.
 #
-# C_COMPILE_FLAGS
-#   Extra compiler flags (C, C++, ObjC).
-#
 # LINK_FLAGS
 #   Extra linker flags.
 #
@@ -1368,7 +1364,6 @@ function(add_swift_host_library name)
         STATIC)
   set(single_parameter_options)
   set(multiple_parameter_options
-        C_COMPILE_FLAGS
         DEPENDS
         INTERFACE_LINK_LIBRARIES
         LINK_FLAGS
@@ -1399,7 +1394,6 @@ function(add_swift_host_library name)
     DEPENDS ${ASHL_DEPENDS}
     LINK_LIBRARIES ${ASHL_LINK_LIBRARIES}
     LLVM_COMPONENT_DEPENDS ${ASHL_LLVM_COMPONENT_DEPENDS}
-    C_COMPILE_FLAGS ${ASHL_C_COMPILE_FLAGS}
     LINK_FLAGS ${ASHL_LINK_FLAGS}
     INTERFACE_LINK_LIBRARIES ${ASHL_INTERFACE_LINK_LIBRARIES}
     INSTALL_IN_COMPONENT "dev"

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1326,7 +1326,6 @@ endfunction()
 #     [INTERFACE_LINK_LIBRARIES dep1 ...]
 #     [SWIFT_MODULE_DEPENDS dep1 ...]
 #     [LLVM_COMPONENT_DEPENDS comp1 ...]
-#     [FILE_DEPENDS target1 ...]
 #     [C_COMPILE_FLAGS flag1...]
 #     [LINK_FLAGS flag1...]
 #     [INSTALL]
@@ -1351,9 +1350,6 @@ endfunction()
 # LLVM_COMPONENT_DEPENDS
 #   LLVM components this library depends on.
 #
-# FILE_DEPENDS
-#   Additional files this library depends on.
-#
 # C_COMPILE_FLAGS
 #   Extra compiler flags (C, C++, ObjC).
 #
@@ -1374,7 +1370,6 @@ function(add_swift_host_library name)
   set(multiple_parameter_options
         C_COMPILE_FLAGS
         DEPENDS
-        FILE_DEPENDS
         INTERFACE_LINK_LIBRARIES
         LINK_FLAGS
         LINK_LIBRARIES
@@ -1404,7 +1399,6 @@ function(add_swift_host_library name)
     DEPENDS ${ASHL_DEPENDS}
     LINK_LIBRARIES ${ASHL_LINK_LIBRARIES}
     LLVM_COMPONENT_DEPENDS ${ASHL_LLVM_COMPONENT_DEPENDS}
-    FILE_DEPENDS ${ASHL_FILE_DEPENDS}
     C_COMPILE_FLAGS ${ASHL_C_COMPILE_FLAGS}
     LINK_FLAGS ${ASHL_LINK_FLAGS}
     INTERFACE_LINK_LIBRARIES ${ASHL_INTERFACE_LINK_LIBRARIES}

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1325,7 +1325,7 @@ endfunction()
 #     [LINK_LIBS lib1 ...]
 #     [INTERFACE_LINK_LIBRARIES dep1 ...]
 #     [SWIFT_MODULE_DEPENDS dep1 ...]
-#     [LLVM_COMPONENT_DEPENDS comp1 ...]
+#     [LINK_COMPONENTS comp1 ...]
 #     [LINK_FLAGS flag1...]
 #     [INSTALL]
 #     INSTALL_IN_COMPONENT comp
@@ -1346,7 +1346,7 @@ endfunction()
 # LINK_LIBS
 #   Libraries this library depends on.
 #
-# LLVM_COMPONENT_DEPENDS
+# LINK_COMPONENTS
 #   LLVM components this library depends on.
 #
 # LINK_FLAGS
@@ -1368,7 +1368,7 @@ function(add_swift_host_library name)
         INTERFACE_LINK_LIBRARIES
         LINK_FLAGS
         LINK_LIBS
-        LLVM_COMPONENT_DEPENDS)
+        LINK_COMPONENTS)
 
   cmake_parse_arguments(ASHL
                         "${options}"
@@ -1393,7 +1393,7 @@ function(add_swift_host_library name)
     ARCHITECTURE ${SWIFT_HOST_VARIANT_ARCH}
     DEPENDS ${ASHL_DEPENDS}
     LINK_LIBRARIES ${ASHL_LINK_LIBS}
-    LLVM_COMPONENT_DEPENDS ${ASHL_LLVM_COMPONENT_DEPENDS}
+    LLVM_COMPONENT_DEPENDS ${ASHL_LINK_COMPONENTS}
     LINK_FLAGS ${ASHL_LINK_FLAGS}
     INTERFACE_LINK_LIBRARIES ${ASHL_INTERFACE_LINK_LIBRARIES}
     INSTALL_IN_COMPONENT "dev"

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1322,7 +1322,7 @@ endfunction()
 #     [SHARED]
 #     [STATIC]
 #     [DEPENDS dep1 ...]
-#     [LINK_LIBRARIES dep1 ...]
+#     [LINK_LIBS lib1 ...]
 #     [INTERFACE_LINK_LIBRARIES dep1 ...]
 #     [SWIFT_MODULE_DEPENDS dep1 ...]
 #     [LLVM_COMPONENT_DEPENDS comp1 ...]
@@ -1343,7 +1343,7 @@ endfunction()
 # DEPENDS
 #   Targets that this library depends on.
 #
-# LINK_LIBRARIES
+# LINK_LIBS
 #   Libraries this library depends on.
 #
 # LLVM_COMPONENT_DEPENDS
@@ -1367,7 +1367,7 @@ function(add_swift_host_library name)
         DEPENDS
         INTERFACE_LINK_LIBRARIES
         LINK_FLAGS
-        LINK_LIBRARIES
+        LINK_LIBS
         LLVM_COMPONENT_DEPENDS)
 
   cmake_parse_arguments(ASHL
@@ -1392,7 +1392,7 @@ function(add_swift_host_library name)
     SDK ${SWIFT_HOST_VARIANT_SDK}
     ARCHITECTURE ${SWIFT_HOST_VARIANT_ARCH}
     DEPENDS ${ASHL_DEPENDS}
-    LINK_LIBRARIES ${ASHL_LINK_LIBRARIES}
+    LINK_LIBRARIES ${ASHL_LINK_LIBS}
     LLVM_COMPONENT_DEPENDS ${ASHL_LLVM_COMPONENT_DEPENDS}
     LINK_FLAGS ${ASHL_LINK_FLAGS}
     INTERFACE_LINK_LIBRARIES ${ASHL_INTERFACE_LINK_LIBRARIES}

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1324,7 +1324,7 @@ endfunction()
 function(add_swift_host_library name)
   set(options FORCE_BUILD_OPTIMIZED)
   set(single_parameter_options)
-  set(multiple_parameter_options)
+  set(multiple_parameter_options GYB_SOURCES)
 
   cmake_parse_arguments(ASHL
                         "${options}"
@@ -1333,7 +1333,10 @@ function(add_swift_host_library name)
                         ${ARGN})
   set(ASHL_SOURCES ${ASHL_UNPARSED_ARGUMENTS})
 
-  llvm_add_library(${name} ${ASHL_UNPARSED_ARGUMENTS})
+  handle_gyb_sources(gyb_generated_targets ASHL_GYB_SOURCES
+    ${SWIFT_HOST_VARIANT_ARCH})
+  llvm_add_library(${name} ${ASHL_GYB_SOURCES} ${ASHL_UNPARSED_ARGUMENTS}
+    DEPENDS ${gyb_generated_targets})
   if(ASHL_FORCE_BUILD_OPTIMIZED)
     target_compile_options(${name} PRIVATE "-O2")
   endif()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1325,7 +1325,6 @@ endfunction()
 #     [LINK_LIBS lib1 ...]
 #     [SWIFT_MODULE_DEPENDS dep1 ...]
 #     [LINK_COMPONENTS comp1 ...]
-#     [LINK_FLAGS flag1...]
 #     [INSTALL]
 #     INSTALL_IN_COMPONENT comp
 #     source1 [source2 source3 ...])
@@ -1348,9 +1347,6 @@ endfunction()
 # LINK_COMPONENTS
 #   LLVM components this library depends on.
 #
-# LINK_FLAGS
-#   Extra linker flags.
-#
 # INSTALL_IN_COMPONENT comp
 #   The Swift installation component that this library belongs to.
 #
@@ -1364,7 +1360,6 @@ function(add_swift_host_library name)
   set(single_parameter_options)
   set(multiple_parameter_options
         DEPENDS
-        LINK_FLAGS
         LINK_LIBS
         LINK_COMPONENTS)
 
@@ -1392,7 +1387,6 @@ function(add_swift_host_library name)
     DEPENDS ${ASHL_DEPENDS}
     LINK_LIBRARIES ${ASHL_LINK_LIBS}
     LLVM_COMPONENT_DEPENDS ${ASHL_LINK_COMPONENTS}
-    LINK_FLAGS ${ASHL_LINK_FLAGS}
     INSTALL_IN_COMPONENT "dev"
     )
 

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1319,49 +1319,12 @@ endfunction()
 #
 # Usage:
 #   add_swift_host_library(name
-#     [SHARED]
-#     [STATIC]
-#     [DEPENDS dep1 ...]
-#     [LINK_LIBS lib1 ...]
-#     [SWIFT_MODULE_DEPENDS dep1 ...]
-#     [LINK_COMPONENTS comp1 ...]
-#     [INSTALL]
-#     INSTALL_IN_COMPONENT comp
-#     source1 [source2 source3 ...])
-#
-# name
-#   Name of the library (e.g., swiftParse).
-#
-# SHARED
-#   Build a shared library.
-#
-# STATIC
-#   Build a static library.
-#
-# DEPENDS
-#   Targets that this library depends on.
-#
-# LINK_LIBS
-#   Libraries this library depends on.
-#
-# LINK_COMPONENTS
-#   LLVM components this library depends on.
-#
-# INSTALL_IN_COMPONENT comp
-#   The Swift installation component that this library belongs to.
-#
-# source1 ...
-#   Sources to add into this library.
+#     [FORCE_BUILD_OPTIMIZED]
+#     [...]
 function(add_swift_host_library name)
-  set(options
-        FORCE_BUILD_OPTIMIZED
-        SHARED
-        STATIC)
+  set(options FORCE_BUILD_OPTIMIZED)
   set(single_parameter_options)
-  set(multiple_parameter_options
-        DEPENDS
-        LINK_LIBS
-        LINK_COMPONENTS)
+  set(multiple_parameter_options)
 
   cmake_parse_arguments(ASHL
                         "${options}"
@@ -1370,25 +1333,10 @@ function(add_swift_host_library name)
                         ${ARGN})
   set(ASHL_SOURCES ${ASHL_UNPARSED_ARGUMENTS})
 
-  translate_flags(ASHL "${options}")
-
-  if(NOT ASHL_SHARED AND NOT ASHL_STATIC)
-    message(FATAL_ERROR "Either SHARED or STATIC must be specified")
+  llvm_add_library(${name} ${ASHL_UNPARSED_ARGUMENTS})
+  if(ASHL_FORCE_BUILD_OPTIMIZED)
+    target_compile_options(${name} PRIVATE "-O2")
   endif()
-
-  _add_swift_library_single(
-    ${name}
-    ${name}
-    ${ASHL_SHARED_keyword}
-    ${ASHL_STATIC_keyword}
-    ${ASHL_SOURCES}
-    SDK ${SWIFT_HOST_VARIANT_SDK}
-    ARCHITECTURE ${SWIFT_HOST_VARIANT_ARCH}
-    DEPENDS ${ASHL_DEPENDS}
-    LINK_LIBRARIES ${ASHL_LINK_LIBS}
-    LLVM_COMPONENT_DEPENDS ${ASHL_LINK_COMPONENTS}
-    INSTALL_IN_COMPONENT "dev"
-    )
 
   swift_install_in_component(dev
     TARGETS ${name}

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1323,7 +1323,6 @@ endfunction()
 #     [STATIC]
 #     [DEPENDS dep1 ...]
 #     [LINK_LIBS lib1 ...]
-#     [INTERFACE_LINK_LIBRARIES dep1 ...]
 #     [SWIFT_MODULE_DEPENDS dep1 ...]
 #     [LINK_COMPONENTS comp1 ...]
 #     [LINK_FLAGS flag1...]
@@ -1365,7 +1364,6 @@ function(add_swift_host_library name)
   set(single_parameter_options)
   set(multiple_parameter_options
         DEPENDS
-        INTERFACE_LINK_LIBRARIES
         LINK_FLAGS
         LINK_LIBS
         LINK_COMPONENTS)
@@ -1395,7 +1393,6 @@ function(add_swift_host_library name)
     LINK_LIBRARIES ${ASHL_LINK_LIBS}
     LLVM_COMPONENT_DEPENDS ${ASHL_LINK_COMPONENTS}
     LINK_FLAGS ${ASHL_LINK_FLAGS}
-    INTERFACE_LINK_LIBRARIES ${ASHL_INTERFACE_LINK_LIBRARIES}
     INSTALL_IN_COMPONENT "dev"
     )
 

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -89,7 +89,7 @@ add_swift_host_library(swiftAST STATIC
     clangAPINotes
     clangBasic
 
-  LLVM_COMPONENT_DEPENDS
+  LINK_COMPONENTS
     bitreader bitwriter coroutines coverage irreader debuginfoDWARF
     profiledata instrumentation object objcarcopts mc mcparser
     bitreader bitwriter lto ipo option core support ${LLVM_TARGETS_TO_BUILD}

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -62,7 +62,7 @@ add_swift_host_library(swiftAST STATIC
   TypeWalker.cpp
   USRGeneration.cpp
 
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftMarkup
     swiftBasic
     swiftSyntax

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -67,28 +67,6 @@ add_swift_host_library(swiftAST STATIC
     swiftBasic
     swiftSyntax
 
-  INTERFACE_LINK_LIBRARIES
-    # Clang dependencies.
-    # FIXME: Clang should really export these in some reasonable manner.
-    clangCodeGen
-    clangIndex
-    clangFormat
-    clangToolingCore
-    clangFrontendTool
-    clangFrontend
-    clangDriver
-    clangSerialization
-    clangParse
-    clangSema
-    clangAnalysis
-    clangEdit
-    clangRewriteFrontend
-    clangRewrite
-    clangAST
-    clangLex
-    clangAPINotes
-    clangBasic
-
   LINK_COMPONENTS
     bitreader bitwriter coroutines coverage irreader debuginfoDWARF
     profiledata instrumentation object objcarcopts mc mcparser
@@ -96,6 +74,10 @@ add_swift_host_library(swiftAST STATIC
 
   ${EXTRA_AST_FLAGS}
   )
+target_link_libraries(swiftAST
+                      INTERFACE
+                        clangTooling
+                        clangFrontendTool)
 
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftAST depends on these

--- a/lib/ASTSectionImporter/CMakeLists.txt
+++ b/lib/ASTSectionImporter/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_swift_host_library(swiftASTSectionImporter STATIC
   ASTSectionImporter.cpp
   LINK_LIBS swiftBasic
-  LLVM_COMPONENT_DEPENDS core)
+  LINK_COMPONENTS core)
 

--- a/lib/ASTSectionImporter/CMakeLists.txt
+++ b/lib/ASTSectionImporter/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_swift_host_library(swiftASTSectionImporter STATIC
   ASTSectionImporter.cpp
-  LINK_LIBRARIES swiftBasic
+  LINK_LIBS swiftBasic
   LLVM_COMPONENT_DEPENDS core)
 

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -99,8 +99,8 @@ add_swift_host_library(swiftBasic STATIC
   # Platform-agnostic fallback TaskQueue implementation
   Default/TaskQueue.inc
 
-  UnicodeExtendedGraphemeClusters.cpp.gyb
-
+  GYB_SOURCES
+    UnicodeExtendedGraphemeClusters.cpp.gyb
   LINK_LIBS
     swiftDemangling
     ${UUID_LIBRARIES}

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -101,7 +101,7 @@ add_swift_host_library(swiftBasic STATIC
 
   UnicodeExtendedGraphemeClusters.cpp.gyb
 
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftDemangling
     ${UUID_LIBRARIES}
   LLVM_COMPONENT_DEPENDS support)

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -1,14 +1,11 @@
 
 # On non-Darwin require UUID.
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set(UUID_INCLUDE "")
   set(UUID_LIBRARIES "")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  set(UUID_INCLUDE "")
   set(UUID_LIBRARIES "rpcrt4.lib")
 else()
   find_package(UUID REQUIRED)
-  set(UUID_INCLUDE "-I${UUID_INCLUDE_DIRS}")
 endif()
 
 # Figure out if we can track VC revisions.
@@ -104,11 +101,13 @@ add_swift_host_library(swiftBasic STATIC
 
   UnicodeExtendedGraphemeClusters.cpp.gyb
 
-  C_COMPILE_FLAGS ${UUID_INCLUDE}
   LINK_LIBRARIES
     swiftDemangling
     ${UUID_LIBRARIES}
   LLVM_COMPONENT_DEPENDS support)
+target_include_directories(swiftBasic
+                           PRIVATE
+                             ${UUID_INCLUDE_DIRS})
 
 message(STATUS "Swift version: ${SWIFT_VERSION}")
 message(STATUS "Swift vendor: ${SWIFT_VENDOR}")

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -104,7 +104,8 @@ add_swift_host_library(swiftBasic STATIC
   LINK_LIBS
     swiftDemangling
     ${UUID_LIBRARIES}
-  LLVM_COMPONENT_DEPENDS support)
+  LINK_COMPONENTS
+    support)
 target_include_directories(swiftBasic
                            PRIVATE
                              ${UUID_INCLUDE_DIRS})

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -16,7 +16,7 @@ add_swift_host_library(swiftClangImporter STATIC
   ImportName.cpp
   ImportType.cpp
   SwiftLookupTable.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftAST
     swiftParse
 )

--- a/lib/Demangling/CMakeLists.txt
+++ b/lib/Demangling/CMakeLists.txt
@@ -9,7 +9,8 @@ add_swift_host_library(swiftDemangling
                     OldRemangler.cpp
                     Punycode.cpp
                     Remangler.cpp
-                    TypeDecoder.cpp
-                  C_COMPILE_FLAGS
-                    -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
+                    TypeDecoder.cpp)
+target_compile_definitions(swiftDemangling
+                           PRIVATE
+                             LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -19,7 +19,8 @@ set(swiftDriver_targetDefines)
 add_swift_host_library(swiftDriver STATIC
   ${swiftDriver_sources}
   DEPENDS SwiftOptions
-  LINK_LIBRARIES swiftAST swiftBasic swiftOption)
+  LINK_LIBS
+    swiftAST swiftBasic swiftOption)
 
 # Generate the static-stdlib-args.lnk file used by -static-stdlib option
 # for 'GenericUnix' (eg linux)

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -12,7 +12,7 @@ add_swift_host_library(swiftFrontend STATIC
   SerializedDiagnosticConsumer.cpp
   DEPENDS
     SwiftOptions
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftSIL
     swiftMigrator
     swiftOption

--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -5,7 +5,7 @@ add_swift_host_library(swiftFrontendTool STATIC
   TBD.cpp
   DEPENDS
     swift-syntax-generated-headers SwiftOptions
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftIndex
     swiftIDE
     swiftTBDGen swiftIRGen swiftSIL swiftSILGen swiftSILOptimizer

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -13,7 +13,7 @@ add_swift_host_library(swiftIDE STATIC
   IDETypeChecking.cpp
   APIDigesterData.cpp
   SourceEntityWalker.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftFrontend
     swiftClangImporter
     swiftParse

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -49,7 +49,7 @@ add_swift_host_library(swiftIRGen STATIC
   SwiftTargetInfo.cpp
   TypeLayoutDumper.cpp
   TypeLayoutVerifier.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftAST
     swiftLLVMPasses
     swiftSIL

--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -7,6 +7,6 @@ add_swift_host_library(swiftImmediate STATIC
     swiftSILGen
     swiftSILOptimizer
     swiftIRGen
-  LLVM_COMPONENT_DEPENDS
+  LINK_COMPONENTS
     linker mcjit)
 

--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_swift_host_library(swiftImmediate STATIC
   Immediate.cpp
   REPL.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftIDE
     swiftFrontend
     swiftSILGen

--- a/lib/Index/CMakeLists.txt
+++ b/lib/Index/CMakeLists.txt
@@ -3,5 +3,5 @@ add_swift_host_library(swiftIndex STATIC
   IndexDataConsumer.cpp
   IndexRecord.cpp
   IndexSymbol.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftAST)

--- a/lib/LLVMPasses/CMakeLists.txt
+++ b/lib/LLVMPasses/CMakeLists.txt
@@ -6,7 +6,7 @@ add_swift_host_library(swiftLLVMPasses STATIC
   LLVMInlineTree.cpp
   LLVMMergeFunctions.cpp
 
-  LLVM_COMPONENT_DEPENDS
-  analysis
+  LINK_COMPONENTS
+    analysis
   )
 

--- a/lib/Markup/CMakeLists.txt
+++ b/lib/Markup/CMakeLists.txt
@@ -2,8 +2,7 @@ add_swift_host_library(swiftMarkup STATIC
   AST.cpp
   LineList.cpp
   Markup.cpp
-  
-  LINK_LIBRARIES
+  LINK_LIBS
     libcmark_static)
 target_compile_definitions(swiftMarkup
                            PRIVATE

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -49,7 +49,8 @@ add_swift_host_library(swiftMigrator STATIC
   Migrator.cpp
   MigrationState.cpp
   RewriteBufferEditsReceiver.cpp
-  LINK_LIBRARIES swiftSyntax swiftIDE)
+  LINK_LIBS
+    swiftSyntax swiftIDE)
 
 add_dependencies(swiftMigrator
   "symlink_migrator_data")

--- a/lib/Option/CMakeLists.txt
+++ b/lib/Option/CMakeLists.txt
@@ -2,6 +2,5 @@ add_swift_host_library(swiftOption STATIC
   Options.cpp
   SanitizerOptions.cpp
   DEPENDS SwiftOptions
-  LINK_LIBRARIES swiftBasic
-  FILE_DEPENDS SwiftOptions)
+  LINK_LIBRARIES swiftBasic)
 

--- a/lib/Option/CMakeLists.txt
+++ b/lib/Option/CMakeLists.txt
@@ -2,5 +2,6 @@ add_swift_host_library(swiftOption STATIC
   Options.cpp
   SanitizerOptions.cpp
   DEPENDS SwiftOptions
-  LINK_LIBRARIES swiftBasic)
+  LINK_LIBS
+    swiftBasic)
 

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -13,7 +13,7 @@ add_swift_host_library(swiftParse STATIC
   Scope.cpp
   SyntaxParsingCache.cpp
   SyntaxParsingContext.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftAST
     swiftSyntax
 )

--- a/lib/ParseSIL/CMakeLists.txt
+++ b/lib/ParseSIL/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_host_library(swiftParseSIL STATIC
   ParseSIL.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftParse
     swiftSema
     swiftSIL

--- a/lib/PrintAsObjC/CMakeLists.txt
+++ b/lib/PrintAsObjC/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_host_library(swiftPrintAsObjC STATIC
   PrintAsObjC.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftIDE
     swiftFrontend
     swiftClangImporter

--- a/lib/RemoteAST/CMakeLists.txt
+++ b/lib/RemoteAST/CMakeLists.txt
@@ -15,5 +15,5 @@ add_swift_host_library(swiftRemoteAST STATIC
   RemoteAST.cpp
   InProcessMemoryReader.cpp
   ${REMOTE_LIB_HEADERS}
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftSema swiftIRGen)

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -44,7 +44,7 @@ add_swift_host_library(swiftSIL STATIC
   SILWitnessTable.cpp
   TypeLowering.cpp
   ValueOwnership.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftSerialization
     swiftSema
 )

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -30,6 +30,6 @@ add_swift_host_library(swiftSILGen STATIC
   SILGenStmt.cpp
   SILGenThunk.cpp
   SILGenType.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftSIL
 )

--- a/lib/SILOptimizer/CMakeLists.txt
+++ b/lib/SILOptimizer/CMakeLists.txt
@@ -35,4 +35,5 @@ add_subdirectory(Utils)
 
 add_swift_host_library(swiftSILOptimizer STATIC
   ${SILOPTIMIZER_SOURCES}
-  LINK_LIBRARIES swiftSIL)
+  LINK_LIBS
+    swiftSIL)

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -58,7 +58,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckSwitchStmt.cpp
   TypeCheckType.cpp
   TypeChecker.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftParse
     swiftAST
     swiftSerialization

--- a/lib/Serialization/CMakeLists.txt
+++ b/lib/Serialization/CMakeLists.txt
@@ -7,6 +7,6 @@ add_swift_host_library(swiftSerialization STATIC
   SerializedSILLoader.cpp
   SerializeDoc.cpp
   SerializeSIL.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftClangImporter)
 

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -2,7 +2,7 @@ add_swift_host_library(swiftDemangle
                   SHARED
                     SwiftDemangle.cpp
                     MangleHack.cpp
-                  LINK_LIBRARIES
+                  LINK_LIBS
                     swiftDemangling)
 target_compile_definitions(swiftDemangle
                            PRIVATE

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -3,9 +3,10 @@ add_swift_host_library(swiftDemangle
                     SwiftDemangle.cpp
                     MangleHack.cpp
                   LINK_LIBRARIES
-                    swiftDemangling
-                  C_COMPILE_FLAGS
-                    -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
+                    swiftDemangling)
+target_compile_definitions(swiftDemangle
+                           PRIVATE
+                             LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 
 swift_install_in_component(compiler
     TARGETS swiftDemangle

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -5,14 +5,15 @@ else()
 endif()
 
 add_swift_host_library(swiftSyntax STATIC
-  SyntaxNodes.cpp.gyb
-  SyntaxBuilders.cpp.gyb
-  SyntaxKind.cpp.gyb
-  SyntaxFactory.cpp.gyb
-  SyntaxVisitor.cpp.gyb
-  Trivia.cpp.gyb
   RawSyntax.cpp
   Syntax.cpp
   SyntaxData.cpp
-  SyntaxSerialization.cpp.gyb
-  UnknownSyntax.cpp)
+  UnknownSyntax.cpp
+  GYB_SOURCES
+    SyntaxNodes.cpp.gyb
+    SyntaxBuilders.cpp.gyb
+    SyntaxKind.cpp.gyb
+    SyntaxFactory.cpp.gyb
+    SyntaxVisitor.cpp.gyb
+    Trivia.cpp.gyb
+    SyntaxSerialization.cpp.gyb)

--- a/lib/TBDGen/CMakeLists.txt
+++ b/lib/TBDGen/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(tapi)
 add_swift_host_library(swiftTBDGen STATIC
   ${TAPI_SOURCES}
   TBDGen.cpp
-  LINK_LIBRARIES
+  LINK_LIBS
     swiftAST
     swiftSIL
 )


### PR DESCRIPTION
…brary`

Split up the `add_swift_library` by extracting the tools host handling aspect of
it.  This has a much more limited option set.  Reducing the options further
would allow us to eliminate this and replace it with a wrapper around
`add_llvm_library`.  Leave the bulk of the logic in place in
`add_swift_target_library` which can now be simplified on its own.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
