### PR TITLE
Remove unwanted exceptions from @inlinable checking

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4031,9 +4031,6 @@ WARNING(inlinable_implies_usable_from_inline,none,
 ERROR(usable_from_inline_attr_in_protocol,none,
       "'@usableFromInline' attribute cannot be used in protocols", ())
 
-ERROR(usable_from_inline_dynamic_not_supported,none,
-      "'@usableFromInline' attribute cannot be applied to 'dynamic' declarations", ())
-
 #define FRAGILE_FUNC_KIND \
   "%select{a '@_transparent' function|" \
   "an '@inline(__always)' function|" \

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2358,9 +2358,11 @@ bool ValueDecl::isUsableFromInline() const {
     if (EED->getParentEnum()->getAttrs().hasAttribute<UsableFromInlineAttr>())
       return true;
 
-  if (auto *ATD = dyn_cast<AssociatedTypeDecl>(this))
-    if (ATD->getProtocol()->getAttrs().hasAttribute<UsableFromInlineAttr>())
+  if (auto *containingProto = dyn_cast<ProtocolDecl>(getDeclContext())) {
+    if (isProtocolRequirement() &&
+        containingProto->getAttrs().hasAttribute<UsableFromInlineAttr>())
       return true;
+  }
 
   if (auto *DD = dyn_cast<DestructorDecl>(this))
     if (auto *CD = dyn_cast<ClassDecl>(DD->getDeclContext()))

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -111,20 +111,14 @@ bool TypeChecker::diagnoseInlinableDeclRef(SourceLoc loc,
                               TreatUsableFromInlineAsPublic).isPublic())
     return false;
 
-  // Enum cases are handled as part of their containing enum.
-  if (isa<EnumElementDecl>(D))
+  // Dynamic declarations were mistakenly not checked in Swift 4.2.
+  // Do enforce the restriction even in pre-Swift-5 modes if the module we're
+  // building is resilient, though.
+  if (D->isDynamic() && !Context.isSwiftVersionAtLeast(5) &&
+      DC->getParentModule()->getResilienceStrategy() !=
+        ResilienceStrategy::Resilient) {
     return false;
-
-  // Protocol requirements are not versioned because there's no
-  // global entry point.
-  if (isa<ProtocolDecl>(D->getDeclContext()) &&
-      D->isProtocolRequirement())
-    return false;
-
-  // Dynamic declarations are not versioned because there's no
-  // global entry point.
-  if (D->isDynamic())
-    return false;
+  }
 
   DowngradeToWarning downgradeToWarning = DowngradeToWarning::No;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1844,16 +1844,6 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
     return;
   }
 
-  // Symbols of dynamically-dispatched declarations are never referenced
-  // directly, so marking them as @usableFromInline does not make sense.
-  if (VD->isDynamic()) {
-    if (attr->isImplicit())
-      attr->setInvalid();
-    else
-      diagnoseAndRemoveAttr(attr, diag::usable_from_inline_dynamic_not_supported);
-    return;
-  }
-
   // On internal declarations, @inlinable implies @usableFromInline.
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
     if (TC.Context.isSwiftVersionAtLeast(4,2))

--- a/test/Compatibility/attr_inlinable_dynamic.swift
+++ b/test/Compatibility/attr_inlinable_dynamic.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4 -enable-objc-interop -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4 -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-testing
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4.2 -enable-objc-interop -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4.2 -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-testing
+
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4 -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-resilience -verify
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4 -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-testing -enable-resilience -verify
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4.2 -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-resilience -verify
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4.2 -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-testing -enable-resilience -verify
+
+@objc internal enum InternalEnum: UInt8 {
+  case dummy
+}
+
+public class Foo {
+  @objc dynamic func dynamicFunc() -> InternalEnum {} // expected-note {{instance method 'dynamicFunc()' is not '@usableFromInline' or public}}
+  @inlinable func inlineMe() {
+    _ = dynamicFunc() // expected-error {{instance method 'dynamicFunc()' is internal and cannot be referenced from an '@inlinable' function}}
+  }
+}

--- a/test/Compatibility/attr_usableFromInline_swift4.swift
+++ b/test/Compatibility/attr_usableFromInline_swift4.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
-// RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4 -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 @usableFromInline private func privateVersioned() {}
 // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}
@@ -121,3 +121,9 @@ enum BadEnum {
 
 @usableFromInline
 class BadClass : InternalClass {}
+
+public class DynamicMembers {
+  @usableFromInline @objc dynamic init() {}
+  @usableFromInline @objc dynamic func foo() {}
+  @usableFromInline @objc dynamic var bar: Int = 0
+}

--- a/test/Compatibility/attr_usableFromInline_swift42.swift
+++ b/test/Compatibility/attr_usableFromInline_swift42.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4.2
-// RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4.2
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4.2 -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 @usableFromInline private func privateVersioned() {}
 // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}
@@ -141,3 +141,9 @@ enum BadEnum {
 @usableFromInline
 class BadClass : InternalClass {}
 // expected-warning@-1 {{type referenced from the superclass of a '@usableFromInline' class should be '@usableFromInline' or public}}
+
+public class DynamicMembers {
+  @usableFromInline @objc dynamic init() {}
+  @usableFromInline @objc dynamic func foo() {}
+  @usableFromInline @objc dynamic var bar: Int = 0
+}

--- a/test/ParseableInterface/access-filter.swift
+++ b/test/ParseableInterface/access-filter.swift
@@ -47,7 +47,11 @@ internal struct UFIStruct {
 
 // CHECK: public protocol PublicProto {{[{]$}}
 public protocol PublicProto {
-} // CHECK: {{^[}]$}}
+  // CHECK-NEXT: associatedtype Assoc = Swift.Int
+  associatedtype Assoc = Int
+  // CHECK-NEXT: func requirement()
+  func requirement()
+} // CHECK-NEXT: {{^[}]$}}
 
 // CHECK: extension PublicProto {{[{]$}}
 extension PublicProto {
@@ -72,6 +76,8 @@ public extension PublicProto {
 }
 
 internal protocol InternalProto_BAD {
+  associatedtype AssocBAD = Int
+  func requirementBAD()
 }
 
 extension InternalProto_BAD {
@@ -84,7 +90,11 @@ extension InternalProto_BAD {
 // CHECK-NEXT: internal protocol UFIProto {{[{]$}}
 @usableFromInline
 internal protocol UFIProto {
-} // CHECK: {{^[}]$}}
+  // CHECK-NEXT: associatedtype Assoc = Swift.Int
+  associatedtype Assoc = Int
+  // CHECK-NEXT: func requirement()
+  func requirement()
+} // CHECK-NEXT: {{^[}]$}}
 
 // CHECK: extension UFIProto {{[{]$}}
 extension UFIProto {
@@ -104,10 +114,38 @@ extension PublicStruct {
 } // CHECK: {{^[}]$}}
 
 extension InternalStruct_BAD: PublicProto {
+  func requirement() {}
   internal static var dummy: Int { return 0 }
 }
 
 // CHECK: extension UFIStruct : PublicProto {{[{]$}}
 extension UFIStruct: PublicProto {
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal typealias Assoc = Swift.Int
+
+  // FIXME: Is it okay for this non-@usableFromInline implementation to satisfy
+  // the protocol?
+  func requirement() {}
   internal static var dummy: Int { return 0 }
+} // CHECK-NEXT: {{^[}]$}}
+
+// CHECK: public enum PublicEnum {{[{]$}}
+public enum PublicEnum {
+  // CHECK-NEXT: case x
+  case x
+  // CHECK-NEXT: case y(Int)
+  case y(Int)
+} // CHECK-NEXT: {{^[}]$}}
+
+enum InternalEnum_BAD {
+  case xBAD
+}
+
+// CHECK: @usableFromInline
+// CHECK-NEXT: internal enum UFIEnum {{[{]$}}
+@usableFromInline enum UFIEnum {
+  // CHECK-NEXT: case x
+  case x
+  // CHECK-NEXT: case y(Int)
+  case y(Int)
 } // CHECK-NEXT: {{^[}]$}}

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -14,3 +14,54 @@
 /* Decl Attribute changes */
 
 /* Protocol Requirement Changes */
+
+// These are requirements of @usableFromInline protocols, which previously
+// were not being tracked.
+Func _AnyHashableBox._downCastConditional(into:) has been added as a protocol requirement
+Func _AnyHashableBox._hash(into:) has been added as a protocol requirement
+Func _AnyHashableBox._isEqual(to:) has been added as a protocol requirement
+Func _AnyHashableBox._rawHashValue(_seed:) has been added as a protocol requirement
+Func _AnyHashableBox._unbox() has been added as a protocol requirement
+Func _AnyIndexBox._isEqual(to:) has been added as a protocol requirement
+Func _AnyIndexBox._isLess(than:) has been added as a protocol requirement
+Func _AnyIndexBox._unbox() has been added as a protocol requirement
+Func _ArrayBufferProtocol._copyContents(subRange:initializing:) has been added as a protocol requirement
+Func _ArrayBufferProtocol.isMutableAndUniquelyReferenced() has been added as a protocol requirement
+Func _ArrayBufferProtocol.replaceSubrange(_:with:elementsOf:) has been added as a protocol requirement
+Func _ArrayBufferProtocol.requestNativeBuffer() has been added as a protocol requirement
+Func _ArrayBufferProtocol.requestUniqueMutableBackingBuffer(minimumCapacity:) has been added as a protocol requirement
+Func _ArrayBufferProtocol.withUnsafeBufferPointer(_:) has been added as a protocol requirement
+Func _ArrayBufferProtocol.withUnsafeMutableBufferPointer(_:) has been added as a protocol requirement
+Func _HasContiguousBytes.withUnsafeBytes(_:) has been added as a protocol requirement
+Func _HashTableDelegate.hashValue(at:) has been added as a protocol requirement
+Func _HashTableDelegate.moveEntry(from:to:) has been added as a protocol requirement
+Func _HasherCore.compress(_:) has been added as a protocol requirement
+Func _HasherCore.finalize(tailAndByteCount:) has been added as a protocol requirement
+Func _StringVariant._copy(into:) has been added as a protocol requirement
+Func _StringVariant._measureFirstExtendedGraphemeClusterSlow() has been added as a protocol requirement
+Func _StringVariant._measureLastExtendedGraphemeClusterSlow() has been added as a protocol requirement
+Func _StringVariant.makeUnicodeScalarIterator() has been added as a protocol requirement
+Func _StringVariant.measureFirstExtendedGraphemeCluster() has been added as a protocol requirement
+Func _StringVariant.measureLastExtendedGraphemeCluster() has been added as a protocol requirement
+Subscript _ArrayBufferProtocol.subscript(_:) has been added as a protocol requirement
+Subscript _StringVariant.subscript(_:) has been added as a protocol requirement
+Var _AnyHashableBox._base has been added as a protocol requirement
+Var _AnyHashableBox._canonicalBox has been added as a protocol requirement
+Var _AnyHashableBox._hashValue has been added as a protocol requirement
+Var _AnyIndexBox._typeID has been added as a protocol requirement
+Var _ArrayBufferProtocol.capacity has been added as a protocol requirement
+Var _ArrayBufferProtocol.firstElementAddress has been added as a protocol requirement
+Var _ArrayBufferProtocol.firstElementAddressIfContiguous has been added as a protocol requirement
+Var _ArrayBufferProtocol.identity has been added as a protocol requirement
+Var _ArrayBufferProtocol.owner has been added as a protocol requirement
+Var _ArrayBufferProtocol.subscriptBaseAddress has been added as a protocol requirement
+Var _ArrayProtocol._baseAddressIfContiguous has been added as a protocol requirement
+Var _ArrayProtocol._buffer has been added as a protocol requirement
+Var _ArrayProtocol._owner has been added as a protocol requirement
+Var _ArrayProtocol.capacity has been added as a protocol requirement
+Var _HeapBufferHeader_.value has been added as a protocol requirement
+Var _StringVariant.isASCII has been added as a protocol requirement
+Var _SwiftStringView._encodedOffsetRange has been added as a protocol requirement
+Var _SwiftStringView._ephemeralContent has been added as a protocol requirement
+Var _SwiftStringView._persistentContent has been added as a protocol requirement
+Var _SwiftStringView._wholeString has been added as a protocol requirement

--- a/test/attr/attr_inlinable_dynamic.swift
+++ b/test/attr/attr_inlinable_dynamic.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-objc-interop -disable-objc-attr-requires-foundation-module -verify
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-testing -verify
+
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-resilience -verify
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-testing -enable-resilience -verify
+
+@objc internal enum InternalEnum: UInt8 {
+  case dummy
+}
+
+public class Foo {
+  @objc dynamic func dynamicFunc() -> InternalEnum {} // expected-note {{instance method 'dynamicFunc()' is not '@usableFromInline' or public}}
+  @inlinable func inlineMe() {
+    _ = dynamicFunc() // expected-error {{instance method 'dynamicFunc()' is internal and cannot be referenced from an '@inlinable' function}}
+  }
+}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2291,13 +2291,10 @@ class User: NSObject {
   }
 }
 
-// 'dynamic' methods cannot be @inlinable or @usableFromInline
+// 'dynamic' methods cannot be @inlinable.
 class BadClass {
   @inlinable @objc dynamic func badMethod1() {}
   // expected-error@-1 {{'@inlinable' attribute cannot be applied to 'dynamic' declarations}}
-
-  @usableFromInline @objc dynamic func badMethod2() {}
-  // expected-error@-1 {{'@usableFromInline' attribute cannot be applied to 'dynamic' declarations}}
 }
 
 @objc

--- a/test/attr/attr_usableFromInline.swift
+++ b/test/attr/attr_usableFromInline.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
-// RUN: %target-typecheck-verify-swift -enable-testing -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-testing
 
 @usableFromInline private func privateVersioned() {}
 // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}
@@ -66,6 +66,12 @@ public func usesEqEnum() -> Bool {
 
   _ = RawEnum.foo.rawValue
   _ = RawEnum(rawValue: 0)
+}
+
+public class DynamicMembers {
+  @usableFromInline @objc dynamic init() {}
+  @usableFromInline @objc dynamic func foo() {}
+  @usableFromInline @objc dynamic var bar: Int = 0
 }
 
 internal struct InternalStruct {}


### PR DESCRIPTION
- Treat protocol requirements just like associated types in how they inherit usable-from-inline-ness, rather than special-casing them in the check for inlinable code.

- Enum elements are already treated this way, so we can remove a redundant check for that.

- Finally, start enforcing that `dynamic` declarations need to be `@usableFromInline` to be used in inlinable functions...in Swift 5 mode or resilient code. I didn't even add a warning in Swift 4/4.2 because it was illegal to use `@usableFromInline` on a `dynamic` declaration in Swift 4.2. (Oops.)

See also #19548, which would reasonably allow us to add that warning.