### PR TITLE
[AST/Printing] Don't omit empty labels in special names

### DIFF
--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -184,7 +184,7 @@ llvm::raw_ostream &DeclName::print(llvm::raw_ostream &os,
 }
 
 llvm::raw_ostream &DeclName::printPretty(llvm::raw_ostream &os) const {
-  return print(os, /*skipEmptyArgumentNames=*/true);
+  return print(os, /*skipEmptyArgumentNames=*/!isSpecial());
 }
 
 ObjCSelector::ObjCSelector(ASTContext &ctx, unsigned numArgs,

--- a/test/ClangImporter/availability.swift
+++ b/test/ClangImporter/availability.swift
@@ -54,19 +54,19 @@ func test_unavailable_accessors(_ obj: UnavailableAccessors,
   UnavailableAccessors.setterUnavailableClass = 0 // expected-error {{setter for 'setterUnavailableClass' is unavailable}}
   UnavailableAccessors.setterUnavailableClass += 1 // expected-error {{setter for 'setterUnavailableClass' is unavailable}}
 
-  _ = sub[0] // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}}
-  sub[0] = "" // expected-error {{setter for 'subscript' is unavailable: bad subscript setter}}
-  sub[0] += "" // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}} expected-error {{setter for 'subscript' is unavailable: bad subscript setter}}
+  _ = sub[0] // expected-error {{getter for 'subscript(_:)' is unavailable: bad subscript getter}}
+  sub[0] = "" // expected-error {{setter for 'subscript(_:)' is unavailable: bad subscript setter}}
+  sub[0] += "" // expected-error {{getter for 'subscript(_:)' is unavailable: bad subscript getter}} expected-error {{setter for 'subscript(_:)' is unavailable: bad subscript setter}}
 
-  _ = subGetter[0] // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}}
+  _ = subGetter[0] // expected-error {{getter for 'subscript(_:)' is unavailable: bad subscript getter}}
   subGetter[0] = ""
-  subGetter[0] += "" // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}}
+  subGetter[0] += "" // expected-error {{getter for 'subscript(_:)' is unavailable: bad subscript getter}}
 
   _ = subSetter[0]
-  subSetter[0] = "" // expected-error {{setter for 'subscript' is unavailable: bad subscript setter}}
-  subSetter[0] += "" // expected-error {{setter for 'subscript' is unavailable: bad subscript setter}}
+  subSetter[0] = "" // expected-error {{setter for 'subscript(_:)' is unavailable: bad subscript setter}}
+  subSetter[0] += "" // expected-error {{setter for 'subscript(_:)' is unavailable: bad subscript setter}}
 
-  _ = subReadOnly[0] // expected-error {{getter for 'subscript' is unavailable}}
+  _ = subReadOnly[0] // expected-error {{getter for 'subscript(_:)' is unavailable}}
 }
 
 func test_deprecated(_ s:UnsafeMutablePointer<CChar>, _ obj: AccessorDeprecations,
@@ -100,19 +100,19 @@ func test_deprecated(_ s:UnsafeMutablePointer<CChar>, _ obj: AccessorDeprecation
   AccessorDeprecations.setterDeprecatedClass = 0 // expected-warning {{setter for 'setterDeprecatedClass' is deprecated}}
   AccessorDeprecations.setterDeprecatedClass += 1 // expected-warning {{setter for 'setterDeprecatedClass' is deprecated}}
 
-  _ = sub[0] // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}}
-  sub[0] = "" // expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}}
-  sub[0] += "" // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}} expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}}
+  _ = sub[0] // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter}}
+  sub[0] = "" // expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter}}
+  sub[0] += "" // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter}} expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter}}
 
-  _ = subGetter[0] // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}}
+  _ = subGetter[0] // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter}}
   subGetter[0] = ""
-  subGetter[0] += "" // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}}
+  subGetter[0] += "" // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter}}
 
   _ = subSetter[0]
-  subSetter[0] = "" // expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}}
-  subSetter[0] += "" // expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}}
+  subSetter[0] = "" // expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter}}
+  subSetter[0] += "" // expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter}}
 
-  _ = subReadOnly[0] // expected-warning {{getter for 'subscript' is deprecated}}
+  _ = subReadOnly[0] // expected-warning {{getter for 'subscript(_:)' is deprecated}}
 }
 
 func test_NSInvocation(_ x: NSInvocation,         // expected-error {{'NSInvocation' is unavailable}}

--- a/test/Compatibility/attr_override.swift
+++ b/test/Compatibility/attr_override.swift
@@ -40,7 +40,7 @@ class A {
   var v9: Int { return 5 } // expected-note{{attempt to override property here}}
   var v10: Int { return 5 } // expected-note{{attempt to override property here}}
 
-  subscript (i: Int) -> String { // expected-note{{potential overridden subscript 'subscript' here}}
+  subscript (i: Int) -> String { // expected-note{{potential overridden subscript 'subscript(_:)' here}}
     get {
       return "hello"
     }
@@ -49,7 +49,7 @@ class A {
     }
   }
 
-  subscript (d: Double) -> String { // expected-note{{overridden declaration is here}} expected-note{{potential overridden subscript 'subscript' here}}
+  subscript (d: Double) -> String { // expected-note{{overridden declaration is here}} expected-note{{potential overridden subscript 'subscript(_:)' here}}
     get {
       return "hello"
     }
@@ -58,11 +58,11 @@ class A {
     }
   }
 
-  subscript (i: Int8) -> A { // expected-note{{potential overridden subscript 'subscript' here}}
+  subscript (i: Int8) -> A { // expected-note{{potential overridden subscript 'subscript(_:)' here}}
     get { return self }
   }
 
-  subscript (i: Int16) -> A { // expected-note{{attempt to override subscript here}} expected-note{{potential overridden subscript 'subscript' here}}
+  subscript (i: Int16) -> A { // expected-note{{attempt to override subscript here}} expected-note{{potential overridden subscript 'subscript(_:)' here}}
     get { return self }
     set { }
   }

--- a/test/Compatibility/special_func_name.swift
+++ b/test/Compatibility/special_func_name.swift
@@ -14,7 +14,7 @@ struct S12 : P1 { // expected-error {{type 'S12' does not conform to protocol 'P
 }
 
 protocol P2 {
-  init(_: Int) // expected-note {{protocol requires initializer 'init' with type 'Int'; do you want to add a stub?}}
+  init(_: Int) // expected-note {{protocol requires initializer 'init(_:)' with type 'Int'; do you want to add a stub?}}
 }
 
 struct S21 : P2 { // expected-error {{type 'S21' does not conform to protocol 'P2'}}

--- a/test/Compatibility/tuple_arguments_4.swift
+++ b/test/Compatibility/tuple_arguments_4.swift
@@ -513,7 +513,7 @@ do {
 }
 
 struct InitTwo {
-  init(_ x: Int, _ y: Int) {} // expected-note 5 {{'init' declared here}}
+  init(_ x: Int, _ y: Int) {} // expected-note 5 {{'init(_:_:)' declared here}}
 }
 
 struct InitTuple {
@@ -564,7 +564,7 @@ do {
 }
 
 struct SubscriptTwo {
-  subscript(_ x: Int, _ y: Int) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript' declared here}}
+  subscript(_ x: Int, _ y: Int) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript(_:_:)' declared here}}
 }
 
 struct SubscriptTuple {
@@ -915,7 +915,7 @@ struct GenericInitLabeled<T> {
 }
 
 struct GenericInitTwo<T> {
-  init(_ x: T, _ y: T) {} // expected-note 10 {{'init' declared here}}
+  init(_ x: T, _ y: T) {} // expected-note 10 {{'init(_:_:)' declared here}}
 }
 
 struct GenericInitTuple<T> {
@@ -1041,7 +1041,7 @@ struct GenericSubscriptLabeled<T> {
 }
 
 struct GenericSubscriptTwo<T> {
-  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript' declared here}}
+  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript(_:_:)' declared here}}
 }
 
 struct GenericSubscriptLabeledTuple<T> {

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -27,7 +27,7 @@ func g(_ x: Int, _ y: Int) -> () {} // expected-note{{found this candidate}}
 C(g) // expected-error{{ambiguous use of 'g'}}
 
 func h<T>(_ x: T) -> () {}
-C(h) // expected-error{{ambiguous use of 'init'}}
+C(h) // expected-error{{ambiguous use of 'init(_:)'}}
 
 func rdar29691909_callee(_ o: AnyObject?) -> Any? { return o } // expected-note {{found this candidate}}
 func rdar29691909_callee(_ o: AnyObject) -> Any { return o } // expected-note {{found this candidate}}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -681,7 +681,7 @@ func r23641896() {
   var g = "Hello World"
   g.replaceSubrange(0...2, with: "ce")  // expected-error {{cannot convert value of type 'ClosedRange<Int>' to expected argument type 'Range<String.Index>'}}
 
-  _ = g[12]  // expected-error {{'subscript' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
+  _ = g[12]  // expected-error {{'subscript(_:)' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
 
 }
 
@@ -1199,7 +1199,7 @@ func platypus<T>(a: [T]) {
 func badTypes() {
   let sequence:AnySequence<[Int]> = AnySequence() { AnyIterator() { [3] }}
   let array = [Int](sequence)
-  // expected-error@-1 {{initializer 'init' requires the types 'Int' and '[Int]' be equivalent}}
+  // expected-error@-1 {{initializer 'init(_:)' requires the types 'Int' and '[Int]' be equivalent}}
 }
 
 // rdar://34357545

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -253,7 +253,7 @@ struct V27515965 {
 
 func test(x: S27515965) -> V27515965 {
   return V27515965(x)
-  // expected-error@-1 {{initializer 'init' requires the types 'Any' and 'Float' be equivalent}}
+  // expected-error@-1 {{initializer 'init(_:)' requires the types 'Any' and 'Float' be equivalent}}
 }
 
 protocol BaseProto {}

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -233,7 +233,7 @@ r23331567 { $0 += 1 }
 // <rdar://problem/30685195> Compiler crash with invalid assignment
 struct G<T> {
   subscript(x: Int) -> T { get { } nonmutating set { } }
-  // expected-note@-1 {{'subscript' declared here}}
+  // expected-note@-1 {{'subscript(_:)' declared here}}
 }
 
 func wump<T>(to: T, _ body: (G<T>) -> ()) {}

--- a/test/Constraints/rdar44569159.swift
+++ b/test/Constraints/rdar44569159.swift
@@ -13,6 +13,6 @@ struct A {
 
 func foo(_ v: Double) {
   _ = A()[S(value: v)]
-// expected-error@-1 {{subscript 'subscript' requires that 'Double' conform to 'P'}}
+// expected-error@-1 {{subscript 'subscript(_:)' requires that 'Double' conform to 'P'}}
 // expected-error@-2 {{referencing initializer 'init(value:)' on 'S' requires that 'Double' conform to 'P'}}
 }

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -68,7 +68,7 @@ extension Int {
   subscript(key: String) -> Double {  get {} }   // expected-note {{found this candidate}}
 }
 
-let _ = 1["1"]  // expected-error {{ambiguous use of 'subscript'}}
+let _ = 1["1"]  // expected-error {{ambiguous use of 'subscript(_:)'}}
 
 let squares = [ 1, 2, 3 ].reduce([:]) { (dict, n) in
   var dict = dict

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -169,7 +169,7 @@ struct MagicKingdom<K> : Kingdom {
 }
 func magify<T>(_ t: T) -> MagicKingdom<T> { return MagicKingdom() }
 func foo(_ pair: (Int, Int)) -> Victory<(x: Int, y: Int)> {
-  return Victory(magify(pair)) // expected-error {{initializer 'init' requires the types '(x: Int, y: Int)' and '(Int, Int)' be equivalent}}
+  return Victory(magify(pair)) // expected-error {{initializer 'init(_:)' requires the types '(x: Int, y: Int)' and '(Int, Int)' be equivalent}}
 }
 
 

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -514,7 +514,7 @@ do {
 }
 
 struct InitTwo {
-  init(_ x: Int, _ y: Int) {} // expected-note 5 {{'init' declared here}}
+  init(_ x: Int, _ y: Int) {} // expected-note 5 {{'init(_:_:)' declared here}}
 }
 
 struct InitTuple {
@@ -565,7 +565,7 @@ do {
 }
 
 struct SubscriptTwo {
-  subscript(_ x: Int, _ y: Int) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript' declared here}}
+  subscript(_ x: Int, _ y: Int) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript(_:_:)' declared here}}
 }
 
 struct SubscriptTuple {
@@ -916,7 +916,7 @@ struct GenericInitLabeled<T> {
 }
 
 struct GenericInitTwo<T> {
-  init(_ x: T, _ y: T) {} // expected-note 10 {{'init' declared here}}
+  init(_ x: T, _ y: T) {} // expected-note 10 {{'init(_:_:)' declared here}}
 }
 
 struct GenericInitTuple<T> {
@@ -1042,7 +1042,7 @@ struct GenericSubscriptLabeled<T> {
 }
 
 struct GenericSubscriptTwo<T> {
-  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript' declared here}}
+  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript(_:_:)' declared here}}
 }
 
 struct GenericSubscriptLabeledTuple<T> {

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -262,7 +262,7 @@ func hasLocalDecls() {
     // CHECK: FAILURE for 'localMethod'
     func localMethod() {}
 
-    // CHECK: FAILURE for 'subscript'
+    // CHECK: FAILURE for 'subscript(_:)'
     subscript(x: Int) { get {} set {} }
 
     // CHECK: decl: FAILURE for ''
@@ -304,7 +304,7 @@ struct HasSubscript {
 // FIXME
 // CHECK: decl: FAILURE	for 'T' usr=s:14swift_ide_test19HasGenericSubscriptV1Txmfp
 struct HasGenericSubscript<T> {
-  // CHECK: subscript<U>(t: T) -> U { get set }	for 'subscript' usr=s:14swift_ide_test19HasGenericSubscriptVyqd__xclui
+  // CHECK: subscript<U>(t: T) -> U { get set }	for 'subscript(_:)' usr=s:14swift_ide_test19HasGenericSubscriptVyqd__xclui
   // FIXME
   // CHECK: decl: FAILURE	for 'U'
   // FIXME

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -54,7 +54,7 @@ _ = Foo() // expected-error {{'Foo' initializer is inaccessible due to 'internal
 // <rdar://problem/27982012> QoI: Poor diagnostic for inaccessible initializer
 struct rdar27982012 {
   var x: Int
-  private init(_ x: Int) { self.x = x } // expected-note {{'init' declared here}}
+  private init(_ x: Int) { self.x = x } // expected-note {{'init(_:)' declared here}}
 }
 
 _ = { rdar27982012($0.0) }((1, 2)) // expected-error {{initializer is inaccessible due to 'private' protection level}}

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -325,7 +325,7 @@ class LazyProperties {
 
 // CHECK-EXPANDED:        TypeDecl {{.*}} StructContainsAbstractStorageDecls [114:1 - 130:1] expanded
 // CHECK-EXPANDED-NEXT: `-TypeOrExtensionBody {{.*}} 'StructContainsAbstractStorageDecls' [114:43 - 130:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}  |-Accessors {{.*}} scope_map.(file).StructContainsAbstractStorageDecls.subscript@{{.*}}scope_map.swift:115:3 [115:37 - 121:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  |-Accessors {{.*}} scope_map.(file).StructContainsAbstractStorageDecls.subscript(_:_:)@{{.*}}scope_map.swift:115:3 [115:37 - 121:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  |-AbstractFunctionDecl {{.*}} _ [116:5 - 117:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [116:5 - 117:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [116:5 - 117:5] expanded
@@ -404,7 +404,7 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [167:32 - 167:42] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} defaultArguments(i:j:) param 0:1 [167:48 - 175:1] expanded
 
-// CHECK-EXPANDED: -Accessors {{.*}} scope_map.(file).ProtoWithSubscript.subscript@{{.*}}scope_map.swift:183:3 [183:33 - 183:43] expanded
+// CHECK-EXPANDED: -Accessors {{.*}} scope_map.(file).ProtoWithSubscript.subscript(_:)@{{.*}}scope_map.swift:183:3 [183:33 - 183:43] expanded
 // CHECK-EXPANDED-NEXT:     |-AbstractFunctionDecl {{.*}} _ [183:35 - 183:35] expanded
 // CHECK-EXPANDED-NEXT:       `-AbstractFunctionParams {{.*}} _ param 0:0 [183:35 - 183:35] expanded
 // CHECK-EXPANDED-NEXT:         `-AbstractFunctionParams {{.*}} _ param 1:0 [183:35 - 183:35] expanded

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -348,7 +348,7 @@ func takesRawBuffer(_ b: UnsafeRawBufferPointer) {}
 
 // <rdar://problem/29586888> UnsafeRawBufferPointer range subscript is inconsistent with Collection.
 func f29586888(b: UnsafeRawBufferPointer) {
-  takesRawBuffer(b[1..<2]) // expected-error {{'subscript' is unavailable: use 'UnsafeRawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.}}
+  takesRawBuffer(b[1..<2]) // expected-error {{'subscript(_:)' is unavailable: use 'UnsafeRawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.}}
   let slice = b[1..<2]
   takesRawBuffer(slice) // expected-error {{cannot convert value of type 'UnsafeRawBufferPointer.SubSequence' (aka 'Slice<UnsafeRawBufferPointer>') to expected argument type 'UnsafeRawBufferPointer'}}
 }

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -41,7 +41,7 @@ class ClassWithUnavailable {
   }
 
   @available(*, unavailable)
-  subscript (i: Int) -> Int { // expected-note{{'subscript' has been explicitly marked unavailable here}}
+  subscript (i: Int) -> Int { // expected-note{{'subscript(_:)' has been explicitly marked unavailable here}}
     return i
   }
 }
@@ -55,7 +55,7 @@ func testInit() {
 }
 
 func testSubscript(cwu: ClassWithUnavailable) {
-  _ = cwu[5] // expected-error{{'subscript' is unavailable}}
+  _ = cwu[5] // expected-error{{'subscript(_:)' is unavailable}}
 }
 
 /* FIXME 'nil == a' fails to type-check with a bogus error message

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -253,7 +253,7 @@ class ClassWithUnavailableInitializer {
   convenience init(s: String) {
         // expected-note@-1 {{add @available attribute to enclosing initializer}}
     
-    self.init(5) // expected-error {{'init' is only available on OS X 10.51 or newer}}
+    self.init(5) // expected-error {{'init(_:)' is only available on OS X 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
   
@@ -267,12 +267,12 @@ func callUnavailableInitializer() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
 
   _ = ClassWithUnavailableInitializer()
-  _ = ClassWithUnavailableInitializer(5) // expected-error {{'init' is only available on OS X 10.51 or newer}}
+  _ = ClassWithUnavailableInitializer(5) // expected-error {{'init(_:)' is only available on OS X 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   let i = ClassWithUnavailableInitializer.self 
   _ = i.init()
-  _ = i.init(5) // expected-error {{'init' is only available on OS X 10.51 or newer}}
+  _ = i.init(5) // expected-error {{'init(_:)' is only available on OS X 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -290,7 +290,7 @@ class SubOfClassWithUnavailableInitializer : SuperWithWithUnavailableInitializer
   override init(_ val: Int) {
         // expected-note@-1 {{add @available attribute to enclosing initializer}}
 
-    super.init(5) // expected-error {{'init' is only available on OS X 10.51 or newer}}
+    super.init(5) // expected-error {{'init(_:)' is only available on OS X 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
   

--- a/test/Serialization/builtin.swift
+++ b/test/Serialization/builtin.swift
@@ -11,4 +11,4 @@ var a : TheBuiltinInt64
 
 // Check that it really is Builtin.Int64.
 var wrapped = Int64(a) // okay
-var badWrapped = Int32(a) // expected-error{{initializer 'init' requires that 'TheBuiltinInt64' conform to 'BinaryInteger'}}
+var badWrapped = Int32(a) // expected-error{{initializer 'init(_:)' requires that 'TheBuiltinInt64' conform to 'BinaryInteger'}}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -680,9 +680,9 @@ class Sub : Base {
   override func unavailableMultiNewlyUnnamed(a: Int, b: Int) {} // expected-error {{'unavailableMultiNewlyUnnamed(a:b:)' has been renamed to 'shinyLabeledArguments(_:_:)'}} {{17-45=shinyLabeledArguments}} {{46-46=_ }} {{54-54=_ }}
 
   override init(unavailableArgNames: Int) {} // expected-error {{'init(unavailableArgNames:)' has been renamed to 'init(shinyNewName:)'}} {{17-17=shinyNewName }}
-  override init(_ unavailableUnnamed: Int) {} // expected-error {{'init' has been renamed to 'init(a:)'}} {{17-18=a}}
+  override init(_ unavailableUnnamed: Int) {} // expected-error {{'init(_:)' has been renamed to 'init(a:)'}} {{17-18=a}}
   override init(unavailableNewlyUnnamed: Int) {} // expected-error {{'init(unavailableNewlyUnnamed:)' has been renamed to 'init(_:)'}} {{17-17=_ }}
-  override init(_ unavailableMultiUnnamed: Int, _ b: Int) {} // expected-error {{'init' has been renamed to 'init(a:b:)'}} {{17-18=a}} {{49-51=}}
+  override init(_ unavailableMultiUnnamed: Int, _ b: Int) {} // expected-error {{'init(_:_:)' has been renamed to 'init(a:b:)'}} {{17-18=a}} {{49-51=}}
   override init(unavailableMultiNewlyUnnamed a: Int, b: Int) {} // expected-error {{'init(unavailableMultiNewlyUnnamed:b:)' has been renamed to 'init(_:_:)'}} {{17-45=_}} {{54-54=_ }}
 
   override func unavailableTooFew(a: Int, b: Int) {} // expected-error {{'unavailableTooFew(a:b:)' has been renamed to 'shinyLabeledArguments(x:)'}} {{none}}
@@ -964,9 +964,9 @@ struct DeprecatedAccessors {
     DeprecatedAccessors.staticDeprecated = 0 // expected-warning {{setter for 'staticDeprecated' is deprecated: bad setter}} {{none}}
     DeprecatedAccessors.staticDeprecated += 1 // expected-warning {{getter for 'staticDeprecated' is deprecated: bad getter}} {{none}} expected-warning {{setter for 'staticDeprecated' is deprecated: bad setter}} {{none}}
 
-    _ = other[0] // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}} {{none}}
-    other[0] = 0 // expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}} {{none}}
-    other[0] += 1 // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}} {{none}} expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}} {{none}}
+    _ = other[0] // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter}} {{none}}
+    other[0] = 0 // expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter}} {{none}}
+    other[0] += 1 // expected-warning {{getter for 'subscript(_:)' is deprecated: bad subscript getter}} {{none}} expected-warning {{setter for 'subscript(_:)' is deprecated: bad subscript setter}} {{none}}
 
     _ = other[alsoDeprecated: 0] // expected-warning {{'subscript(alsoDeprecated:)' is deprecated: bad subscript!}} {{none}}
     other[alsoDeprecated: 0] = 0 // expected-warning {{'subscript(alsoDeprecated:)' is deprecated: bad subscript!}} {{none}}
@@ -1019,9 +1019,9 @@ struct UnavailableAccessors {
     UnavailableAccessors.staticUnavailable = 0 // expected-error {{setter for 'staticUnavailable' is unavailable: bad setter}} {{none}}
     UnavailableAccessors.staticUnavailable += 1 // expected-error {{getter for 'staticUnavailable' is unavailable: bad getter}} {{none}} expected-error {{setter for 'staticUnavailable' is unavailable: bad setter}} {{none}}
 
-    _ = other[0] // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}} {{none}}
-    other[0] = 0 // expected-error {{setter for 'subscript' is unavailable: bad subscript setter}} {{none}}
-    other[0] += 1 // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}} {{none}} expected-error {{setter for 'subscript' is unavailable: bad subscript setter}} {{none}}
+    _ = other[0] // expected-error {{getter for 'subscript(_:)' is unavailable: bad subscript getter}} {{none}}
+    other[0] = 0 // expected-error {{setter for 'subscript(_:)' is unavailable: bad subscript setter}} {{none}}
+    other[0] += 1 // expected-error {{getter for 'subscript(_:)' is unavailable: bad subscript getter}} {{none}} expected-error {{setter for 'subscript(_:)' is unavailable: bad subscript setter}} {{none}}
 
     _ = other[alsoUnavailable: 0] // expected-error {{'subscript(alsoUnavailable:)' is unavailable: bad subscript!}} {{none}}
     other[alsoUnavailable: 0] = 0 // expected-error {{'subscript(alsoUnavailable:)' is unavailable: bad subscript!}} {{none}}

--- a/test/attr/attr_availability_objc.swift
+++ b/test/attr/attr_availability_objc.swift
@@ -106,9 +106,9 @@ final class SchnozType : OlfactoryProtocol {
   @objc func unavailableMultiNewlyUnnamed(a: Int, b: Int) {} // expected-error {{'unavailableMultiNewlyUnnamed(a:b:)' has been renamed to 'shinyLabeledArguments(_:_:)'}} {{14-42=shinyLabeledArguments}} {{43-43=_ }} {{51-51=_ }}
 
   @objc init(unavailableArgNames: Int) {} // expected-error {{'init(unavailableArgNames:)' has been renamed to 'init(shinyNewName:)'}} {{14-14=shinyNewName }}
-  @objc init(_ unavailableUnnamed: Int) {} // expected-error {{'init' has been renamed to 'init(a:)'}} {{14-15=a}}
+  @objc init(_ unavailableUnnamed: Int) {} // expected-error {{'init(_:)' has been renamed to 'init(a:)'}} {{14-15=a}}
   @objc init(unavailableNewlyUnnamed: Int) {} // expected-error {{'init(unavailableNewlyUnnamed:)' has been renamed to 'init(_:)'}} {{14-14=_ }}
-  @objc init(_ unavailableMultiUnnamed: Int, _ b: Int) {} // expected-error {{'init' has been renamed to 'init(a:b:)'}} {{14-15=a}} {{46-48=}}
+  @objc init(_ unavailableMultiUnnamed: Int, _ b: Int) {} // expected-error {{'init(_:_:)' has been renamed to 'init(a:b:)'}} {{14-15=a}} {{46-48=}}
   @objc init(unavailableMultiNewlyUnnamed a: Int, b: Int) {} // expected-error {{'init(unavailableMultiNewlyUnnamed:b:)' has been renamed to 'init(_:_:)'}} {{14-42=_}} {{51-51=_ }}
 
   @objc func unavailableTooFew(a: Int, b: Int) {} // expected-error {{'unavailableTooFew(a:b:)' has been renamed to 'shinyLabeledArguments(x:)'}} {{none}}

--- a/test/attr/attr_dynamic.swift
+++ b/test/attr/attr_dynamic.swift
@@ -28,7 +28,7 @@ class Foo {
   @objc dynamic subscript(x: Int) -> ObjCClass { get {} }
 
   @objc dynamic subscript(x: Int) -> NotObjCAble { get {} } // expected-error{{subscript cannot be marked @objc because its type cannot be represented in Objective-C}} expected-note{{Swift structs cannot be represented in Objective-C}}
-  // expected-error@-1{{'dynamic' subscript 'subscript' must also be '@objc'}}
+  // expected-error@-1{{'dynamic' subscript 'subscript(_:)' must also be '@objc'}}
   
   dynamic deinit {} // expected-error{{'dynamic' modifier cannot be applied to this declaration}} {{3-11=}}
 

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -40,7 +40,7 @@ class A {
   var v9: Int { return 5 } // expected-note{{attempt to override property here}}
   var v10: Int { return 5 } // expected-note{{attempt to override property here}}
 
-  subscript (i: Int) -> String { // expected-note{{potential overridden subscript 'subscript' here}}
+  subscript (i: Int) -> String { // expected-note{{potential overridden subscript 'subscript(_:)' here}}
     get {
       return "hello"
     }
@@ -49,7 +49,7 @@ class A {
     }
   }
 
-  subscript (d: Double) -> String { // expected-note{{overridden declaration is here}} expected-note{{potential overridden subscript 'subscript' here}}
+  subscript (d: Double) -> String { // expected-note{{overridden declaration is here}} expected-note{{potential overridden subscript 'subscript(_:)' here}}
     get {
       return "hello"
     }
@@ -58,11 +58,11 @@ class A {
     }
   }
 
-  subscript (i: Int8) -> A { // expected-note{{potential overridden subscript 'subscript' here}}
+  subscript (i: Int8) -> A { // expected-note{{potential overridden subscript 'subscript(_:)' here}}
     get { return self }
   }
 
-  subscript (i: Int16) -> A { // expected-note{{attempt to override subscript here}} expected-note{{potential overridden subscript 'subscript' here}}
+  subscript (i: Int16) -> A { // expected-note{{attempt to override subscript here}} expected-note{{potential overridden subscript 'subscript(_:)' here}}
     get { return self }
     set { }
   }

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -265,8 +265,8 @@ class Base24646184 {
   func foo(ok: SubTy) { }
 }
 class Derived24646184 : Base24646184 {
-  override init(_: Ty) { } // expected-note {{'init' previously overridden here}}
-  override init(_: SubTy) { } // expected-error {{'init' has already been overridden}}
+  override init(_: Ty) { } // expected-note {{'init(_:)' previously overridden here}}
+  override init(_: SubTy) { } // expected-error {{'init(_:)' has already been overridden}}
   override func foo(_: Ty) { } // expected-note {{'foo' previously overridden here}}
   override func foo(_: SubTy) { } // expected-error {{'foo' has already been overridden}}
 
@@ -285,7 +285,7 @@ class SubscriptBase {
 
 class SubscriptDerived : SubscriptBase {
   override subscript(a: Int) -> Int { return a }
-  // expected-error@-1 {{argument labels for method 'subscript' do not match those of overridden method 'subscript(a:)'}}
+  // expected-error@-1 {{argument labels for method 'subscript(_:)' do not match those of overridden method 'subscript(a:)'}}
 }
 
 // Generic subscripts

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -870,26 +870,26 @@ extension PConstrained6 {
   var prop2: Int { return 0 } // expected-note{{'prop2' previously declared here}}
 
   subscript (key: Int) -> Int { return key }
-  subscript (key: Double) -> Double { return key } // expected-note{{'subscript' previously declared here}}
+  subscript (key: Double) -> Double { return key } // expected-note{{'subscript(_:)' previously declared here}}
 }
 
 extension PConstrained6 {
   var prop2: Int { return 0 } // expected-error{{invalid redeclaration of 'prop2'}}
-  subscript (key: Double) -> Double { return key } // expected-error{{invalid redeclaration of 'subscript'}}
+  subscript (key: Double) -> Double { return key } // expected-error{{invalid redeclaration of 'subscript(_:)'}}
 }
 
 extension PConstrained6 where Assoc : PConstrained5 {
   var prop1: Int { return 0 } // okay
   var prop3: Int { return 0 } // expected-note{{'prop3' previously declared here}}
   subscript (key: Int) -> Int { return key } // ok
-  subscript (key: String) -> String { return key } // expected-note{{'subscript' previously declared here}}
+  subscript (key: String) -> String { return key } // expected-note{{'subscript(_:)' previously declared here}}
 
   func foo() { } // expected-note{{'foo()' previously declared here}}
 }
 
 extension PConstrained6 where Assoc : PConstrained5 {
   var prop3: Int { return 0 } // expected-error{{invalid redeclaration of 'prop3'}}
-  subscript (key: String) -> String { return key } // expected-error{{invalid redeclaration of 'subscript'}}
+  subscript (key: String) -> String { return key } // expected-error{{invalid redeclaration of 'subscript(_:)'}}
   func foo() { } // expected-error{{invalid redeclaration of 'foo()'}}
 }
 

--- a/test/decl/func/keyword-argument-defaults.swift
+++ b/test/decl/func/keyword-argument-defaults.swift
@@ -57,11 +57,11 @@ struct Subscripts1 {
 }
 
 struct Subscripts2 {
-  subscript (i: Int) -> Int { // expected-note{{'subscript' previously declared here}}
+  subscript (i: Int) -> Int { // expected-note{{'subscript(_:)' previously declared here}}
     get { return i }
   }
 
-  subscript (j: Int) -> Int { // expected-error{{invalid redeclaration of 'subscript'}}
+  subscript (j: Int) -> Int { // expected-error{{invalid redeclaration of 'subscript(_:)'}}
     get { return j }
   }
 }

--- a/test/decl/func/special_func_name.swift
+++ b/test/decl/func/special_func_name.swift
@@ -14,7 +14,7 @@ struct S12 : P1 { // expected-error {{type 'S12' does not conform to protocol 'P
 }
 
 protocol P2 {
-  init(_: Int) // expected-note {{protocol requires initializer 'init' with type 'Int'; do you want to add a stub?}}
+  init(_: Int) // expected-note {{protocol requires initializer 'init(_:)' with type 'Int'; do you want to add a stub?}}
 }
 
 struct S21 : P2 { // expected-error {{type 'S21' does not conform to protocol 'P2'}}

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -244,7 +244,7 @@ struct Subscript2 {
     get { return a }
   }
 
-  subscript (a: Int) -> Int { // expected-error{{invalid redeclaration of 'subscript'}}
+  subscript (a: Int) -> Int { // expected-error{{invalid redeclaration of 'subscript(_:)'}}
     get { return a }
   }
 
@@ -264,7 +264,7 @@ struct GenericSubscripts {
 }
 
 extension GenericSubscripts {
-  subscript<U>(x: U) -> Int { return 0 } // expected-error{{invalid redeclaration of 'subscript'}}
+  subscript<U>(x: U) -> Int { return 0 } // expected-error{{invalid redeclaration of 'subscript(_:)'}}
   subscript<T, U>(x: T) -> U { fatalError() }
   subscript<T>(x: T) -> T { fatalError() }
   subscript(x: Int) -> Int { return 0 }
@@ -275,7 +275,7 @@ struct GenericSubscripts2<T> {
 }
 
 extension GenericSubscripts2 {
-  subscript(x: T) -> Int { return 0 } // expected-error{{invalid redeclaration of 'subscript'}}
+  subscript(x: T) -> Int { return 0 } // expected-error{{invalid redeclaration of 'subscript(_:)'}}
   subscript<U>(x: U) -> Int { return 0 }
   subscript(x: T) -> T { fatalError() }
   subscript<U>(x: T) -> U { fatalError() }
@@ -288,7 +288,7 @@ struct GenericSubscripts3<T> {
 }
 
 extension GenericSubscripts3 {
-  subscript<U>(x: T) -> U { fatalError() } // expected-error{{invalid redeclaration of 'subscript'}}
+  subscript<U>(x: T) -> U { fatalError() } // expected-error{{invalid redeclaration of 'subscript(_:)'}}
   subscript<U, V>(x: U) -> V { fatalError() }
   subscript<U>(x: U) -> U { fatalError() }
   subscript(x: Int) -> Int { return 0 }

--- a/test/decl/protocol/conforms/inherited.swift
+++ b/test/decl/protocol/conforms/inherited.swift
@@ -106,7 +106,7 @@ class A : P1, P2, P3, P4, P5, P6, P7, P8, P9, P10 {
   }
 
   // P3
-  subscript (i: Int) -> A { // expected-error{{protocol 'P3' requirement 'subscript' cannot be satisfied by a non-final class ('A') because it uses 'Self' in a non-parameter, non-result type position}}
+  subscript (i: Int) -> A { // expected-error{{protocol 'P3' requirement 'subscript(_:)' cannot be satisfied by a non-final class ('A') because it uses 'Self' in a non-parameter, non-result type position}}
     get {
      return self
     }

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -144,7 +144,7 @@ struct XSubP0a : SubscriptP0 {
 
 struct XSubP0b : SubscriptP0 {
 // expected-error@-1{{type 'XSubP0b' does not conform to protocol 'SubscriptP0'}}
-  subscript (i: Int) -> Float { get { return Float(i) } } // expected-note{{inferred type 'Float' (by matching requirement 'subscript') is invalid: does not conform to 'PSimple'}}
+  subscript (i: Int) -> Float { get { return Float(i) } } // expected-note{{inferred type 'Float' (by matching requirement 'subscript(_:)') is invalid: does not conform to 'PSimple'}}
 }
 
 struct XSubP0c : SubscriptP0 {

--- a/test/decl/protocol/req/name_mismatch.swift
+++ b/test/decl/protocol/req/name_mismatch.swift
@@ -41,10 +41,10 @@ struct UnlabeledWitness : LabeledRequirement {
 
 // rdar://problem/21333445
 protocol P2 {
-	init(_ : Int) // expected-note{{requirement 'init' declared here}}
+	init(_ : Int) // expected-note{{requirement 'init(_:)' declared here}}
 }
 
-struct XP2 : P2 { // expected-error{{initializer 'init(foo:)' has different argument labels from those required by protocol 'P2' ('init')}}
+struct XP2 : P2 { // expected-error{{initializer 'init(foo:)' has different argument labels from those required by protocol 'P2' ('init(_:)')}}
   let foo: Int 
 }
 
@@ -54,7 +54,7 @@ protocol P3 {
 }
 
 class MislabeledSubscript : P3 {
-  subscript(val: String, label: String) -> Int { // expected-error{{method 'subscript' has different argument labels from those required by protocol 'P3' ('subscript(_:label:)')}}
+  subscript(val: String, label: String) -> Int { // expected-error{{method 'subscript(_:_:)' has different argument labels from those required by protocol 'P3' ('subscript(_:label:)')}}
     return 1
   }
 }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -195,7 +195,7 @@ func test_subscript(_ x2: inout X2, i: Int, j: Int, value: inout Int, no: NoSubs
 
   value = ovl[(i, j, i)] // expected-error{{cannot convert value of type '(Int, Int, Int)' to expected argument type 'Int'}}
 
-  ret[i] // expected-error{{ambiguous use of 'subscript'}}
+  ret[i] // expected-error{{ambiguous use of 'subscript(_:)'}}
 
   value = ret[i]
   ret[i] = value
@@ -303,7 +303,7 @@ func testSubscript1(_ s1 : SubscriptTest1) {
   // expected-note@-2 {{to match this opening '('}}
 
   let _ = s1["hello"]
-  // expected-error@-1 {{ambiguous use of 'subscript'}}
+  // expected-error@-1 {{ambiguous use of 'subscript(_:)'}}
   // expected-error@-2 {{expected ')' in expression list}}
 }
 
@@ -331,12 +331,12 @@ func testSubscript1(_ s2 : SubscriptTest2) {
 // sr-114 & rdar://22007370
 
 class Foo {
-    subscript(key: String) -> String { // expected-note {{'subscript' previously declared here}}
+    subscript(key: String) -> String { // expected-note {{'subscript(_:)' previously declared here}}
         get { a } // expected-error {{use of unresolved identifier 'a'}}
         set { b } // expected-error {{use of unresolved identifier 'b'}}
     }
     
-    subscript(key: String) -> String { // expected-error {{invalid redeclaration of 'subscript'}}
+    subscript(key: String) -> String { // expected-error {{invalid redeclaration of 'subscript(_:)'}}
         get { a } // expected-error {{use of unresolved identifier 'a'}}
         set { b } // expected-error {{use of unresolved identifier 'b'}}
     }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -576,12 +576,12 @@ func conversionTest(_ a: inout Double, b: inout Int) {
   var pi_d1 = Double(pi_d)
   var pi_s1 = SpecialPi(pi_s) // expected-error {{argument passed to call that takes no arguments}}
 
-  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'init'}}
-  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'init'}}
+  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
+  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
   var pi_s2: SpecialPi = getPi() // no-warning
   
   var float = Float.self
-  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'init'}}
+  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
   var pi_f4 = float.init(pi_f)
 
   var e = Empty(f)

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -51,7 +51,7 @@ struct Unavailable {
 
   @available(*, unavailable)
   subscript(x: Sub) -> Int { get { } set { } }
-  // expected-note@-1 {{'subscript' has been explicitly marked unavailable here}}
+  // expected-note@-1 {{'subscript(_:)' has been explicitly marked unavailable here}}
 }
 
 struct Deprecated {
@@ -203,10 +203,10 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _ = \C<Int>.[noHashableConstraint: nonHashableSub] // expected-error{{subscript index of type 'NonHashableSub' in a key path must be Hashable}}
 
   let _ = \Unavailable.unavailableProperty // expected-error {{'unavailableProperty' is unavailable}}
-  let _ = \Unavailable.[sub] // expected-error {{'subscript' is unavailable}}
+  let _ = \Unavailable.[sub] // expected-error {{'subscript(_:)' is unavailable}}
 
   let _ = \Deprecated.deprecatedProperty // expected-warning {{'deprecatedProperty' is deprecated}}
-  let _ = \Deprecated.[sub] // expected-warning {{'subscript' is deprecated}}
+  let _ = \Deprecated.[sub] // expected-warning {{'subscript(_:)' is deprecated}}
 
   let _ = \A.[getDeprecatedSub()] // expected-warning {{'getDeprecatedSub()' is deprecated}}
 }
@@ -504,7 +504,7 @@ func testImplicitConversionInSubscriptIndex() {
 // Crash in diagnostics
 struct AmbiguousSubscript {
   subscript(sub: Sub) -> Int { get { } set { } }
-  // expected-note@-1 {{'subscript' declared here}}
+  // expected-note@-1 {{'subscript(_:)' declared here}}
 
   subscript(y y: Sub) -> Int { get { } set { } }
   // expected-note@-1 {{'subscript(y:)' declared here}}

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -27,7 +27,7 @@ struct A {
 }
 
 extension A: K {
-    static let j = S(\A.id + "id") // expected-error {{initializer 'init' requires that 'String' conform to 'K'}}
+    static let j = S(\A.id + "id") // expected-error {{initializer 'init(_:)' requires that 'String' conform to 'K'}}
 }
 
 // SR-5034

--- a/test/stdlib/StringCompatibilityDiagnostics4.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics4.swift
@@ -22,7 +22,7 @@ func testPopFirst() {
   dump(charSubView)
 
   var _ = String(str.utf8) ?? "" // expected-warning{{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}}
-  var _: String = String(str.utf8)! // expected-error{{'init' is unavailable: Please use non-failable String.init(_:UTF8View) instead}}
+  var _: String = String(str.utf8)! // expected-error{{'init(_:)' is unavailable: Please use non-failable String.init(_:UTF8View) instead}}
   var _: String = String(str.utf8) // ok
 }
 

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -7,19 +7,19 @@ import Foundation
 // Common pitfall: trying to subscript a string with integers.
 func testIntSubscripting(s: String, i: Int) {
   // FIXME swift-3-indexing-model: test new overloads of ..<, ...
-  _ = s[i] // expected-error{{'subscript' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
-  _ = s[17] // expected-error{{'subscript' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
-  _ = s[i...i] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
-  _ = s[17..<20] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
-  _ = s[17...20] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[i] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
+  _ = s[17] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
+  _ = s[i...i] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[17..<20] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[17...20] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
 
-  _ = s[Range(i...i)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
-  _ = s[Range(17..<20)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
-  _ = s[Range(17...20)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(i...i)] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(17..<20)] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(17...20)] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
 
-  _ = s[Range(i...i)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
-  _ = s[Range(17..<20)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
-  _ = s[Range(17...20)] // expected-error{{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(i...i)] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(17..<20)] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
+  _ = s[Range(17...20)] // expected-error{{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}}
 }
 
 func testNonAmbiguousStringComparisons() {

--- a/test/stdlib/UnavailableStringAPIs.swift.gyb
+++ b/test/stdlib/UnavailableStringAPIs.swift.gyb
@@ -8,15 +8,15 @@ func test_StringSubscriptByInt(
   r1: Range<Int>,
   r2: ClosedRange<Int>
 ) {
-  _ = x[i] // expected-error {{'subscript' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}} {{none}}
-  _ = x[r1] // expected-error {{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}} {{none}}
-  _ = x[r2] // expected-error {{'subscript' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}} {{none}}
+  _ = x[i] // expected-error {{'subscript(_:)' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}} {{none}}
+  _ = x[r1] // expected-error {{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}} {{none}}
+  _ = x[r2] // expected-error {{'subscript(_:)' is unavailable: cannot subscript String with an integer range, see the documentation comment for discussion}} {{none}}
 }
 
 % if _runtime == 'objc':
 func test_UTF16ViewSubscriptByInt(x: String.UTF16View, i: Int, r: Range<Int>) {
-  _ = x[i] // expected-error {{'subscript' is unavailable: Indexing a String's UTF16View requires a String.UTF16View.Index, which can be constructed from Int when Foundation is imported}} {{none}}
-  _ = x[r] // expected-error {{'subscript' is unavailable: Slicing a String's UTF16View requires a Range<String.UTF16View.Index>, String.UTF16View.Index can be constructed from Int when Foundation is imported}} {{none}}
+  _ = x[i] // expected-error {{'subscript(_:)' is unavailable: Indexing a String's UTF16View requires a String.UTF16View.Index, which can be constructed from Int when Foundation is imported}} {{none}}
+  _ = x[r] // expected-error {{'subscript(_:)' is unavailable: Slicing a String's UTF16View requires a Range<String.UTF16View.Index>, String.UTF16View.Index can be constructed from Int when Foundation is imported}} {{none}}
 }
 % end
 

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -22,21 +22,21 @@ func unsafePointerConversionAvailability(
   let oups: UnsafePointer<String>? = ups
 
   _ = UnsafeMutableRawPointer(mrp)
-  _ = UnsafeMutableRawPointer(rp)   // expected-error {{'init' has been renamed to 'init(mutating:)'}}
+  _ = UnsafeMutableRawPointer(rp)   // expected-error {{'init(_:)' has been renamed to 'init(mutating:)'}}
   _ = UnsafeMutableRawPointer(umpv)
-  _ = UnsafeMutableRawPointer(upv)  // expected-error {{'init' has been renamed to 'init(mutating:)'}}
+  _ = UnsafeMutableRawPointer(upv)  // expected-error {{'init(_:)' has been renamed to 'init(mutating:)'}}
   _ = UnsafeMutableRawPointer(umpi)
-  _ = UnsafeMutableRawPointer(upi)  // expected-error {{'init' has been renamed to 'init(mutating:)'}}
+  _ = UnsafeMutableRawPointer(upi)  // expected-error {{'init(_:)' has been renamed to 'init(mutating:)'}}
   _ = UnsafeMutableRawPointer(umps)
-  _ = UnsafeMutableRawPointer(ups)  // expected-error {{'init' has been renamed to 'init(mutating:)'}}
+  _ = UnsafeMutableRawPointer(ups)  // expected-error {{'init(_:)' has been renamed to 'init(mutating:)'}}
   _ = UnsafeMutableRawPointer(omrp)
-  _ = UnsafeMutableRawPointer(orp)   // expected-error {{'init' has been renamed to 'init(mutating:)'}}
+  _ = UnsafeMutableRawPointer(orp)   // expected-error {{'init(_:)' has been renamed to 'init(mutating:)'}}
   _ = UnsafeMutableRawPointer(oumpv)
-  _ = UnsafeMutableRawPointer(oupv)  // expected-error {{'init' has been renamed to 'init(mutating:)'}}
+  _ = UnsafeMutableRawPointer(oupv)  // expected-error {{'init(_:)' has been renamed to 'init(mutating:)'}}
   _ = UnsafeMutableRawPointer(oumpi)
-  _ = UnsafeMutableRawPointer(oupi)  // expected-error {{'init' has been renamed to 'init(mutating:)'}}
+  _ = UnsafeMutableRawPointer(oupi)  // expected-error {{'init(_:)' has been renamed to 'init(mutating:)'}}
   _ = UnsafeMutableRawPointer(oumps)
-  _ = UnsafeMutableRawPointer(oups)  // expected-error {{'init' has been renamed to 'init(mutating:)'}}
+  _ = UnsafeMutableRawPointer(oups)  // expected-error {{'init(_:)' has been renamed to 'init(mutating:)'}}
 
   // These all correctly pass with no error.
   _ = UnsafeRawPointer(mrp)


### PR DESCRIPTION
This makes diagnostics more verbose and accurate, because
it's possible to distinguish how many parameters there are
based on the message itself.

Also there are multiple diagnostic messages in a format of
`<descriptive-kind> <decl-name> ...` that get printed as
e.g. `subscript 'subscript'` if empty labels are omitted.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
