### PR TITLE
[vim] Add swiftParenthesisRegion

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -141,6 +141,8 @@ syn match swiftTypeDeclaration skipwhite nextgroup=swiftType,swiftInOutKeyword
 syn match swiftTypeDeclaration skipwhite nextgroup=swiftType
       \ /->/
 
+syn region swiftParenthesisRegion matchgroup=NONE start=/(/ end=/)/ contains=TOP
+
 syn region swiftString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=swiftInterpolationRegion
 syn region swiftInterpolationRegion matchgroup=swiftInterpolation start=/\\(/ end=/)/ contained contains=TOP
 syn region swiftComment start="/\*" end="\*/" contains=swiftComment,swiftLineComment,swiftTodo


### PR DESCRIPTION
<!-- What's in this pull request? -->

`swiftInterpolationRegion` has a problem with `)`.
Therefore I added swiftParenthesisRegion and fixed it.

## Problematic patterns

![2018-09-25 11 30 21](https://user-images.githubusercontent.com/629993/45989778-05e1ce00-c0b8-11e8-913d-7449bf23e0cd.png)

## Expects

![2018-09-25 11 24 13](https://user-images.githubusercontent.com/629993/45989864-66710b00-c0b8-11e8-9de4-b3212eac916d.png)

## Other test case

![2018-09-25 11 24 18](https://user-images.githubusercontent.com/629993/45989870-6b35bf00-c0b8-11e8-8818-08e1e26b2d43.png)

