### PR TITLE
(SR-8786) delete builtin "__tfop"

### DIFF
--- a/include/swift/SIL/GraphOperationBuilder.h
+++ b/include/swift/SIL/GraphOperationBuilder.h
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the construction logic for a GraphOperationInst, in
-// particular encoding the mangled inst name string for the operands and
+// particular encoding the mangled inst name string for the arguments and
 // attributes.
 //
 //===----------------------------------------------------------------------===//
@@ -42,12 +42,12 @@ public:
   /// Start building a GraphOperationInst for op `OpName`.
   GraphOperationBuilder(llvm::StringRef OpName);
 
-  /// Add a single operand to the GraphOperationInst, with an optional name.
-  void addOperand(SILValue operand, llvm::StringRef name = llvm::StringRef());
+  /// Add a single argument to the GraphOperationInst, with an optional name.
+  void addArgument(SILValue argument, llvm::StringRef name = llvm::StringRef());
 
-  /// Add a list operand to the GraphOperationInst, with an optional name.
-  void addListOperand(llvm::ArrayRef<SILValue> operands,
-                      llvm::StringRef name = llvm::StringRef());
+  /// Add a list argument to the GraphOperationInst, with an optional name.
+  void addListArgument(llvm::ArrayRef<SILValue> arguments,
+                       llvm::StringRef name = llvm::StringRef());
 
   /// Add an attribute with known constant value to the GraphOperationInst.
   /// Returns a reference to the attribute, valid for the lifetime of the

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -79,7 +79,7 @@ struct GraphOperationInfo {
   };
 
   /// Return the string suffix for the specified OperandLowering.
-  static const char * getOperandLoweringSuffix(OperandLowering lowering);
+  static const char *getOperandLoweringSuffix(OperandLowering lowering);
 
   /// The instruction being analyzed.
   GraphOperationInst *inst;
@@ -146,8 +146,7 @@ struct GraphOperationInfo {
       return OperandList;
     }
 
-    /// Returns the result of GraphOperationInfo::decodeOperandName on this
-    /// operand.
+    /// Returns this operand's name, without suffix, and the OperandLowering.
     std::pair<StringRef, OperandLowering> decodeName() const;
   };
 

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -30,57 +30,56 @@ namespace tf {
 /// Holds information about a TensorFlow operation as represented in SIL
 /// as GraphOperationInst.
 struct GraphOperationInfo {
-  /// One of these records exists for every operand that the BuiltinInst has,
-  /// classifying the operand into a couple of buckets.  The most coarse grain
-  /// classification is "input" vs "attribute": the inputs come first,
-  /// followed by the attributes.  However, we need to be able to model the
-  /// fact that some input arguments are aggregated together into a single
-  /// input that is an array of tensors.  An integer attribute may be either
-  /// a Tensor value or an integer-encoded DType, etc.
-  enum class OperandClass {
-    /// Indicates one of the following:
-    /// 1) A normal tensor input: the value is a TensorHandle.
-    /// 2) An normal attribute (without modifier).
-    /// 3) A tensor or shape attribute (need a modifier for proper lowering).
-    /// 4) An array attribute (needed for parsing tfop, and dropped before graph
-    ///    lowering).
+  /// Indicates how the operand should be lowered to the TF graph.
+  enum class OperandLowering {
+    /// This is a TensorFlow value type, aggregate of TensorFlow value types,
+    /// array of TensorFlow value types, or array of aggregates of TensorFlow
+    /// value types. It should be lowered to an Input or InputList.
+    ///
+    /// Written as unnamed operand.
     Input,
 
-    /// No modifier.
-    Normal,
+    /// This should be lowered to an attribute, in the most direct way. e.g.
+    /// integers should be lowered to integer attributes, metatypes should be
+    /// lowered to type attributes, TensorShapes should be lowered to shape
+    /// attributes, etc.
+    ///
+    /// Written as named operand without "$" suffix.
+    NormalAttribute,
 
-    /// Indicates that the array or scalar should be turned into a TF_Tensor.
-    Tensor,
+    /// An array or scalar that should be converted to a Tensor before lowering
+    /// to an attribute.
+    ///
+    /// Written as named operand with "$tensor" suffix.
+    TensorAttribute,
 
-    /// Indicates that the array of integers should be interpreted as a shape.
-    Shape,
+    /// An array of integers that should be lowered to a shape attribute.
+    ///
+    /// Written as named operand with "$shape" suffix.
+    ShapeAttribute,
 
-    /// Indicates the metatype of a TensorFlow value type or an aggregate of
-    /// TensorFlow value types should be turned into a list of unknown shapes.
-    UnknownShapeList,
+    /// A metatype of a TensorFlow value type or aggregate of TensorFlow value
+    /// types that should be lowered into a list of unknown shape attributes.
+    ///
+    /// Written as named operand with "$unknownShapeList" suffix.
+    UnknownShapeListAttribute,
 
-    /// Indicates that the operand should be interpreted as an array. When
-    /// applied to the metatype of a TensorFlow value type or an aggregate of
-    /// TensorFlow value types, it will be flattened into an array of dtypes of
-    /// each TensorFlow value type as a Normal operand.
-    Array,
+    /// A metatype of a TensorFlow value type or aggregate of TensorFlow value
+    /// types that should be lowered into a list of type attributes.
+    ///
+    /// Written as named operand with "$typeList" suffix.
+    TypeListAttribute,
 
     /// An operand specifying the address where an indirect output should be
-    /// stored.  This occurs when the tfop exists in a context where its output
-    /// is address-only.  Deabstraction eliminates Out operands before forming
-    /// graph_ops, by rewriting the tfop to return the value directly.  This
-    /// rewriting is possible because tfop outputs must always be loadable in
-    /// deabstraction scopes.
+    /// stored. This occurs when the graph_op exists in a context where its
+    /// output is address-only.
+    ///
+    /// Written as operand with name "$out".
     Out,
   };
 
-  /// Return the string suffix for the specified attribute modifier.
-  static const char *
-  getOperandClassSuffix(GraphOperationInfo::OperandClass opClass);
-
-  /// Return the operand class of the specified string form like "tensor"
-  static llvm::Optional<GraphOperationInfo::OperandClass>
-  getOperandClass(StringRef suffix);
+  /// Return the string suffix for the specified OperandLowering.
+  static const char * getOperandLoweringSuffix(OperandLowering lowering);
 
   /// The instruction being analyzed.
   GraphOperationInst *inst;
@@ -132,7 +131,8 @@ struct GraphOperationInfo {
       return Kind;
     }
 
-    StringRef getName() const {
+    /// Returns the name, including a suffix that denotes the OperandLowering.
+    StringRef getNameWithSuffix() const {
       return Name;
     }
 
@@ -145,18 +145,27 @@ struct GraphOperationInfo {
       assert(getKind() == SOK_List);
       return OperandList;
     }
+
+    /// Returns the result of GraphOperationInfo::decodeOperandName on this
+    /// operand.
+    std::pair<StringRef, OperandLowering> decodeName() const;
   };
+
+  /// Get the TensorFlow op name.
+  llvm::StringRef getName() const;
 
   /// Decode the name of a graph_op into its TensorFlow op name and a list of
   /// StructuredOperands.
   llvm::StringRef decodeName(
       llvm::SmallVectorImpl<StructuredOperand> &structuredOperands) const;
 
-  /// Given an attribute name like foo$tensor, decode the name and the class.
-  /// If there is no modifier specified, this defaults to
-  /// OperandClass::Normal.
-  static std::pair<llvm::StringRef, OperandClass>
-  decodeAttributeName(Identifier name);
+  /// Given an operand name like foo$tensor, decode the name and the
+  /// OperandLowering.  If the name is empty, this defaults to
+  /// OperandLowering::Input.  If the name is non-empty but there is no
+  /// modifier specified, then this defaults to
+  /// OperandLowering::NormalAttribute.
+  static std::pair<llvm::StringRef, OperandLowering>
+  decodeOperandName(StringRef Name);
 
   /// Get an int-typed attribute at `attrIdx`, which must have `attrName`.
   int64_t getIntAttr(unsigned attrIdx, llvm::StringRef attrName) const;

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the parsing logic for a GraphOperationInst, in particular
-// decoding the mangled inst name string for the operands and attributes.
+// decoding the mangled inst name string for the arguments and attributes.
 //
 //===----------------------------------------------------------------------===//
 
@@ -30,13 +30,14 @@ namespace tf {
 /// Holds information about a TensorFlow operation as represented in SIL
 /// as GraphOperationInst.
 struct GraphOperationInfo {
-  /// Indicates how the operand should be lowered to the TF graph.
-  enum class OperandLowering {
+public:
+  /// Indicates how the argument should be lowered to the TF graph.
+  enum class ArgumentLowering {
     /// This is a TensorFlow value type, aggregate of TensorFlow value types,
     /// array of TensorFlow value types, or array of aggregates of TensorFlow
     /// value types. It should be lowered to an Input or InputList.
     ///
-    /// Written as unnamed operand.
+    /// Written as unnamed argument.
     Input,
 
     /// This should be lowered to an attribute, in the most direct way. e.g.
@@ -44,127 +45,124 @@ struct GraphOperationInfo {
     /// lowered to type attributes, TensorShapes should be lowered to shape
     /// attributes, etc.
     ///
-    /// Written as named operand without "$" suffix.
+    /// Written as named argument without "$" suffix.
     NormalAttribute,
 
     /// An array or scalar that should be converted to a Tensor before lowering
     /// to an attribute.
     ///
-    /// Written as named operand with "$tensor" suffix.
+    /// Written as named argument with "$tensor" suffix.
     TensorAttribute,
 
     /// An array of integers that should be lowered to a shape attribute.
     ///
-    /// Written as named operand with "$shape" suffix.
+    /// Written as named argument with "$shape" suffix.
     ShapeAttribute,
 
     /// A metatype of a TensorFlow value type or aggregate of TensorFlow value
     /// types that should be lowered into a list of unknown shape attributes.
     ///
-    /// Written as named operand with "$unknownShapeList" suffix.
+    /// Written as named argument with "$unknownShapeList" suffix.
     UnknownShapeListAttribute,
 
     /// A metatype of a TensorFlow value type or aggregate of TensorFlow value
     /// types that should be lowered into a list of type attributes.
     ///
-    /// Written as named operand with "$typeList" suffix.
+    /// Written as named argument with "$typeList" suffix.
     TypeListAttribute,
 
-    /// An operand specifying the address where an indirect output should be
+    /// An argument specifying the address where an indirect output should be
     /// stored. This occurs when the graph_op exists in a context where its
     /// output is address-only.
     ///
-    /// Written as operand with name "$out".
+    /// Written as argument with name "$out".
     Out,
   };
 
-  /// Return the string suffix for the specified OperandLowering.
-  static const char *getOperandLoweringSuffix(OperandLowering lowering);
-
-  /// The instruction being analyzed.
-  GraphOperationInst *inst;
-
-  explicit GraphOperationInfo(GraphOperationInst *inst) : inst(inst) {}
-
-  /// Return the device attribute associated with `inst`, which is required to
-  /// exist.
-  // StringRef getDeviceString() const;
-
-  // /// Return the device type for this instruction.
-  // DeviceType getDeviceType() const {
-  //   return getOpDeviceType(getDeviceString());
-  // }
-
-  enum StructuredOperandKind {
-    /// Single operand.
+  enum StructuredArgumentKind {
+    /// Single argument.
     /// Mangled name is ",i${name}" where ${name} is an optional name.
-    SOK_Single,
-    /// Operand list.
+    SAK_Single,
+    /// Argument list.
     /// Mangled name is ",L${name},e,...,e" where ${name} is an optional name
     /// and where the number of e's denotes the number of elements.
-    SOK_List,
+    SAK_List,
   };
 
-  /// The operands to a GraphOperationInst may be grouped into various
+  /// The arguments to a GraphOperationInst may be grouped into various
   /// structures. This is a tagged union representing those structures.
-  class StructuredOperand {
+  class StructuredArgument {
     friend struct GraphOperationInfo;
 
-    StructuredOperandKind Kind;
+    StructuredArgumentKind Kind;
     StringRef Name;
     union {
-      /// Operand for SOK_Single.
-      SILValue SingleOperand;
-      /// Operands for SOK_List.
-      ArrayRef<Operand> OperandList;
+      /// Argument for SAK_Single.
+      SILValue SingleArgument;
+      /// Arguments for SAK_List.
+      ArrayRef<Operand> ArgumentList;
     };
 
   public:
-   StructuredOperand(StructuredOperandKind Kind, StringRef Name,
-                      SILValue SingleOperand)
-        : Kind(Kind), Name(Name), SingleOperand(SingleOperand) {}
-    StructuredOperand(StructuredOperandKind Kind, StringRef Name,
-                      ArrayRef<Operand> OperandList)
-        : Kind(Kind), Name(Name), OperandList(OperandList) {}
+   StructuredArgument(StructuredArgumentKind Kind, StringRef Name,
+                      SILValue SingleArgument)
+        : Kind(Kind), Name(Name), SingleArgument(SingleArgument) {}
+    StructuredArgument(StructuredArgumentKind Kind, StringRef Name,
+                      ArrayRef<Operand> ArgumentList)
+        : Kind(Kind), Name(Name), ArgumentList(ArgumentList) {}
 
-    StructuredOperandKind getKind() const {
+    StructuredArgumentKind getKind() const {
       return Kind;
     }
 
-    /// Returns the name, including a suffix that denotes the OperandLowering.
-    StringRef getNameWithSuffix() const {
+    /// Returns the name, including a suffix that denotes the ArgumentLowering.
+    StringRef getArgumentNameWithSuffix() const {
       return Name;
     }
 
-    SILValue getSingleOperand() const {
-      assert(getKind() == SOK_Single);
-      return SingleOperand;
+    SILValue getSingleArgument() const {
+      assert(getKind() == SAK_Single);
+      return SingleArgument;
     }
 
-    OperandValueArrayRef getOperandList() const {
-      assert(getKind() == SOK_List);
-      return OperandList;
+    OperandValueArrayRef getArgumentList() const {
+      assert(getKind() == SAK_List);
+      return ArgumentList;
     }
 
-    /// Returns this operand's name, without suffix, and the OperandLowering.
-    std::pair<StringRef, OperandLowering> decodeName() const;
+    /// Returns this argument's name, without suffix, and the ArgumentLowering.
+    std::pair<StringRef, ArgumentLowering> getArgumentNameAndLowering() const;
   };
 
+private:
+  /// The instruction being analyzed.
+  GraphOperationInst *inst;
+
+  /// The TensorFlow op name, decoded from inst.
+  StringRef OperationName;
+
+  /// The StructuredArguments for this operation, decoded from inst. (See
+  /// documentation on StructuredArgument for explanation).
+  llvm::SmallVector<StructuredArgument, 4> StructuredArguments;
+
+public:
+  explicit GraphOperationInfo(GraphOperationInst *inst);
+
+  /// Get the instruction being analyzed.
+  GraphOperationInst *getInst() const {
+    return inst;
+  }
+
   /// Get the TensorFlow op name.
-  llvm::StringRef getName() const;
+  llvm::StringRef getOperationName() const {
+    return OperationName;
+  }
 
-  /// Decode the name of a graph_op into its TensorFlow op name and a list of
-  /// StructuredOperands.
-  llvm::StringRef decodeName(
-      llvm::SmallVectorImpl<StructuredOperand> &structuredOperands) const;
-
-  /// Given an operand name like foo$tensor, decode the name and the
-  /// OperandLowering.  If the name is empty, this defaults to
-  /// OperandLowering::Input.  If the name is non-empty but there is no
-  /// modifier specified, then this defaults to
-  /// OperandLowering::NormalAttribute.
-  static std::pair<llvm::StringRef, OperandLowering>
-  decodeOperandName(StringRef Name);
+  /// Get the StructuredArguments for this operation. (See documentation on
+  /// StructuredArgument for explanation).
+  const llvm::SmallVectorImpl<StructuredArgument> &getStructuredArguments() const {
+    return StructuredArguments;
+  }
 
   /// Get an int-typed attribute at `attrIdx`, which must have `attrName`.
   int64_t getIntAttr(unsigned attrIdx, llvm::StringRef attrName) const;
@@ -175,6 +173,17 @@ struct GraphOperationInfo {
   // float getFloatAttr(unsigned attrIdx, llvm::StringRef attrName) const;
 
   void assertWithDump(bool cond, const char *assertMsg) const;
+
+  /// Return the string suffix for the specified ArgumentLowering.
+  static const char *getArgumentLoweringSuffix(ArgumentLowering lowering);
+
+  /// Given an argument name like foo$tensor, decode the name and the
+  /// ArgumentLowering.  If the name is empty, this defaults to
+  /// ArgumentLowering::Input.  If the name is non-empty but there is no
+  /// modifier specified, then this defaults to
+  /// ArgumentLowering::NormalAttribute.
+  static std::pair<llvm::StringRef, ArgumentLowering>
+  decodeArgumentName(StringRef Name);
 };
 } // end namespace tf
 } // end namespace swift

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1607,7 +1607,7 @@ void SILCloner<ImplClass>::visitGraphOperationInst(GraphOperationInst *Inst) {
     getOpValueArray<4>(OperandValueArrayRef(Inst->getArguments()));
   SmallVector<SILType, 4> resultTypes;
   for (auto result : Inst->getResults())
-    resultTypes.push_back(result->getType());
+    resultTypes.push_back(getOpType(result->getType()));
   doPostProcess(Inst,
       getBuilder().createGraphOperation(getOpLocation(Inst->getLoc()),
                                         Inst->getName(), arguments,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 432; // Last change: change adjoint's format in @differentiable
+const uint16_t VERSION_MINOR = 433; // Last change: add graph_op serialization
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/AST/GraphOperationBuilder.cpp
+++ b/lib/AST/GraphOperationBuilder.cpp
@@ -25,21 +25,21 @@ GraphOperationBuilder::GraphOperationBuilder(StringRef OpName)
          "graph_op name cannot include ','");
 }
 
-/// Add a single operand to the GraphOperationInst, with an optional name.
-void GraphOperationBuilder::addOperand(SILValue operand, StringRef name) {
+/// Add a single argument to the GraphOperationInst, with an optional name.
+void GraphOperationBuilder::addArgument(SILValue argument, StringRef name) {
   MangledName += ",i";
   MangledName += name;
-  Operands.push_back(operand);
+  Operands.push_back(argument);
 }
 
-/// Add a list operand to the GraphOperationInst, with an optional name.
-void GraphOperationBuilder::addListOperand(ArrayRef<SILValue> operands,
-                                           StringRef name) {
+/// Add a list argument to the GraphOperationInst, with an optional name.
+void GraphOperationBuilder::addListArgument(ArrayRef<SILValue> arguments,
+                                            StringRef name) {
   MangledName += ",L";
   MangledName += name;
-  for (auto operand : operands) {
+  for (auto argument : arguments) {
     MangledName += ",e";
-    Operands.push_back(operand);
+    Operands.push_back(argument);
   }
 }
 

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -116,31 +116,6 @@ getLoweredTypeAndTypeInfo(IRGenModule &IGM, Type unloweredType) {
   return {lowered, IGM.getTypeInfo(lowered)};
 }
 
-// SWIFT_ENABLE_TENSORFLOW
-// Injects printf + abort function calls to abort with an error message.
-static void abortOnTFOpBuiltin(IRGenFunction &IGF, llvm::StringRef errMessage) {
-  auto &llvmModule = IGF.IGM.Module;
-  auto &llvmContext = llvmModule.getContext();
-  auto printfFunc = llvmModule.getOrInsertFunction(
-      "printf", llvm::TypeBuilder<int(char *, ...), false>::get(llvmContext));
-  auto strConstant =
-      llvm::ConstantDataArray::getString(llvmContext, errMessage);
-  auto GVStr =
-      new llvm::GlobalVariable(llvmModule, strConstant->getType(), true,
-                               llvm::GlobalValue::InternalLinkage, strConstant);
-  llvm::Constant *zero = llvm::Constant::getNullValue(
-      llvm::IntegerType::getInt32Ty(llvmContext));
-  llvm::Constant *zeroes[] = {zero, zero};
-  llvm::Constant *strVal = llvm::ConstantExpr::getGetElementPtr(
-      GVStr->getValueType(), GVStr, zeroes, true);
-  IGF.Builder.CreateCall(printfFunc, {strVal});
-
-  auto abortFunc = llvmModule.getOrInsertFunction(
-      "abort", llvm::FunctionType::get(
-                   llvm::Type::getVoidTy(llvmContext), {}, false));
-  IGF.Builder.CreateCall(abortFunc, {});
-}
-
 /// emitBuiltinCall - Emit a call to a builtin function.
 void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
                             Identifier FnId, SILType resultType,
@@ -1056,26 +1031,6 @@ if (Builtin.ID == BuiltinValueKind::id) { \
     // Load value from pointer.
     auto value = IGF.Builder.CreateLoad(pointer, IGF.IGM.getPointerAlignment());
     out.add(value);
-    return;
-  }
-
-  // SWIFT_ENABLE_TENSORFLOW
-  if (FnId.str().startswith("__tfop")) {
-
-    // TFOp builtins are never actually used at runtime: they are always
-    // extracted out of the program to a TensorFlow graph.  However, they do
-    // make it here when building the TensorFlow module itself.  For those
-    // cases, we abort here with an error message.
-    const std::string errMessage = "!!! Compiler bug -- Tensor op builtin " +
-                              FnId.str().str() +
-                              " cannot be lowered to LLVM IR !!!\n";
-    abortOnTFOpBuiltin(IGF, errMessage.c_str());
-
-    (void)args.claimAll();
-    // Finally, we set up our explosion results full of undef values.
-    ExplosionSchema schema = IGF.getTypeInfo(resultType).getSchema();
-    for (auto &elt : schema)
-      out.add(llvm::UndefValue::get(elt.getScalarType()));
     return;
   }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1897,14 +1897,12 @@ static void abortOnGraphOp(IRGenFunction &IGF, llvm::StringRef errMessage) {
 /// TODO: Fix this mis-compilation.
 void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
   tf::GraphOperationInfo opInfo(i);
-  SmallVector<tf::GraphOperationInfo::StructuredOperand, 4> structuredOperands;
-  auto opName = opInfo.decodeName(structuredOperands);
 
   if (!llvm::TFDynamicCompilation) {
     // graph_ops do make it here when building the TensorFlow module itself.
     // For those cases, we abort here with an error message.
     const std::string errMessage = "!!! Compiler bug -- graph_op " +
-                              opInfo.getName().str() +
+                              opInfo.getOperationName().str() +
                               " cannot be lowered to LLVM IR !!!\n";
     abortOnGraphOp(*this, errMessage.c_str());
 
@@ -1923,9 +1921,10 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
 
   // TODO: Remove these. They are a temporary way of testing that dynamic
   // attributes make it here.
-  LLVM_DEBUG(llvm::dbgs() << "IRGen for graph_op: " << opName << "\n");
-  LLVM_DEBUG(for (auto structuredOperand : structuredOperands) {
-    llvm::dbgs() << "  operand: " << structuredOperand.getNameWithSuffix()
+  LLVM_DEBUG(llvm::dbgs() << "IRGen for graph_op: "
+                          << opInfo.getOperationName() << "\n");
+  LLVM_DEBUG(for (auto structuredArgument : opInfo.getStructuredArguments()) {
+    llvm::dbgs() << "  operand: " << structuredArgument.getArgumentNameWithSuffix()
                  << "\n";
   });
   LLVM_DEBUG(llvm::dbgs() << "end operands\n");

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2991,14 +2991,14 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
                                           parseListOperandElement);
         if (status.isError())
           return status;
-        opBuilder.addListOperand(elements, operandName);
+        opBuilder.addListArgument(elements, operandName);
         return makeParserSuccess();
       } else {
         // It is a single operand.
         SILValue value;
         if (parseTypedValueRef(value, B))
           return makeParserError();
-        opBuilder.addOperand(value, operandName);
+        opBuilder.addArgument(value, operandName);
         return makeParserSuccess();
       }
     };

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2882,38 +2882,29 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     P.Context.TheBuiltinModule->lookupMember(foundBuiltins,
                                              P.Context.TheBuiltinModule, Id,
                                              Identifier());
-    // SWIFT_ENABLE_TENSORFLOW
-    SubstitutionMap subMap;
-    if (!foundBuiltins.empty()) {
-      assert(foundBuiltins.size() == 1 && "ambiguous builtin name?!");
 
-      auto *builtinFunc = cast<FuncDecl>(foundBuiltins[0]);
-      GenericEnvironment *genericEnv = builtinFunc->getGenericEnvironment();
-
-      SmallVector<ParsedSubstitution, 4> parsedSubs;
-      if (parseSubstitutions(parsedSubs))
-        return true;
-
-      if (!parsedSubs.empty()) {
-        if (!genericEnv) {
-          P.diagnose(P.Tok, diag::sil_substitutions_on_non_polymorphic_type);
-          return true;
-        }
-        subMap = getApplySubstitutionsFromParsed(*this, genericEnv, parsedSubs);
-        if (!subMap)
-          return true;
-      }
-      // SWIFT_ENABLE_TENSORFLOW: TODO: We can clean this up once Swift has a
-      // better understanding of the TensorFlow operations.
-    } else if (Id.str().startswith("__tfop") ||
-      // TODO: tf_tensor_to_i1 can become a named builtin in Builtins.def when
-      // TensorHandle become a builtin type.
-               Id.str() == "tf_tensor_to_i1") {
-      // TensorFlow builtins don't have a decl associated with them, and don't
-      // have substitutions.
-    } else {
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "builtin name");
+    if (foundBuiltins.empty()) {
+      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr,"builtin name");
       return true;
+    }
+    assert(foundBuiltins.size() == 1 && "ambiguous builtin name?!");
+
+    auto *builtinFunc = cast<FuncDecl>(foundBuiltins[0]);
+    GenericEnvironment *genericEnv = builtinFunc->getGenericEnvironment();
+    
+    SmallVector<ParsedSubstitution, 4> parsedSubs;
+    SubstitutionMap subMap;
+    if (parseSubstitutions(parsedSubs))
+      return true;
+    
+    if (!parsedSubs.empty()) {
+      if (!genericEnv) {
+        P.diagnose(P.Tok, diag::sil_substitutions_on_non_polymorphic_type);
+        return true;
+      }
+      subMap = getApplySubstitutionsFromParsed(*this, genericEnv, parsedSubs);
+      if (!subMap)
+        return true;
     }
 
     if (P.Tok.getKind() != tok::l_paren) {

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -102,7 +102,6 @@ static bool isOwnershipForwardingValueKind(SILNodeKind K) {
   case SILNodeKind::DestructureTupleInst:
   // SWIFT_ENABLE_TENSORFLOW
   case SILNodeKind::GradientInst:
-  case SILNodeKind::GraphOperationInst:
     return true;
   default:
     return false;
@@ -577,7 +576,6 @@ FORWARD_ANY_OWNERSHIP_INST(DestructureStruct)
 FORWARD_ANY_OWNERSHIP_INST(DestructureTuple)
 // SWIFT_ENABLE_TENSORFLOW
 FORWARD_ANY_OWNERSHIP_INST(Gradient)
-FORWARD_ANY_OWNERSHIP_INST(GraphOperation)
 #undef FORWARD_ANY_OWNERSHIP_INST
 
 // An instruction that forwards a constant ownership or trivial ownership.
@@ -1356,13 +1354,15 @@ BUILTINS_THAT_SHOULD_HAVE_BEEN_LOWERED_TO_SILINSTS(ProjectTailElems)
 
 OwnershipUseCheckerResult
 OwnershipCompatibilityUseChecker::visitBuiltinInst(BuiltinInst *BI) {
-  // SWIFT_ENABLE_TENSORFLOW
-  if (BI->getName().str().startswith("__tfop")) {
-    // TF op builtins take operands at +0.
-    return {true, UseLifetimeConstraint::MustBeLive};
-  }
-
   return OwnershipCompatibilityBuiltinUseChecker(*this).check(BI);
+}
+
+// SWIFT_ENABLE_TENSORFLOW
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitGraphOperationInst(
+    GraphOperationInst *GI) {
+  // Graph ops take operands at +0.
+  return {true, UseLifetimeConstraint::MustBeLive};
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1250,22 +1250,22 @@ public:
   // SWIFT_ENABLE_TENSORFLOW
   void visitGraphOperationInst(GraphOperationInst *GI) {
     tf::GraphOperationInfo info(GI);
-    SmallVector<tf::GraphOperationInfo::StructuredOperand, 4> operands;
-    auto opName = info.decodeName(operands);
+    auto opName = info.getOperationName();
+    auto &arguments = info.getStructuredArguments();
 
     *this << QuotedString(opName);
 
     *this << "(";
-    interleave(operands, [&](tf::GraphOperationInfo::StructuredOperand operand) {
-      if (!operand.getNameWithSuffix().empty())
-        *this << operand.getNameWithSuffix() << " ";
-      switch (operand.getKind()) {
-      case tf::GraphOperationInfo::SOK_Single:
-        *this << getIDAndType(operand.getSingleOperand());
+    interleave(arguments, [&](tf::GraphOperationInfo::StructuredArgument argument) {
+      if (!argument.getArgumentNameWithSuffix().empty())
+        *this << argument.getArgumentNameWithSuffix() << " ";
+      switch (argument.getKind()) {
+      case tf::GraphOperationInfo::SAK_Single:
+        *this << getIDAndType(argument.getSingleArgument());
         break;
-      case tf::GraphOperationInfo::SOK_List:
+      case tf::GraphOperationInfo::SAK_List:
         *this << "[";
-        interleave(operand.getOperandList(), [&](SILValue v) {
+        interleave(argument.getArgumentList(), [&](SILValue v) {
           *this << getIDAndType(v);
         }, [&] {
           *this << ", ";

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1257,8 +1257,8 @@ public:
 
     *this << "(";
     interleave(operands, [&](tf::GraphOperationInfo::StructuredOperand operand) {
-      if (!operand.getName().empty())
-        *this << operand.getName() << " ";
+      if (!operand.getNameWithSuffix().empty())
+        *this << operand.getNameWithSuffix() << " ";
       switch (operand.getKind()) {
       case tf::GraphOperationInfo::SOK_Single:
         *this << getIDAndType(operand.getSingleOperand());

--- a/lib/SIL/ValueOwnershipKindClassifier.cpp
+++ b/lib/SIL/ValueOwnershipKindClassifier.cpp
@@ -597,14 +597,6 @@ UNOWNED_OR_TRIVIAL_DEPENDING_ON_RESULT(ZeroInitializer)
 
 ValueOwnershipKind
 ValueOwnershipKindClassifier::visitBuiltinInst(BuiltinInst *BI) {
-  // SWIFT_ENABLE_TENSORFLOW
-  if (BI->getName().str().startswith("__tfop")) {
-    assert(BI->getNumResults() == 1);
-    auto type = BI->getResults()[0]->getType();
-    return type.isVoid() ? ValueOwnershipKind::Trivial
-                         : ValueOwnershipKind::Owned;
-  }
-
   // For now, just conservatively say builtins are None. We need to use a
   // builtin in here to guarantee correctness.
   return ValueOwnershipKindBuiltinVisitor().visit(BI);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2935,7 +2935,7 @@ visitObjectLiteralExpr(ObjectLiteralExpr *E, SGFContext C) {
           SGF.emitRValueAsSingleValue(tuple->getElement(i),
                                       SGFContext::AllowGuaranteedPlusZero)
              .getValue();
-      opBuilder.addOperand(operand, tuple->getElementName(i).str());
+      opBuilder.addArgument(operand, tuple->getElementName(i).str());
     }
   }
 
@@ -2948,7 +2948,7 @@ visitObjectLiteralExpr(ObjectLiteralExpr *E, SGFContext C) {
                                                    resultTL));
   } else {
     auto address = SGF.getBufferForExprResult(E, resultTL.getLoweredType(), C);
-    opBuilder.addOperand(address, "$out");
+    opBuilder.addArgument(address, "$out");
     auto voidTy = SGF.getLoweredType(SGF.getASTContext().TheEmptyTupleType);
     opBuilder.build(SGF.B, SGF.getASTContext(), E, voidTy);
     return RValue(SGF, E, SGF.manageBufferForExprResult(address, resultTL, C));

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -919,8 +919,8 @@ SILBasicBlock *SingleExitLoopTransformer::createNewExitBlockWithDemux(
     // Create a condition to compare exitIndex to a constant
     std::string equalOpName = "Equal";
     GraphOperationBuilder equalOpBuilder(equalOpName);
-    equalOpBuilder.addOperand(exitIndexArg);
-    equalOpBuilder.addOperand(
+    equalOpBuilder.addArgument(exitIndexArg);
+    equalOpBuilder.addArgument(
         createTFIntegerConst(*deviceInfo, builder, headerLocation,
                              /*bitwidth*/ 32, exitIndices.lookup(trueBlock)));
     deviceInfo->handleDevicePlacement(

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -396,18 +396,18 @@ static GraphOperationInst *simplifyOperands(GraphOperationInst *origInst,
   };
 
   // If we don't have to change any operands, don't rewrite the graph_op.
-  bool mustChangeBuiltin = false;
+  bool mustChangeGraphOp = false;
   for (auto &operand : origOperands) {
     assert(operand.getKind() == GraphOperationInfo::SOK_Single &&
            "SILGen should not have generated a list operand");
     if (canSimplifyOperand(operand.getSingleOperand()->getType(),
                            std::get<1>(operand.decodeName()))) {
-      mustChangeBuiltin = true;
+      mustChangeGraphOp = true;
       break;
     }
   }
 
-  if (!mustChangeBuiltin) return origInst;
+  if (!mustChangeGraphOp) return origInst;
 
   // Mark the function as being mutated.
   TFDA.aboutToChangeFunction();
@@ -417,8 +417,6 @@ static GraphOperationInst *simplifyOperands(GraphOperationInst *origInst,
   GraphOperationBuilder opBuilder(origName);
   SILValue outParameterAddress;
   for (auto &operand : origOperands) {
-    // auto operand = std::get<0>(operandAndClass).get();
-    // auto operandClass = std::get<1>(operandAndClass);
     assert(operand.getKind() == GraphOperationInfo::SOK_Single &&
            "SILGen should not have generated a list operand");
     auto operandValue = operand.getSingleOperand();

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2031,9 +2031,6 @@ bool TFFunctionPartition::markFunction(bool &hasTensorOps) {
     for (auto bbi = BB->begin(), e = BB->end(); bbi != e; ++bbi) {
       auto *inst = &*bbi;
 
-      assert(!SILTensorOpInfo::decode(inst) &&
-             "The input to partition pass should not have any builtin TFops!");
-
       // Graph operations are tensor ops.
       auto *graphOp = dyn_cast<GraphOperationInst>(inst);
       if (!graphOp)
@@ -2642,7 +2639,7 @@ static SILValue createIntValue(intmax_t value, SILBuilder &B, SILLocation loc,
   return createSomeIntegerValue(value, B, loc, intDecl, ILI);
 }
 
-/// Add a RecvFromHost builtin to the accelerator function, as a placeholder for
+/// Add a RecvFromHost graph_op to the accelerator function, as a placeholder for
 /// the subsequent graph lowering pass to generate the appropriate TF graph
 /// nodes to receive tensors from Swift host.
 /// `isScalar` specifies whether the value being received is a promoted scalar.
@@ -2744,7 +2741,7 @@ static SILValue createHostReceive(SILBuilder &B, SILLocation loc,
                        /*isNonThrowing*/ false);
 }
 
-/// Add a SendToHost builtin to the accelerator function, as a placeholder for
+/// Add a SendToHost graph_op to the accelerator function, as a placeholder for
 /// the subsequent graph lowering pass to generate the appropriate TF graph
 /// nodes to send tensors to Swift host.
 ///
@@ -3360,7 +3357,7 @@ bool PartitionCloner::finalizeOriginal() {
     auto inst = instructionsToRemove[idx];
 
 #ifndef NDEBUG
-    // When removing a builtin or ApplyInst tensor op instruction TO, for each
+    // When removing a graph_op or ApplyInst tensor op instruction TO, for each
     // tensor argument TA of it, since we know TA is taken at +0, we need not
     // rebalance the retain/release count of TA.
     if (isa<BuiltinInst>(inst)) {

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2496,7 +2496,7 @@ void PartitionCloner::visitScalarInst(SingleValueInstruction *inst) {
     operandRange = operandRange.drop_back();
 
   for (auto &op : operandRange)
-    opBuilder.addOperand(remapValue(op.get()));
+    opBuilder.addArgument(remapValue(op.get()));
 
   // The type of the new builtin is usually the same as the input type, but
   // "remapped", which turns Float into TensorHandle<Float>.
@@ -2753,7 +2753,7 @@ void createAcceleratorSend(SILBuilder &B, SILLocation loc, SILValue value,
   auto voidTy = B.getModule().Types.getEmptyTupleType();
   auto opType = "tfc.SendToHost";
   GraphOperationBuilder opBuilder(opType);
-  opBuilder.addOperand({value});
+  opBuilder.addArgument({value});
   opBuilder.addAttribute(
       {ctx.getIdentifier("tensorId"), SymbolicValue::getInteger(idNumber, 32)});
   deviceInfo.handleDevicePlacement(opType, /*opDevice*/ "",
@@ -3061,8 +3061,8 @@ void PartitionCloner::handleSendRecvForTerminator(TermInst *inst) {
       // Omit the metatype attr T for simplicity, and TF graphDef compiler can
       // infer the type.
       GraphOperationBuilder equalOpBuilder("Equal");
-      equalOpBuilder.addOperand(receivedCaseId);
-      equalOpBuilder.addOperand(constTensorWithCaseId);
+      equalOpBuilder.addArgument(receivedCaseId);
+      equalOpBuilder.addArgument(constTensorWithCaseId);
 
       auto boolFieldSILType =
           extractBuiltinTypeFromStdlibNumericType(ctx.getBoolDecl());

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -367,15 +367,15 @@ tf::createConstTensor(Type elementType, SymbolicValue scalars,
        SymbolicValue::getMetatype(elementType->getCanonicalType())});
 
   // Add an attribute for the value$tensor attribute.
-  auto tensorSuffix = GraphOperationInfo::getOperandLoweringSuffix(
-      GraphOperationInfo::OperandLowering::TensorAttribute);
+  auto tensorSuffix = GraphOperationInfo::getArgumentLoweringSuffix(
+      GraphOperationInfo::ArgumentLowering::TensorAttribute);
   opBuilder.addAttribute(
       {context.getIdentifier(std::string("value") + tensorSuffix), scalars});
 
   // Add the shape$shape attribute if we have an array value.
   if (scalars.getKind() == SymbolicValue::Array) {
-    auto shapeId = GraphOperationInfo::OperandLowering::ShapeAttribute;
-    auto shapeSuffix = GraphOperationInfo::getOperandLoweringSuffix(shapeId);
+    auto shapeId = GraphOperationInfo::ArgumentLowering::ShapeAttribute;
+    auto shapeSuffix = GraphOperationInfo::getArgumentLoweringSuffix(shapeId);
     opBuilder.addAttribute(
         {context.getIdentifier(std::string("shape") + shapeSuffix), shape});
   }
@@ -395,7 +395,7 @@ tf::createTensorToInt1Inst(SILValue value, SILBuilder &builder,
                            GraphFunctionDeviceInfo &deviceInfo) {
   ASTContext &context = builder.getASTContext();
   GraphOperationBuilder opBuilder("tf_tensor_to_i1");
-  opBuilder.addOperand(value);
+  opBuilder.addArgument(value);
   deviceInfo.handleDevicePlacement(
       "tf_tensor_to_i1",
       /*opDevice*/ getDeviceString(DeviceType::ALL),

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -101,53 +101,6 @@ SubstitutionMap getSingleSubstitutionMapForElementTypeAndSignature(
 SubstitutionMap getSingleSubstitutionMapForElementType(Type ty,
                                                        ASTContext &ctx);
 
-/// Holds information about a TensorFlow operation as represented in SIL
-/// as Builtin instructions.
-struct SILTensorOpInfo {
-  /// The instruction being analyzed.
-  BuiltinInst *inst;
-
-  /// This is the name for the entire builtin that we'll partition out.
-  StringRef builtinName;
-
-  /// This is the TensorFlow name for the op.
-  StringRef opName;
-
-  /// These are the names of any attribute operands at the end of the list.
-  SmallVector<std::pair<StringRef, GraphOperationInfo::OperandClass>, 4>
-      operandClasses;
-
-  /// Return true if the specified operand is an input (not an attribute).
-  bool isInput(unsigned operandNumber) const {
-    return operandClasses[operandNumber].second ==
-           GraphOperationInfo::OperandClass::Input;
-  }
-
-  /// Returns the full name that this builtin would have if its operands
-  /// changed to the passed-in values.
-  std::string getBuiltinNameWithNewOperands(
-      const SmallVectorImpl<
-          std::pair<StringRef, GraphOperationInfo::OperandClass>>
-          &newOperandClasses) const {
-    std::string name = "__tfop_" + opName.str();
-    for (const auto &newOperandClass : newOperandClasses) {
-      name += ",";
-      name += newOperandClass.first;
-      name += GraphOperationInfo::getOperandClassSuffix(newOperandClass.second);
-    }
-    return name;
-  }
-
-  /// Analyze the specified SIL instruction and return a SILTensorOpInfo
-  /// result if the instruction is a valid tensor operation.  This is the
-  /// way that SILTensorOpInfo's are created.
-  static Optional<SILTensorOpInfo> decode(SILInstruction *inst);
-
-private:
-  SILTensorOpInfo(BuiltinInst *inst) : inst(inst) {}
-  bool decodeBuiltin();
-};
-
 /// `inst` must have a single result, and return that result value.
 static inline SILValue getSingleValueResult(GraphOperationInst *inst) {
   assert(inst->getNumResults() == 1);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -958,6 +958,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   Builder.setCurrentDebugScope(Fn->getDebugScope());
   unsigned RawOpCode = 0, TyCategory = 0, TyCategory2 = 0, TyCategory3 = 0,
            Attr = 0, NumSubs = 0, NumConformances = 0, IsNonThrowingApply = 0;
+  // SWIFT_ENABLE_TENSORFLOW
+  unsigned NumArguments = 0;
   ValueID ValID, ValID2, ValID3;
   TypeID TyID, TyID2, TyID3;
   TypeID ConcreteTyID;
@@ -1058,6 +1060,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     }
     break;
   }
+  // SWIFT_ENABLE_TENSORFLOW
+  case SIL_INST_GRAPH_OPERATION:
+    SILInstGraphOperationLayout::readRecord(scratch, ValID, NumArguments,
+                                            ListOfValues);
+    RawOpCode = (unsigned)SILInstructionKind::GraphOperationInst;
+    break;
   case SIL_INST_NO_OPERAND:
     SILInstNoOperandLayout::readRecord(scratch, RawOpCode);
     break;
@@ -1436,7 +1444,25 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   }
   // SWIFT_ENABLE_TENSORFLOW
   case SILInstructionKind::GraphOperationInst: {
-    llvm_unreachable("Unimplemented");
+    auto EndOfArgValues = 3 * NumArguments;
+    Identifier MangledName = MF->getIdentifier(ValID);
+    SmallVector<SILValue, 4> Args;
+    for (unsigned i = 0, e = EndOfArgValues; i < e; i += 3) {
+      auto ArgASTTy = MF->getType(ListOfValues[i+1]);
+      auto ArgTy = getSILType(ArgASTTy,
+                              (SILValueCategory)(unsigned)ListOfValues[i+2]);
+      Args.push_back(getLocalValue(ListOfValues[i], ArgTy));
+    }
+    SmallVector<SILType, 4> ResultSILTypes;
+    for (unsigned i = EndOfArgValues, e = ListOfValues.size(); i < e; i += 2) {
+      auto ASTTy = MF->getType(ListOfValues[i]);
+      auto Ty = getSILType(ASTTy,
+                           (SILValueCategory)(unsigned)ListOfValues[i+1]);
+      ResultSILTypes.push_back(Ty);
+    }
+    ResultVal = Builder.createGraphOperation(Loc, MangledName, Args, {},
+                                             ResultSILTypes);
+    break;
   }
   case SILInstructionKind::AllocGlobalInst: {
     // Format: Name and type. Use SILOneOperandLayout.

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1444,6 +1444,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   }
   // SWIFT_ENABLE_TENSORFLOW
   case SILInstructionKind::GraphOperationInst: {
+    // TODO(SR-8848): Deserialize attributes.
     auto EndOfArgValues = 3 * NumArguments;
     Identifier MangledName = MF->getIdentifier(ValID);
     SmallVector<SILValue, 4> Args;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -173,6 +173,7 @@ namespace sil_block {
     SIL_TWO_OPERANDS_EXTRA_ATTR,
     // SWIFT_ENABLE_TENSORFLOW
     SIL_REVERSE_DIFFERENTIABLE_ATTR,
+    SIL_INST_GRAPH_OPERATION,
 
     // We also share these layouts from the decls block. Their enumerators must
     // not overlap with ours.
@@ -407,6 +408,16 @@ namespace sil_block {
     TypeIDField,          // callee substituted type
     ValueIDField,         // callee value
     BCArray<ValueIDField> // a list of arguments
+  >;
+
+  // SWIFT_ENABLE_TENSORFLOW
+  using SILInstGraphOperationLayout = BCRecordLayout<
+      SIL_INST_GRAPH_OPERATION,
+      ValueIDField,          // the (mangled) graph_op name
+      BCVBR<8>,              // number of arguments
+      BCArray<ValueIDField>  // 3 entries per argument (value, type, and type
+                             // category)
+      // followed by 2 entries per result type (type, and type category)
   >;
 
   // SIL instructions with one type. (alloc_stack)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -857,6 +857,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(sil_block, SIL_TWO_OPERANDS_EXTRA_ATTR);
   // SWIFT_ENABLE_TENSORFLOW
   BLOCK_RECORD(sil_block, SIL_REVERSE_DIFFERENTIABLE_ATTR);
+  BLOCK_RECORD(sil_block, SIL_INST_GRAPH_OPERATION);
 
   // These layouts can exist in both decl blocks and sil blocks.
 #define BLOCK_RECORD_WITH_NAMESPACE(K, X) emitRecordID(Out, X, #X, nameBuffer)

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -938,7 +938,24 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   // SWIFT_ENABLE_TENSORFLOW
   case SILInstructionKind::GraphOperationInst: {
-    llvm_unreachable("Unimplemented");
+    const GraphOperationInst *GI = cast<GraphOperationInst>(&SI);
+    assert(GI->getNumAttributes() == 0 &&
+           "attribute serialization not implemented");
+    SmallVector<ValueID, 4> ListOfValues;
+    for (auto Arg : GI->getArguments()) {
+      ListOfValues.push_back(addValueRef(Arg));
+      ListOfValues.push_back(S.addTypeRef(Arg->getType().getASTType()));
+      ListOfValues.push_back((unsigned)Arg->getType().getCategory());
+    }
+    for (auto ResultTy : GI->getResultTypes()) {
+      ListOfValues.push_back(S.addTypeRef(ResultTy.getASTType()));
+      ListOfValues.push_back((unsigned)ResultTy.getCategory());
+    }
+    SILInstGraphOperationLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILInstGraphOperationLayout::Code],
+        S.addDeclBaseNameRef(GI->getName()), GI->getArguments().size(),
+        ListOfValues);
+    break;
   }
   case SILInstructionKind::ApplyInst: {
     // Format: attributes such as transparent and number of substitutions,
@@ -2443,6 +2460,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   registerSILAbbr<SILSpecializeAttrLayout>();
   // SWIFT_ENABLE_TENSORFLOW
   registerSILAbbr<SILReverseDifferentiableAttrLayout>();
+  registerSILAbbr<SILInstGraphOperationLayout>();
 
   // Register the abbreviation codes so these layouts can exist in both
   // decl blocks and sil blocks.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -938,6 +938,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   // SWIFT_ENABLE_TENSORFLOW
   case SILInstructionKind::GraphOperationInst: {
+    // TODO(SR-8848): Serialize attributes.
     const GraphOperationInst *GI = cast<GraphOperationInst>(&SI);
     assert(GI->getNumAttributes() == 0 &&
            "attribute serialization not implemented");

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -60,7 +60,7 @@ public extension Dataset {
     let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
     self.init(
       _handle: #tfop("RandomDataset", seed1, seed2,
-                     output_types$array: Element.self,
+                     output_types$typeList: Element.self,
                      output_shapes$unknownShapeList: Element.self)
     )
   }
@@ -74,7 +74,7 @@ public extension Dataset {
     self.init(
       _handle: #tfop(
         "TensorSliceDataset", [elements],
-        Toutput_types$array: Element.self,
+        Toutput_types$typeList: Element.self,
         output_shapes$unknownShapeList: Element.self
       )
     )
@@ -88,7 +88,7 @@ extension Dataset : Sequence {
   @inlinable @inline(__always)
   public func makeIterator() -> DatasetIterator<Element> {
     let resource: ResourceHandle =
-      #tfop("AnonymousIterator", output_types$array: Element.self,
+      #tfop("AnonymousIterator", output_types$typeList: Element.self,
             output_shapes$unknownShapeList: Element.self)
     #tfop("MakeIterator", _handle, resource) as Void
     return DatasetIterator(_handle: resource)
@@ -111,7 +111,7 @@ public extension Dataset where Element == Tensor<Float> {
       _handle: #tfop(
         "MapDataset", _handle, [Tensor<Int32>(0)], f: transform,
         Targuments: [Int32.self],
-        output_types$array: Element.self,
+        output_types$typeList: Element.self,
         output_shapes$unknownShapeList: Element.self
       )
     )
@@ -130,7 +130,7 @@ public extension Dataset where Element == Tensor<Float> {
       _handle: #tfop(
         "FilterDataset", _handle, [Tensor<Int32>(0)],
         predicate: isIncluded, Targuments: [Int32.self],
-        output_types$array: Element.self,
+        output_types$typeList: Element.self,
         output_shapes$unknownShapeList: Element.self
       )
     )
@@ -146,7 +146,7 @@ public extension Dataset {
     return Dataset(
       _handle: #tfop(
         "ShuffleDataset", _handle, Tensor<Int64>(sampleCount), seed1, seed2,
-        output_types$array: Element.self,
+        output_types$typeList: Element.self,
         output_shapes$unknownShapeList: Element.self
       )
     )
@@ -157,7 +157,7 @@ public extension Dataset {
     return Dataset(
       _handle: #tfop(
         "BatchDataset", _handle, Tensor<Int64>(batchSize),
-        output_types$array: Element.self,
+        output_types$typeList: Element.self,
         output_shapes$unknownShapeList: Element.self
       )
     )
@@ -182,13 +182,13 @@ extension DatasetIterator : IteratorProtocol {
   public mutating func next() -> Element? {
     let optional: VariantHandle =
       #tfop("IteratorGetNextAsOptional", _handle,
-            output_types$array: Element.self,
+            output_types$typeList: Element.self,
             output_shapes$unknownShapeList: Element.self)
     guard _TFGetScalarOrDie(#tfop("OptionalHasValue", optional)) else {
       return nil
     }
     return #tfop("OptionalGetValue", optional,
-                 output_types$array: Element.self,
+                 output_types$typeList: Element.self,
                  output_shapes$unknownShapeList: Element.self) as Element
   }
 }
@@ -199,6 +199,6 @@ public func zip<T>(
   _ dataset1: Dataset<T>, _ dataset2: Dataset<T>
 ) -> Dataset<(T, T)> {
   return #tfop("ZipDataset", [dataset1, dataset2],
-               output_types$array: (T, T).self,
+               output_types$typeList: (T, T).self,
                output_shapes$unknownShapeList: (T, T).self)
 }

--- a/test/TensorFlow/canonicalize_cfg_xla.sil
+++ b/test/TensorFlow/canonicalize_cfg_xla.sil
@@ -27,31 +27,31 @@ struct TensorCore<Element> {}
 sil private @testLoop : $@callee_owned (TensorCore<Float>) -> (TensorCore<Float>, TensorCore<Float>) {
 // %0                                             // users: %1, %1
 bb0(%0 : $TensorCore<Float>):
-  %1 = builtin "__tfop_Sub__:t__,t,t"(%0 : $TensorCore<Float>, %0 : $TensorCore<Float>) : $TensorCore<Float> // users: %6, %6
+  %1 = graph_op "Sub"(%0 : $TensorCore<Float>, %0 : $TensorCore<Float>) : $TensorCore<Float> // users: %6, %6
   %2 = integer_literal $Builtin.Int64, 0          // user: %3
-  %3 = builtin "__tfop_Const__:t__,dc"(%2 : $Builtin.Int64) : $TensorCore<Builtin.Int64> // user: %10
+  %3 = graph_op "Const"(value$tensor %2 : $Builtin.Int64) : $TensorCore<Builtin.Int64> // user: %10
   %4 = integer_literal $Builtin.Int64, 100        // user: %5
-  %5 = builtin "__tfop_Const__:t__,dc"(%4 : $Builtin.Int64) : $TensorCore<Builtin.Int64> // user: %17
-  %6 = builtin "__tfop_Add__:t__,t,t"(%1 : $TensorCore<Float>, %1 : $TensorCore<Float>) : $TensorCore<Float> // users: %7, %7
-  %7 = builtin "__tfop_Add__:t__,t,t"(%6 : $TensorCore<Float>, %6 : $TensorCore<Float>) : $TensorCore<Float> // user: %10
+  %5 = graph_op "Const"(value$tensor %4 : $Builtin.Int64) : $TensorCore<Builtin.Int64> // user: %17
+  %6 = graph_op "Add"(%1 : $TensorCore<Float>, %1 : $TensorCore<Float>) : $TensorCore<Float> // users: %7, %7
+  %7 = graph_op "Add"(%6 : $TensorCore<Float>, %6 : $TensorCore<Float>) : $TensorCore<Float> // user: %10
   %8 = integer_literal $Builtin.Int64, 1          // user: %9
-  %9 = builtin "__tfop_Const__:t__,dc"(%8 : $Builtin.Int64) : $TensorCore<Builtin.Int64> // user: %16
+  %9 = graph_op "Const"(value$tensor %8 : $Builtin.Int64) : $TensorCore<Builtin.Int64> // user: %16
   br bb2(%3 : $TensorCore<Builtin.Int64>, %7 : $TensorCore<Float>) // id: %10
 
 bb1:                                              // Preds: bb2
-  %11 = builtin "__tfop_Sub__:t__,t,t"(%20 : $TensorCore<Float>, %20 : $TensorCore<Float>) : $TensorCore<Float> // user: %12
+  %11 = graph_op "Sub"(%20 : $TensorCore<Float>, %20 : $TensorCore<Float>) : $TensorCore<Float> // user: %12
   %12 = tuple (%20 : $TensorCore<Float>, %11 : $TensorCore<Float>) // user: %13
   return %12 : $(TensorCore<Float>, TensorCore<Float>) // id: %13
 
 // %14                                            // user: %16
 // %15                                            // users: %18, %18
 bb2(%14 : $TensorCore<Builtin.Int64>, %15 : $TensorCore<Float>): // Preds: bb3 bb0
-  %16 = builtin "__tfop_Add__:t__,t,t"(%14 : $TensorCore<Builtin.Int64>, %9 : $TensorCore<Builtin.Int64>) : $TensorCore<Builtin.Int64> // users: %23, %17
-  %17 = builtin "__tfop_Equal__:t<bool>__,t,t"(%16 : $TensorCore<Builtin.Int64>, %5 : $TensorCore<Builtin.Int64>) : $TensorCore<Builtin.Int1> // user: %21
-  %18 = builtin "__tfop_Add__:t__,t,t"(%15 : $TensorCore<Float>, %15 : $TensorCore<Float>) : $TensorCore<Float> // user: %19
-  %19 = builtin "tensorflowSend"<TensorCore<Float>>(%18 : $TensorCore<Float>) : $()
-  %20 = builtin "tensorflowReceive"<TensorCore<Float>>() : $TensorCore<Float> // users: %12, %23, %11, %11
-  %21 = builtin "tf_tensor_to_i1"(%17 : $TensorCore<Builtin.Int1>) : $Builtin.Int1 // user: %22
+  %16 = graph_op "Add"(%14 : $TensorCore<Builtin.Int64>, %9 : $TensorCore<Builtin.Int64>) : $TensorCore<Builtin.Int64> // users: %23, %17
+  %17 = graph_op "Equal"(%16 : $TensorCore<Builtin.Int64>, %5 : $TensorCore<Builtin.Int64>) : $TensorCore<Builtin.Int1> // user: %21
+  %18 = graph_op "Add"(%15 : $TensorCore<Float>, %15 : $TensorCore<Float>) : $TensorCore<Float> // user: %19
+  %19 = graph_op "tensorflowSend"(%18 : $TensorCore<Float>) : $()
+  %20 = graph_op "tensorflowReceive"() : $TensorCore<Float> // users: %12, %23, %11, %11
+  %21 = graph_op "tf_tensor_to_i1"(%17 : $TensorCore<Builtin.Int1>) : $Builtin.Int1 // user: %22
   cond_br %21, bb1, bb3                           // id: %22
 
 bb3:                                              // Preds: bb2
@@ -83,20 +83,20 @@ sil private @testIf : $@callee_owned (TensorCore<Float>, Builtin.Int1) -> Tensor
 // %0                                             // users: %2, %2
 // %1                                             // user: %4
 bb0(%0 : $TensorCore<Float>, %1 : $Builtin.Int1):
-  %2 = builtin "__tfop_Sub__:t__,t,t"(%0 : $TensorCore<Float>, %0 : $TensorCore<Float>) : $TensorCore<Float> // users: %3, %5, %5
+  %2 = graph_op "Sub"(%0 : $TensorCore<Float>, %0 : $TensorCore<Float>) : $TensorCore<Float> // users: %3, %5, %5
   cond_br %1, bb1, bb2                            // id: %4
 
 bb1:                                              // Preds: bb0
-  %5 = builtin "__tfop_Sub__:t__,t,t"(%2 : $TensorCore<Float>, %2 : $TensorCore<Float>) : $TensorCore<Float> // user: %6
+  %5 = graph_op "Sub"(%2 : $TensorCore<Float>, %2 : $TensorCore<Float>) : $TensorCore<Float> // user: %6
   br bb3(%5 : $TensorCore<Float>)                 // id: %6
 
 bb2:                                              // Preds: bb0
-  %7 = builtin "__tfop_Add__:t__,t,t"(%2 : $TensorCore<Float>, %2 : $TensorCore<Float>) : $TensorCore<Float>
+  %7 = graph_op "Add"(%2 : $TensorCore<Float>, %2 : $TensorCore<Float>) : $TensorCore<Float>
   br bb3(%7 : $TensorCore<Float>)                 // id: %8
 
 // %9                                             // users: %10, %11, %11
 bb3(%9 : $TensorCore<Float>):                     // Preds: bb2 bb1
-  %11 = builtin "__tfop_Sub__:t__,t,t"(%9 : $TensorCore<Float>, %9 : $TensorCore<Float>) : $TensorCore<Float> // user: %12
+  %11 = graph_op "Sub"(%9 : $TensorCore<Float>, %9 : $TensorCore<Float>) : $TensorCore<Float> // user: %12
   return %11 : $TensorCore<Float>                 // id: %12
 }
 
@@ -132,28 +132,28 @@ bb3(%9 : $TensorCore<Float>):                     // Preds: bb2 bb1
 sil private @testIfIf : $@callee_owned (TensorCore<Float>, TensorCore<Builtin.Int1>, TensorCore<Builtin.Int1>) -> TensorCore<Float> {
 // %0                                             // users: %1, %1
 bb0(%0 : $TensorCore<Float>, %3: $TensorCore<Builtin.Int1>, %7: $TensorCore<Builtin.Int1>):
-  %1 = builtin "__tfop_Sub__:t__,t,t"(%0 : $TensorCore<Float>, %0 : $TensorCore<Float>) : $TensorCore<Float>
-  %4 = builtin "tf_tensor_to_i1"(%3 : $TensorCore<Builtin.Int1>) : $Builtin.Int1
+  %1 = graph_op "Sub"(%0 : $TensorCore<Float>, %0 : $TensorCore<Float>) : $TensorCore<Float>
+  %4 = graph_op "tf_tensor_to_i1"(%3 : $TensorCore<Builtin.Int1>) : $Builtin.Int1
   cond_br %4, bb1, bb4                            // id: %5
 
 bb1:                                              // Preds: bb0
-  %6 = builtin "__tfop_Add__:t__,t,t"(%1 : $TensorCore<Float>, %1 : $TensorCore<Float>) : $TensorCore<Float>
-  %8 = builtin "tf_tensor_to_i1"(%7 : $TensorCore<Builtin.Int1>) : $Builtin.Int1 // user: %9
+  %6 = graph_op "Add"(%1 : $TensorCore<Float>, %1 : $TensorCore<Float>) : $TensorCore<Float>
+  %8 = graph_op "tf_tensor_to_i1"(%7 : $TensorCore<Builtin.Int1>) : $Builtin.Int1 // user: %9
   cond_br %8, bb3, bb2                            // id: %9
 
 bb2:                                              // Preds: bb1
   br bb5(%6 : $TensorCore<Float>)                 // id: %10
 
 bb3:                                              // Preds: bb1
-  %11 = builtin "__tfop_Add__:t__,t,t"(%6 : $TensorCore<Float>, %6 : $TensorCore<Float>) : $TensorCore<Float> // user: %12
+  %11 = graph_op "Add"(%6 : $TensorCore<Float>, %6 : $TensorCore<Float>) : $TensorCore<Float> // user: %12
   br bb5(%11 : $TensorCore<Float>)                // id: %12
 
 bb4:                                              // Preds: bb0
-  %13 = builtin "__tfop_Add__:t__,t,t"(%1 : $TensorCore<Float>, %1 : $TensorCore<Float>) : $TensorCore<Float>
+  %13 = graph_op "Add"(%1 : $TensorCore<Float>, %1 : $TensorCore<Float>) : $TensorCore<Float>
   br bb5(%13 : $TensorCore<Float>)                // id: %14
 
 // %15                                            // users: %16, %17, %17
 bb5(%15 : $TensorCore<Float>):                    // Preds: bb4 bb2 bb3
-  %17 = builtin "__tfop_Sub__:t__,t,t"(%15 : $TensorCore<Float>, %15 : $TensorCore<Float>) : $TensorCore<Float> // user: %18
+  %17 = graph_op "Sub"(%15 : $TensorCore<Float>, %15 : $TensorCore<Float>) : $TensorCore<Float> // user: %18
   return %17 : $TensorCore<Float>                 // id: %18
 }

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -253,11 +253,6 @@ public func testMultiResultOp_send_recv() {
   _hostOp(y)
 }
 
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testMultiResultOp_send_recv{{.*}}
-// CHECK:  builtin "__tfop_tfc.SendToHost
-// CHECK:  builtin "__tfop_tfc.SendToHost
-// CHECK:  builtin "__tfop_tfc.RecvFromHost
-
 var globalThing: Int32!
 
 public func testStructExtractBBArg(x: Tensor<Float>) -> Tensor<Int32> {
@@ -276,12 +271,6 @@ public func SR8191() {
     i += 1
   } while i < 10
 }
-
-// CHECK-LABEL: --- XLA CFG Canonicalize: {{.*}}SR8191{{.*}}
-// CHECK:    [sequence
-// CHECK:      <while Preheader: bb0, Header: bb1, exit: bb3
-// CHECK:        block bb2>
-// CHECK:      block bb3]
 
 // `a` and `b` are both arguments to the tensor program, which starts at
 // "let _= a + b", and ends in that BB. So the tensor start point and tensor end

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil %s -verify | %FileCheck %s
 
 // This file contains various regression tests that crashed the compiler.
 
@@ -253,6 +253,11 @@ public func testMultiResultOp_send_recv() {
   _hostOp(y)
 }
 
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testMultiResultOp_send_recv{{.*}}
+// CHECK:  graph_op "tfc.SendToHost"
+// CHECK:  graph_op "tfc.SendToHost"
+// CHECK:  graph_op "tfc.RecvFromHost"
+
 var globalThing: Int32!
 
 public func testStructExtractBBArg(x: Tensor<Float>) -> Tensor<Int32> {
@@ -271,6 +276,16 @@ public func SR8191() {
     i += 1
   } while i < 10
 }
+
+// CHECK-LABEL: --- XLA CFG Canonicalize: {{.*}}SR8191{{.*}}
+// CHECK: [sequence
+// CHECK:   <while Preheader: bb0, Header: bb5, exit: bb4
+// CHECK:     [sequence
+// CHECK:       {condition Header: bb1
+// CHECK:         block bb3
+// CHECK:         block bb2}
+// CHECK:       block bb6]>
+// CHECK:   block bb4]
 
 // `a` and `b` are both arguments to the tensor program, which starts at
 // "let _= a + b", and ends in that BB. So the tensor start point and tensor end

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -263,7 +263,7 @@ public func testExtractDTypeList() {
   // TODO: Support unpacking a struct value into an input list so that we can replace
   // `[elements.a, elements.b]` with `elements`.
   let _: VariantHandle = #tfop("TensorSliceDataset", [elements.a, elements.b],
-                               Toutput_types$array: Foo.self,
+                               Toutput_types$typeList: Foo.self,
                                output_shapes: [TensorShape()])
 }
 
@@ -273,7 +273,7 @@ public func testExtractDTypeList() {
 public func testExtractTupleDTypeList() {
     let bar: (a: Tensor<Int32>, b: Tensor<Int32>) = (Tensor(0), Tensor(1))
     let _: VariantHandle = #tfop("TensorSliceDataset", [bar.a, bar.b],
-                                 Toutput_types$array: type(of: bar),
+                                 Toutput_types$typeList: type(of: bar),
                                  output_shapes: [TensorShape()])
 }
 

--- a/test/TensorFlow/graph_op_inst_serialization.sil
+++ b/test/TensorFlow/graph_op_inst_serialization.sil
@@ -1,0 +1,23 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name graph_op
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name graph_op
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name graph_op | %FileCheck %s
+
+import Swift
+
+// Dummy struct mimicking the real `Tensor` type.
+struct Tensor<Scalar> {}
+
+sil [serialized] @test_func : $@convention(thin) () -> () {
+// CHECK-LABEL: sil [serialized] @test_func
+bb0:
+// CHECK-NEXT: bb0
+  %0 = graph_op "Dummy1"() : $Tensor<Float>
+  // CHECK-NEXT: %0 = graph_op "Dummy1"() : $Tensor<Float>
+  %1 = graph_op "Dummy2"(%0 : $Tensor<Float>) : $Tensor<Float>
+  // CHECK-NEXT: %1 = graph_op "Dummy2"(%0 : $Tensor<Float>) : $Tensor<Float>
+  (%2, %3) = graph_op "Dummy3"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) : $Tensor<Float>, $Tensor<Float>
+  // CHECK-NEXT: (%2, %3) = graph_op "Dummy3"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) : $Tensor<Float>, $Tensor<Float>
+  return undef : $()
+}

--- a/test/TensorFlow/tfop_packing_with_deabstraction_error.swift
+++ b/test/TensorFlow/tfop_packing_with_deabstraction_error.swift
@@ -95,7 +95,7 @@ public func testExtractDTypeList() {
   }
   // expected-error @+1 {{a TensorFlow value or an aggregate of TensorFlow values}}
   let _: VariantHandle = #tfop("TensorSliceDataset", [] as [TensorHandle<Float>],
-                               Toutput_types$array: Foo.self,
+                               Toutput_types$typeList: Foo.self,
                                output_shapes: [TensorShape()])
 }
 


### PR DESCRIPTION
This makes SILGen create graph_ops instead of builtin "__tfop"s.

I made the new graph_ops look very similar to the original builtin "__tfop"s, to minimize the changes necessary to make everything compatible with the graph_ops.

I had to change SILOwnershipVerifier to make it happy with the new graph_ops, but I don't know what my changes actually do. Does anyone know enough about SILOwnershipVerifier to tell if the changes are correct?

Removes a builtin-tfop-specific code path in `TFLowerGraph`: decodeShapeArrayLegacy, decodeShapeElementsLegacy, and createDatasetCreationContext.