### PR TITLE
[DynamicCompilation] Add _AnyTensorHandle and Swift-C round trip entry points

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -93,17 +93,12 @@ static bool isUserIgnoredByPartitioning(SILInstruction *inst) {
   return isa<RefCountingInst>(inst);
 }
 
-/// Given a decl for a struct that has a single field (typically because it is
-/// known to be a standard library type like Int or Float), return the canonical
-/// type of the single member, asserting and aborting if we get something
-/// unexpected.
+/// Given a decl for a struct or class that has a single field (typically
+/// because it is known to be a standard library type like Int or Float), return
+/// the canonical type of the single member, asserting and aborting if we get
+/// something unexpected.
 static CanType getSingleElementDeclFieldType(NominalTypeDecl *decl) {
   auto *field = tf::getFieldIfContainsSingleField(decl);
-  if (!field)
-    if (auto *cd = decl->getAsClassOrClassExtensionContext())
-      if (auto superclass = cd->getSuperclass())
-        if (auto *superclassDecl = superclass->getAnyNominal())
-          field = getFieldIfContainsSingleField(superclassDecl);
   assert(field && "Struct should have one member");
   return field->getType()->getCanonicalType();
 }

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -97,37 +97,26 @@ llvm::raw_ostream *tf::getTFDumpIntermediateStream() {
   return &fileStream;
 }
 
-/// Given a class decl, return true if the decl or its superclass decls have any
-/// fields.
-static bool hasAnyFieldsInInheritanceHierarchy(ClassDecl *decl) {
-  if (!decl->getStoredProperties().empty())
-    return true;
-  if (auto *superclass = decl->getSuperclassDecl())
-    return hasAnyFieldsInInheritanceHierarchy(decl->getSuperclassDecl());
-  return false;
+/// Given a nominal type decl, collect all fields. If it's a class decl, collect
+/// all fields along the inheritance hierarchy.
+static void getAllFields(NominalTypeDecl *decl,
+                         SmallVectorImpl<VarDecl *> &fields) {
+  for (auto *field : decl->getStoredProperties())
+    fields.push_back(field);
+  if (auto *classdecl = decl->getAsClassOrClassExtensionContext())
+    if (auto *superclass = classdecl->getSuperclassDecl())
+      getAllFields(superclass, fields);
 }
 
 /// If the specified decl has a single stored field, return it.  If it's a class
 /// type, return there's exactly one field in the entire inheritance hierarchy.
 /// Otherwise return null.
 VarDecl *tf::getFieldIfContainsSingleField(NominalTypeDecl *decl) {
-  // Check to see if there is a single stored field.
-  auto fieldIt = decl->getStoredProperties().begin();
-  if (fieldIt == decl->getStoredProperties().end()) {
-    // If it's a class type, then its superclasses may have fields.
-    if (auto *cd = decl->getAsClassOrClassExtensionContext())
-      return getFieldIfContainsSingleField(cd->getSuperclassDecl());
-    return nullptr;
-  }
-  auto result = *fieldIt++;
-  // Now that we've found a single field, if this is a class type, its
-  // superclasses must not have any fields.
-  if (auto *classDecl = decl->getAsClassOrClassExtensionContext())
-    if (hasAnyFieldsInInheritanceHierarchy(classDecl->getSuperclassDecl()))
-      return nullptr;
-  if (fieldIt != decl->getStoredProperties().end())
-    return nullptr;
-  return result;
+  SmallVector<VarDecl *, 4> fields;
+  getAllFields(decl, fields);
+  if (fields.size() == 1)
+    return fields.front();
+  return nullptr;
 }
 
 bool tf::isTensorHandle(SILType ty) {

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1205,6 +1205,7 @@ public func _CreateTensorHandleFromC(
   }
 }
 
+@inlinable
 @_silgen_name("_swift_tfc_CreateFloatTensorHandleFromCTensorHandle")
 public func _CreateTensorHandleFromCTensorHandle(
   _ ownedCHandle: CTensorHandle

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1171,7 +1171,7 @@ public func _TFCExtractCTensorHandle(
 
 @inlinable
 @_silgen_name("_swift_tfc_GetCTensorHandleFromSwift")
-public func _GetCTensorHandleFromSwift(
+public func _TFCGetCTensorHandleFromSwift(
   _ handle: _AnyTensorHandle
 ) -> CTensorHandle {
   return handle.cTensorHandle

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -495,9 +495,8 @@ internal func dumpCTensorHandleContent(
   let dType: TF_DataType = TFE_TensorHandleDataType(inputTensorHandle)
   debugLog("Tensor \(idx) has TF data type \(dType).")
   switch dType {
-  case TF_INT8: dumpTensorContent(inputTensorHandle, Int8.self)
   case TF_UINT8: dumpTensorContent(inputTensorHandle, UInt8.self)
-  case TF_INT16: dumpTensorContent(inputTensorHandle, Int16.self)
+  case TF_INT8: dumpTensorContent(inputTensorHandle, Int8.self)
   case TF_UINT16: dumpTensorContent(inputTensorHandle, UInt16.self)
   case TF_INT16: dumpTensorContent(inputTensorHandle, Int16.self)
   case TF_UINT32: dumpTensorContent(inputTensorHandle, UInt32.self)
@@ -1132,7 +1131,7 @@ public func _TFCTerminateTensorComputation(_ computation: _TensorComputation) {
 ///   function.
 @inlinable
 @_silgen_name("_swift_tfc_CreateCTensorHandle")
-public func _TFCCreateCTensorHandle<T>(_ value : T,
+public func _TFCCreateCTensorHandle<T>(_ value: T,
                                        _ dtype: TF_DataType) -> CTensorHandle {
   // Create a new CTensor and initialize it to the scalar value.
   let tensor = TF_AllocateTensor(dtype, nil, 0, MemoryLayout<T>.stride)
@@ -1166,3 +1165,45 @@ public func _GetGlobalEagerContext() -> CTFEContext {
   return _ExecutionContext.global.eagerContext
 }
 
+@inlinable
+@_silgen_name("_swift_tfc_GetCTensorHandleFromSwift")
+public func _GetCTensorHandleFromSwift(
+  _ handle: _AnyTensorHandle
+) -> CTensorHandle {
+  return handle.cTensorHandle
+}
+
+@inlinable
+@_silgen_name("_swift_tfc_CreateTensorHandleFromC")
+public func _CreateTensorHandleFromC(
+  _ cHandle: CTensorHandle, _ dtype: TF_DataType
+) -> _AnyTensorHandle {
+  switch dtype {
+  case TF_BFLOAT16:
+    return TensorHandle<BFloat16>(owning: cHandle)
+  case TF_UINT8:
+    return TensorHandle<UInt8>(owning: cHandle)
+  case TF_INT8:
+    return TensorHandle<Int8>(owning: cHandle)
+  case TF_UINT16:
+    return TensorHandle<UInt16>(owning: cHandle)
+  case TF_INT16:
+    return TensorHandle<Int16>(owning: cHandle)
+  case TF_UINT32:
+    return TensorHandle<UInt32>(owning: cHandle)
+  case TF_INT32:
+    return TensorHandle<Int32>(owning: cHandle)
+  case TF_UINT64:
+    return TensorHandle<UInt64>(owning: cHandle)
+  case TF_INT64:
+    return TensorHandle<Int64>(owning: cHandle)
+  case TF_FLOAT:
+    return TensorHandle<Float>(owning: cHandle)
+  case TF_DOUBLE:
+    return TensorHandle<Double>(owning: cHandle)
+  case TF_BOOL:
+    return TensorHandle<Bool>(owning: cHandle)
+  default:
+    fatalError("Unsupported dtype \(dtype)")
+  }
+}

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1176,34 +1176,22 @@ public func _GetCTensorHandleFromSwift(
 @inlinable
 @_silgen_name("_swift_tfc_CreateTensorHandleFromC")
 public func _CreateTensorHandleFromC(
-  _ cHandle: CTensorHandle, _ dtype: TF_DataType
+  _ cHandle: CTensorHandle
 ) -> _AnyTensorHandle {
+  let dtype = TFE_TensorHandleDataType(cHandle)
   switch dtype {
-  case TF_BFLOAT16:
-    return TensorHandle<BFloat16>(owning: cHandle)
-  case TF_UINT8:
-    return TensorHandle<UInt8>(owning: cHandle)
-  case TF_INT8:
-    return TensorHandle<Int8>(owning: cHandle)
-  case TF_UINT16:
-    return TensorHandle<UInt16>(owning: cHandle)
-  case TF_INT16:
-    return TensorHandle<Int16>(owning: cHandle)
-  case TF_UINT32:
-    return TensorHandle<UInt32>(owning: cHandle)
-  case TF_INT32:
-    return TensorHandle<Int32>(owning: cHandle)
-  case TF_UINT64:
-    return TensorHandle<UInt64>(owning: cHandle)
-  case TF_INT64:
-    return TensorHandle<Int64>(owning: cHandle)
-  case TF_FLOAT:
-    return TensorHandle<Float>(owning: cHandle)
-  case TF_DOUBLE:
-    return TensorHandle<Double>(owning: cHandle)
-  case TF_BOOL:
-    return TensorHandle<Bool>(owning: cHandle)
-  default:
-    fatalError("Unsupported dtype \(dtype)")
+  case TF_BFLOAT16: return TensorHandle<BFloat16>(owning: cHandle)
+  case TF_UINT8: return TensorHandle<UInt8>(owning: cHandle)
+  case TF_INT8: return TensorHandle<Int8>(owning: cHandle)
+  case TF_UINT16: return TensorHandle<UInt16>(owning: cHandle)
+  case TF_INT16: return TensorHandle<Int16>(owning: cHandle)
+  case TF_UINT32: return TensorHandle<UInt32>(owning: cHandle)
+  case TF_INT32: return TensorHandle<Int32>(owning: cHandle)
+  case TF_UINT64: return TensorHandle<UInt64>(owning: cHandle)
+  case TF_INT64: return TensorHandle<Int64>(owning: cHandle)
+  case TF_FLOAT: return TensorHandle<Float>(owning: cHandle)
+  case TF_DOUBLE: return TensorHandle<Double>(owning: cHandle)
+  case TF_BOOL: return TensorHandle<Bool>(owning: cHandle)
+  default: fatalError("Unsupported dtype \(dtype)")
   }
 }

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1184,7 +1184,7 @@ public func _GetCTensorHandleFromSwift(
 
 @inlinable
 @_silgen_name("_swift_tfc_CreateTensorHandleFromC")
-public func _CreateTensorHandleFromC(
+public func _TFCCreateTensorHandleFromC(
   _ cHandle: CTensorHandle
 ) -> _AnyTensorHandle {
   let dtype = TFE_TensorHandleDataType(cHandle)
@@ -1207,7 +1207,7 @@ public func _CreateTensorHandleFromC(
 
 @inlinable
 @_silgen_name("_swift_tfc_CreateFloatTensorHandleFromCTensorHandle")
-public func _CreateTensorHandleFromCTensorHandle(
+public func _TFCCreateTensorHandleFromCTensorHandle(
   _ ownedCHandle: CTensorHandle
 ) -> TensorHandle<Float> {
   return TensorHandle<Float>(owning: ownedCHandle)

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -21,6 +21,7 @@
 
 import CTensorFlow
 
+@_fixed_layout
 public struct _TensorDataType {
   internal var cDataType: TF_DataType
 

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -6,6 +6,7 @@
 // This file contains testing over a dataset as a global variable. This requires
 // sends/recvs support for variant handles.
 
+import CTensorFlow
 import TensorFlow
 import TensorFlowUnittest
 import StdlibUnittest

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -12,14 +12,14 @@ var RuntimeEntryPointTests = TestSuite("RuntimeEntryPoint")
 RuntimeEntryPointTests.testCPUOrGPU("RoundTrip_CTensorHandle_AnyTensorHandle") {
   let zero: TensorHandle<Float> =
     #tfop("Const", dtype: Float.self, value$tensor: 0.0)
-  var cHandle = _GetCTensorHandleFromSwift(zero as _AnyTensorHandle)
+  var cHandle = _TFCGetCTensorHandleFromSwift(zero as _AnyTensorHandle)
   let status = TF_NewStatus()
   // We must do a copy, i.e. a retain on the tensor handle, to make sure it won't
   // get double-free'd when both `zero` and `anyHandle` below go out of scope.
   cHandle = TFE_TensorHandleCopySharingTensor(cHandle, status)
   expectEqual(TF_GetCode(status), TF_OK)
   TF_DeleteStatus(status)
-  let anyHandle = _CreateTensorHandleFromC(cHandle)
+  let anyHandle = _TFCCreateTensorHandleFromC(cHandle)
   let tensor = Tensor(handle: anyHandle as! TensorHandle<Float>)
   print(tensor)
   expectTrue(tensor == Tensor(0.0))

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -19,7 +19,7 @@ RuntimeEntryPointTests.testCPUOrGPU("RoundTrip_CTensorHandle_AnyTensorHandle") {
   cHandle = TFE_TensorHandleCopySharingTensor(cHandle, status)
   expectEqual(TF_GetCode(status), TF_OK)
   TF_DeleteStatus(status)
-  let anyHandle = _CreateTensorHandleFromC(cHandle, TF_FLOAT)
+  let anyHandle = _CreateTensorHandleFromC(cHandle)
   let tensor = Tensor(handle: anyHandle as! TensorHandle<Float>)
   print(tensor)
   expectTrue(tensor == Tensor(0.0))

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -1,0 +1,28 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+
+import CTensorFlow
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+var RuntimeEntryPointTests = TestSuite("RuntimeEntryPoint")
+
+RuntimeEntryPointTests.testCPUOrGPU("RoundTrip_CTensorHandle_AnyTensorHandle") {
+  let zero: TensorHandle<Float> =
+    #tfop("Const", dtype: Float.self, value$tensor: 0.0)
+  var cHandle = _GetCTensorHandleFromSwift(zero as _AnyTensorHandle)
+  let status = TF_NewStatus()
+  // We must do a copy, i.e. a retain on the tensor handle, to make sure it won't
+  // get double-free'd when both `zero` and `anyHandle` below go out of scope.
+  cHandle = TFE_TensorHandleCopySharingTensor(cHandle, status)
+  expectEqual(TF_GetCode(status), TF_OK)
+  TF_DeleteStatus(status)
+  let anyHandle = _CreateTensorHandleFromC(cHandle, TF_FLOAT)
+  let tensor = Tensor(handle: anyHandle as! TensorHandle<Float>)
+  print(tensor)
+  expectTrue(tensor == Tensor(0.0))
+}
+
+runAllTests()


### PR DESCRIPTION
Introduce a scalar-type-erased `_AnyTensorHandle` as a base class for `TensorHandle<T>`, along with two runtime entry points that assist `graph_op` lowering in IRGen.

1. `_swift_tfc_GetCTensorHandleFromSwift`
    ```swift
    @_silgen_name("_swift_tfc_GetCTensorHandleFromSwift")
    public func _GetCTensorHandleFromSwift(_: _AnyTensorHandle) -> CTensorHandle
    ```

2. `_swift_tfc_CreateTensorHandleFromC`
    ```swift
    @_silgen_name("_swift_tfc_CreateTensorHandleFromC")
    public func _CreateTensorHandleFromC(_: CTensorHandle, _: TF_DataType) -> _AnyTensorHandle
    ```
    It is unfortunate that this function has to switch on all supported dtypes, but that's the only way to create a concrete `TensorHandle<T>` type. The `switch` in `dumpTensorContents` should be unified with this.