### PR TITLE
[vim] Fix tuple hilight problem with swiftType

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -127,7 +127,7 @@ syn match swiftTypePair contained skipwhite nextgroup=swiftTypeParameters,swiftT
 " (Type[, Type]) (tuple)
 " FIXME: we should be able to use skip="," and drop swiftParamDelim
 syn region swiftType contained contains=swiftType,swiftParamDelim
-      \ matchgroup=Delimiter start="[^@](" end=")" matchgroup=NONE skip=","
+      \ matchgroup=Delimiter start="[^@]\?(" end=")" matchgroup=NONE skip=","
 syn match swiftParamDelim contained
       \ /,/
 " <Generic Clause> (generics)


### PR DESCRIPTION
<!-- What's in this pull request? -->

Fix a little regular expression problem that for `swiftType`.
## Problematic patterns

![2018-09-25 16 13 23](https://user-images.githubusercontent.com/629993/45998523-173dd100-c0de-11e8-9fc4-d6a93ae2b4de.png)

## Expects

![2018-09-25 16 14 09](https://user-images.githubusercontent.com/629993/45998533-1e64df00-c0de-11e8-8bcb-52d40502b437.png)
