### PR TITLE
SR-8649: Range types conform to Codable

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -494,7 +494,13 @@ extension ClosedRange: Decodable where Bound: Decodable {
     var container = try decoder.unkeyedContainer()
     let lowerBound = try container.decode(Bound.self)
     let upperBound = try container.decode(Bound.self)
-    self = lowerBound...upperBound
+    guard lowerBound <= upperBound else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "Cannot initialize \(ClosedRange.self) with a lowerBound (\(lowerBound)) greater than upperBound (\(upperBound))"))
+    }
+    self.init(uncheckedBounds: (lower: lowerBound, upper: upperBound))
   }
 }
 

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -490,28 +490,16 @@ public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
   where Bound.Stride : SignedInteger
 
 extension ClosedRange: Codable where Bound: Codable {
-  private enum CodingKeys: String, CodingKey {
-    case lowerBound = "from"
-    case upperBound = "through"
-  }
-
   public init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    let lowerBound = try container.decode(Bound.self, forKey: .lowerBound)
-    let upperBound = try container.decode(Bound.self, forKey: .upperBound)
-    guard lowerBound <= upperBound else {
-      throw DecodingError.dataCorruptedError(
-        forKey: CodingKeys.upperBound,
-        in: container,
-        debugDescription: "upperBound (through) cannot be less than lowerBound (from)"
-      )
-    }
+    var container = try decoder.unkeyedContainer()
+    let lowerBound = try container.decode(Bound.self)
+    let upperBound = try container.decode(Bound.self)
     self = lowerBound...upperBound
   }
 
   public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.lowerBound, forKey: .lowerBound)
-    try container.encode(self.upperBound, forKey: .upperBound)
+    var container = encoder.unkeyedContainer()
+    try container.encode(self.lowerBound)
+    try container.encode(self.upperBound)
   }
 }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -489,14 +489,16 @@ extension ClosedRange {
 public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
   where Bound.Stride : SignedInteger
 
-extension ClosedRange: Codable where Bound: Codable {
+extension ClosedRange: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
     let lowerBound = try container.decode(Bound.self)
     let upperBound = try container.decode(Bound.self)
     self = lowerBound...upperBound
   }
+}
 
+extension ClosedRange: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
     try container.encode(self.lowerBound)

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -492,7 +492,7 @@ public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
 extension ClosedRange: Codable where Bound: Codable {
   private enum CodingKeys: String, CodingKey {
     case lowerBound = "from"
-    case upperBound = "to"
+    case upperBound = "through"
   }
 
   public init(from decoder: Decoder) throws {
@@ -500,7 +500,11 @@ extension ClosedRange: Codable where Bound: Codable {
     let lowerBound = try container.decode(Bound.self, forKey: .lowerBound)
     let upperBound = try container.decode(Bound.self, forKey: .upperBound)
     guard lowerBound <= upperBound else {
-      throw DecodingError.dataCorruptedError(forKey: CodingKeys.upperBound, in: container, debugDescription: "upperBound (to) cannot be lower than lowerBound (from)")
+      throw DecodingError.dataCorruptedError(
+        forKey: CodingKeys.upperBound,
+        in: container,
+        debugDescription: "upperBound (to) cannot be less than lowerBound (through)"
+      )
     }
     self = lowerBound...upperBound
   }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -503,7 +503,7 @@ extension ClosedRange: Codable where Bound: Codable {
       throw DecodingError.dataCorruptedError(
         forKey: CodingKeys.upperBound,
         in: container,
-        debugDescription: "upperBound (to) cannot be less than lowerBound (through)"
+        debugDescription: "upperBound (through) cannot be less than lowerBound (from)"
       )
     }
     self = lowerBound...upperBound

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -491,25 +491,23 @@ public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
 
 extension ClosedRange: Codable where Bound: Codable {
   private enum CodingKeys: String, CodingKey {
-    case from
-    case to
+    case lowerBound = "from"
+    case upperBound = "to"
   }
 
-  @inlinable
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    let lowerBound = try container.decode(Bound.self, forKey: .from)
-    let upperBound = try container.decode(Bound.self, forKey: .to)
+    let lowerBound = try container.decode(Bound.self, forKey: .lowerBound)
+    let upperBound = try container.decode(Bound.self, forKey: .upperBound)
     guard lowerBound <= upperBound else {
-      throw DecodingError.dataCorruptedError(forKey: CodingKeys.to, in: container, debugDescription: "upperBound (to) cannot be lower than lowerBound (from)")
+      throw DecodingError.dataCorruptedError(forKey: CodingKeys.upperBound, in: container, debugDescription: "upperBound (to) cannot be lower than lowerBound (from)")
     }
     self = lowerBound...upperBound
   }
 
-  @inlinable
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.lowerBound, forKey: .from)
-    try container.encode(self.upperBound, forKey: .to)
+    try container.encode(self.lowerBound, forKey: .lowerBound)
+    try container.encode(self.upperBound, forKey: .upperBound)
   }
 }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -488,3 +488,28 @@ extension ClosedRange {
 // shorthand. TODO: Add documentation
 public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
   where Bound.Stride : SignedInteger
+
+extension ClosedRange: Codable where Bound: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case from
+    case to
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lowerBound = try container.decode(Bound.self, forKey: .from)
+    let upperBound = try container.decode(Bound.self, forKey: .to)
+    guard lowerBound <= upperBound else {
+      throw DecodingError.dataCorruptedError(forKey: CodingKeys.to, in: container, debugDescription: "upperBound (to) cannot be lower than lowerBound (from)")
+    }
+    self = lowerBound...upperBound
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.lowerBound, forKey: .from)
+    try container.encode(self.upperBound, forKey: .to)
+  }
+}

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -406,29 +406,17 @@ extension Range: Hashable where Bound: Hashable {
 }
 
 extension Range: Codable where Bound: Codable {
-  private enum CodingKeys: String, CodingKey {
-    case lowerBound = "from"
-    case upperBound = "upTo"
-  }
-
   public init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    let lowerBound = try container.decode(Bound.self, forKey: .lowerBound)
-    let upperBound = try container.decode(Bound.self, forKey: .upperBound)
-    guard lowerBound <= upperBound else {
-      throw DecodingError.dataCorruptedError(
-        forKey: CodingKeys.upperBound,
-        in: container,
-        debugDescription: "upperBound (upTo) cannot be less than lowerBound (from)"
-      )
-    }
+    var container = try decoder.unkeyedContainer()
+    let lowerBound = try container.decode(Bound.self)
+    let upperBound = try container.decode(Bound.self)
     self = lowerBound..<upperBound
   }
 
   public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.lowerBound, forKey: .lowerBound)
-    try container.encode(self.upperBound, forKey: .upperBound)
+    var container = encoder.unkeyedContainer()
+    try container.encode(self.lowerBound)
+    try container.encode(self.upperBound)
   }
 }
 
@@ -475,18 +463,14 @@ extension PartialRangeUpTo: RangeExpression {
 }
 
 extension PartialRangeUpTo: Codable where Bound: Codable {
-  private enum CodingKeys: String, CodingKey {
-    case upperBound = "fromStartUpTo"
-  }
-
   public init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    self = try (..<container.decode(Bound.self, forKey: .upperBound))
+    var container = try decoder.unkeyedContainer()
+    self = try (..<container.decode(Bound.self))
   }
 
   public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.upperBound, forKey: .upperBound)
+    var container = encoder.unkeyedContainer()
+    try container.encode(self.upperBound)
   }
 }
 
@@ -532,18 +516,14 @@ extension PartialRangeThrough: RangeExpression {
 }
 
 extension PartialRangeThrough: Codable where Bound: Codable {
-  private enum CodingKeys: String, CodingKey {
-    case upperBound = "fromStartThrough"
-  }
-
   public init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    self = try (...container.decode(Bound.self, forKey: .upperBound))
+    var container = try decoder.unkeyedContainer()
+    self = try (...container.decode(Bound.self))
   }
 
   public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.upperBound, forKey: .upperBound)
+    var container = encoder.unkeyedContainer()
+    try container.encode(self.upperBound)
   }
 }
 
@@ -684,18 +664,14 @@ extension PartialRangeFrom: Sequence
 }
 
 extension PartialRangeFrom: Codable where Bound: Codable {
-  private enum CodingKeys: String, CodingKey {
-    case lowerBound = "toEndFrom"
-  }
-
   public init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    self = try container.decode(Bound.self, forKey: .lowerBound)...
+    var container = try decoder.unkeyedContainer()
+    self = try container.decode(Bound.self)...
   }
 
   public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.lowerBound, forKey: .lowerBound)
+    var container = encoder.unkeyedContainer()
+    try container.encode(self.lowerBound)
   }
 }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -410,7 +410,13 @@ extension Range: Decodable where Bound: Decodable {
     var container = try decoder.unkeyedContainer()
     let lowerBound = try container.decode(Bound.self)
     let upperBound = try container.decode(Bound.self)
-    self = lowerBound..<upperBound
+    guard lowerBound <= upperBound else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "Cannot initialize \(Range.self) with a lowerBound (\(lowerBound)) greater than upperBound (\(upperBound))"))
+    }
+    self.init(uncheckedBounds: (lower: lowerBound, upper: upperBound))
   }
 }
 
@@ -467,7 +473,7 @@ extension PartialRangeUpTo: RangeExpression {
 extension PartialRangeUpTo: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
-    self = try (..<container.decode(Bound.self))
+    try self.init(container.decode(Bound.self))
   }
 }
 
@@ -522,7 +528,7 @@ extension PartialRangeThrough: RangeExpression {
 extension PartialRangeThrough: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
-    self = try (...container.decode(Bound.self))
+    try self.init(container.decode(Bound.self))
   }
 }
 
@@ -672,7 +678,7 @@ extension PartialRangeFrom: Sequence
 extension PartialRangeFrom: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
-    self = try container.decode(Bound.self)...
+    try self.init(container.decode(Bound.self))
   }
 }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -405,14 +405,16 @@ extension Range: Hashable where Bound: Hashable {
   }
 }
 
-extension Range: Codable where Bound: Codable {
+extension Range: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
     let lowerBound = try container.decode(Bound.self)
     let upperBound = try container.decode(Bound.self)
     self = lowerBound..<upperBound
   }
+}
 
+extension Range: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
     try container.encode(self.lowerBound)
@@ -462,12 +464,14 @@ extension PartialRangeUpTo: RangeExpression {
   }
 }
 
-extension PartialRangeUpTo: Codable where Bound: Codable {
+extension PartialRangeUpTo: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
     self = try (..<container.decode(Bound.self))
   }
+}
 
+extension PartialRangeUpTo: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
     try container.encode(self.upperBound)
@@ -515,12 +519,14 @@ extension PartialRangeThrough: RangeExpression {
   }
 }
 
-extension PartialRangeThrough: Codable where Bound: Codable {
+extension PartialRangeThrough: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
     self = try (...container.decode(Bound.self))
   }
+}
 
+extension PartialRangeThrough: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
     try container.encode(self.upperBound)
@@ -663,12 +669,14 @@ extension PartialRangeFrom: Sequence
   }
 }
 
-extension PartialRangeFrom: Codable where Bound: Codable {
+extension PartialRangeFrom: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
     self = try container.decode(Bound.self)...
   }
+}
 
+extension PartialRangeFrom: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
     try container.encode(self.lowerBound)

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -405,6 +405,31 @@ extension Range: Hashable where Bound: Hashable {
   }
 }
 
+extension Range: Codable where Bound: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case from
+    case upTo
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lowerBound = try container.decode(Bound.self, forKey: .from)
+    let upperBound = try container.decode(Bound.self, forKey: .upTo)
+    guard lowerBound <= upperBound else {
+      throw DecodingError.dataCorruptedError(forKey: CodingKeys.upTo, in: container, debugDescription: "upperBound (upTo) cannot be lower than lowerBound (from)")
+    }
+    self = lowerBound..<upperBound
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.lowerBound, forKey: .from)
+    try container.encode(self.upperBound, forKey: .upTo)
+  }
+}
+
 /// A partial half-open interval up to, but not including, an upper bound.
 ///
 /// You create `PartialRangeUpTo` instances by using the prefix half-open range
@@ -447,6 +472,24 @@ extension PartialRangeUpTo: RangeExpression {
   }
 }
 
+extension PartialRangeUpTo: Codable where Bound: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case beginningUpTo
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self = ..<try container.decode(Bound.self, forKey: .beginningUpTo)
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.upperBound, forKey: .beginningUpTo)
+  }
+}
+
 /// A partial interval up to, and including, an upper bound.
 ///
 /// You create `PartialRangeThrough` instances by using the prefix closed range
@@ -485,6 +528,24 @@ extension PartialRangeThrough: RangeExpression {
   @_transparent
   public func contains(_ element: Bound) -> Bool {
     return element <= upperBound
+  }
+}
+
+extension PartialRangeThrough: Codable where Bound: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case beginningTo
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self = ...try container.decode(Bound.self, forKey: .beginningTo)
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.upperBound, forKey: .beginningTo)
   }
 }
 
@@ -621,6 +682,24 @@ extension PartialRangeFrom: Sequence
   @inlinable
   public __consuming func makeIterator() -> Iterator { 
     return Iterator(_current: lowerBound) 
+  }
+}
+
+extension PartialRangeFrom: Codable where Bound: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case toEndFrom
+  }
+
+  @inlinable
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self = try container.decode(Bound.self, forKey: .toEndFrom)...
+  }
+
+  @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.lowerBound, forKey: .toEndFrom)
   }
 }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -416,7 +416,11 @@ extension Range: Codable where Bound: Codable {
     let lowerBound = try container.decode(Bound.self, forKey: .lowerBound)
     let upperBound = try container.decode(Bound.self, forKey: .upperBound)
     guard lowerBound <= upperBound else {
-      throw DecodingError.dataCorruptedError(forKey: CodingKeys.upperBound, in: container, debugDescription: "upperBound (upTo) cannot be lower than lowerBound (from)")
+      throw DecodingError.dataCorruptedError(
+        forKey: CodingKeys.upperBound,
+        in: container,
+        debugDescription: "upperBound (upTo) cannot be less than lowerBound (from)"
+      )
     }
     self = lowerBound..<upperBound
   }
@@ -472,7 +476,7 @@ extension PartialRangeUpTo: RangeExpression {
 
 extension PartialRangeUpTo: Codable where Bound: Codable {
   private enum CodingKeys: String, CodingKey {
-    case upperBound = "beginningUpTo"
+    case upperBound = "fromStartUpTo"
   }
 
   public init(from decoder: Decoder) throws {
@@ -529,7 +533,7 @@ extension PartialRangeThrough: RangeExpression {
 
 extension PartialRangeThrough: Codable where Bound: Codable {
   private enum CodingKeys: String, CodingKey {
-    case upperBound = "beginningTo"
+    case upperBound = "fromStartThrough"
   }
 
   public init(from decoder: Decoder) throws {

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -407,26 +407,24 @@ extension Range: Hashable where Bound: Hashable {
 
 extension Range: Codable where Bound: Codable {
   private enum CodingKeys: String, CodingKey {
-    case from
-    case upTo
+    case lowerBound = "from"
+    case upperBound = "upTo"
   }
 
-  @inlinable
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    let lowerBound = try container.decode(Bound.self, forKey: .from)
-    let upperBound = try container.decode(Bound.self, forKey: .upTo)
+    let lowerBound = try container.decode(Bound.self, forKey: .lowerBound)
+    let upperBound = try container.decode(Bound.self, forKey: .upperBound)
     guard lowerBound <= upperBound else {
-      throw DecodingError.dataCorruptedError(forKey: CodingKeys.upTo, in: container, debugDescription: "upperBound (upTo) cannot be lower than lowerBound (from)")
+      throw DecodingError.dataCorruptedError(forKey: CodingKeys.upperBound, in: container, debugDescription: "upperBound (upTo) cannot be lower than lowerBound (from)")
     }
     self = lowerBound..<upperBound
   }
 
-  @inlinable
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.lowerBound, forKey: .from)
-    try container.encode(self.upperBound, forKey: .upTo)
+    try container.encode(self.lowerBound, forKey: .lowerBound)
+    try container.encode(self.upperBound, forKey: .upperBound)
   }
 }
 
@@ -474,19 +472,17 @@ extension PartialRangeUpTo: RangeExpression {
 
 extension PartialRangeUpTo: Codable where Bound: Codable {
   private enum CodingKeys: String, CodingKey {
-    case beginningUpTo
+    case upperBound = "beginningUpTo"
   }
 
-  @inlinable
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self = ..<try container.decode(Bound.self, forKey: .beginningUpTo)
+    self = try (..<container.decode(Bound.self, forKey: .upperBound))
   }
 
-  @inlinable
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.upperBound, forKey: .beginningUpTo)
+    try container.encode(self.upperBound, forKey: .upperBound)
   }
 }
 
@@ -533,19 +529,17 @@ extension PartialRangeThrough: RangeExpression {
 
 extension PartialRangeThrough: Codable where Bound: Codable {
   private enum CodingKeys: String, CodingKey {
-    case beginningTo
+    case upperBound = "beginningTo"
   }
 
-  @inlinable
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self = ...try container.decode(Bound.self, forKey: .beginningTo)
+    self = try (...container.decode(Bound.self, forKey: .upperBound))
   }
 
-  @inlinable
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.upperBound, forKey: .beginningTo)
+    try container.encode(self.upperBound, forKey: .upperBound)
   }
 }
 
@@ -687,19 +681,17 @@ extension PartialRangeFrom: Sequence
 
 extension PartialRangeFrom: Codable where Bound: Codable {
   private enum CodingKeys: String, CodingKey {
-    case toEndFrom
+    case lowerBound = "toEndFrom"
   }
 
-  @inlinable
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self = try container.decode(Bound.self, forKey: .toEndFrom)...
+    self = try container.decode(Bound.self, forKey: .lowerBound)...
   }
 
-  @inlinable
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.lowerBound, forKey: .toEndFrom)
+    try container.encode(self.lowerBound, forKey: .lowerBound)
   }
 }
 


### PR DESCRIPTION
## Overview
Conform `Range`, `ClosedRange`, `PartialRangeUpTo`, `PartialRangeThrough` and `PartialRangeFrom` to `Codable`.

### Bug Report 
[SR-8649](https://bugs.swift.org/browse/SR-8649)
### Forum Thread
[Range conform to Codable](https://forums.swift.org/t/range-conform-to-codable/15552)
### Proposal Amendment PR
[Swift Evolution PR #915](https://github.com/apple/swift-evolution/pull/915)