### PR TITLE
[stdlib] Set, Dictionary: Enable per-instance hash seeds

### DIFF
--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -94,7 +94,6 @@ extension _HashTable {
     for object: AnyObject,
     scale: Int8
   ) -> Int {
-#if false // FIXME: Enable per-instance seeding
     // We generate a new hash seed whenever a new hash table is allocated and
     // whenever an existing table is resized, so that we avoid certain copy
     // operations becoming quadratic.  (For background details, see
@@ -115,10 +114,6 @@ extension _HashTable {
     // guarantee that no two tables with the same seed can coexist at the same
     // time (apart from copy-on-write derivatives of the same table).
     return unsafeBitCast(object, to: Int.self)
-#else
-    // Use per-capacity seeding for now.
-    return Int(scale)
-#endif
   }
 }
 


### PR DESCRIPTION
Set and Dictionary operations that copy elements from two hash tables of the same size are still quadratic with certain load factors.

This makes simple-looking loops like this extremely slow: (adapted from stdlib’s current implementation for union)

```swift
let count = 625_000
var a = Set(0 ..< count)
let b = Set(count ..< 2 * count)
for element in b {
  a.insert(element)
}
```

This is because `a` and `b` above share the same hash seed, both being sets of the same size. This causes the loop to fill the hash table of `a` extremely unevenly; the initial part of `a`’s hash table gets a load factor well over 100% — essentially converting it into an unsorted array until the overall alpha increases enough to trigger a storage resize and full rehash.

This performance pitfall can be eliminated by choosing a new hash seed for every new Set/Dictionary, so we should do that. (Except for copy-on-write copies, of course.) This makes the above code 11 times faster:

```
$ time swift -O /tmp/set.swift  # before
        7.89 real         7.72 user         0.11 sys
$ time swift -O /tmp/set.swift # after
        0.67 real         0.58 user         0.06 sys
```

See below: log-log chart of amortized per-element performance of `Set.union` for two non-overlapping sets of the same size, before & after this change.

![set-new attaresult - 2 tasks](https://user-images.githubusercontent.com/608696/46022060-cc21bf00-c0d9-11e8-994b-955eaa25ee0e.png)

rdar://problem/44760778