### PR TITLE
[vim] add swiftTupleIndexNumber

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -158,7 +158,7 @@ syn match swiftOperator "\.\.[<.]" skipwhite nextgroup=swiftTypeParameters
 
 syn match swiftChar /'\([^'\\]\|\\\(["'tnr0\\]\|x[0-9a-fA-F]\{2}\|u[0-9a-fA-F]\{4}\|U[0-9a-fA-F]\{8}\)\)'/
 
-syn match swiftTupleIndexNumber nextgroup=swiftTupleIndexNumber contains=swiftDecimal
+syn match swiftTupleIndexNumber contains=swiftDecimal
       \ /\.[0-9]\+/
 syn match swiftDecimal contained
       \ /[0-9]\+/

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -158,6 +158,11 @@ syn match swiftOperator "\.\.[<.]" skipwhite nextgroup=swiftTypeParameters
 
 syn match swiftChar /'\([^'\\]\|\\\(["'tnr0\\]\|x[0-9a-fA-F]\{2}\|u[0-9a-fA-F]\{4}\|U[0-9a-fA-F]\{8}\)\)'/
 
+syn match swiftTupleIndexNumber nextgroup=swiftTupleIndexNumber contains=swiftDecimal
+      \ /\.[0-9]\+/
+syn match swiftDecimal contained
+      \ /[0-9]\+/
+
 syn match swiftPreproc /#\(\<file\>\|\<line\>\|\<function\>\)/
 syn match swiftPreproc /^\s*#\(\<if\>\|\<else\>\|\<elseif\>\|\<endif\>\|\<error\>\|\<warning\>\)/
 syn region swiftPreprocFalse start="^\s*#\<if\>\s\+\<false\>" end="^\s*#\(\<else\>\|\<elseif\>\|\<endif\>\)"


### PR DESCRIPTION
<!-- What's in this pull request? -->

When using tuples with index numbers, syntax highlighting uses `swiftDecimal`.
Therefore, I added `swiftTupleIndexNumber` and tried to improve it.

### The highlight before added
    
![2018-09-26 1 04 21](https://user-images.githubusercontent.com/629993/46027165-25184400-c128-11e8-99ca-89477eb1db9b.png)

### The highlight after added

![2018-09-26 1 26 20](https://user-images.githubusercontent.com/629993/46028371-58100700-c12b-11e8-8b97-a977a292e4b1.png)
