### PR TITLE
[stdlib] Set, Dictionary: Use a mutation counter to detect invalid indices

### DIFF
--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -43,7 +43,8 @@ struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
 struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
-  __swift_intptr_t scale;
+  __swift_int8_t scale;
+  __swift_int32_t age;
   __swift_intptr_t seed;
   void *rawKeys;
   void *rawValues;
@@ -52,7 +53,8 @@ struct _SwiftDictionaryBodyStorage {
 struct _SwiftSetBodyStorage {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
-  __swift_intptr_t scale;
+  __swift_int8_t scale;
+  __swift_int32_t age;
   __swift_intptr_t seed;
   void *rawElements;
 };

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -44,6 +44,8 @@ struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
   __swift_int8_t scale;
+  __swift_int8_t reservedScale;
+  __swift_int16_t extra;
   __swift_int32_t age;
   __swift_intptr_t seed;
   void *rawKeys;
@@ -54,6 +56,8 @@ struct _SwiftSetBodyStorage {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
   __swift_int8_t scale;
+  __swift_int8_t reservedScale;
+  __swift_int16_t extra;
   __swift_int32_t age;
   __swift_intptr_t seed;
   void *rawElements;
@@ -87,6 +91,16 @@ SWIFT_RUNTIME_STDLIB_API
 struct _SwiftHashingParameters _swift_stdlib_Hashing_parameters;
 
 #ifdef __cplusplus
+
+static_assert(
+  sizeof(_SwiftDictionaryBodyStorage) ==
+    5 * sizeof(__swift_intptr_t) + sizeof(__swift_int64_t),
+  "_SwiftDictionaryBodyStorage has unexpected size");
+
+static_assert(
+  sizeof(_SwiftSetBodyStorage) ==
+    4 * sizeof(__swift_intptr_t) + sizeof(__swift_int64_t),
+  "_SwiftSetBodyStorage has unexpected size");
 
 static_assert(std::is_pod<_SwiftEmptyArrayStorage>::value,
               "empty array type should be POD");

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -47,6 +47,7 @@
 //   | _count                                                    |
 //   | _capacity                                                 |
 //   | _scale                                                    |
+//   | _age                                                      |
 //   | _seed                                                     |
 //   | _rawKeys                                                  |
 //   | _rawValue                                                 |
@@ -149,6 +150,13 @@
 // dictionary storage are bounds-checked, this scheme never compromises memory
 // safety.
 //
+// As a safeguard against using invalid indices, Set and Dictionary maintain a
+// mutation counter in their storage header (`_age`). This counter gets bumped
+// every time an element is removed and whenever the contents are
+// rehashed. Native indices include a copy of this counter so that index
+// validation can verify it matches with current storage. This can't catch all
+// misuse, because counters may match by accident; but it does make indexing a
+// lot more reliable.
 //
 // Bridging
 // ========

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1827,7 +1827,7 @@ extension Dictionary.Index: Hashable {
       hasher.combine(cocoaIndex.currentKeyIndex)
     }
   #else
-    hasher.combine(_asNative.bucket)
+    hasher.combine(_asNative.bucket.offset)
   #endif
   }
 }

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -792,7 +792,7 @@ extension Dictionary {
       // FIXME: This code should be moved to _variant, with Dictionary.subscript
       // yielding `&_variant[key]`.
 
-      let (index, found) = _variant.mutatingFind(key)
+      let (bucket, found) = _variant.mutatingFind(key)
 
       // FIXME: Mark this entry as being modified in hash table metadata
       // so that lldb can recognize it's not valid.
@@ -800,7 +800,12 @@ extension Dictionary {
       // Move the old value (if any) out of storage, wrapping it into an
       // optional before yielding it.
       let native = _variant.asNative
-      var value: Value? = found ? (native._values + index.bucket).move() : nil
+      var value: Value?
+      if found {
+        value = (native._values + bucket.bucket).move()
+      } else {
+        value = nil
+      }
       yield &value
 
       // Value is now potentially different. Check which one of the four
@@ -808,15 +813,15 @@ extension Dictionary {
       switch (value, found) {
       case (let value?, true): // Mutation
         // Initialize storage to new value.
-        (native._values + index.bucket).initialize(to: value)
+        (native._values + bucket.bucket).initialize(to: value)
       case (let value?, false): // Insertion
         // Insert the new entry at the correct place.
         // We've already ensured we have enough capacity.
-        native._insert(at: index, key: key, value: value)
+        native._insert(at: bucket, key: key, value: value)
       case (nil, true): // Removal
         // We've already removed the value; deinitialize and remove the key too.
-        (native._values + index.bucket).deinitialize(count: 1)
-        native._delete(at: index)
+        (native._values + bucket.bucket).deinitialize(count: 1)
+        native._delete(at: bucket)
       case (nil, false): // Noop
         // Easy!
         break
@@ -848,9 +853,9 @@ extension Dictionary: ExpressibleByDictionaryLiteral {
   public init(dictionaryLiteral elements: (Key, Value)...) {
     let native = _NativeDictionary<Key, Value>(capacity: elements.count)
     for (key, value) in elements {
-      let (index, found) = native.find(key)
+      let (bucket, found) = native.find(key)
       _precondition(!found, "Dictionary literal contains duplicate keys")
-      native._insert(at: index, key: key, value: value)
+      native._insert(at: bucket, key: key, value: value)
     }
     self.init(_native: native)
   }
@@ -916,13 +921,13 @@ extension Dictionary {
       return _variant.lookup(key) ?? defaultValue()
     }
     _modify {
-      let (index, found) = _variant.mutatingFind(key)
+      let (bucket, found) = _variant.mutatingFind(key)
       let native = _variant.asNative
       if !found {
         let value = defaultValue()
-        native._insert(at: index, key: key, value: value)
+        native._insert(at: bucket, key: key, value: value)
       }
-      let address = native._values + index.bucket
+      let address = native._values + bucket.bucket
       yield &address.pointee
       _fixLifetime(self)
     }
@@ -1451,7 +1456,8 @@ extension Dictionary {
       }
       _modify {
         let index = _variant.ensureUniqueNative(preserving: position)
-        let address = _variant.asNative._values + index.bucket
+        _variant.asNative.validate(index)
+        let address = _variant.asNative._values + index.bucket.bucket
         yield &address.pointee
         _fixLifetime(self)
       }
@@ -1498,8 +1504,8 @@ extension Dictionary: Equatable where Value: Equatable {
       }
 
       for (k, v) in lhs {
-        let (index, found) = rhsNative.find(k)
-        guard found, rhsNative.uncheckedValue(at: index) == v else {
+        let (bucket, found) = rhsNative.find(k)
+        guard found, rhsNative.uncheckedValue(at: bucket) == v else {
           return false
         }
       }
@@ -1515,8 +1521,9 @@ extension Dictionary: Equatable where Value: Equatable {
       }
 
       defer { _fixLifetime(lhsNative) }
-      for index in lhsNative.hashTable {
-        let (key, value) = lhsNative.lookup(index)
+      for bucket in lhsNative.hashTable {
+        let key = lhsNative.uncheckedKey(at: bucket)
+        let value = lhsNative.uncheckedValue(at: bucket)
         guard
           let rhsValue = rhsCocoa.lookup(_bridgeAnythingToObjectiveC(key)),
           value == _forceBridgeFromObjectiveC(rhsValue, Value.self)
@@ -1805,7 +1812,7 @@ extension Dictionary.Index: Hashable {
     switch _variant {
     case .native(let nativeIndex):
       hasher.combine(0 as UInt8)
-      hasher.combine(nativeIndex.bucket)
+      hasher.combine(nativeIndex.bucket.bucket)
     case .cocoa(let cocoaIndex):
       _cocoaPath()
       hasher.combine(1 as UInt8)

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -810,7 +810,7 @@ extension Dictionary {
       let native = _variant.asNative
       var value: Value?
       if found {
-        value = (native._values + bucket.bucket).move()
+        value = (native._values + bucket.offset).move()
       } else {
         value = nil
       }
@@ -821,14 +821,14 @@ extension Dictionary {
       switch (value, found) {
       case (let value?, true): // Mutation
         // Initialize storage to new value.
-        (native._values + bucket.bucket).initialize(to: value)
+        (native._values + bucket.offset).initialize(to: value)
       case (let value?, false): // Insertion
         // Insert the new entry at the correct place.
         // We've already ensured we have enough capacity.
         native._insert(at: bucket, key: key, value: value)
       case (nil, true): // Removal
         // We've already removed the value; deinitialize and remove the key too.
-        (native._values + bucket.bucket).deinitialize(count: 1)
+        (native._values + bucket.offset).deinitialize(count: 1)
         native._delete(at: bucket)
       case (nil, false): // Noop
         // Easy!
@@ -935,7 +935,7 @@ extension Dictionary {
         let value = defaultValue()
         native._insert(at: bucket, key: key, value: value)
       }
-      let address = native._values + bucket.bucket
+      let address = native._values + bucket.offset
       yield &address.pointee
       _fixLifetime(self)
     }
@@ -1465,7 +1465,7 @@ extension Dictionary {
       _modify {
         let index = _variant.ensureUniqueNative(preserving: position)
         _variant.asNative.validate(index)
-        let address = _variant.asNative._values + index.bucket.bucket
+        let address = _variant.asNative._values + index.bucket.offset
         yield &address.pointee
         _fixLifetime(self)
       }
@@ -1820,7 +1820,7 @@ extension Dictionary.Index: Hashable {
     switch _variant {
     case .native(let nativeIndex):
       hasher.combine(0 as UInt8)
-      hasher.combine(nativeIndex.bucket.bucket)
+      hasher.combine(nativeIndex.bucket.offset)
     case .cocoa(let cocoaIndex):
       _cocoaPath()
       hasher.combine(1 as UInt8)

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -62,8 +62,8 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
 
   @nonobjc internal var base: _NativeDictionary<Key, Value>
   @nonobjc internal var bridgedKeys: _BridgingHashBuffer?
-  @nonobjc internal var nextIndex: _NativeDictionary<Key, Value>.Index
-  @nonobjc internal var endIndex: _NativeDictionary<Key, Value>.Index
+  @nonobjc internal var nextBucket: _NativeDictionary<Key, Value>.Bucket
+  @nonobjc internal var endBucket: _NativeDictionary<Key, Value>.Bucket
 
   @objc
   internal override required init() {
@@ -74,8 +74,8 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
     _sanityCheck(_isBridgedVerbatimToObjectiveC(Key.self))
     self.base = base
     self.bridgedKeys = nil
-    self.nextIndex = base.startIndex
-    self.endIndex = base.endIndex
+    self.nextBucket = base.hashTable.startIndex
+    self.endBucket = base.hashTable.endIndex
   }
 
   @nonobjc
@@ -83,26 +83,26 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
     _sanityCheck(!_isBridgedVerbatimToObjectiveC(Key.self))
     self.base = deferred.native
     self.bridgedKeys = deferred.bridgeKeys()
-    self.nextIndex = base.startIndex
-    self.endIndex = base.endIndex
+    self.nextBucket = base.hashTable.startIndex
+    self.endBucket = base.hashTable.endIndex
   }
 
-  private func bridgedKey(at index: _HashTable.Index) -> AnyObject {
-    _sanityCheck(base.hashTable.isOccupied(index))
+  private func bridgedKey(at bucket: _HashTable.Bucket) -> AnyObject {
+    _sanityCheck(base.hashTable.isOccupied(bucket))
     if let bridgedKeys = self.bridgedKeys {
-      return bridgedKeys[index]
+      return bridgedKeys[bucket]
     }
-    return _bridgeAnythingToObjectiveC(base.uncheckedKey(at: index))
+    return _bridgeAnythingToObjectiveC(base.uncheckedKey(at: bucket))
   }
 
   @objc
   internal func nextObject() -> AnyObject? {
-    if nextIndex == endIndex {
+    if nextBucket == endBucket {
       return nil
     }
-    let index = nextIndex
-    nextIndex = base.index(after: nextIndex)
-    return self.bridgedKey(at: index)
+    let bucket = nextBucket
+    nextBucket = base.hashTable.index(after: nextBucket)
+    return self.bridgedKey(at: bucket)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -118,7 +118,7 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
     }
 
-    if nextIndex == endIndex {
+    if nextBucket == endBucket {
       state.pointee = theState
       return 0
     }
@@ -126,8 +126,8 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
     // Return only a single element so that code can start iterating via fast
     // enumeration, terminate it, and continue via NSEnumerator.
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects)
-    unmanagedObjects[0] = self.bridgedKey(at: nextIndex)
-    nextIndex = base.index(after: nextIndex)
+    unmanagedObjects[0] = self.bridgedKey(at: nextBucket)
+    nextBucket = base.hashTable.index(after: nextBucket)
     state.pointee = theState
     return 1
   }
@@ -140,6 +140,9 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
 /// of AnyObject will be constructed containing all the bridged elements.
 final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   : __SwiftNativeNSDictionary, _NSDictionaryCore {
+
+  @usableFromInline
+  internal typealias Bucket = _HashTable.Bucket
 
   // This stored property must be stored at offset zero.  We perform atomic
   // operations on it.
@@ -225,9 +228,9 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     let bridged = _BridgingHashBuffer.allocate(
       owner: native._storage,
       hashTable: native.hashTable)
-    for index in native.hashTable {
-      let object = _bridgeAnythingToObjectiveC(native.uncheckedKey(at: index))
-      bridged.initialize(at: index, to: object)
+    for bucket in native.hashTable {
+      let object = _bridgeAnythingToObjectiveC(native.uncheckedKey(at: bucket))
+      bridged.initialize(at: bucket, to: object)
     }
 
     // Atomically put the bridged keys in place.
@@ -244,18 +247,16 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     let bridged = _BridgingHashBuffer.allocate(
       owner: native._storage,
       hashTable: native.hashTable)
-    for index in native.hashTable {
-      let object = _bridgeAnythingToObjectiveC(native.uncheckedValue(at: index))
-      bridged.initialize(at: index, to: object)
+    for bucket in native.hashTable {
+      let value = native.uncheckedValue(at: bucket)
+      let cocoaValue = _bridgeAnythingToObjectiveC(value)
+      bridged.initialize(at: bucket, to: cocoaValue)
     }
 
     // Atomically put the bridged values in place.
     _initializeBridgedValues(bridged)
     return _bridgedValues!
   }
-
-  @usableFromInline
-  internal typealias Index = _HashTable.Index
 
   @objc(copyWithZone:)
   internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
@@ -264,39 +265,36 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     return self
   }
 
+  @inline(__always)
+  private func _key(
+    at bucket: Bucket,
+    bridgedKeys: _BridgingHashBuffer?
+  ) -> AnyObject {
+    if let bridgedKeys = bridgedKeys {
+      return bridgedKeys[bucket]
+    }
+    return _bridgeAnythingToObjectiveC(native.uncheckedKey(at: bucket))
+  }
+
+  @inline(__always)
+  private func _value(
+    at bucket: Bucket,
+    bridgedValues: _BridgingHashBuffer?
+  ) -> AnyObject {
+    if let bridgedValues = bridgedValues {
+      return bridgedValues[bucket]
+    }
+    return _bridgeAnythingToObjectiveC(native.uncheckedValue(at: bucket))
+  }
+
   @objc(objectForKey:)
   internal func object(forKey aKey: AnyObject) -> AnyObject? {
     guard let nativeKey = _conditionallyBridgeFromObjectiveC(aKey, Key.self)
     else { return nil }
 
-    let (index, found) = native.find(nativeKey)
+    let (bucket, found) = native.find(nativeKey)
     guard found else { return nil }
-    if let bridgedValues = bridgeValues() {
-      return bridgedValues[index]
-    }
-    return _bridgeAnythingToObjectiveC(native.uncheckedValue(at: index))
-  }
-
-  @inline(__always)
-  private func _key(
-    at index: Index,
-    bridgedKeys: _BridgingHashBuffer?
-  ) -> AnyObject {
-    if let bridgedKeys = bridgedKeys {
-      return bridgedKeys[index]
-    }
-    return _bridgeAnythingToObjectiveC(native.uncheckedKey(at: index))
-  }
-
-  @inline(__always)
-  private func _value(
-    at index: Index,
-    bridgedValues: _BridgingHashBuffer?
-  ) -> AnyObject {
-    if let bridgedValues = bridgedValues {
-      return bridgedValues[index]
-    }
-    return _bridgeAnythingToObjectiveC(native.uncheckedValue(at: index))
+    return _value(at: bucket, bridgedValues: bridgeValues())
   }
 
   @objc
@@ -324,21 +322,21 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
 
     switch (_UnmanagedAnyObjectArray(keys), _UnmanagedAnyObjectArray(objects)) {
     case (let unmanagedKeys?, let unmanagedObjects?):
-      for index in native.hashTable {
-        unmanagedKeys[i] = _key(at: index, bridgedKeys: bridgedKeys)
-        unmanagedObjects[i] = _value(at: index, bridgedValues: bridgedValues)
+      for bucket in native.hashTable {
+        unmanagedKeys[i] = _key(at: bucket, bridgedKeys: bridgedKeys)
+        unmanagedObjects[i] = _value(at: bucket, bridgedValues: bridgedValues)
         i += 1
         guard i < count else { break }
       }
     case (let unmanagedKeys?, nil):
-      for index in native.hashTable {
-        unmanagedKeys[i] = _key(at: index, bridgedKeys: bridgedKeys)
+      for bucket in native.hashTable {
+        unmanagedKeys[i] = _key(at: bucket, bridgedKeys: bridgedKeys)
         i += 1
         guard i < count else { break }
       }
     case (nil, let unmanagedObjects?):
-      for index in native.hashTable {
-        unmanagedObjects[i] = _value(at: index, bridgedValues: bridgedValues)
+      for bucket in native.hashTable {
+        unmanagedObjects[i] = _value(at: bucket, bridgedValues: bridgedValues)
         i += 1
         guard i < count else { break }
       }
@@ -362,9 +360,9 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     defer { _fixLifetime(self) }
 
     var stop: UInt8 = 0
-    for index in native.hashTable {
-      let key = _key(at: index, bridgedKeys: bridgedKeys)
-      let value = _value(at: index, bridgedValues: bridgedValues)
+    for bucket in native.hashTable {
+      let key = _key(at: bucket, bridgedKeys: bridgedKeys)
+      let value = _value(at: bucket, bridgedValues: bridgedValues)
       block(
         Unmanaged.passUnretained(key),
         Unmanaged.passUnretained(value),
@@ -384,12 +382,15 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     objects: UnsafeMutablePointer<AnyObject>?,
     count: Int
   ) -> Int {
+    defer { _fixLifetime(self) }
+    let hashTable = native.hashTable
+
     var theState = state.pointee
     if theState.state == 0 {
       theState.state = 1 // Arbitrary non-zero value.
       theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
-      theState.extra.0 = CUnsignedLong(native.startIndex.bucket)
+      theState.extra.0 = CUnsignedLong(hashTable.startIndex.bucket)
     }
 
     // Test 'objects' rather than 'count' because (a) this is very rare anyway,
@@ -400,21 +401,21 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     }
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
-    var index = _HashTable.Index(bucket: Int(theState.extra.0))
-    let endIndex = native.endIndex
-    _precondition(index == endIndex || native.hashTable.isOccupied(index))
+    var bucket = _HashTable.Bucket(bucket: Int(theState.extra.0))
+    let endBucket = hashTable.endIndex
+    _precondition(bucket == endBucket || hashTable.isOccupied(bucket))
     var stored = 0
 
     // Only need to bridge once, so we can hoist it out of the loop.
     let bridgedKeys = bridgeKeys()
     for i in 0..<count {
-      if index == endIndex { break }
+      if bucket == endBucket { break }
 
-      unmanagedObjects[i] = _key(at: index, bridgedKeys: bridgedKeys)
+      unmanagedObjects[i] = _key(at: bucket, bridgedKeys: bridgedKeys)
       stored += 1
-      index = native.index(after: index)
+      bucket = hashTable.index(after: bucket)
     }
-    theState.extra.0 = CUnsignedLong(index.bucket)
+    theState.extra.0 = CUnsignedLong(bucket.bucket)
     state.pointee = theState
     return stored
   }

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -43,9 +43,10 @@ internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
   @nonobjc
   internal final var _scale: Int8
 
+  /// A mutation count, enabling stricter index validation.
   @usableFromInline
   @nonobjc
-  internal final var _mutationCount: Int32
+  internal final var _age: Int32
 
   @usableFromInline
   internal final var _seed: Int
@@ -249,7 +250,7 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
     let newStorage = _DictionaryStorage<Key, Value>.allocate(
       scale: scale,
       // Invalidate indices if we're rehashing.
-      mutationCount: rehash ? nil : original._mutationCount
+      age: rehash ? nil : original._age
     )
     return (newStorage, rehash)
   }
@@ -258,12 +259,12 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
   @_effects(releasenone)
   static internal func allocate(capacity: Int) -> _DictionaryStorage {
     let scale = _HashTable.scale(forCapacity: capacity)
-    return allocate(scale: scale, mutationCount: nil)
+    return allocate(scale: scale, age: nil)
   }
 
   static internal func allocate(
     scale: Int8,
-    mutationCount: Int32?
+    age: Int32?
   ) -> _DictionaryStorage {
     // The entry count must be representable by an Int value; hence the scale's
     // peculiar upper bound.
@@ -288,12 +289,12 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
     storage._capacity = _HashTable.capacity(forScale: scale)
     storage._scale = scale
 
-    if let mutationCount = mutationCount {
-      storage._mutationCount = mutationCount
+    if let age = age {
+      storage._age = age
     } else {
       // The default mutation count is simply a scrambled version of the storage
       // address.
-      storage._mutationCount = Int32(
+      storage._age = Int32(
         truncatingIfNeeded: ObjectIdentifier(storage).hashValue)
     }
 

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -293,8 +293,8 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
     } else {
       // The default mutation count is simply a scrambled version of the storage
       // address.
-      storage._mutationCount = Int32(truncatingIfNeeded:
-        unsafeBitCast(storage, to: Int.self).hashValue)
+      storage._mutationCount = Int32(
+        truncatingIfNeeded: ObjectIdentifier(storage).hashValue)
     }
 
     storage._rawKeys = UnsafeMutableRawPointer(keysAddr)

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -16,16 +16,14 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
-//
-// See the docs at the top of the file for more details on this type
-//
-// NOTE: The precise layout of this type is relied on in the runtime
-// to provide a statically allocated empty singleton.
-// See stdlib/public/stubs/GlobalObjects.cpp for details.
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 @_objc_non_lazy_realization
 internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
+  // NOTE: The precise layout of this type is relied on in the runtime to
+  // provide a statically allocated empty singleton.  See
+  // stdlib/public/stubs/GlobalObjects.cpp for details.
+
   /// The current number of occupied entries in this dictionary.
   @usableFromInline
   @nonobjc
@@ -48,13 +46,17 @@ internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
   @nonobjc
   internal final var _age: Int32
 
+  /// The hash seed used to hash elements in this dictionary instance.
   @usableFromInline
   internal final var _seed: Int
 
+  /// A raw pointer to the start of the tail-allocated hash buffer holding keys.
   @usableFromInline
   @nonobjc
   internal final var _rawKeys: UnsafeMutableRawPointer
 
+  /// A raw pointer to the start of the tail-allocated hash buffer holding
+  /// values.
   @usableFromInline
   @nonobjc
   internal final var _rawValues: UnsafeMutableRawPointer

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -41,6 +41,19 @@ internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
   @nonobjc
   internal final var _scale: Int8
 
+  /// The scale corresponding to the highest `reserveCapacity(_:)` call so far,
+  /// or 0 if there were none. This may be used later to allow removals to
+  /// resize storage.
+  ///
+  /// FIXME: <rdar://problem/18114559> Shrink storage on deletion
+  @usableFromInline
+  @nonobjc
+  internal final var _reservedScale: Int8
+
+  // Currently unused, set to zero.
+  @nonobjc
+  internal final var _extra: Int16
+
   /// A mutation count, enabling stricter index validation.
   @usableFromInline
   @nonobjc
@@ -394,6 +407,8 @@ extension _DictionaryStorage {
     storage._count = 0
     storage._capacity = _HashTable.capacity(forScale: scale)
     storage._scale = scale
+    storage._reservedScale = 0
+    storage._extra = 0
 
     if let age = age {
       storage._age = age

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -312,7 +312,7 @@ extension Dictionary._Variant {
   @inline(__always)
   internal mutating func mutatingFind(
     _ key: Key
-  ) -> (index: _NativeDictionary<Key, Value>.Index, found: Bool) {
+  ) -> (bucket: _NativeDictionary<Key, Value>.Bucket, found: Bool) {
     switch self {
     case .native:
       let isUnique = isUniquelyReferenced()
@@ -354,9 +354,11 @@ extension Dictionary._Variant {
       let native = _NativeDictionary<Key, Value>(cocoa)
       self = .native(native)
       let nativeKey = _forceBridgeFromObjectiveC(cocoaKey, Key.self)
-      let (nativeIndex, found) = native.find(nativeKey)
+      let (bucket, found) = native.find(nativeKey)
       _precondition(found, "Bridging did not preserve equality")
-      return nativeIndex
+      return _NativeDictionary<Key, Value>.Index(
+        bucket: bucket,
+        age: native.age)
 #endif
     }
   }
@@ -415,19 +417,19 @@ extension Dictionary._Variant {
   internal mutating func removeValue(forKey key: Key) -> Value? {
     switch self {
     case .native:
-      let (index, found) = asNative.find(key)
+      let (bucket, found) = asNative.find(key)
       guard found else { return nil }
       let isUnique = isUniquelyReferenced()
-      return asNative.uncheckedRemove(at: index, isUnique: isUnique).value
+      return asNative.uncheckedRemove(at: bucket, isUnique: isUnique).value
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
       let cocoaKey = _bridgeAnythingToObjectiveC(key)
       guard cocoa.lookup(cocoaKey) != nil else { return nil }
       var native = _NativeDictionary<Key, Value>(cocoa)
-      let (index, found) = native.find(key)
+      let (bucket, found) = native.find(key)
       _precondition(found, "Bridging did not preserve equality")
-      let old = native.uncheckedRemove(at: index, isUnique: true).value
+      let old = native.uncheckedRemove(at: bucket, isUnique: true).value
       self = .native(native)
       return old
 #endif

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -60,12 +60,12 @@ extension _HashTable {
     @inline(__always) get { return 3 / 4 }
   }
 
-  internal static func capacity(forScale scale: Int) -> Int {
-    let bucketCount = 1 &<< scale
+  internal static func capacity(forScale scale: Int8) -> Int {
+    let bucketCount = (1 as Int) &<< scale
     return Int(Double(bucketCount) * maxLoadFactor)
   }
 
-  internal static func scale(forCapacity capacity: Int) -> Int {
+  internal static func scale(forCapacity capacity: Int) -> Int8 {
     let capacity = Swift.max(capacity, 1)
     // Calculate the minimum number of entries we need to allocate to satisfy
     // the maximum load factor. `capacity + 1` below ensures that we always
@@ -78,9 +78,10 @@ extension _HashTable {
     // exponent.
     let exponent = (Swift.max(minimumEntries, 2) - 1)._binaryLogarithm() + 1
     _sanityCheck(exponent >= 0 && exponent < Int.bitWidth)
-    _sanityCheck(self.capacity(forScale: exponent) >= capacity)
     // The scale is the exponent corresponding to the bucket count.
-    return exponent
+    let scale = Int8(truncatingIfNeeded: exponent)
+    _sanityCheck(self.capacity(forScale: scale) >= capacity)
+    return scale
   }
 }
 

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -448,34 +448,3 @@ extension _HashTable {
     words[hole.word].uncheckedRemove(hole.bit)
   }
 }
-
-extension _HashTable {
-  /// Check for consistency and return the count of occupied entries.
-  internal func _invariantCheck(with delegate: _HashTableDelegate) -> Int {
-#if INTERNAL_CHECKS_ENABLED
-    _sanityCheck(bucketCount > 0 && bucketCount & (bucketCount &- 1) == 0,
-      "Invalid bucketCount")
-    _sanityCheck(_isValidAddress(UInt(bitPattern: words)),
-      "Invalid words pointer")
-    _sanityCheck(_isValidAddress(UInt(bitPattern: words + wordCount - 1)),
-      "Invalid words buffer")
-
-    var occupiedCount = 0
-    for i in self {
-      occupiedCount += 1
-      let hashValue = delegate.hashValue(at: i)
-      var c = idealIndex(forHashValue: hashValue)
-      // There must be no holes between the ideal and actual buckets for this
-      // hash value.
-      while c != i {
-        _sanityCheck(_isOccupied(c),
-          "Some hash table elements are stored outside their collision chain")
-        c = index(wrappedAfter: c)
-      }
-    }
-    return occupiedCount
-#else
-    return 0
-#endif
-  }
-}

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -131,7 +131,7 @@ internal final class _BridgingHashBuffer
 
   deinit {
     for bucket in header.hashTable {
-      (firstElementAddress + bucket.bucket).deinitialize(count: 1)
+      (firstElementAddress + bucket.offset).deinitialize(count: 1)
     }
     _fixLifetime(self)
   }
@@ -140,14 +140,14 @@ internal final class _BridgingHashBuffer
     @inline(__always) get {
       _sanityCheck(header.hashTable.isOccupied(bucket))
       defer { _fixLifetime(self) }
-      return firstElementAddress[bucket.bucket]
+      return firstElementAddress[bucket.offset]
     }
   }
 
   @inline(__always)
   internal func initialize(at bucket: _HashTable.Bucket, to object: AnyObject) {
     _sanityCheck(header.hashTable.isOccupied(bucket))
-    (firstElementAddress + bucket.bucket).initialize(to: object)
+    (firstElementAddress + bucket.offset).initialize(to: object)
     _fixLifetime(self)
   }
 }

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -130,24 +130,24 @@ internal final class _BridgingHashBuffer
   }
 
   deinit {
-    for index in header.hashTable {
-      (firstElementAddress + index.bucket).deinitialize(count: 1)
+    for bucket in header.hashTable {
+      (firstElementAddress + bucket.bucket).deinitialize(count: 1)
     }
     _fixLifetime(self)
   }
 
-  internal subscript(index: _HashTable.Index) -> AnyObject {
+  internal subscript(bucket: _HashTable.Bucket) -> AnyObject {
     @inline(__always) get {
-      _sanityCheck(header.hashTable.isOccupied(index))
+      _sanityCheck(header.hashTable.isOccupied(bucket))
       defer { _fixLifetime(self) }
-      return firstElementAddress[index.bucket]
+      return firstElementAddress[bucket.bucket]
     }
   }
 
   @inline(__always)
-  internal func initialize(at index: _HashTable.Index, to object: AnyObject) {
-    _sanityCheck(header.hashTable.isOccupied(index))
-    (firstElementAddress + index.bucket).initialize(to: object)
+  internal func initialize(at bucket: _HashTable.Bucket, to object: AnyObject) {
+    _sanityCheck(header.hashTable.isOccupied(bucket))
+    (firstElementAddress + bucket.bucket).initialize(to: object)
     _fixLifetime(self)
   }
 }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -60,6 +60,9 @@ internal struct _NativeDictionary<Key: Hashable, Value> {
 }
 
 extension _NativeDictionary { // Primitive fields
+  @usableFromInline
+  internal typealias Bucket = _HashTable.Bucket
+
   @inlinable
   internal var capacity: Int {
     @inline(__always)
@@ -72,6 +75,13 @@ extension _NativeDictionary { // Primitive fields
   internal var hashTable: _HashTable {
     @inline(__always) get {
       return _storage._hashTable
+    }
+  }
+
+  @inlinable
+  internal var age: Int32 {
+    @inline(__always) get {
+      return _storage._age
     }
   }
 
@@ -96,39 +106,39 @@ extension _NativeDictionary { // Primitive fields
 extension _NativeDictionary { // Low-level unchecked operations
   @inlinable
   @inline(__always)
-  internal func uncheckedKey(at index: Index) -> Key {
+  internal func uncheckedKey(at bucket: Bucket) -> Key {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(index))
-    return _keys[index.bucket]
+    _sanityCheck(hashTable.isOccupied(bucket))
+    return _keys[bucket.bucket]
   }
 
   @inlinable
   @inline(__always)
-  internal func uncheckedValue(at index: Index) -> Value {
+  internal func uncheckedValue(at bucket: Bucket) -> Value {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(index))
-    return _values[index.bucket]
+    _sanityCheck(hashTable.isOccupied(bucket))
+    return _values[bucket.bucket]
   }
 
   @usableFromInline
   @inline(__always)
   internal func uncheckedInitialize(
-    at index: Index,
+    at bucket: Bucket,
     toKey key: Key,
     value: Value) {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isValid(index))
-    (_keys + index.bucket).initialize(to: key)
-    (_values + index.bucket).initialize(to: value)
+    _sanityCheck(hashTable.isValid(bucket))
+    (_keys + bucket.bucket).initialize(to: key)
+    (_values + bucket.bucket).initialize(to: value)
   }
 
   @usableFromInline
   @inline(__always)
-  internal func uncheckedDestroy(at index: Index) {
+  internal func uncheckedDestroy(at bucket: Bucket) {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(index))
-    (_keys + index.bucket).deinitialize(count: 1)
-    (_values + index.bucket).deinitialize(count: 1)
+    _sanityCheck(hashTable.isOccupied(bucket))
+    (_keys + bucket.bucket).deinitialize(count: 1)
+    (_values + bucket.bucket).deinitialize(count: 1)
   }
 }
 
@@ -141,7 +151,7 @@ extension _NativeDictionary { // Low-level lookup operations
 
   @inlinable
   @inline(__always)
-  internal func find(_ key: Key) -> (index: Index, found: Bool) {
+  internal func find(_ key: Key) -> (bucket: Bucket, found: Bool) {
     return find(key, hashValue: self.hashValue(for: key))
   }
 
@@ -154,16 +164,16 @@ extension _NativeDictionary { // Low-level lookup operations
   internal func find(
     _ key: Key,
     hashValue: Int
-  ) -> (index: Index, found: Bool) {
+  ) -> (bucket: Bucket, found: Bool) {
     let hashTable = self.hashTable
-    var index = hashTable.idealIndex(forHashValue: hashValue)
-    while hashTable._isOccupied(index) {
-      if uncheckedKey(at: index) == key {
-        return (index, true)
+    var bucket = hashTable.idealIndex(forHashValue: hashValue)
+    while hashTable._isOccupied(bucket) {
+      if uncheckedKey(at: bucket) == key {
+        return (bucket, true)
       }
-      index = hashTable.index(wrappedAfter: index)
+      bucket = hashTable.index(wrappedAfter: bucket)
     }
-    return (index, false)
+    return (bucket, false)
   }
 }
 
@@ -174,9 +184,9 @@ extension _NativeDictionary { // ensureUnique
     let result = _NativeDictionary(
       _DictionaryStorage<Key, Value>.allocate(capacity: capacity))
     if count > 0 {
-      for index in hashTable {
-        let key = (_keys + index.bucket).move()
-        let value = (_values + index.bucket).move()
+      for bucket in hashTable {
+        let key = (_keys + bucket.bucket).move()
+        let value = (_values + bucket.bucket).move()
         result._unsafeInsertNew(key: key, value: value)
       }
       // Clear out old storage, ensuring that its deinit won't overrelease the
@@ -196,18 +206,18 @@ extension _NativeDictionary { // ensureUnique
     let result = _NativeDictionary(newStorage)
     if count > 0 {
       if rehash {
-        for index in hashTable {
+        for bucket in hashTable {
           result._unsafeInsertNew(
-            key: self.uncheckedKey(at: index),
-            value: self.uncheckedValue(at: index))
+            key: self.uncheckedKey(at: bucket),
+            value: self.uncheckedValue(at: bucket))
         }
       } else {
         result.hashTable.copyContents(of: hashTable)
         result._storage._count = self.count
-        for index in hashTable {
-          let key = uncheckedKey(at: index)
-          let value = uncheckedValue(at: index)
-          result.uncheckedInitialize(at: index, toKey: key, value: value)
+        for bucket in hashTable {
+          let key = uncheckedKey(at: bucket)
+          let value = uncheckedValue(at: bucket)
+          result.uncheckedInitialize(at: bucket, toKey: key, value: value)
         }
       }
     }
@@ -236,23 +246,36 @@ extension _NativeDictionary { // ensureUnique
   }
 }
 
-extension _NativeDictionary: _DictionaryBuffer {
+extension _NativeDictionary {
   @usableFromInline
-  internal typealias Index = _HashTable.Index
+  internal typealias Index = _HashTable.AgedIndex
 
   @inlinable
+  @inline(__always)
+  func validate(_ index: Index) {
+    _precondition(hashTable.isOccupied(index.bucket) && index.age == age,
+      "Attempting to access Dictionary elements using an invalid Index")
+  }
+}
+
+extension _NativeDictionary: _DictionaryBuffer {
+  @inlinable
   internal var startIndex: Index {
-    return hashTable.startIndex
+    let bucket = hashTable.startIndex
+    return Index(bucket: bucket, age: age)
   }
 
   @inlinable
   internal var endIndex: Index {
-    return hashTable.endIndex
+    let bucket = hashTable.endIndex
+    return Index(bucket: bucket, age: age)
   }
 
   @inlinable
   internal func index(after index: Index) -> Index {
-    return hashTable.index(after: index)
+    validate(index)
+    let bucket = hashTable.index(after: index.bucket)
+    return Index(bucket: bucket, age: age)
   }
 
   @inlinable
@@ -261,8 +284,9 @@ extension _NativeDictionary: _DictionaryBuffer {
       // Fast path that avoids computing the hash of the key.
       return nil
     }
-    let (index, found) = find(key)
-    return found ? index : nil
+    let (bucket, found) = find(key)
+    guard found else { return nil }
+    return Index(bucket: bucket, age: age)
   }
 
   @inlinable
@@ -285,34 +309,32 @@ extension _NativeDictionary: _DictionaryBuffer {
       // Fast path that avoids computing the hash of the key.
       return nil
     }
-    let (index, found) = self.find(key)
-    return found ? self.uncheckedValue(at: index) : nil
+    let (bucket, found) = self.find(key)
+    guard found else { return nil }
+    return self.uncheckedValue(at: bucket)
   }
 
   @inlinable
   @inline(__always)
   func lookup(_ index: Index) -> (key: Key, value: Value) {
-    _precondition(hashTable.isOccupied(index),
-      "Attempting to access Dictionary elements using an invalid Index")
-    let key = self.uncheckedKey(at: index)
-    let value = self.uncheckedValue(at: index)
+    validate(index)
+    let key = self.uncheckedKey(at: index.bucket)
+    let value = self.uncheckedValue(at: index.bucket)
     return (key, value)
   }
 
   @inlinable
   @inline(__always)
   func key(at index: Index) -> Key {
-    _precondition(hashTable.isOccupied(index),
-      "Attempting to access Dictionary elements using an invalid Index")
-    return self.uncheckedKey(at: index)
+    validate(index)
+    return self.uncheckedKey(at: index.bucket)
   }
 
   @inlinable
   @inline(__always)
   func value(at index: Index) -> Value {
-    _precondition(hashTable.isOccupied(index),
-      "Attempting to access Dictionary elements using an invalid Index")
-    return self.uncheckedValue(at: index)
+    validate(index)
+    return self.uncheckedValue(at: index.bucket)
   }
 }
 
@@ -345,15 +367,15 @@ extension _NativeDictionary { // Insertions
       // elements -- these imply that the Element type violates Hashable
       // requirements. This is generally more costly than a direct insertion,
       // because we'll need to compare elements in case of hash collisions.
-      let (index, found) = find(key, hashValue: hashValue)
+      let (bucket, found) = find(key, hashValue: hashValue)
       guard !found else {
         KEY_TYPE_OF_DICTIONARY_VIOLATES_HASHABLE_REQUIREMENTS(Key.self)
       }
-      hashTable.insert(index)
-      uncheckedInitialize(at: index, toKey: key, value: value)
+      hashTable.insert(bucket)
+      uncheckedInitialize(at: bucket, toKey: key, value: value)
     } else {
-      let index = hashTable.insertNew(hashValue: hashValue)
-      uncheckedInitialize(at: index, toKey: key, value: value)
+      let bucket = hashTable.insertNew(hashValue: hashValue)
+      uncheckedInitialize(at: bucket, toKey: key, value: value)
     }
     _storage._count += 1
   }
@@ -377,8 +399,8 @@ extension _NativeDictionary { // Insertions
   internal mutating func mutatingFind(
     _ key: Key,
     isUnique: Bool
-  ) -> (index: Index, found: Bool) {
-    let (index, found) = find(key)
+  ) -> (bucket: Bucket, found: Bool) {
+    let (bucket, found) = find(key)
 
     // Prepare storage.
     // If `key` isn't in the dictionary yet, assume that this access will end
@@ -388,22 +410,22 @@ extension _NativeDictionary { // Insertions
     let rehashed = ensureUnique(
       isUnique: isUnique,
       capacity: count + (found ? 0 : 1))
-    guard rehashed else { return (index, found) }
-    let (i, f) = find(key)
+    guard rehashed else { return (bucket, found) }
+    let (b, f) = find(key)
     if f != found {
       KEY_TYPE_OF_DICTIONARY_VIOLATES_HASHABLE_REQUIREMENTS(Key.self)
     }
-    return (i, found)
+    return (b, found)
   }
 
   @inlinable
   internal func _insert(
-    at index: Index,
+    at bucket: Bucket,
     key: __owned Key,
     value: __owned Value) {
     _sanityCheck(count < capacity)
-    hashTable.insert(index)
-    uncheckedInitialize(at: index, toKey: key, value: value)
+    hashTable.insert(bucket)
+    uncheckedInitialize(at: bucket, toKey: key, value: value)
     _storage._count += 1
   }
 
@@ -413,17 +435,17 @@ extension _NativeDictionary { // Insertions
     forKey key: Key,
     isUnique: Bool
   ) -> Value? {
-    let (index, found) = mutatingFind(key, isUnique: isUnique)
+    let (bucket, found) = mutatingFind(key, isUnique: isUnique)
     if found {
-      let oldValue = (_values + index.bucket).move()
-      (_values + index.bucket).initialize(to: value)
+      let oldValue = (_values + bucket.bucket).move()
+      (_values + bucket.bucket).initialize(to: value)
       // FIXME: Replacing the old key with the new is unnecessary, unintuitive,
       // and actively harmful to some usecases. We shouldn't do it.
       // rdar://problem/32144087
-      (_keys + index.bucket).pointee = key
+      (_keys + bucket.bucket).pointee = key
       return oldValue
     }
-    _insert(at: index, key: key, value: value)
+    _insert(at: bucket, key: key, value: value)
     return nil
   }
 
@@ -433,15 +455,15 @@ extension _NativeDictionary { // Insertions
     forKey key: Key,
     isUnique: Bool
   ) {
-    let (index, found) = mutatingFind(key, isUnique: isUnique)
+    let (bucket, found) = mutatingFind(key, isUnique: isUnique)
     if found {
-      (_values + index.bucket).pointee = value
+      (_values + bucket.bucket).pointee = value
       // FIXME: Replacing the old key with the new is unnecessary, unintuitive,
       // and actively harmful to some usecases. We shouldn't do it.
       // rdar://problem/32144087
-      (_keys + index.bucket).pointee = key
+      (_keys + bucket.bucket).pointee = key
     } else {
-      _insert(at: index, key: key, value: value)
+      _insert(at: bucket, key: key, value: value)
     }
   }
 }
@@ -449,13 +471,13 @@ extension _NativeDictionary { // Insertions
 extension _NativeDictionary: _HashTableDelegate {
   @inlinable
   @inline(__always)
-  internal func hashValue(at index: Index) -> Int {
-    return hashValue(for: uncheckedKey(at: index))
+  internal func hashValue(at bucket: Bucket) -> Int {
+    return hashValue(for: uncheckedKey(at: bucket))
   }
 
   @inlinable
   @inline(__always)
-  internal func moveEntry(from source: Index, to target: Index) {
+  internal func moveEntry(from source: Bucket, to target: Bucket) {
     (_keys + target.bucket)
       .moveInitialize(from: _keys + source.bucket, count: 1)
     (_values + target.bucket)
@@ -465,8 +487,8 @@ extension _NativeDictionary: _HashTableDelegate {
 
 extension _NativeDictionary { // Deletion
   @inlinable
-  internal func _delete(at index: Index) {
-    hashTable.delete(at: index, with: self)
+  internal func _delete(at bucket: Bucket) {
+    hashTable.delete(at: bucket, with: self)
     _storage._count -= 1
     _sanityCheck(_storage._count >= 0)
     invalidateIndices()
@@ -475,23 +497,23 @@ extension _NativeDictionary { // Deletion
   @inlinable
   @inline(__always)
   internal mutating func uncheckedRemove(
-    at index: Index,
+    at bucket: Bucket,
     isUnique: Bool
   ) -> Element {
-    _sanityCheck(hashTable.isOccupied(index))
+    _sanityCheck(hashTable.isOccupied(bucket))
     let rehashed = ensureUnique(isUnique: isUnique, capacity: capacity)
     _sanityCheck(!rehashed)
-    let oldKey = (_keys + index.bucket).move()
-    let oldValue = (_values + index.bucket).move()
-    _delete(at: index)
+    let oldKey = (_keys + bucket.bucket).move()
+    let oldValue = (_values + bucket.bucket).move()
+    _delete(at: bucket)
     return (oldKey, oldValue)
   }
 
   @inlinable
   @inline(__always)
   internal mutating func remove(at index: Index, isUnique: Bool) -> Element {
-    _precondition(hashTable.isOccupied(index), "Invalid index")
-    return uncheckedRemove(at: index, isUnique: isUnique)
+    validate(index)
+    return uncheckedRemove(at: index.bucket, isUnique: isUnique)
   }
 
   @usableFromInline
@@ -503,9 +525,9 @@ extension _NativeDictionary { // Deletion
         age: nil)
       return
     }
-    for index in hashTable {
-      (_keys + index.bucket).deinitialize(count: 1)
-      (_values + index.bucket).deinitialize(count: 1)
+    for bucket in hashTable {
+      (_keys + bucket.bucket).deinitialize(count: 1)
+      (_values + bucket.bucket).deinitialize(count: 1)
     }
     hashTable.clear()
     _storage._count = 0
@@ -522,10 +544,10 @@ extension _NativeDictionary { // High-level operations
     // Because the keys in the current and new buffer are the same, we can
     // initialize to the same locations in the new buffer, skipping hash value
     // recalculations.
-    for index in hashTable {
-      let key = self.uncheckedKey(at: index)
-      let value = self.uncheckedValue(at: index)
-      try result._insert(at: index, key: key, value: transform(value))
+    for bucket in hashTable {
+      let key = self.uncheckedKey(at: bucket)
+      let value = self.uncheckedValue(at: bucket)
+      try result._insert(at: bucket, key: key, value: transform(value))
     }
     return result
   }
@@ -538,18 +560,18 @@ extension _NativeDictionary { // High-level operations
   ) rethrows where S.Element == (Key, Value) {
     var isUnique = isUnique
     for (key, value) in keysAndValues {
-      let (index, found) = mutatingFind(key, isUnique: isUnique)
+      let (bucket, found) = mutatingFind(key, isUnique: isUnique)
       isUnique = true
       if found {
         do {
-          let v = (_values + index.bucket).move()
+          let v = (_values + bucket.bucket).move()
           let newValue = try combine(v, value)
-          (_values + index.bucket).initialize(to: newValue)
+          (_values + bucket.bucket).initialize(to: newValue)
         } catch _MergeError.keyCollision {
           fatalError("Duplicate values for key: '\(key)'")
         }
       } else {
-        _insert(at: index, key: key, value: value)
+        _insert(at: bucket, key: key, value: value)
       }
     }
   }
@@ -563,11 +585,11 @@ extension _NativeDictionary { // High-level operations
     self.init()
     for value in values {
       let key = try keyForValue(value)
-      let (index, found) = mutatingFind(key, isUnique: true)
+      let (bucket, found) = mutatingFind(key, isUnique: true)
       if found {
-        _values[index.bucket].append(value)
+        _values[bucket.bucket].append(value)
       } else {
-        _insert(at: index, key: key, value: [value])
+        _insert(at: bucket, key: key, value: [value])
       }
     }
   }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -478,7 +478,7 @@ extension _NativeDictionary {
     let io = i.bucket.offset
     let jo = j.bucket.offset
     let value = (_values + io).move()
-    (_values + io).moveInitialize(from: _values + j.bucket.offset, count: 1)
+    (_values + io).moveInitialize(from: _values + jo, count: 1)
     (_values + jo).initialize(to: value)
   }
 }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -89,7 +89,7 @@ extension _NativeDictionary { // Primitive fields
   @inlinable
   @inline(__always)
   internal func invalidateIndices() {
-    _storage._mutationCount &+= 1
+    _storage._age &+= 1
   }
 }
 
@@ -500,7 +500,7 @@ extension _NativeDictionary { // Deletion
       let scale = self._storage._scale
       _storage = _DictionaryStorage<Key, Value>.allocate(
         scale: scale,
-        mutationCount: nil)
+        age: nil)
       return
     }
     for index in hashTable {

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -124,8 +124,8 @@ extension _NativeDictionary { // Low-level unchecked operations
   @inline(__always)
   internal func uncheckedInitialize(
     at bucket: Bucket,
-    toKey key: Key,
-    value: Value) {
+    toKey key: __owned Key,
+    value: __owned Value) {
     defer { _fixLifetime(self) }
     _sanityCheck(hashTable.isValid(bucket))
     (_keys + bucket.offset).initialize(to: key)

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -468,6 +468,21 @@ extension _NativeDictionary { // Insertions
   }
 }
 
+extension _NativeDictionary {
+  @inlinable
+  internal mutating func swapValuesAt(_ i: Index, _ j: Index, isUnique: Bool) {
+    let rehashed = ensureUnique(isUnique: isUnique, capacity: capacity)
+    _sanityCheck(!rehashed)
+    validate(i)
+    validate(j)
+    let io = i.bucket.offset
+    let jo = j.bucket.offset
+    let value = (_values + io).move()
+    (_values + io).moveInitialize(from: _values + j.bucket.offset, count: 1)
+    (_values + jo).initialize(to: value)
+  }
+}
+
 extension _NativeDictionary: _HashTableDelegate {
   @inlinable
   @inline(__always)

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -73,6 +73,13 @@ extension _NativeSet { // Primitive fields
     }
   }
 
+  @inlinable
+  internal var age: Int32 {
+    @inline(__always) get {
+      return _storage._age
+    }
+  }
+
   // This API is unsafe and needs a `_fixLifetime` in the caller.
   @inlinable
   internal var _elements: UnsafeMutablePointer<Element> {
@@ -82,7 +89,7 @@ extension _NativeSet { // Primitive fields
   @inlinable
   @inline(__always)
   internal func invalidateIndices() {
-    _storage._mutationCount &+= 1
+    _storage._age &+= 1
   }
 }
 
@@ -405,7 +412,7 @@ extension _NativeSet { // Deletion
   internal mutating func removeAll(isUnique: Bool) {
     guard isUnique else {
       let scale = self._storage._scale
-      _storage = _SetStorage<Element>.allocate(scale: scale, mutationCount: nil)
+      _storage = _SetStorage<Element>.allocate(scale: scale, age: nil)
       return
     }
     for index in hashTable {

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -59,7 +59,7 @@ internal struct _NativeSet<Element: Hashable> {
 
 extension _NativeSet { // Primitive fields
   @usableFromInline
-  internal typealias Bucket = _HashTable.Index
+  internal typealias Bucket = _HashTable.Bucket
 
   @inlinable
   internal var capacity: Int {
@@ -214,47 +214,8 @@ extension _NativeSet { // ensureUnique
 
 extension _NativeSet {
   @usableFromInline
-  @_fixed_layout
-  internal struct Index {
-    @usableFromInline
-    let bucket: Bucket
+  internal typealias Index = _HashTable.AgedIndex
 
-    @usableFromInline
-    let age: Int32
-
-    @inlinable
-    internal init(bucket: Bucket, age: Int32) {
-      self.bucket = bucket
-      self.age = age
-    }
-  }
-}
-
-extension _NativeSet.Index: Equatable {
-  @inlinable
-  internal static func ==(
-    lhs: _NativeSet.Index,
-    rhs: _NativeSet.Index
-  ) -> Bool {
-    _precondition(lhs.age == rhs.age,
-      "Can't compare indices belonging to different Sets")
-    return lhs.bucket == rhs.bucket
-  }
-}
-
-extension _NativeSet.Index: Comparable {
-  @inlinable
-  internal static func <(
-    lhs: _NativeSet.Index,
-    rhs: _NativeSet.Index
-  ) -> Bool {
-    _precondition(lhs.age == rhs.age,
-      "Can't compare indices belonging to different Sets")
-    return lhs.bucket < rhs.bucket
-  }
-}
-
-extension _NativeSet {
   @inlinable
   @inline(__always)
   func validate(_ index: Index) {

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -107,7 +107,9 @@ extension _NativeSet { // Low-level unchecked operations
 
   @inlinable
   @inline(__always)
-  internal func uncheckedInitialize(at bucket: Bucket, to element: Element) {
+  internal func uncheckedInitialize(
+    at bucket: Bucket,
+    to element: __owned Element) {
     _sanityCheck(hashTable.isValid(bucket))
     (_elements + bucket.offset).initialize(to: element)
   }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -222,12 +222,12 @@ extension Set: ExpressibleByArrayLiteral {
     }
     let native = _NativeSet<Element>(capacity: elements.count)
     for element in elements {
-      let (index, found) = native.find(element)
+      let (bucket, found) = native.find(element)
       if found {
         // FIXME: Shouldn't this trap?
         continue
       }
-      native._unsafeInsertNew(element, at: index)
+      native._unsafeInsertNew(element, at: bucket)
     }
     self.init(_native: native)
   }
@@ -441,8 +441,8 @@ extension Set: Equatable {
       }
 
       defer { _fixLifetime(lhsNative) }
-      for i in lhsNative.hashTable {
-        let key = lhsNative.element(at: i)
+      for bucket in lhsNative.hashTable {
+        let key = lhsNative.uncheckedElement(at: bucket)
         let bridgedKey = _bridgeAnythingToObjectiveC(key)
         if rhsCocoa.contains(bridgedKey) {
           continue
@@ -1422,7 +1422,7 @@ extension Set.Index: Hashable {
     switch _variant {
     case .native(let nativeIndex):
       hasher.combine(0 as UInt8)
-      hasher.combine(nativeIndex.bucket)
+      hasher.combine(nativeIndex.bucket.bucket)
     case .cocoa(let cocoaIndex):
       _cocoaPath()
       hasher.combine(1 as UInt8)

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1429,7 +1429,7 @@ extension Set.Index: Hashable {
       hasher.combine(cocoaIndex.currentKeyIndex)
     }
   #else
-    hasher.combine(_asNative.bucket)
+    hasher.combine(_asNative.bucket.offset)
   #endif
   }
 }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1422,7 +1422,7 @@ extension Set.Index: Hashable {
     switch _variant {
     case .native(let nativeIndex):
       hasher.combine(0 as UInt8)
-      hasher.combine(nativeIndex.bucket.bucket)
+      hasher.combine(nativeIndex.bucket.offset)
     case .cocoa(let cocoaIndex):
       _cocoaPath()
       hasher.combine(1 as UInt8)

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -88,7 +88,7 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     self.endBucket = base.hashTable.endIndex
   }
 
-  private func bridgedElement(at bucket: _HashTable.Index) -> AnyObject {
+  private func bridgedElement(at bucket: _HashTable.Bucket) -> AnyObject {
     _sanityCheck(base.hashTable.isOccupied(bucket))
     if let bridgedElements = self.bridgedElements {
       return bridgedElements[bucket]
@@ -266,7 +266,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     }
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
-    var bucket = _HashTable.Index(bucket: Int(theState.extra.0))
+    var bucket = _HashTable.Bucket(bucket: Int(theState.extra.0))
     let endBucket = hashTable.endIndex
     _precondition(bucket == endBucket || hashTable.isOccupied(bucket),
       "Invalid fast enumeration state")

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -250,6 +250,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   ) -> Int {
     defer { _fixLifetime(self) }
     let hashTable = native.hashTable
+
     var theState = state.pointee
     if theState.state == 0 {
       theState.state = 1 // Arbitrary non-zero value.

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -63,8 +63,8 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
 
   @nonobjc internal var base: _NativeSet<Element>
   @nonobjc internal var bridgedElements: _BridgingHashBuffer?
-  @nonobjc internal var nextIndex: _NativeSet<Element>.Index
-  @nonobjc internal var endIndex: _NativeSet<Element>.Index
+  @nonobjc internal var nextBucket: _NativeSet<Element>.Bucket
+  @nonobjc internal var endBucket: _NativeSet<Element>.Bucket
 
   @objc
   internal override required init() {
@@ -75,8 +75,8 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     _sanityCheck(_isBridgedVerbatimToObjectiveC(Element.self))
     self.base = base
     self.bridgedElements = nil
-    self.nextIndex = base.startIndex
-    self.endIndex = base.endIndex
+    self.nextBucket = base.hashTable.startIndex
+    self.endBucket = base.hashTable.endIndex
   }
 
   @nonobjc
@@ -84,16 +84,16 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     _sanityCheck(!_isBridgedVerbatimToObjectiveC(Element.self))
     self.base = deferred.native
     self.bridgedElements = deferred.bridgeElements()
-    self.nextIndex = base.startIndex
-    self.endIndex = base.endIndex
+    self.nextBucket = base.hashTable.startIndex
+    self.endBucket = base.hashTable.endIndex
   }
 
-  private func bridgedElement(at index: _HashTable.Index) -> AnyObject {
-    _sanityCheck(base.hashTable.isOccupied(index))
+  private func bridgedElement(at bucket: _HashTable.Index) -> AnyObject {
+    _sanityCheck(base.hashTable.isOccupied(bucket))
     if let bridgedElements = self.bridgedElements {
-      return bridgedElements[index]
+      return bridgedElements[bucket]
     }
-    return _bridgeAnythingToObjectiveC(base.element(at: index))
+    return _bridgeAnythingToObjectiveC(base.uncheckedElement(at: bucket))
   }
 
   //
@@ -104,12 +104,12 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
 
   @objc
   internal func nextObject() -> AnyObject? {
-    if nextIndex == endIndex {
+    if nextBucket == endBucket {
       return nil
     }
-    let index = nextIndex
-    nextIndex = base.index(after: nextIndex)
-    return self.bridgedElement(at: index)
+    let bucket = nextBucket
+    nextBucket = base.hashTable.index(after: nextBucket)
+    return self.bridgedElement(at: bucket)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -125,7 +125,7 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
     }
 
-    if nextIndex == endIndex {
+    if nextBucket == endBucket {
       state.pointee = theState
       return 0
     }
@@ -133,8 +133,8 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     // Return only a single element so that code can start iterating via fast
     // enumeration, terminate it, and continue via NSEnumerator.
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects)
-    unmanagedObjects[0] = self.bridgedElement(at: nextIndex)
-    nextIndex = base.index(after: nextIndex)
+    unmanagedObjects[0] = self.bridgedElement(at: nextBucket)
+    nextBucket = base.hashTable.index(after: nextBucket)
     state.pointee = theState
     return 1
   }
@@ -198,9 +198,10 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     let bridged = _BridgingHashBuffer.allocate(
       owner: native._storage,
       hashTable: native.hashTable)
-    for index in native.hashTable {
-      let object = _bridgeAnythingToObjectiveC(native.element(at: index))
-      bridged.initialize(at: index, to: object)
+    for bucket in native.hashTable {
+      let object = _bridgeAnythingToObjectiveC(
+        native.uncheckedElement(at: bucket))
+      bridged.initialize(at: bucket, to: object)
     }
 
     // Atomically put the bridged elements in place.
@@ -225,10 +226,10 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     guard let element = _conditionallyBridgeFromObjectiveC(object, Element.self)
     else { return nil }
 
-    let (index, found) = native.find(element)
+    let (bucket, found) = native.find(element)
     guard found else { return nil }
     let bridged = bridgeElements()
-    return bridged[index]
+    return bridged[bucket]
   }
 
   @objc
@@ -247,12 +248,14 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     objects: UnsafeMutablePointer<AnyObject>?,
     count: Int
   ) -> Int {
+    defer { _fixLifetime(self) }
+    let hashTable = native.hashTable
     var theState = state.pointee
     if theState.state == 0 {
       theState.state = 1 // Arbitrary non-zero value.
       theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
-      theState.extra.0 = CUnsignedLong(native.startIndex.bucket)
+      theState.extra.0 = CUnsignedLong(hashTable.startIndex.bucket)
     }
 
     // Test 'objects' rather than 'count' because (a) this is very rare anyway,
@@ -263,21 +266,22 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     }
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
-    var index = _NativeSet<Element>.Index(bucket: Int(theState.extra.0))
-    let endIndex = native.endIndex
-    _precondition(index == endIndex || native.hashTable.isValid(index))
+    var bucket = _HashTable.Index(bucket: Int(theState.extra.0))
+    let endBucket = hashTable.endIndex
+    _precondition(bucket == endBucket || hashTable.isOccupied(bucket),
+      "Invalid fast enumeration state")
 
     // Only need to bridge once, so we can hoist it out of the loop.
     let bridgedElements = bridgeElements()
 
     var stored = 0
     for i in 0..<count {
-      if index == endIndex { break }
-      unmanagedObjects[i] = bridgedElements[index]
+      if bucket == endBucket { break }
+      unmanagedObjects[i] = bridgedElements[bucket]
       stored += 1
-      index = native.index(after: index)
+      bucket = hashTable.index(after: bucket)
     }
-    theState.extra.0 = CUnsignedLong(index.bucket)
+    theState.extra.0 = CUnsignedLong(bucket.bucket)
     state.pointee = theState
     return stored
   }

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -162,7 +162,6 @@ extension _EmptySetSingleton: _NSSetCore {
 #endif
 }
 
-// See the docs at the top of this file for a description of this type
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 final internal class _SetStorage<Element: Hashable>

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -16,16 +16,14 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
-//
-// See the docs at the top of the file for more details on this type
-//
-// NOTE: The precise layout of this type is relied on in the runtime
-// to provide a statically allocated empty singleton.
-// See stdlib/public/stubs/GlobalObjects.cpp for details.
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 @_objc_non_lazy_realization
 internal class _RawSetStorage: __SwiftNativeNSSet {
+  // NOTE: The precise layout of this type is relied on in the runtime to
+  // provide a statically allocated empty singleton.  See
+  // stdlib/public/stubs/GlobalObjects.cpp for details.
+
   /// The current number of occupied entries in this set.
   @usableFromInline
   @nonobjc
@@ -48,9 +46,12 @@ internal class _RawSetStorage: __SwiftNativeNSSet {
   @nonobjc
   internal final var _age: Int32
 
+  /// The hash seed used to hash elements in this set instance.
   @usableFromInline
   internal final var _seed: Int
 
+  /// A raw pointer to the start of the tail-allocated hash buffer holding set
+  /// members.
   @usableFromInline
   @nonobjc
   internal final var _rawElements: UnsafeMutableRawPointer

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -41,6 +41,19 @@ internal class _RawSetStorage: __SwiftNativeNSSet {
   @nonobjc
   internal final var _scale: Int8
 
+  /// The scale corresponding to the highest `reserveCapacity(_:)` call so far,
+  /// or 0 if there were none. This may be used later to allow removals to
+  /// resize storage.
+  ///
+  /// FIXME: <rdar://problem/18114559> Shrink storage on deletion
+  @usableFromInline
+  @nonobjc
+  internal final var _reservedScale: Int8
+
+  // Currently unused, set to zero.
+  @nonobjc
+  internal final var _extra: Int16
+
   /// A mutation count, enabling stricter index validation.
   @usableFromInline
   @nonobjc
@@ -316,6 +329,8 @@ extension _SetStorage {
     storage._count = 0
     storage._capacity = _HashTable.capacity(forScale: scale)
     storage._scale = scale
+    storage._reservedScale = 0
+    storage._extra = 0
 
     if let age = age {
       storage._age = age

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -318,8 +318,8 @@ extension _SetStorage {
     } else {
       // The default mutation count is simply a scrambled version of the storage
       // address.
-      storage._mutationCount = Int32(truncatingIfNeeded:
-        unsafeBitCast(storage, to: Int.self).hashValue)
+      storage._mutationCount = Int32(
+        truncatingIfNeeded: ObjectIdentifier(storage).hashValue)
     }
 
     storage._rawElements = UnsafeMutableRawPointer(elementsAddr)

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -43,9 +43,10 @@ internal class _RawSetStorage: __SwiftNativeNSSet {
   @nonobjc
   internal final var _scale: Int8
 
+  /// A mutation count, enabling stricter index validation.
   @usableFromInline
   @nonobjc
-  internal final var _mutationCount: Int32
+  internal final var _age: Int32
 
   @usableFromInline
   internal final var _seed: Int
@@ -278,7 +279,7 @@ extension _SetStorage {
     let newStorage = _SetStorage<Element>.allocate(
       scale: scale,
       // Invalidate indices if we're rehashing.
-      mutationCount: rehash ? nil : original._mutationCount
+      age: rehash ? nil : original._age
     )
     return (newStorage, rehash)
   }
@@ -287,12 +288,12 @@ extension _SetStorage {
   @_effects(releasenone)
   static internal func allocate(capacity: Int) -> _SetStorage {
     let scale = _HashTable.scale(forCapacity: capacity)
-    return allocate(scale: scale, mutationCount: nil)
+    return allocate(scale: scale, age: nil)
   }
 
   static internal func allocate(
     scale: Int8,
-    mutationCount: Int32?
+    age: Int32?
   ) -> _SetStorage {
     // The entry count must be representable by an Int value; hence the scale's
     // peculiar upper bound.
@@ -313,12 +314,12 @@ extension _SetStorage {
     storage._capacity = _HashTable.capacity(forScale: scale)
     storage._scale = scale
 
-    if let mutationCount = mutationCount {
-      storage._mutationCount = mutationCount
+    if let age = age {
+      storage._age = age
     } else {
       // The default mutation count is simply a scrambled version of the storage
       // address.
-      storage._mutationCount = Int32(
+      storage._age = Int32(
         truncatingIfNeeded: ObjectIdentifier(storage).hashValue)
     }
 

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -241,7 +241,7 @@ final internal class _SetStorage<Element: Hashable>
     }
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
-    var bucket = _HashTable.Index(bucket: Int(theState.extra.0))
+    var bucket = _HashTable.Bucket(bucket: Int(theState.extra.0))
     let endBucket = hashTable.endIndex
     _precondition(bucket == endBucket || hashTable.isOccupied(bucket),
       "Invalid fast enumeration state")

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -271,12 +271,12 @@ extension Set._Variant {
   ) -> (inserted: Bool, memberAfterInsert: Element) {
     switch self {
     case .native:
-      let (index, found) = asNative.find(element)
+      let (bucket, found) = asNative.find(element)
       if found {
-        return (false, asNative.uncheckedElement(at: index))
+        return (false, asNative.uncheckedElement(at: bucket))
       }
       let isUnique = self.isUniquelyReferenced()
-      asNative.insertNew(element, at: index, isUnique: isUnique)
+      asNative.insertNew(element, at: bucket, isUnique: isUnique)
       return (true, element)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
@@ -318,10 +318,10 @@ extension Set._Variant {
   internal mutating func remove(_ member: Element) -> Element? {
     switch self {
     case .native:
-      let (index, found) = asNative.find(member)
+      let (bucket, found) = asNative.find(member)
       guard found else { return nil }
       let isUnique = isUniquelyReferenced()
-      return asNative.uncheckedRemove(at: index, isUnique: isUnique)
+      return asNative.uncheckedRemove(at: bucket, isUnique: isUnique)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -341,9 +341,9 @@ extension Set._Variant {
     // FIXME(performance): fuse data migration and element deletion into one
     // operation.
     var native = _NativeSet<Element>(cocoa)
-    let (index, found) = native.find(member)
+    let (bucket, found) = native.find(member)
     _precondition(found, "Bridging did not preserve equality")
-    let old = native.remove(at: index, isUnique: true)
+    let old = native.uncheckedRemove(at: bucket, isUnique: true)
     _precondition(member == old, "Bridging did not preserve equality")
     self = .native(native)
     return old

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -66,6 +66,8 @@ swift::_SwiftEmptyDictionarySingleton swift::_swiftEmptyDictionarySingleton = {
     0, // int count;
     0, // int capacity;                                    
     0, // int8 scale;
+    0, // int8 reservedScale;
+    0, // int16 extra;
     0, // int32 age;
     0, // int seed;
     (void *)1, // void* keys; (non-null garbage)
@@ -91,6 +93,8 @@ swift::_SwiftEmptySetSingleton swift::_swiftEmptySetSingleton = {
     0, // int count;
     0, // int capacity;                                    
     0, // int8 scale;
+    0, // int8 reservedScale;
+    0, // int16 extra;
     0, // int32 age;
     0, // int seed;
     (void *)1, // void *rawElements; (non-null garbage)

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -65,7 +65,8 @@ swift::_SwiftEmptyDictionarySingleton swift::_swiftEmptyDictionarySingleton = {
     // 0 so that any insertion will lead to real storage being allocated.
     0, // int count;
     0, // int capacity;                                    
-    0, // int scale;
+    0, // int8 scale;
+    0, // int32 age;
     0, // int seed;
     (void *)1, // void* keys; (non-null garbage)
     (void *)1  // void* values; (non-null garbage)
@@ -89,7 +90,8 @@ swift::_SwiftEmptySetSingleton swift::_swiftEmptySetSingleton = {
     // 0 so that any insertion will lead to real storage being allocated.
     0, // int count;
     0, // int capacity;                                    
-    0, // int scale;
+    0, // int8 scale;
+    0, // int32 age;
     0, // int seed;
     (void *)1, // void *rawElements; (non-null garbage)
   },


### PR DESCRIPTION
Set and Dictionary invalidate all previously vended indices whenever one of these two operations occur:

- The removal of any element
- Resizing of the hash table

Currently, we attempt to detect if someone reuses an invalid index or uses an index from an unrelated collection by simply verifying that it points to an occupied bucket. This isn't nearly enough.

We can detect invalid indices with a much higher degree of confidence by including a mutation counter in the storage header of every set/dictionary, and inside every native index. 

- The hash value of the storage object identifier is a nice way to generate an initial value for the counter.
- The counter in the header needs to be changed whenever the above operations occur. 
- For validation, the counter in the index needs to be compared to the one in the header. 

Obviously this isn't a 100% foolproof method -- mutation counters can wrap around, or just happen to be initialized to the same value. However, it is a cheap and reasonably reliable way to catch accidental misuse:

```swift
var set = Set(0..<100)
let index = set.index(of: 42)!
set.remove(7)

// Before:
print(set[index]) // May print 42, some other number, or trap

// After:
print(set[index]) // ⚡️ "Attempting to access Dictionary elements using an invalid Index"
```



rdar://problem/18191576