### PR TITLE
[IRGen][Runtime] Adjust the ObjC reserved bits on x86-64 to exactly match what the target uses.

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -311,6 +311,9 @@ code for the target that is not the build machine:
 * ``%target-os``: the target operating system (``macosx``, ``darwin``,
   ``linux``, ``freebsd``, ``windows-cygnus``, ``windows-gnu``).
 
+* ``%target-is-simulator``: ``true`` if the target is a simulator (iOS,
+  watchOS, tvOS), otherwise ``false``.
+
 * ``%target-object-format``: the platform's object format (``elf``, ``macho``,
   ``coff``).
 

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -22,6 +22,7 @@
 #include "swift/ABI/System.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/IRGenOptions.h"
+#include "swift/Basic/Platform.h"
 
 using namespace swift;
 using namespace irgen;
@@ -66,9 +67,15 @@ static void configureX86_64(IRGenModule &IGM, const llvm::Triple &triple,
                             SwiftTargetInfo &target) {
   setToMask(target.PointerSpareBits, 64,
             SWIFT_ABI_X86_64_SWIFT_SPARE_BITS_MASK);
-  setToMask(target.ObjCPointerReservedBits, 64,
-            SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK);
   setToMask(target.IsObjCPointerBit, 64, SWIFT_ABI_X86_64_IS_OBJC_BIT);
+
+  if (tripleIsAnySimulator(triple)) {
+    setToMask(target.ObjCPointerReservedBits, 64,
+              SWIFT_ABI_X86_64_SIMULATOR_OBJC_RESERVED_BITS_MASK);
+  } else {
+    setToMask(target.ObjCPointerReservedBits, 64,
+              SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK);
+  }
 
   if (triple.isOSDarwin()) {
     target.LeastValidPointerValue =

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -13,6 +13,7 @@ set(sources
   SwiftStddef.h
   SwiftStdint.h
   System.h
+  Target.h
   ThreadLocalStorage.h
   UnicodeShims.h
   Visibility.h

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -15,6 +15,7 @@
 #include "RefCount.h"
 #include "SwiftStddef.h"
 #include "System.h"
+#include "Target.h"
 
 #define SWIFT_ABI_HEAP_OBJECT_HEADER_SIZE_64 16
 #define SWIFT_ABI_HEAP_OBJECT_HEADER_SIZE_32 8
@@ -117,10 +118,20 @@ static_assert(alignof(HeapObject) == alignof(void*),
 #endif
 #define _swift_abi_SwiftSpareBitsMask                                          \
   (__swift_uintptr_t) SWIFT_ABI_X86_64_SWIFT_SPARE_BITS_MASK
+#if SWIFT_TARGET_OS_SIMULATOR
+#define _swift_abi_ObjCReservedBitsMask                                        \
+  (__swift_uintptr_t) SWIFT_ABI_X86_64_SIMULATOR_OBJC_RESERVED_BITS_MASK
+#define _swift_abi_ObjCReservedLowBits                                         \
+  (unsigned) SWIFT_ABI_X86_64_SIMULATOR_OBJC_NUM_RESERVED_LOW_BITS
+#else
 #define _swift_abi_ObjCReservedBitsMask                                        \
   (__swift_uintptr_t) SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_X86_64_OBJC_NUM_RESERVED_LOW_BITS
+#endif
+
+#define _swift_BridgeObject_TaggedPointerBits                                  \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_64
 
 #elif defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64)
 
@@ -137,6 +148,8 @@ static_assert(alignof(HeapObject) == alignof(void*),
   (__swift_uintptr_t) SWIFT_ABI_ARM64_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_ARM64_OBJC_NUM_RESERVED_LOW_BITS
+#define _swift_BridgeObject_TaggedPointerBits                                  \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_64
 
 #elif defined(__powerpc64__)
 
@@ -148,6 +161,8 @@ static_assert(alignof(HeapObject) == alignof(void*),
   (__swift_uintptr_t) SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS
+#define _swift_BridgeObject_TaggedPointerBits                                  \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_64
 
 #elif defined(__s390x__)
 
@@ -159,6 +174,8 @@ static_assert(alignof(HeapObject) == alignof(void*),
   (__swift_uintptr_t) SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS
+#define _swift_BridgeObject_TaggedPointerBits                                  \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_64
 
 #else
 
@@ -180,6 +197,15 @@ static_assert(alignof(HeapObject) == alignof(void*),
   (__swift_uintptr_t) SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
   (unsigned) SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS
+
+#if __POINTER_WIDTH__ == 64
+#define _swift_BridgeObject_TaggedPointerBits                                  \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_64
+#else
+#define _swift_BridgeObject_TaggedPointerBits                                  \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_32
+#endif
+
 #endif
 
 /// Corresponding namespaced decls
@@ -191,13 +217,11 @@ static const __swift_uintptr_t SwiftSpareBitsMask =
     _swift_abi_SwiftSpareBitsMask;
 static const __swift_uintptr_t ObjCReservedBitsMask =
     _swift_abi_ObjCReservedBitsMask;
-static const unsigned ObjCReservedLowBits = _swift_abi_ObjCReservedLowBits;
+static const unsigned ObjCReservedLowBits =
+    _swift_abi_ObjCReservedLowBits;
+static const __swift_uintptr_t BridgeObjectTagBitsMask =
+    _swift_BridgeObject_TaggedPointerBits;
 } // heap_object_abi
 #endif // __cplusplus
-
-/// BridgeObject masks
-
-#define _swift_BridgeObject_TaggedPointerBits _swift_abi_ObjCReservedBitsMask
-
 
 #endif // SWIFT_STDLIB_SHIMS_HEAPOBJECT_H

--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -62,6 +62,10 @@
 #define SWIFT_ABI_DEFAULT_OBJC_WEAK_REFERENCE_MARKER_MASK 0
 #define SWIFT_ABI_DEFAULT_OBJC_WEAK_REFERENCE_MARKER_VALUE 0
 
+// BridgeObject uses this bit to indicate a tagged value.
+#define SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_32 0U
+#define SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_64 0x8000000000000000ULL
+
 /*********************************** i386 *************************************/
 
 // Heap objects are pointer-aligned, so the low two bits are unused.
@@ -102,22 +106,30 @@
 // Only the bottom 56 bits are used, and heap objects are eight-byte-aligned.
 #define SWIFT_ABI_X86_64_SWIFT_SPARE_BITS_MASK 0xFF00000000000007ULL
 
-// Objective-C reserves the high and low bits for tagged pointers.
-// Systems exist which use either bit.
-#define SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK 0x8000000000000001ULL
+// Objective-C reserves the low bit for tagged pointers on macOS, but
+// reserves the high bit on simulators.
+#define SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK 0x0000000000000001ULL
 #define SWIFT_ABI_X86_64_OBJC_NUM_RESERVED_LOW_BITS 1
+#define SWIFT_ABI_X86_64_SIMULATOR_OBJC_RESERVED_BITS_MASK 0x8000000000000000ULL
+#define SWIFT_ABI_X86_64_SIMULATOR_OBJC_NUM_RESERVED_LOW_BITS 0
+
 
 // BridgeObject uses this bit to indicate whether it holds an ObjC object or
 // not.
 #define SWIFT_ABI_X86_64_IS_OBJC_BIT 0x4000000000000000ULL
 
-// ObjC weak reference discriminator is the two bits
-// reserved for ObjC tagged pointers plus one more low bit.
+// ObjC weak reference discriminator is the bit reserved for ObjC tagged
+// pointers plus one more low bit.
 #define SWIFT_ABI_X86_64_OBJC_WEAK_REFERENCE_MARKER_MASK  \
   (SWIFT_ABI_X86_64_OBJC_RESERVED_BITS_MASK |          \
    1<<SWIFT_ABI_X86_64_OBJC_NUM_RESERVED_LOW_BITS)
 #define SWIFT_ABI_X86_64_OBJC_WEAK_REFERENCE_MARKER_VALUE \
   (1<<SWIFT_ABI_X86_64_OBJC_NUM_RESERVED_LOW_BITS)
+#define SWIFT_ABI_X86_64_SIMULATOR_OBJC_WEAK_REFERENCE_MARKER_MASK  \
+  (SWIFT_ABI_X86_64_SIMULATOR_OBJC_RESERVED_BITS_MASK |          \
+   1<<SWIFT_ABI_X86_64_SIMULATOR_OBJC_NUM_RESERVED_LOW_BITS)
+#define SWIFT_ABI_X86_64_SIMULATOR_OBJC_WEAK_REFERENCE_MARKER_VALUE \
+  (1<<SWIFT_ABI_X86_64_SIMULATOR_OBJC_NUM_RESERVED_LOW_BITS)
 
 /*********************************** arm64 ************************************/
 

--- a/stdlib/public/SwiftShims/Target.h
+++ b/stdlib/public/SwiftShims/Target.h
@@ -1,0 +1,32 @@
+//===--- Target.h - Info about the current compilation target ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Info about the current compilation target.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_TARGET_H
+#define SWIFT_ABI_TARGET_H
+
+#if !defined(__has_builtin)
+#define __has_builtin(x) 0
+#endif
+
+// Is the target platform a simulator? We can't use TargetConditionals
+// when included from SwiftShims, so use the builtin.
+#if __has_builtin(__is_target_environment)
+# if __is_target_environment(simulator)
+#  define SWIFT_TARGET_OS_SIMULATOR 1
+# endif
+#endif
+
+#endif /* SWIFT_ABI_TARGET_H */

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -93,7 +93,8 @@ struct _BridgeStorage<
   public // @testable
   func isNativeWithClearedSpareBits(_ bits: Int) -> Bool {
     return (_bitPattern(rawValue) &
-            (_objCTaggedPointerBits | _objectPointerIsObjCBit |
+            (_bridgeObjectTaggedPointerBits | _objCTaggedPointerBits |
+             _objectPointerIsObjCBit |
              (UInt(bits)) << _objectPointerLowSpareBitShift)) == 0
   }
 

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -489,10 +489,11 @@ _objcClassUsesNativeSwiftReferenceCounting(const Metadata *theClass) {
 #endif
 }
 
-// The non-pointer bits, excluding the ObjC tag bits.
+// The non-pointer bits, excluding the tag bits.
 static auto const unTaggedNonNativeBridgeObjectBits
   = heap_object_abi::SwiftSpareBitsMask
-  & ~heap_object_abi::ObjCReservedBitsMask;
+  & ~heap_object_abi::ObjCReservedBitsMask
+  & ~heap_object_abi::BridgeObjectTagBitsMask;
 
 #if SWIFT_OBJC_INTEROP
 
@@ -579,7 +580,7 @@ static bool isNonNative_unTagged_bridgeObject(void *object) {
   static_assert((heap_object_abi::SwiftSpareBitsMask & objectPointerIsObjCBit) ==
                 objectPointerIsObjCBit,
                 "isObjC bit not within spare bits");
-  return (uintptr_t(object) & objectPointerIsObjCBit) != 0;
+  return (uintptr_t(object) & objectPointerIsObjCBit) != 0 && (uintptr_t(object) & heap_object_abi::BridgeObjectTagBitsMask) == 0;
 }
 #endif
 

--- a/stdlib/public/runtime/WeakReference.h
+++ b/stdlib/public/runtime/WeakReference.h
@@ -20,6 +20,7 @@
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
+#include "../../../stdlib/public/SwiftShims/Target.h"
 
 #if SWIFT_OBJC_INTEROP
 #include "swift/Runtime/ObjCBridge.h"
@@ -78,6 +79,9 @@ class WeakReferenceBits {
 #if !SWIFT_OBJC_INTEROP
     NativeMarkerMask  = 0,
     NativeMarkerValue = 0
+#elif defined(__x86_64__) && SWIFT_TARGET_OS_SIMULATOR
+    NativeMarkerMask  = SWIFT_ABI_X86_64_SIMULATOR_OBJC_WEAK_REFERENCE_MARKER_MASK,
+    NativeMarkerValue = SWIFT_ABI_X86_64_SIMULATOR_OBJC_WEAK_REFERENCE_MARKER_VALUE
 #elif defined(__x86_64__)
     NativeMarkerMask  = SWIFT_ABI_X86_64_OBJC_WEAK_REFERENCE_MARKER_MASK,
     NativeMarkerValue = SWIFT_ABI_X86_64_OBJC_WEAK_REFERENCE_MARKER_VALUE

--- a/test/IRGen/bridge_object_x86_64.sil
+++ b/test/IRGen/bridge_object_x86_64.sil
@@ -34,7 +34,7 @@ entry(%c : $C, %w : $Builtin.Word):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i64 } @convert_from_bridge_object
 // CHECK:         [[BOBITS:%.*]] = ptrtoint [[BRIDGE]] %0 to i64
 // --                                                     0x8000_0000_0000_0001
-// CHECK:         [[TAGBITS:%.*]] = and i64 [[BOBITS]], -9223372036854775807
+// CHECK:         [[TAGBITS:%.*]] = and i64 [[BOBITS]], 1
 // CHECK:         [[TAGGED:%.*]] = icmp eq i64 [[TAGBITS]], 0
 // CHECK:         br i1 [[TAGGED]], label %not-tagged-pointer, label %tagged-pointer
 // CHECK:       tagged-pointer:

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1,6 +1,6 @@
 // #if directives don't work with SIL keywords, therefore please put ObjC tests
 // in `enum_objc.sil`.
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -enable-objc-interop  | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -enable-objc-interop  | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize-simulator-%target-is-simulator
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
@@ -1134,8 +1134,10 @@ enum SinglePayloadClass {
 // CHECK-64: entry:
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
-// CHECK-objc-64:   i64 2, label {{%.*}}
-// CHECK-objc-64:   i64 4, label {{%.*}}
+// CHECK-objc-64-simulator-false:   i64 2, label {{%.*}}
+// CHECK-objc-64-simulator-false:   i64 4, label {{%.*}}
+// CHECK-objc-64-simulator-true:   i64 1, label {{%.*}}
+// CHECK-objc-64-simulator-true:   i64 2, label {{%.*}}
 // CHECK-native-64: i64 1, label {{%.*}}
 // CHECK-native-64: i64 2, label {{%.*}}
 // CHECK-64:   ]
@@ -1179,8 +1181,10 @@ enum SinglePayloadClassProtocol {
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i64, i64) {{.*}} {
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
-// CHECK-objc-64:     i64 2, label {{%.*}}
-// CHECK-objc-64:     i64 4, label {{%.*}}
+// CHECK-objc-64-simulator-false:     i64 2, label {{%.*}}
+// CHECK-objc-64-simulator-false:     i64 4, label {{%.*}}
+// CHECK-objc-64-simulator-true:     i64 1, label {{%.*}}
+// CHECK-objc-64-simulator-true:     i64 2, label {{%.*}}
 // CHECK-native-64:   i64 1, label {{%.*}}
 // CHECK-native-64:   i64 2, label {{%.*}}
 // CHECK-64:   ]
@@ -2457,7 +2461,8 @@ entry(%0 : $DynamicSingleton<NoPayloads>):
 // Check that payloads get properly masked in nested single-payload enums.
 // rdar://problem/18841262
 // CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i64, i64)
-// CHECK-objc-64:       icmp eq i64 %0, 2
+// CHECK-objc-64-simulator-false:       icmp eq i64 %0, 2
+// CHECK-objc-64-simulator-true:       icmp eq i64 %0, 1
 // CHECK-native-64:     icmp eq i64 %0, 1
 // CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i32, i32)
 // CHECK-32:         icmp eq i32 %0, 1

--- a/test/IRGen/enum_objc.sil
+++ b/test/IRGen/enum_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-simulator-%target-is-simulator
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 
@@ -32,8 +32,10 @@ enum SinglePayloadObjCProtocol {
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i64, i64) {{.*}} {
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
-// CHECK-64:     i64 2, label {{%.*}}
-// CHECK-64:     i64 4, label {{%.*}}
+// CHECK-64-simulator-false:     i64 2, label {{%.*}}
+// CHECK-64-simulator-false:     i64 4, label {{%.*}}
+// CHECK-64-simulator-true:     i64 1, label {{%.*}}
+// CHECK-64-simulator-true:     i64 2, label {{%.*}}
 // CHECK-64:   ]
 
 // CHECK-64:     inttoptr i64 %0 to %objc_object*
@@ -69,8 +71,10 @@ end:
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_objc_protocol_switch(i64) {{.*}} {
 // CHECK-64:   switch i64 %0, label {{%.*}}
 // CHECK-64:     i64 0, label {{%.*}}
-// CHECK-64:     i64 2, label {{%.*}}
-// CHECK-64:     i64 4, label {{%.*}}
+// CHECK-64-simulator-false:     i64 2, label {{%.*}}
+// CHECK-64-simulator-false:     i64 4, label {{%.*}}
+// CHECK-64-simulator-true:     i64 1, label {{%.*}}
+// CHECK-64-simulator-true:     i64 2, label {{%.*}}
 // CHECK-64:   ]
 // CHECK-64:     inttoptr i64 %0 to %objc_object*
 

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-objc-%target-os
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-simulator-%target-is-simulator --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-objc-%target-os
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-native-%target-os
 
 // REQUIRES: CPU=x86_64
@@ -287,8 +287,10 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK:        i64 0, label %[[DONE:[0-9]+]]
 // CHECK-native:      i64 1, label %[[DONE]]
 // CHECK-native:      i64 2, label %[[DONE]]
-// CHECK-objc:        i64 2, label %[[DONE]]
-// CHECK-objc:        i64 4, label %[[DONE]]
+// CHECK-objc-simulator-false:        i64 2, label %[[DONE]]
+// CHECK-objc-simulator-false:        i64 4, label %[[DONE]]
+// CHECK-objc-simulator-true:        i64 1, label %[[DONE]]
+// CHECK-objc-simulator-true:        i64 2, label %[[DONE]]
 // CHECK:      ]
 
 // CHECK:      ; <label>:[[RELEASE_PAYLOAD]]

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime  --check-prefix=CHECK-%target-runtime-simulator-%target-is-simulator
 
 // REQUIRES: CPU=x86_64
 
@@ -135,7 +135,8 @@ enum MultipleEmptyRefcounted {
 // CHECK:   switch i64 %2, label %3 [
 // CHECK:     i64 0, label %5
 // CHECK-native:   i64 1, label %5
-// CHECK-objc:     i64 2, label %5
+// CHECK-objc-simulator-false:     i64 2, label %5
+// CHECK-objc-simulator-true:     i64 1, label %5
 // CHECK:   ]
 // CHECK: ; <label>:3:                                      ; preds = %entry
 // CHECK:   %4 = bitcast %T34enum_value_semantics_special_cases23MultipleEmptyRefcountedO* %0 to %swift.refcounted**

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1005,6 +1005,17 @@ if (not getattr(config, 'target_run', None) and
 config.substitutions.append(('%env-', TARGET_ENV_PREFIX))
 config.substitutions.append(("%target-sdk-name", config.target_sdk_name))
 
+simulator_sdks = [
+    'iphonesimulator',
+    'watchsimulator',
+    'appletvsimulator'
+]
+if config.target_sdk_name in simulator_sdks:
+    config.substitutions.append(('%target-is-simulator', 'true'))
+else:
+    config.substitutions.append(('%target-is-simulator', 'false'))
+
+
 config.compiler_rt_libs = []
 config.compiler_rt_platform = {
     'iphoneos': 'ios',


### PR DESCRIPTION
Previously we had a single mask for all x86-64 targets which included both the top and bottom bits. This accommodated simulators, which use the top bit, while macOS uses the bottom bit, but reserved one bit more than necessary on each. This change breaks out x86-64 simulators from non-simulators and reserves only the one bit used on each.

This PR also includes a new substitution in `lit.cfg` to allow some tests to distinguish between simulator and non-simulator targets. This was needed because x86-64 simulator and non-simulator now generate slightly different output for some tests.

rdar://problem/34805348 rdar://problem/29765919