### PR TITLE
[sourcekit] Fix use-after free after sourcekitd_shutdown()

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/Context.h
+++ b/tools/SourceKit/include/SourceKit/Core/Context.h
@@ -30,7 +30,7 @@ namespace SourceKit {
 class Context {
   std::string RuntimeLibPath;
   std::unique_ptr<LangSupport> SwiftLang;
-  std::unique_ptr<NotificationCenter> NotificationCtr;
+  std::shared_ptr<NotificationCenter> NotificationCtr;
 
 public:
   Context(StringRef RuntimeLibPath,
@@ -43,7 +43,7 @@ public:
 
   LangSupport &getSwiftLangSupport() { return *SwiftLang; }
 
-  NotificationCenter &getNotificationCenter() { return *NotificationCtr; }
+  std::shared_ptr<NotificationCenter> getNotificationCenter() { return NotificationCtr; }
 };
 
 } // namespace SourceKit

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -171,15 +171,15 @@ void InvocationOptions::profile(llvm::FoldingSetNodeID &ID) const {
 namespace SourceKit {
   struct ASTUnit::Implementation {
     const uint64_t Generation;
-    SwiftStatistics &Stats;
+    std::shared_ptr<SwiftStatistics> Stats;
     SmallVector<ImmutableTextSnapshotRef, 4> Snapshots;
     EditorDiagConsumer CollectDiagConsumer;
     CompilerInstance CompInst;
     OwnedResolver TypeResolver{ nullptr, nullptr };
     WorkQueue Queue{ WorkQueue::Dequeuing::Serial, "sourcekit.swift.ConsumeAST" };
 
-    Implementation(uint64_t Generation, SwiftStatistics &Statistics)
-        : Generation(Generation), Stats(Statistics) {}
+    Implementation(uint64_t Generation, std::shared_ptr<SwiftStatistics> Stats)
+        : Generation(Generation), Stats(Stats) {}
 
     void consumeAsync(SwiftASTConsumerRef ASTConsumer, ASTUnitRef ASTRef);
   };
@@ -200,14 +200,14 @@ namespace SourceKit {
     });
   }
 
-  ASTUnit::ASTUnit(uint64_t Generation, SwiftStatistics &Stats)
+  ASTUnit::ASTUnit(uint64_t Generation, std::shared_ptr<SwiftStatistics> Stats)
       : Impl(*new Implementation(Generation, Stats)) {
-    auto numASTs = ++Stats.numASTsInMem;
-    Stats.maxASTsInMem.updateMax(numASTs);
+    auto numASTs = ++Stats->numASTsInMem;
+    Stats->maxASTsInMem.updateMax(numASTs);
   }
 
   ASTUnit::~ASTUnit() {
-    --Impl.Stats.numASTsInMem;
+    --Impl.Stats->numASTsInMem;
     delete &Impl;
   }
 
@@ -347,13 +347,14 @@ struct CacheKeyHashInfo<ASTKey> {
 } // namespace swift
 
 struct SwiftASTManager::Implementation {
-  explicit Implementation(SwiftLangSupport &LangSupport)
-      : EditorDocs(LangSupport.getEditorDocuments()),
-        Stats(LangSupport.getStatistics()),
-        RuntimeResourcePath(LangSupport.getRuntimeResourcePath()) {}
+  explicit Implementation(
+      std::shared_ptr<SwiftEditorDocumentFileMap> EditorDocs,
+      std::shared_ptr<SwiftStatistics> Stats, StringRef RuntimeResourcePath)
+      : EditorDocs(EditorDocs), Stats(Stats),
+        RuntimeResourcePath(RuntimeResourcePath) {}
 
-  SwiftEditorDocumentFileMap &EditorDocs;
-  SwiftStatistics &Stats;
+  std::shared_ptr<SwiftEditorDocumentFileMap> EditorDocs;
+  std::shared_ptr<SwiftStatistics> Stats;
   std::string RuntimeResourcePath;
   SourceManager SourceMgr;
   Cache<ASTKey, ASTProducerRef> ASTCache{ "sourcekit.swift.ASTCache" };
@@ -370,9 +371,10 @@ struct SwiftASTManager::Implementation {
                                                       std::string &Error);
 };
 
-SwiftASTManager::SwiftASTManager(SwiftLangSupport &LangSupport)
-  : Impl(*new Implementation(LangSupport)) {
-}
+SwiftASTManager::SwiftASTManager(
+    std::shared_ptr<SwiftEditorDocumentFileMap> EditorDocs,
+    std::shared_ptr<SwiftStatistics> Stats, StringRef RuntimeResourcePath)
+    : Impl(*new Implementation(EditorDocs, Stats, RuntimeResourcePath)) {}
 
 SwiftASTManager::~SwiftASTManager() {
   delete &Impl;
@@ -566,7 +568,7 @@ void SwiftASTManager::processASTAsync(SwiftInvocationRef InvokRef,
 
   if (ASTUnitRef Unit = Producer->getExistingAST()) {
     if (ASTConsumer->canUseASTWithSnapshots(Unit->getSnapshots())) {
-      ++Impl.Stats.numASTsUsedWithSnaphots;
+      ++Impl.Stats->numASTsUsedWithSnaphots;
       Unit->Impl.consumeAsync(std::move(ASTConsumer), Unit);
       return;
     }
@@ -621,7 +623,7 @@ static FileContent getFileContentFromSnap(ImmutableTextSnapshotRef Snap,
 FileContent SwiftASTManager::Implementation::getFileContent(
     StringRef UnresolvedPath, bool IsPrimary, std::string &Error) {
   std::string FilePath = SwiftLangSupport::resolvePathSymlinks(UnresolvedPath);
-  if (auto EditorDoc = EditorDocs.findByPath(FilePath))
+  if (auto EditorDoc = EditorDocs->findByPath(FilePath))
     return getFileContentFromSnap(EditorDoc->getLatestSnapshot(), IsPrimary,
                                   FilePath);
 
@@ -633,7 +635,7 @@ FileContent SwiftASTManager::Implementation::getFileContent(
 }
 
 BufferStamp SwiftASTManager::Implementation::getBufferStamp(StringRef FilePath){
-  if (auto EditorDoc = EditorDocs.findByPath(FilePath))
+  if (auto EditorDoc = EditorDocs->findByPath(FilePath))
     return EditorDoc->getLatestSnapshot()->getStamp();
 
   llvm::sys::fs::file_status Status;
@@ -706,7 +708,7 @@ ASTUnitRef ASTProducer::getASTUnitImpl(SwiftASTManager::Implementation &MgrImpl,
       MgrImpl.ASTCache.set(InvokRef->Impl.Key, ThisProducer);
     }
   } else {
-    ++MgrImpl.Stats.numASTCacheHits;
+    ++MgrImpl.Stats->numASTCacheHits;
   }
 
   return AST;
@@ -834,7 +836,7 @@ static std::atomic<uint64_t> ASTUnitGeneration{ 0 };
 ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
                                       ArrayRef<ImmutableTextSnapshotRef> Snapshots,
                                       std::string &Error) {
-  ++MgrImpl.Stats.numASTBuilds;
+  ++MgrImpl.Stats->numASTBuilds;
 
   Stamps.clear();
   DependencyStamps.clear();

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -84,7 +84,7 @@ public:
 
 typedef std::shared_ptr<SwiftASTConsumer> SwiftASTConsumerRef;
 
-class SwiftASTManager {
+class SwiftASTManager : public std::enable_shared_from_this<SwiftASTManager> {
 public:
   explicit SwiftASTManager(SwiftLangSupport &LangSupport);
   ~SwiftASTManager();
@@ -131,8 +131,6 @@ public:
   void removeCachedAST(SwiftInvocationRef Invok);
 
   struct Implementation;
-
-private:
   Implementation &Impl;
 };
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -49,7 +49,7 @@ public:
   struct Implementation;
   Implementation &Impl;
 
-  explicit ASTUnit(uint64_t Generation, SwiftStatistics &Statistics);
+  explicit ASTUnit(uint64_t Generation, std::shared_ptr<SwiftStatistics> Stats);
   ~ASTUnit();
 
   swift::CompilerInstance &getCompilerInstance() const;
@@ -86,7 +86,9 @@ typedef std::shared_ptr<SwiftASTConsumer> SwiftASTConsumerRef;
 
 class SwiftASTManager : public std::enable_shared_from_this<SwiftASTManager> {
 public:
-  explicit SwiftASTManager(SwiftLangSupport &LangSupport);
+  explicit SwiftASTManager(std::shared_ptr<SwiftEditorDocumentFileMap>,
+                           std::shared_ptr<SwiftStatistics> Stats,
+                           StringRef RuntimeResourcePath);
   ~SwiftASTManager();
 
   SwiftInvocationRef getInvocation(ArrayRef<const char *> Args,

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -147,7 +147,7 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
   }
 
   CompilerInvocation Invocation;
-  bool Failed = Lang.getASTManager().initCompilerInvocation(
+  bool Failed = Lang.getASTManager()->initCompilerInvocation(
       Invocation, Args, CI.getDiags(), InputFile->getBufferIdentifier(), Error);
   if (Failed) {
     return false;

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1335,7 +1335,7 @@ void SwiftLangSupport::findLocalRenameRanges(
   /// FIXME: When request cancellation is implemented and Xcode adopts it,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;
-  getASTManager().processASTAsync(Invok, ASTConsumer, &OncePerASTToken);
+  getASTManager()->processASTAsync(Invok, ASTConsumer, &OncePerASTToken);
 }
 
 SourceFile *SwiftLangSupport::getSyntacticSourceFile(
@@ -1343,7 +1343,7 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
     CompilerInstance &ParseCI, std::string &Error) {
   CompilerInvocation Invocation;
 
-  bool Failed = getASTManager().initCompilerInvocationNoInputs(
+  bool Failed = getASTManager()->initCompilerInvocationNoInputs(
       Invocation, Args, ParseCI.getDiags(), Error);
   if (Failed) {
     Error = "Compiler invocation init failed";
@@ -1398,7 +1398,7 @@ void SwiftLangSupport::getDocInfo(llvm::MemoryBuffer *InputBuf,
 
   CompilerInvocation Invocation;
   std::string Error;
-  bool Failed = getASTManager().initCompilerInvocationNoInputs(
+  bool Failed = getASTManager()->initCompilerInvocationNoInputs(
       Invocation, Args, CI.getDiags(), Error, /*AllowInputs=*/false);
 
   if (Failed) {
@@ -1434,7 +1434,7 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
   CI.addDiagnosticConsumer(&PrintDiags);
   std::vector<StringRef> Groups;
   std::string Error;
-  if (getASTManager().initCompilerInvocationNoInputs(Invocation, Args,
+  if (getASTManager()->initCompilerInvocationNoInputs(Invocation, Args,
                                                      CI.getDiags(), Error)) {
     Receiver(Groups, Error);
     return;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2034,19 +2034,19 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
                                   ArrayRef<const char *> Args) {
 
   ImmutableTextSnapshotRef Snapshot = nullptr;
-  auto EditorDoc = EditorDocuments.getByUnresolvedName(Name);
+  auto EditorDoc = EditorDocuments->getByUnresolvedName(Name);
   if (!EditorDoc) {
     EditorDoc = new SwiftEditorDocument(Name, *this);
     Snapshot = EditorDoc->initializeText(Buf, Args);
     EditorDoc->parse(Snapshot, *this, Consumer.syntaxTreeEnabled());
-    if (EditorDocuments.getOrUpdate(Name, *this, EditorDoc)) {
+    if (EditorDocuments->getOrUpdate(Name, *this, EditorDoc)) {
       // Document already exists, re-initialize it. This should only happen
       // if we get OPEN request while the previous document is not closed.
       LOG_WARN_FUNC("Document already exists in editorOpen(..): " << Name);
       Snapshot = nullptr;
     }
-    auto numOpen = ++Stats.numOpenDocs;
-    Stats.maxOpenDocs.updateMax(numOpen);
+    auto numOpen = ++Stats->numOpenDocs;
+    Stats->maxOpenDocs.updateMax(numOpen);
   }
 
   if (!Snapshot) {
@@ -2075,9 +2075,9 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
 //===----------------------------------------------------------------------===//
 
 void SwiftLangSupport::editorClose(StringRef Name, bool RemoveCache) {
-  auto Removed = EditorDocuments.remove(Name);
+  auto Removed = EditorDocuments->remove(Name);
   if (Removed) {
-    --Stats.numOpenDocs;
+    --Stats->numOpenDocs;
   } else {
     IFaceGenContexts.remove(Name);
   }
@@ -2186,7 +2186,7 @@ void SwiftLangSupport::editorReplaceText(StringRef Name,
   bool LogReuseRegions = ::getenv("SOURCEKIT_LOG_INCREMENTAL_REUSE_REGIONS");
   bool ValidateSyntaxTree = ::getenv("SOURCEKIT_INCREMENTAL_PARSE_VALIDATION");
 
-  auto EditorDoc = EditorDocuments.getByUnresolvedName(Name);
+  auto EditorDoc = EditorDocuments->getByUnresolvedName(Name);
   if (!EditorDoc) {
     Consumer.handleRequestError("No associated Editor Document");
     return;
@@ -2272,7 +2272,7 @@ void SwiftLangSupport::editorReplaceText(StringRef Name,
 //===----------------------------------------------------------------------===//
 void SwiftLangSupport::editorApplyFormatOptions(StringRef Name,
                                                 OptionsDictionary &FmtOptions) {
-  auto EditorDoc = EditorDocuments.getByUnresolvedName(Name);
+  auto EditorDoc = EditorDocuments->getByUnresolvedName(Name);
   if (EditorDoc)
     EditorDoc->applyFormatOptions(FmtOptions);
 }
@@ -2280,7 +2280,7 @@ void SwiftLangSupport::editorApplyFormatOptions(StringRef Name,
 void SwiftLangSupport::editorFormatText(StringRef Name, unsigned Line,
                                         unsigned Length,
                                         EditorConsumer &Consumer) {
-  auto EditorDoc = EditorDocuments.getByUnresolvedName(Name);
+  auto EditorDoc = EditorDocuments->getByUnresolvedName(Name);
   if (!EditorDoc) {
     Consumer.handleRequestError("No associated Editor Document");
     return;
@@ -2318,7 +2318,7 @@ void SwiftLangSupport::editorConvertMarkupToXML(StringRef Source,
 void SwiftLangSupport::editorExpandPlaceholder(StringRef Name, unsigned Offset,
                                                unsigned Length,
                                                EditorConsumer &Consumer) {
-  auto EditorDoc = EditorDocuments.getByUnresolvedName(Name);
+  auto EditorDoc = EditorDocuments->getByUnresolvedName(Name);
   if (!EditorDoc) {
     Consumer.handleRequestError("No associated Editor Document");
     return;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1060,7 +1060,7 @@ struct SwiftEditorDocument::Implementation {
       : LangSupport(LangSupport), FilePath(FilePath), FormatOptions(options) {
     SemanticInfo = new SwiftDocumentSemanticInfo(
         FilePath, LangSupport.getASTManager().shared_from_this(),
-        LangSupport.getContext().getNotificationCenter());
+        LangSupport.getNotificationCenter());
   }
 };
 
@@ -1637,7 +1637,7 @@ ImmutableTextSnapshotRef SwiftEditorDocument::initializeText(
 
   Impl.SemanticInfo = new SwiftDocumentSemanticInfo(
       Impl.FilePath, Impl.LangSupport.getASTManager().shared_from_this(),
-      Impl.LangSupport.getContext().getNotificationCenter());
+      Impl.LangSupport.getNotificationCenter());
   Impl.SemanticInfo->setCompilerArgs(Args);
   return Impl.EditableBuffer->getSnapshot();
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1058,7 +1058,7 @@ struct SwiftEditorDocument::Implementation {
 
   Implementation(StringRef FilePath, SwiftLangSupport &LangSupport,
                  CodeFormatOptions options)
-      : ASTMgr(LangSupport.getASTManager().shared_from_this()),
+      : ASTMgr(LangSupport.getASTManager()),
         NotificationCtr(LangSupport.getNotificationCenter()),
         FilePath(FilePath), FormatOptions(options) {
     SemanticInfo =
@@ -1735,7 +1735,7 @@ void SwiftEditorDocument::parse(ImmutableTextSnapshotRef Snapshot,
     Args.push_back("-");
     std::string Error;
     // Ignore possible error(s)
-    Lang.getASTManager().
+    Lang.getASTManager()->
       initCompilerInvocation(CompInv, Args, StringRef(), Error);
   }
   CompInv.getLangOptions().BuildSyntaxTree = BuildSyntaxTree;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -596,7 +596,7 @@ class SwiftDocumentSemanticInfo :
 
   const std::string Filename;
   SwiftASTManager &ASTMgr;
-  NotificationCenter &NotificationCtr;
+  std::weak_ptr<NotificationCenter> NotificationCtr;
   ThreadSafeRefCntPtr<SwiftInvocation> InvokRef;
   std::string CompilerArgsError;
 
@@ -873,7 +873,8 @@ void SwiftDocumentSemanticInfo::updateSemanticInfo(
   }
 
   LOG_INFO_FUNC(High, "posted document update notification for: " << Filename);
-  NotificationCtr.postDocumentUpdateNotification(Filename);
+  if (auto notifications = NotificationCtr.lock())
+    notifications->postDocumentUpdateNotification(Filename);
 }
 
 namespace {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -596,7 +596,7 @@ class SwiftDocumentSemanticInfo :
 
   const std::string Filename;
   std::weak_ptr<SwiftASTManager> ASTMgr;
-  std::weak_ptr<NotificationCenter> NotificationCtr;
+  std::shared_ptr<NotificationCenter> NotificationCtr;
   ThreadSafeRefCntPtr<SwiftInvocation> InvokRef;
   std::string CompilerArgsError;
 
@@ -612,7 +612,7 @@ class SwiftDocumentSemanticInfo :
 public:
   SwiftDocumentSemanticInfo(StringRef Filename,
                             std::weak_ptr<SwiftASTManager> ASTMgr,
-                            std::weak_ptr<NotificationCenter> NotificationCtr)
+                            std::shared_ptr<NotificationCenter> NotificationCtr)
       : Filename(Filename), ASTMgr(ASTMgr), NotificationCtr(NotificationCtr) {}
 
   SwiftInvocationRef getInvocation() const {
@@ -878,8 +878,7 @@ void SwiftDocumentSemanticInfo::updateSemanticInfo(
   }
 
   LOG_INFO_FUNC(High, "posted document update notification for: " << Filename);
-  if (auto notifications = NotificationCtr.lock())
-    notifications->postDocumentUpdateNotification(Filename);
+  NotificationCtr->postDocumentUpdateNotification(Filename);
 }
 
 namespace {
@@ -1030,7 +1029,7 @@ void SwiftDocumentSemanticInfo::processLatestSnapshotAsync(
 
 struct SwiftEditorDocument::Implementation {
   std::weak_ptr<SwiftASTManager> ASTMgr;
-  std::weak_ptr<NotificationCenter> NotificationCtr;
+  std::shared_ptr<NotificationCenter> NotificationCtr;
 
   const std::string FilePath;
   EditableTextBufferRef EditableBuffer;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -661,7 +661,7 @@ void SwiftLangSupport::editorOpenTypeInterface(EditorConsumer &Consumer,
 
   CompilerInvocation Invocation;
   std::string Error;
-  if (getASTManager().initCompilerInvocation(Invocation, Args, CI.getDiags(),
+  if (getASTManager()->initCompilerInvocation(Invocation, Args, CI.getDiags(),
                                              StringRef(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
@@ -701,7 +701,7 @@ void SwiftLangSupport::editorOpenInterface(EditorConsumer &Consumer,
 
   CompilerInvocation Invocation;
   std::string Error;
-  if (getASTManager().initCompilerInvocationNoInputs(Invocation, Args,
+  if (getASTManager()->initCompilerInvocationNoInputs(Invocation, Args,
                                                      CI.getDiags(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
@@ -775,7 +775,7 @@ void SwiftLangSupport::editorOpenSwiftSourceInterface(StringRef Name,
   auto AstConsumer = std::make_shared<PrimaryFileInterfaceConsumer>(Name,
     SourceName, IFaceGenContexts, Consumer, Invocation);
   static const char OncePerASTToken = 0;
-  getASTManager().processASTAsync(Invocation, AstConsumer, &OncePerASTToken);
+  getASTManager()->processASTAsync(Invocation, AstConsumer, &OncePerASTToken);
 }
 
 void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
@@ -794,7 +794,7 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
   std::string Error;
 
   ArrayRef<const char *> SwiftArgs = UsingSwiftArgs ? Args : llvm::None;
-  if (getASTManager().initCompilerInvocationNoInputs(Invocation, SwiftArgs,
+  if (getASTManager()->initCompilerInvocationNoInputs(Invocation, SwiftArgs,
                                                      CI.getDiags(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
@@ -844,7 +844,7 @@ void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
 
   CompilerInvocation Invocation;
   std::string Error;
-  if (getASTManager().initCompilerInvocation(Invocation, Args, CI.getDiags(),
+  if (getASTManager()->initCompilerInvocation(Invocation, Args, CI.getDiags(),
                                              StringRef(), Error)) {
     Info.Error = Error;
     return Receiver(Info);

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -251,10 +251,10 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   CompilerInvocation Invocation;
   bool Failed = true;
   if (IsModuleIndexing) {
-    Failed = getASTManager().initCompilerInvocationNoInputs(
+    Failed = getASTManager()->initCompilerInvocationNoInputs(
         Invocation, Args, CI.getDiags(), Error);
   } else {
-    Failed = getASTManager().initCompilerInvocation(
+    Failed = getASTManager()->initCompilerInvocation(
         Invocation, Args, CI.getDiags(), InputFile, Error);
   }
   if (Failed) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -178,7 +178,7 @@ SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
   llvm::sys::path::append(LibPath, "swift");
   RuntimeResourcePath = LibPath.str();
 
-  ASTMgr.reset(new SwiftASTManager(*this));
+  ASTMgr = std::make_shared<SwiftASTManager>(*this);
   // By default, just use the in-memory cache.
   CCCache->inMemory = llvm::make_unique<ide::CodeCompletionCache>();
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -173,7 +173,8 @@ UIdent UIdentVisitor::visitExtensionDecl(const ExtensionDecl *D) {
 }
 
 SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
-    : SKCtx(SKCtx), CCCache(new SwiftCompletionCache) {
+    : NotificationCtr(SKCtx.getNotificationCenter()),
+      CCCache(new SwiftCompletionCache) {
   llvm::SmallString<128> LibPath(SKCtx.getRuntimeLibPath());
   llvm::sys::path::append(LibPath, "swift");
   RuntimeResourcePath = LibPath.str();

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -179,7 +179,10 @@ SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
   llvm::sys::path::append(LibPath, "swift");
   RuntimeResourcePath = LibPath.str();
 
-  ASTMgr = std::make_shared<SwiftASTManager>(*this);
+  Stats = std::make_shared<SwiftStatistics>();
+  EditorDocuments = std::make_shared<SwiftEditorDocumentFileMap>();
+  ASTMgr = std::make_shared<SwiftASTManager>(EditorDocuments, Stats,
+                                             RuntimeResourcePath);
   // By default, just use the in-memory cache.
   CCCache->inMemory = llvm::make_unique<ide::CodeCompletionCache>();
 }
@@ -766,7 +769,7 @@ std::string SwiftLangSupport::resolvePathSymlinks(StringRef FilePath) {
 
 void SwiftLangSupport::getStatistics(StatisticsReceiver receiver) {
   std::vector<Statistic *> stats = {
-#define SWIFT_STATISTIC(VAR, UID, DESC) &Stats.VAR,
+#define SWIFT_STATISTIC(VAR, UID, DESC) &Stats->VAR,
 #include "SwiftStatistics.def"
   };
   receiver(stats);

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -292,7 +292,7 @@ public:
 
   StringRef getRuntimeResourcePath() const { return RuntimeResourcePath; }
 
-  SwiftASTManager &getASTManager() { return *ASTMgr; }
+  std::shared_ptr<SwiftASTManager> getASTManager() { return ASTMgr; }
 
   std::shared_ptr<SwiftEditorDocumentFileMap> getEditorDocuments() { return EditorDocuments; }
   SwiftInterfaceGenMap &getIFaceGenContexts() { return IFaceGenContexts; }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -271,7 +271,7 @@ struct SwiftStatistics {
 };
 
 class SwiftLangSupport : public LangSupport {
-  std::weak_ptr<NotificationCenter> NotificationCtr;
+  std::shared_ptr<NotificationCenter> NotificationCtr;
   std::string RuntimeResourcePath;
   std::shared_ptr<SwiftASTManager> ASTMgr;
   std::shared_ptr<SwiftEditorDocumentFileMap> EditorDocuments;
@@ -287,7 +287,7 @@ public:
   ~SwiftLangSupport();
 
   std::shared_ptr<NotificationCenter> getNotificationCenter() const {
-    return NotificationCtr.lock();
+    return NotificationCtr;
   }
 
   StringRef getRuntimeResourcePath() const { return RuntimeResourcePath; }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -272,7 +272,7 @@ struct SwiftStatistics {
 class SwiftLangSupport : public LangSupport {
   SourceKit::Context &SKCtx;
   std::string RuntimeResourcePath;
-  std::unique_ptr<SwiftASTManager> ASTMgr;
+  std::shared_ptr<SwiftASTManager> ASTMgr;
   SwiftEditorDocumentFileMap EditorDocuments;
   SwiftInterfaceGenMap IFaceGenContexts;
   ThreadSafeRefCntPtr<SwiftCompletionCache> CCCache;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -67,6 +67,7 @@ namespace SourceKit {
   class SwiftASTManager;
   class SwiftLangSupport;
   class Context;
+  class NotificationCenter;
 
 class SwiftEditorDocument :
     public ThreadSafeRefCountedBase<SwiftEditorDocument> {
@@ -270,7 +271,7 @@ struct SwiftStatistics {
 };
 
 class SwiftLangSupport : public LangSupport {
-  SourceKit::Context &SKCtx;
+  std::weak_ptr<NotificationCenter> NotificationCtr;
   std::string RuntimeResourcePath;
   std::shared_ptr<SwiftASTManager> ASTMgr;
   SwiftEditorDocumentFileMap EditorDocuments;
@@ -285,7 +286,9 @@ public:
   explicit SwiftLangSupport(SourceKit::Context &SKCtx);
   ~SwiftLangSupport();
 
-  SourceKit::Context &getContext() { return SKCtx; }
+  std::shared_ptr<NotificationCenter> getNotificationCenter() const {
+    return NotificationCtr.lock();
+  }
 
   StringRef getRuntimeResourcePath() const { return RuntimeResourcePath; }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -274,13 +274,13 @@ class SwiftLangSupport : public LangSupport {
   std::weak_ptr<NotificationCenter> NotificationCtr;
   std::string RuntimeResourcePath;
   std::shared_ptr<SwiftASTManager> ASTMgr;
-  SwiftEditorDocumentFileMap EditorDocuments;
+  std::shared_ptr<SwiftEditorDocumentFileMap> EditorDocuments;
   SwiftInterfaceGenMap IFaceGenContexts;
   ThreadSafeRefCntPtr<SwiftCompletionCache> CCCache;
   ThreadSafeRefCntPtr<SwiftPopularAPI> PopularAPI;
   CodeCompletion::SessionCacheMap CCSessions;
   ThreadSafeRefCntPtr<SwiftCustomCompletions> CustomCompletions;
-  SwiftStatistics Stats;
+  std::shared_ptr<SwiftStatistics> Stats;
 
 public:
   explicit SwiftLangSupport(SourceKit::Context &SKCtx);
@@ -294,13 +294,11 @@ public:
 
   SwiftASTManager &getASTManager() { return *ASTMgr; }
 
-  SwiftEditorDocumentFileMap &getEditorDocuments() { return EditorDocuments; }
+  std::shared_ptr<SwiftEditorDocumentFileMap> getEditorDocuments() { return EditorDocuments; }
   SwiftInterfaceGenMap &getIFaceGenContexts() { return IFaceGenContexts; }
   IntrusiveRefCntPtr<SwiftCompletionCache> getCodeCompletionCache() {
     return CCCache;
   }
-
-  SwiftStatistics &getStatistics() { return Stats; }
 
   static SourceKit::UIdent getUIDForDecl(const swift::Decl *D,
                                          bool IsRef = false);

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1372,7 +1372,7 @@ static void resolveCursor(SwiftLangSupport &Lang,
   const void *Once = nullptr;
   if (CancelOnSubsequentRequest)
     Once = Actionables ? &OncePerASTTokenWithActionables : &OncePerASTToken;
-  Lang.getASTManager().processASTAsync(Invok, std::move(Consumer), Once);
+  Lang.getASTManager()->processASTAsync(Invok, std::move(Consumer), Once);
 }
 
 static void resolveName(SwiftLangSupport &Lang, StringRef InputFile,
@@ -1459,7 +1459,7 @@ static void resolveName(SwiftLangSupport &Lang, StringRef InputFile,
   auto Consumer = std::make_shared<NameInfoConsumer>(
     InputFile, Offset, Lang, Invok, TryExistingAST, Input, Receiver);
 
-  Lang.getASTManager().processASTAsync(Invok, std::move(Consumer), nullptr);
+  Lang.getASTManager()->processASTAsync(Invok, std::move(Consumer), nullptr);
 }
 
 static void resolveRange(SwiftLangSupport &Lang,
@@ -1547,7 +1547,7 @@ static void resolveRange(SwiftLangSupport &Lang,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;
   const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
-  Lang.getASTManager().processASTAsync(Invok, std::move(Consumer), Once);
+  Lang.getASTManager()->processASTAsync(Invok, std::move(Consumer), Once);
 }
 
 void SwiftLangSupport::getCursorInfo(
@@ -1773,7 +1773,7 @@ resolveCursorFromUSR(SwiftLangSupport &Lang, StringRef InputFile, StringRef USR,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;
   const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
-  Lang.getASTManager().processASTAsync(Invok, std::move(Consumer), Once);
+  Lang.getASTManager()->processASTAsync(Invok, std::move(Consumer), Once);
 }
 
 void SwiftLangSupport::getCursorInfoFromUSR(
@@ -2021,5 +2021,5 @@ semanticRefactoring(StringRef Filename, SemanticRefactoringInfo Info,
   /// FIXME: When request cancellation is implemented and Xcode adopts it,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;
-  getASTManager().processASTAsync(Invok, std::move(Consumer), &OncePerASTToken);
+  getASTManager()->processASTAsync(Invok, std::move(Consumer), &OncePerASTToken);
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -562,7 +562,7 @@ tryRemappingLocToLatestSnapshot(SwiftLangSupport &Lang,
                                 StringRef Filename,
                          ArrayRef<ImmutableTextSnapshotRef> PreviousASTSnaps) {
   ImmutableTextSnapshotRef LatestSnap;
-  if (auto EditorDoc = Lang.getEditorDocuments().findByPath(Filename))
+  if (auto EditorDoc = Lang.getEditorDocuments()->findByPath(Filename))
     LatestSnap = EditorDoc->getLatestSnapshot();
   if (!LatestSnap)
     return Range;
@@ -1143,7 +1143,7 @@ public:
     // blocked waiting on the AST to be fully typechecked.
 
     ImmutableTextSnapshotRef InputSnap;
-    if (auto EditorDoc = Lang.getEditorDocuments().findByPath(InputFile))
+    if (auto EditorDoc = Lang.getEditorDocuments()->findByPath(InputFile))
       InputSnap = EditorDoc->getLatestSnapshot();
       if (!InputSnap)
         return false;

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -111,7 +111,7 @@ void sourcekitd::initialize() {
   llvm::EnablePrettyStackTrace();
   GlobalCtx = new SourceKit::Context(sourcekitd::getRuntimeLibPath(),
                                      SourceKit::createSwiftLangSupport);
-  GlobalCtx->getNotificationCenter().addDocumentUpdateNotificationReceiver(
+  GlobalCtx->getNotificationCenter()->addDocumentUpdateNotificationReceiver(
     onDocumentUpdateNotification);
 }
 void sourcekitd::shutdown() {

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -122,7 +122,7 @@ public:
   }
 
   void addNotificationReceiver(DocumentUpdateNotificationReceiver Receiver) {
-    Ctx.getNotificationCenter().addDocumentUpdateNotificationReceiver(Receiver);
+    Ctx.getNotificationCenter()->addDocumentUpdateNotificationReceiver(Receiver);
   }
 
   void open(const char *DocName, StringRef Text,

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -114,7 +114,7 @@ public:
                                  SourceKit::createSwiftLangSupport,
                                  /*dispatchOnMain=*/false);
     auto localDocUpdState = std::make_shared<DocUpdateMutexState>();
-    Ctx->getNotificationCenter().addDocumentUpdateNotificationReceiver(
+    Ctx->getNotificationCenter()->addDocumentUpdateNotificationReceiver(
         [localDocUpdState](StringRef docName) {
           std::unique_lock<std::mutex> lk(localDocUpdState->Mtx);
           localDocUpdState->HasUpdate = true;
@@ -133,7 +133,7 @@ public:
   }
 
   void addNotificationReceiver(DocumentUpdateNotificationReceiver Receiver) {
-    Ctx->getNotificationCenter().addDocumentUpdateNotificationReceiver(Receiver);
+    Ctx->getNotificationCenter()->addDocumentUpdateNotificationReceiver(Receiver);
   }
 
   bool waitForDocUpdate(bool reset = false) {


### PR DESCRIPTION
Shutdown of the service immediately destroys the global context, but parts of the context (ASTManager, NotificationCenter, EditorDocumentMap) are referenced by asynchronous AST builds, which could cause use-after-free.  The solution is to move these values under `shared_ptr` and `weak_ptr` to fix the lifetime.

This issue was seen (rarely) when running under ASan in CI, but can be made more likely to occur by calling `sleep` right before exiting.  This has always been an issue, but is unlikely to be detected without ASan if your process exits immediately after shutting down sourcekitd, which seems to be common.

rdar://problem/43121217