### PR TITLE
[Sema] Diagnose 'init' use as identifier in "case" statements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4175,6 +4175,11 @@ ERROR(possibly_non_exhaustive_switch,none,
       "the compiler is unable to check that this switch is exhaustive in reasonable time",
       ())
 
+ERROR(case_keyword_used_as_identifier,none,
+      "keyword '%0' cannot be used as an identifier here", (StringRef))
+NOTE(case_use_backticks_to_escape,none,
+     "use backticks to escape it", ())
+
 NOTE(missing_several_cases,none,
      "do you want to add "
      "%select{missing cases|a default clause}0"

--- a/test/stmt/switch_stmt1.swift
+++ b/test/stmt/switch_stmt1.swift
@@ -5,9 +5,35 @@ enum E {
   case e2
 }
 
+enum E2 {
+  case `init`, `subscript`, foo, bar
+}
+
 func foo1(e : E, i : Int) {
   switch e {} // expected-error{{switch must be exhaustive}}
   // expected-note@-1 {{missing case: '.e1'}}
   // expected-note@-2 {{missing case: '.e2'}}
   switch i {} // expected-error{{'switch' statement body must have at least one 'case' or 'default' block; do you want to add a default case?}}{{13-13=default:\n<#code#>\n}}
+}
+
+func foo2(e: E2) {
+  switch (e) {
+  case .init: break
+  // expected-error@-1 {{keyword 'init' cannot be used as an identifier here}}
+  // expected-note@-2 {{use backticks to escape it}} {{9-13=`init`}}
+  case .subscript: break // Ok
+  default: break
+  }
+
+  switch (e) {
+  case .init, .foo: break
+  // expected-error@-1 {{keyword 'init' cannot be used as an identifier here}}
+  // expected-note@-2 {{use backticks to escape it}} {{9-13=`init`}}
+  case .subscript, .bar: break // Ok
+  }
+
+  switch (e) {
+  case .`init`, .subscript: break // Ok
+  case .foo, .bar: break
+  }
 }


### PR DESCRIPTION
Provide a diagnostic which points out that 'init' can only
be used in "case" statements when properly escaped.

Resolves: rdar://problem/44751408

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
