### PR TITLE
build: create a helper function to define custom targets

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -44,81 +44,57 @@ if(SWIFT_BUILD_STATIC_STDLIB)
   list(APPEND SWIFT_STDLIB_LIBRARY_BUILD_TYPES STATIC)
 endif()
 
-add_custom_target(swift-stdlib-all)
-add_custom_target(swift-stdlib-sib-all)
-add_custom_target(swift-stdlib-sibopt-all)
-add_custom_target(swift-stdlib-sibgen-all)
-foreach(SDK ${SWIFT_SDKS})
-  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
-  add_custom_target("swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
-  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib")
-  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt")
-  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen")
+function(swift_create_stdlib_targets name variant define_all_alias)
+  if(NOT variant STREQUAL "")
+    set(variant "-${variant}")
+  endif()
 
-  set_property(TARGET
-      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-      "swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib"
-      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt"
-      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen"
-      PROPERTY FOLDER "Swift libraries/Aggregate")
+  if(define_all_alias)
+    add_custom_target(${name}${variant}-all)
+    set_target_properties(${name}${variant}-all
+      PROPERTIES
+      FOLDER "Swift libraries/Aggregate")
+  endif()
 
-  foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
-    set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
-    add_custom_target("swift-stdlib${VARIANT_SUFFIX}")
-    add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sib")
-    add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibopt")
-    add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibgen")
-    add_custom_target("swift-test-stdlib${VARIANT_SUFFIX}")
+  foreach(sdk ${SWIFT_SDKS})
+    add_custom_target(${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}${variant})
+    set_target_properties(${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}${variant}
+      PROPERTIES
+      FOLDER "Swift libraries/Aggregate")
 
-    set_property(TARGET
-        "swift-stdlib${VARIANT_SUFFIX}"
-        "swift-stdlib${VARIANT_SUFFIX}-sib"
-        "swift-stdlib${VARIANT_SUFFIX}-sibopt"
-        "swift-stdlib${VARIANT_SUFFIX}-sibgen"
-        "swift-test-stdlib${VARIANT_SUFFIX}"
-        PROPERTY FOLDER "Swift libraries/Aggregate")
+    foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+      set(target_variant -${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch})
 
-    add_dependencies(swift-stdlib-all "swift-stdlib${VARIANT_SUFFIX}")
-    add_dependencies(swift-stdlib-sib-all "swift-stdlib${VARIANT_SUFFIX}-sib")
-    add_dependencies(swift-stdlib-sibopt-all "swift-stdlib${VARIANT_SUFFIX}-sibopt")
-    add_dependencies(swift-stdlib-sibgen-all "swift-stdlib${VARIANT_SUFFIX}-sibgen")
-
-    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-      "swift-stdlib${VARIANT_SUFFIX}")
-    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib"
-      "swift-stdlib${VARIANT_SUFFIX}-sib")
-    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt"
-        "swift-stdlib${VARIANT_SUFFIX}-sibopt")
-    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen"
-        "swift-stdlib${VARIANT_SUFFIX}-sibgen")
-
-    add_dependencies("swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-        "swift-test-stdlib${VARIANT_SUFFIX}")
+      add_custom_target(${name}${target_variant}${variant})
+      set_target_properties(${name}${target_variant}${variant}
+        PROPERTIES
+        FOLDER "Swift libraries/Aggregate")
+      if(define_all_alias)
+        add_dependencies(${name}${variant}-all
+          ${name}${target_variant}${variant})
+      endif()
+      add_dependencies(${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}${variant}
+        ${name}${target_variant}${variant})
+    endforeach()
   endforeach()
-endforeach()
-add_custom_target(swift-stdlib
-    DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}")
-add_custom_target(swift-stdlib-sib
-  DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sib")
-add_custom_target(swift-stdlib-sibopt
-  DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sibopt")
-add_custom_target(swift-stdlib-sibgen
-    DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sibgen")
-add_custom_target(swift-test-stdlib ALL
-    DEPENDS "swift-test-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}")
 
-set_property(TARGET
-    swift-stdlib-all
-    swift-stdlib-sib-all
-    swift-stdlib-sibopt-all
-    swift-stdlib-sibgen-all
-    swift-stdlib
-    swift-stdlib-sib
-    swift-stdlib-sibopt
-    swift-stdlib-sibgen
-    swift-test-stdlib
-    PROPERTY FOLDER "Swift libraries/Aggregate")
+  if(NOT define_all_alias)
+    set(ALL_keyword ALL)
+  endif()
+  add_custom_target(${name}${variant}
+    ${ALL_keyword}
+    DEPENDS
+    ${name}${SWIFT_PRIMARY_VARIANT_SUFFIX}${variant})
+  set_target_properties(${name}${variant}
+    PROPERTIES
+    FOLDER "Swift libraries/Aggregate")
+endfunction()
+
+swift_create_stdlib_targets("swift-stdlib" "" TRUE)
+swift_create_stdlib_targets("swift-stdlib" "sib" TRUE)
+swift_create_stdlib_targets("swift-stdlib" "sibopt" TRUE)
+swift_create_stdlib_targets("swift-stdlib" "sibgen" TRUE)
+swift_create_stdlib_targets("swift-test-stdlib" "" FALSE)
 
 add_subdirectory(public)
 add_subdirectory(private)


### PR DESCRIPTION
Replace the duplicated logic for defining the targets for the standard
library variants with a call to a function that creates the targets.
This allows us to easily add variants of the standard library without
having to track all the sites for the name.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
