### PR TITLE
[IRGenSIL] DI variable decl for visitAllocBoxInst is always indirect.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4190,8 +4190,7 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
   IGM.DebugInfo->emitVariableDeclaration(
       Builder,
       Storage,
-      DbgTy, i->getDebugScope(), Decl, Name, 0,
-      DbgTy.isImplicitlyIndirect() ? DirectValue : IndirectValue);
+      DbgTy, i->getDebugScope(), Decl, Name, 0, IndirectValue);
 }
 
 void IRGenSILFunction::visitProjectBoxInst(swift::ProjectBoxInst *i) {


### PR DESCRIPTION
This code is presumably dead, and now we're a step closer to
remove the broken isImplicitlyIndirect().

<rdar://problem/44744592>
