### PR TITLE
[4.2] Allow '@usableFromInline' on 'dynamic' decls

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3844,9 +3844,6 @@ WARNING(inlinable_implies_usable_from_inline,none,
 ERROR(usable_from_inline_attr_in_protocol,none,
       "'@usableFromInline' attribute cannot be used in protocols", ())
 
-ERROR(usable_from_inline_dynamic_not_supported,none,
-      "'@usableFromInline' attribute cannot be applied to 'dynamic' declarations", ())
-
 #define FRAGILE_FUNC_KIND \
   "%select{a '@_transparent' function|" \
   "an '@inline(__always)' function|" \

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1970,13 +1970,6 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
     return;
   }
 
-  // Symbols of dynamically-dispatched declarations are never referenced
-  // directly, so marking them as @usableFromInline does not make sense.
-  if (VD->isDynamic()) {
-    diagnoseAndRemoveAttr(attr, diag::usable_from_inline_dynamic_not_supported);
-    return;
-  }
-
   // On internal declarations, @inlinable implies @usableFromInline.
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
     if (TC.Context.isSwiftVersionAtLeast(4,2))

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2286,13 +2286,10 @@ class User: NSObject {
   }
 }
 
-// 'dynamic' methods cannot be @inlinable or @usableFromInline
+// 'dynamic' methods cannot be @inlinable.
 class BadClass {
   @inlinable @objc dynamic func badMethod1() {}
   // expected-error@-1 {{'@inlinable' attribute cannot be applied to 'dynamic' declarations}}
-
-  @usableFromInline @objc dynamic func badMethod2() {}
-  // expected-error@-1 {{'@usableFromInline' attribute cannot be applied to 'dynamic' declarations}}
 }
 
 @objc

--- a/test/attr/attr_usableFromInline.swift
+++ b/test/attr/attr_usableFromInline.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -enable-testing
+// RUN: %target-typecheck-verify-swift -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-typecheck-verify-swift -enable-testing -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 @usableFromInline private func privateVersioned() {}
 // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}
@@ -65,4 +65,10 @@ public func usesEqEnum() -> Bool {
 
   _ = RawEnum.foo.rawValue
   _ = RawEnum(rawValue: 0)
+}
+
+public class DynamicMembers {
+  @usableFromInline @objc dynamic init() {}
+  @usableFromInline @objc dynamic func foo() {}
+  @usableFromInline @objc dynamic var bar: Int = 0
 }


### PR DESCRIPTION
- **Explanation**: In Swift 4.2 we allowed inlinable functions to reference `dynamic` declarations regardless of whether they were `@usableFromInline`, but that breaks assumptions elsewhere in the compiler. We're going to enforce that restriction in Swift 5, but it would break source compatibility at this point to do so in Swift 4.2. This patch *allows* `@usableFromInline` to be written on `dynamic` declarations in Swift 4.2 without *requiring* it, so that there'll be one spelling that works everywhere.
- **Scope**: Only affects `dynamic` declarations, but unfortunately any `@objc` member in an extension is inferred to be one of those.
- **Risk**: Very low. This change removes a diagnostic and does nothing else; all existing code paths should work for the newly-supported code.
- **Testing**: Added a compiler regression test; more testing coming on master.
- **Reviewer**: @slavapestov 

See also #19522.