### PR TITLE
[stdlib] Remove RNG's next extension methods from public interface

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2441,23 +2441,23 @@ where Self.RawSignificand : FixedWidthInteger {
       delta.isFinite,
       "There is no uniform distribution on an infinite range"
     )
-    let rand: Self.RawSignificand
-    if Self.RawSignificand.bitWidth == Self.significandBitCount + 1 {
-      rand = generator.next()
+    let rand: RawSignificand
+    if RawSignificand.bitWidth == Self.significandBitCount + 1 {
+      rand = RawSignificand._random(using: &generator)
 %     if 'Closed' in Range:
-      let tmp: UInt8 = generator.next() & 1
-      if rand == Self.RawSignificand.max && tmp == 1 {
+      let tmp = UInt8._random(using: &generator) & 1
+      if rand == RawSignificand.max && tmp == 1 {
         return range.upperBound
       }
 %     end
     } else {
       let significandCount = Self.significandBitCount + 1
-      let maxSignificand: Self.RawSignificand = 1 << significandCount
+      let maxSignificand: RawSignificand = 1 << significandCount
 %     if 'Closed' not in Range:
       // Rather than use .next(upperBound:), which has to work with arbitrary
       // upper bounds, and therefore does extra work to avoid bias, we can take
       // a shortcut because we know that maxSignificand is a power of two.
-      rand = generator.next() & (maxSignificand - 1)
+      rand = RawSignificand._random(using: &generator) & (maxSignificand - 1)
 %     else:
       rand = generator.next(upperBound: maxSignificand + 1)
       if rand == maxSignificand {

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -2621,7 +2621,7 @@ extension FixedWidthInteger {
     // If we used &+ instead, the result would be zero, which isn't helpful,
     // so we actually need to handle this case separately.
     if delta == Magnitude.max {
-      return Self(truncatingIfNeeded: generator.next() as Magnitude)
+      return Self(truncatingIfNeeded: Magnitude._random(using: &generator))
     }
     // Need to widen delta to account for the right-endpoint of a closed range.
     delta += 1


### PR DESCRIPTION
This is currently pending core team approval/evolution review. [Evolution Post](https://forums.swift.org/t/se-0202-amendment-remove-rngs-next-extension-methods/16457) and [Evolution PR](https://github.com/apple/swift-evolution/pull/912)

The generic version of `next<T>() -> T` was causing an issue where implementers of `RandomNumberGenerator` were not required to write `next() -> UInt64` requirement. This patch removes both the extension methods on `RandomNumberGenerator` from public interface (I actually removed `next<T>() -> T` because it was a one-liner for `T._random(using:)`.) Users are encouraged to write somewhat more meaningful code like `Int.random(in: 0 ..< 10, using: &generator)`. 

Resolves: [SR-8758](https://bugs.swift.org/browse/SR-8758)

cc: @airspeedswift @stephentyrone 