### PR TITLE
[stdlib] Remove redundant >, <=, >= on Comparable types

### DIFF
--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -183,7 +183,8 @@ extension Comparable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  @inlinable
+  // Transparent because some use with literals generate compile-time warnings.
+  @_transparent
   public static func > (lhs: Self, rhs: Self) -> Bool {
     return rhs < lhs
   }
@@ -197,7 +198,8 @@ extension Comparable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  @inlinable
+  // Transparent because some use with literals generate compile-time warnings.
+  @_transparent
   public static func <= (lhs: Self, rhs: Self) -> Bool {
     return !(rhs < lhs)
   }
@@ -213,7 +215,8 @@ extension Comparable {
   ///   - rhs: Another value to compare.
   /// - Returns: `true` if `lhs` is greater than or equal to `rhs`; otherwise,
   ///   `false`.
-  @inlinable
+  // Transparent because some use with literals generate compile-time warnings.
+  @_transparent
   public static func >= (lhs: Self, rhs: Self) -> Bool {
     return !(lhs < rhs)
   }

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1424,21 +1424,6 @@ extension FloatingPoint {
   public static func < (lhs: Self, rhs: Self) -> Bool {
     return lhs.isLess(than: rhs)
   }
-
-  @_transparent
-  public static func <= (lhs: Self, rhs: Self) -> Bool {
-    return lhs.isLessThanOrEqualTo(rhs)
-  }
-
-  @_transparent
-  public static func > (lhs: Self, rhs: Self) -> Bool {
-    return rhs.isLess(than: lhs)
-  }
-
-  @_transparent
-  public static func >= (lhs: Self, rhs: Self) -> Bool {
-    return rhs.isLessThanOrEqualTo(lhs)
-  }
 }
 
 /// A radix-2 (binary) floating-point type.

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1771,20 +1771,6 @@ ${assignmentOperatorComment(x.operator, True)}
 
 %   end
 
-  @_transparent
-  public static func <= (lhs: ${Self}, rhs: ${Self}) -> Bool {
-    return !(rhs < lhs)
-  }
-
-  @_transparent
-  public static func >= (lhs: ${Self}, rhs: ${Self}) -> Bool {
-    return !(lhs < rhs)
-  }
-
-  @_transparent
-  public static func > (lhs: ${Self}, rhs: ${Self}) -> Bool {
-    return rhs < lhs
-  }
 }
 
 


### PR DESCRIPTION
Very similar to #19535 but for `Comparable`