### PR TITLE
[CSBindings] Don't consider dependent member types even if they are w…

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -118,8 +118,11 @@ Optional<Type> ConstraintSystem::checkTypeOfBinding(TypeVariableType *typeVar,
     return None;
   }
 
-  // Don't bind to a dependent member type.
-  if (type->is<DependentMemberType>()) return None;
+  // Don't bind to a dependent member type, even if it's currently
+  // wrapped in any number of optionals, because binding producer
+  // might unwrap and try to attempt it directly later.
+  if (type->lookThroughAllOptionalTypes()->is<DependentMemberType>())
+    return None;
 
   // Okay, allow the binding (with the simplified type).
   return type;

--- a/validation-test/compiler_crashers_2_fixed/0174-rdar44770297.swift
+++ b/validation-test/compiler_crashers_2_fixed/0174-rdar44770297.swift
@@ -1,0 +1,11 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+protocol P {
+  associatedtype A
+}
+
+func foo<T: P>(_: () throws -> T) -> T.A? {
+  fatalError()
+}
+
+_ = foo() { fatalError() } & nil


### PR DESCRIPTION
…rapped in optionals

Because binding producer is going to attempt to unwrap optionals
and try the type, which would lead to infinite recursion because
dependent member types aren't bindable.

Resolves: rdar://problem/44770297

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
