### PR TITLE
Relaxed the checks in SILDeserializer::readSILFunctionChecked()

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -430,8 +430,9 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     break;
     
   case SILStage::Lowered:
-    llvm_unreachable("cannot deserialize into a module that has entered "
-                     "Lowered stage");
+    if (!declarationOnly)
+      llvm_unreachable("cannot deserialize into a module that has entered "
+                       "Lowered stage");
   }
   
   if (FID == 0)


### PR DESCRIPTION
to allow deserializing SIL function decls/signatures (but not bodies) during IRGen phase.

This is needed in the tensorflow branch, where we want to generate calls to swift
functions (via their silgen names) in IRGen. e.g. the call generated at
https://github.com/apple/swift/blob/ad7def2c6bffd95d62e5e665c9faed0f8dac49f5/lib/IRGen/IRGenSIL.cpp#L1956-L1957,
where the swift function is defined at https://github.com/apple/swift/blob/ad7def2c6bffd95d62e5e665c9faed0f8dac49f5/stdlib/public/TensorFlow/CompilerRuntime.swift#L1163-L1167.

https://github.com/apple/swift/pull/19524 has more context.
