### PR TITLE
[Runtime] Properly form generic arguments for metadata-to-demangle-tree.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -527,7 +527,7 @@ _findNominalTypeDescriptor(Demangle::NodePointer node,
                          [&](const void *context) -> NodePointer {
                            return _buildDemanglingForContext(
                                (const ContextDescriptor *) context,
-                               {}, false, Dem);
+                               {}, Dem);
                          });
 
   // Look for an existing entry.
@@ -662,7 +662,7 @@ _findProtocolDescriptor(const Demangle::NodePointer &node,
                          [&](const void *context) -> NodePointer {
                            return _buildDemanglingForContext(
                                (const ContextDescriptor *) context,
-                               {}, false, Dem);
+                               {}, Dem);
                          });
 
   // Look for an existing entry.

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -345,7 +345,6 @@ public:
   Demangle::NodePointer
   _buildDemanglingForContext(const ContextDescriptor *context,
                              llvm::ArrayRef<NodePointer> demangledGenerics,
-                             bool concretizedGenerics,
                              Demangle::Demangler &Dem);
   
   /// Symbolic reference resolver that produces the demangling tree for the
@@ -360,7 +359,7 @@ public:
       auto descriptor =
         (const ContextDescriptor *)detail::applyRelativeOffset(base, offset);
       
-      return _buildDemanglingForContext(descriptor, {}, false, Dem);
+      return _buildDemanglingForContext(descriptor, {}, Dem);
     }
   };
 

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -1822,9 +1822,8 @@ mirrors.test("GenericNestedWithSameTypeConstraints") {
   var output = ""
   dump(value, to: &output)
 
-  // FIXME: The generic arguments are in the wrong place
   let expected =
-    "▿ (extension in Mirror):Mirror.OuterTwoParams.InnerEqualParams<Mirror.ConformsToP1AndP2, Mirror.ConformsToP3>\n" +
+    "▿ (extension in Mirror):Mirror.OuterTwoParams<Mirror.ConformsToP1AndP2, Mirror.ConformsToP1AndP2>.InnerEqualParams<Mirror.ConformsToP3>\n" +
     "  - x: Mirror.ConformsToP1AndP2\n" +
     "  - y: Mirror.ConformsToP1AndP2\n" +
     "  - z: Mirror.ConformsToP3\n"

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -782,8 +782,8 @@ RuntimeClassNamesTestSuite.test("private class nested in same-type-constrained e
   let clas = unsafeBitCast(type(of: util), to: NSObject.self)
   // Name should look like _TtC1aP.*Inner
   let desc = clas.description
-  expectEqual(desc.prefix(7), "_TtC1aP")
-  expectEqual(desc.suffix(5), "Inner")
+  expectEqual("_TtGC1a", desc.prefix(7))
+  expectEqual("Data_", desc.suffix(5))
 }
 
 runAllTests()

--- a/test/stdlib/TypeName.swift
+++ b/test/stdlib/TypeName.swift
@@ -203,9 +203,9 @@ extension SomeOuterGenericClass where T == Int {
 }
 
 TypeNameTests.test("NestedInConstrainedExtension") {
-  expectEqual("(extension in main):main.SomeOuterGenericClass.AnotherInnerStruct",
+  expectEqual("(extension in main):main.SomeOuterGenericClass<Swift.Int>.AnotherInnerStruct",
               _typeName(SomeOuterGenericClass<Int>.AnotherInnerStruct.self));
-  expectEqual("(extension in main):main.SomeOuterGenericClass.AnotherInnerGenericStruct<Swift.String>",
+  expectEqual("(extension in main):main.SomeOuterGenericClass<Swift.Int>.AnotherInnerGenericStruct<Swift.String>",
               _typeName(SomeOuterGenericClass<Int>.AnotherInnerGenericStruct<String>.self));
 }
 


### PR DESCRIPTION
When mapping from type metadata to a demangle tree, fill in the complete
set of generic arguments. Most of the effort here is in dealing with
extensions that involve same-type constraints on a generic parameter, e.g.,

```swift
extension Array where String == Element { }
extension Dictionary where Key == Value { }
```

In such cases, the metadata won’t contain generic arguments for every
generic parameter. Rather, the generic arguments for non-key generic
parameters will need to be computed based on the same-type requirements
of the context. Do so, and eliminate the old hacks that put the generic
arguments on the innermost type. We don’t need them any more.

Part of rdar://problem/37170296.
