### PR TITLE
Remove FunctionType::getInput()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5954,9 +5954,6 @@ public:
   SourceLoc getStartLoc() const { return getConstructorLoc(); }
   SourceRange getSourceRange() const;
 
-  /// getArgumentInterfaceType - get the interface type of the argument tuple
-  Type getArgumentInterfaceType() const;
-
   /// \brief Get the interface type of the constructed object.
   Type getResultInterfaceType() const;
 

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -217,14 +217,14 @@ class TypeMatcher {
           if (firstElt.getLabel() != secondElt.getLabel() ||
               firstElt.isVariadic() != secondElt.isVariadic() ||
               firstElt.isInOut() != secondElt.isInOut())
-            return mismatch(firstElt.getType().getPointer(),
-                            secondElt.getType(),
-                            sugaredFirstFunc->getParams()[i].getType());
+            return mismatch(firstElt.getOldType().getPointer(),
+                            secondElt.getOldType(),
+                            sugaredFirstFunc->getParams()[i].getOldType());
 
           // Recurse on parameter components.
-          if (!this->visit(firstElt.getType()->getCanonicalType(),
-                           secondElt.getType(),
-                           sugaredFirstFunc->getParams()[i].getType()))
+          if (!this->visit(firstElt.getOldType()->getCanonicalType(),
+                           secondElt.getOldType(),
+                           sugaredFirstFunc->getParams()[i].getOldType()))
             return false;
         }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2647,13 +2647,21 @@ public:
     ParameterTypeFlags Flags = {};
     
   public:
-    /// FIXME(Remove InOutType): This is mostly for copying between param
-    /// types and should go away.
-    Type getType() const;
+    /// FIXME: Remove this. Return the formal type of the parameter in the
+    /// function type, including the InOutType if there is one.
+    ///
+    /// For example, 'inout Int' => 'inout Int', 'Int...' => 'Int'.
+    Type getOldType() const;
 
+    /// Return the formal type of the parameter.
+    ///
+    /// For example, 'inout Int' => 'Int', 'Int...' => 'Int'.
     Type getPlainType() const { return Ty; }
 
-    /// The type of the parameter.  Adjusts for varargs, but not inout.
+    /// The type of the parameter when referenced inside the function body
+    /// as an rvalue.
+    ///
+    /// For example, 'inout Int' => 'Int', 'Int...' => '[Int]'.
     Type getParameterType(bool forCanonical = false,
                           ASTContext *ctx = nullptr) const;
 
@@ -2699,7 +2707,7 @@ public:
   public:
     static CanParam getFromParam(const Param &param) { return CanParam(param); }
 
-    CanType getType() const { return CanType(Param::getType()); }
+    CanType getOldType() const { return CanType(Param::getOldType()); }
     CanType getPlainType() const { return CanType(Param::getPlainType()); }
     CanType getParameterType() const {
       return CanType(Param::getParameterType(/*forCanonical*/ true));

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1029,8 +1029,8 @@ FuncDecl *ASTContext::getEqualIntDecl() const {
                                  intType, [=](FunctionType *type) {
     // Check for the signature: (Int, Int) -> Bool
     if (type->getParams().size() != 2) return false;
-    if (!type->getParams()[0].getType()->isEqual(intType) ||
-        !type->getParams()[1].getType()->isEqual(intType)) return false;
+    if (!type->getParams()[0].getOldType()->isEqual(intType) ||
+        !type->getParams()[1].getOldType()->isEqual(intType)) return false;
     return type->getResult()->isEqual(boolType);
   });
   getImpl().EqualIntDecl = decl;
@@ -1046,7 +1046,7 @@ FuncDecl *ASTContext::getGetBoolDecl(LazyResolver *resolver) const {
                                          resolver, [=](FunctionType *type) {
     // Look for the signature (Builtin.Int1) -> Bool
     if (type->getParams().size() != 1) return false;
-    if (!isBuiltinInt1Type(type->getParams()[0].getType())) return false;
+    if (!isBuiltinInt1Type(type->getParams()[0].getOldType())) return false;
     return type->getResult()->isEqual(boolType);
   });
   getImpl().GetBoolDecl = decl;
@@ -1238,7 +1238,7 @@ FuncDecl *ASTContext::getIsOSVersionAtLeastDecl(LazyResolver *resolver) const {
     return nullptr;
 
   if (llvm::any_of(intrinsicsParams, [](const AnyFunctionType::Param &p) {
-    return !isBuiltinWordType(p.getType());
+    return !isBuiltinWordType(p.getOldType());
   })) {
     return nullptr;
   }
@@ -3155,11 +3155,8 @@ Type TupleTypeElt::getType() const {
   return ElementType;
 }
 
-Type AnyFunctionType::Param::getType() const {
+Type AnyFunctionType::Param::getOldType() const {
   if (Flags.isInOut()) return InOutType::get(Ty);
-  // FIXME: Callers are inconsistenly setting this flag and retrieving this
-  // type with and without the Array Slice type.
-//  if (Flags.isVariadic()) return ArraySliceType::get(Ty);
   return Ty;
 }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3404,7 +3404,7 @@ namespace {
         if (param.hasLabel())
           printField("name", param.getLabel().str());
         dumpParameterFlags(param.getParameterFlags());
-        printRec(param.getType());
+        printRec(param.getOldType());
         OS << ")";
       }
       Indent -= 2;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5765,7 +5765,9 @@ Type EnumElementDecl::getArgumentInterfaceType() const {
 
   auto funcTy = interfaceType->castTo<AnyFunctionType>();
   funcTy = funcTy->getResult()->castTo<FunctionType>();
-  return funcTy->getInput();
+  return AnyFunctionType::composeInput(funcTy->getASTContext(),
+                                       funcTy->getParams(),
+                                       /*canonicalVararg=*/false);
 }
 
 EnumCaseDecl *EnumElementDecl::getParentCase() const {
@@ -5799,13 +5801,6 @@ SourceRange ConstructorDecl::getSourceRange() const {
     End = getSignatureSourceRange().End;
 
   return { getConstructorLoc(), End };
-}
-
-Type ConstructorDecl::getArgumentInterfaceType() const {
-  Type ArgTy = getInterfaceType();
-  ArgTy = ArgTy->castTo<AnyFunctionType>()->getResult();
-  ArgTy = ArgTy->castTo<AnyFunctionType>()->getInput();
-  return ArgTy;
 }
 
 Type ConstructorDecl::getResultInterfaceType() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3772,7 +3772,7 @@ findProtocolSelfReferences(const ProtocolDecl *proto, Type type,
   if (auto funcTy = type->getAs<AnyFunctionType>()) {
     auto inputKind = SelfReferenceKind::None();
     for (auto &elt : funcTy->getParams()) {
-      inputKind |= findProtocolSelfReferences(proto, elt.getType(),
+      inputKind |= findProtocolSelfReferences(proto, elt.getOldType(),
                                               skipAssocTypes);
     }
     auto resultKind = findProtocolSelfReferences(proto, funcTy->getResult(),
@@ -3882,7 +3882,7 @@ ProtocolDecl::findProtocolSelfReferences(const ValueDecl *value,
     if (!allowCovariantParameters) {
       auto inputKind = SelfReferenceKind::None();
       for (auto &elt : type->castTo<AnyFunctionType>()->getParams()) {
-        inputKind |= ::findProtocolSelfReferences(this, elt.getType(),
+        inputKind |= ::findProtocolSelfReferences(this, elt.getOldType(),
                                                   skipAssocTypes);
       }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1119,12 +1119,10 @@ CanType TypeBase::computeCanonicalType() {
 
     if (genericSig) {
       Result = GenericFunctionType::get(genericSig, canParams, resultTy,
-                                        funcTy->getExtInfo(),
-                                        /*canonicalVararg=*/true);
+                                        funcTy->getExtInfo());
     } else {
       Result = FunctionType::get(canParams, resultTy,
-                                 funcTy->getExtInfo(),
-                                 /*canonicalVararg=*/true);
+                                 funcTy->getExtInfo());
     }
     assert(Result->isCanonical());
     break;
@@ -3740,15 +3738,13 @@ case TypeKind::Id:
 
       auto genericSig = genericFnType->getGenericSignature();
       return GenericFunctionType::get(genericSig, substParams, resultTy,
-                                      function->getExtInfo(),
-                                   /*canonicalVararg=*/function->isCanonical());
+                                      function->getExtInfo());
     }
 
     if (isUnchanged) return *this;
 
     return FunctionType::get(substParams, resultTy,
-                             function->getExtInfo(),
-                             /*canonicalVararg=*/function->isCanonical());
+                             function->getExtInfo());
   }
 
   case TypeKind::ArraySlice: {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2680,17 +2680,6 @@ Type ProtocolCompositionType::get(const ASTContext &C,
   return build(C, CanTypes, HasExplicitAnyObject);
 }
 
-bool AnyFunctionType::isCanonicalFunctionInputType(Type input) {
-  // Canonically, we should have a tuple type or parenthesized type.
-  if (auto tupleTy = dyn_cast<TupleType>(input.getPointer()))
-    return tupleTy->isCanonical();
-  if (auto parenTy = dyn_cast<ParenType>(input.getPointer()))
-    return parenTy->getUnderlyingType()->isCanonical();
-
-  // FIXME: Still required for the constraint solver.
-  return isa<TypeVariableType>(input.getPointer());
-}
-
 FunctionType *
 GenericFunctionType::substGenericArgs(SubstitutionMap subs) {
   auto substFn = Type(this).subst(subs)->castTo<AnyFunctionType>();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1538,8 +1538,8 @@ bool TypeBase::isBindableTo(Type b) {
           return false;
         
         for (unsigned i : indices(func->getParams())) {
-          if (!visit(func->getParams()[i].getType(),
-                     substFunc.getParams()[i].getType()))
+          if (!visit(func->getParams()[i].getOldType(),
+                     substFunc.getParams()[i].getOldType()))
             return false;
         }
         
@@ -1916,7 +1916,7 @@ getForeignRepresentable(Type type, ForeignLanguage language,
     for (const auto &param : functionType->getParams()) {
       if (param.isVariadic())
         return failure();
-      if (recurse(param.getType()))
+      if (recurse(param.getOldType()))
         return failure();
     }
 
@@ -2277,7 +2277,7 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
 
       // Inputs are contravariant.
       for (auto i : indices(fn2.getParams())) {
-        if (!matches(fn2Params[i].getType(), fn1Params[i].getType(),
+        if (!matches(fn2Params[i].getOldType(), fn1Params[i].getOldType(),
                      matchMode, ParameterPosition::ParameterTupleElement,
                      OptionalUnwrapping::None)) {
           return false;

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -85,7 +85,7 @@ class Traversal : public TypeVisitor<Traversal, bool>
 
   bool visitAnyFunctionType(AnyFunctionType *ty) {
     for (const auto &param : ty->getParams()) {
-      if (doIt(param.getType()))
+      if (doIt(param.getOldType()))
         return true;
     }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1648,7 +1648,7 @@ static std::pair<Type, ParamDecl *> decomposeSubscriptSetter(FuncDecl *setter) {
                          ->castTo<AnyFunctionType>()
                          ->getResult()
                          ->castTo<AnyFunctionType>()
-                         ->getParams().front().getType();
+                         ->getParams().front().getOldType();
   ParamDecl *keyDecl = PL->get(1);
 
   return {elementType, keyDecl};

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1567,7 +1567,7 @@ static bool hasTrivialTrailingClosure(const FuncDecl *FD,
   if (defaultMap.size() - defaultMap.count() == 1) {
     auto param = funcType->getParams().back();
     if (!param.isAutoClosure()) {
-      if (auto Fn = param.getType()->getAs<AnyFunctionType>()) {
+      if (auto Fn = param.getOldType()->getAs<AnyFunctionType>()) {
         return Fn->getParams().empty() && Fn->getResult()->isVoid();
       }
     }
@@ -3885,8 +3885,8 @@ public:
           if (seenNames.insert(Param.getLabel()).second)
             ExpectedNames.push_back(Param.getLabel().str());
         } else {
-          if (seenTypes.insert(Param.getType().getPointer()).second)
-            ExpectedTypes.push_back(Param.getType());
+          if (seenTypes.insert(Param.getOldType().getPointer()).second)
+            ExpectedTypes.push_back(Param.getOldType());
         }
       }
     }

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -935,7 +935,7 @@ static void VisitNodeConstructor(
             // inits are typed as (Foo.Type) -> (args...) -> Foo, but don't
             // assert that in case we're dealing with broken code.
             if (identifier_func->getParams().size() == 1 &&
-                identifier_func->getParams()[0].getType()->is<AnyMetatypeType>() &&
+                identifier_func->getParams()[0].getOldType()->is<AnyMetatypeType>() &&
                 identifier_func->getResult()->is<AnyFunctionType>()) {
               identifier_func =
                   identifier_func->getResult()->getAs<AnyFunctionType>();
@@ -1227,7 +1227,8 @@ static bool CompareFunctionTypes(const AnyFunctionType *f,
     auto label1 = getLabel(fLabels, param1, i);
     auto label2 = getLabel(gLabels, param2, i);
 
-    if (label1.equals(label2) && param1.getType()->isEqual(param2.getType()))
+    if (label1.equals(label2) &&
+        param1.getOldType()->isEqual(param2.getOldType()))
       continue;
 
     in_matches = false;

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3046,7 +3046,7 @@ void NecessaryBindings::addTypeMetadata(CanType type) {
   }
   if (auto fn = dyn_cast<FunctionType>(type)) {
     for (const auto &elt : fn.getParams())
-      addTypeMetadata(elt.getType());
+      addTypeMetadata(elt.getOldType());
     addTypeMetadata(fn.getResult());
     return;
   }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1909,7 +1909,7 @@ private:
     if (!FT->getParams().empty()) {
       interleave(FT->getParams(),
                  [this](const AnyFunctionType::Param &param) {
-                   print(param.getType(), OTK_None, param.getLabel(),
+                   print(param.getOldType(), OTK_None, param.getLabel(),
                          IsFunctionParam);
                  },
                  [this] { os << ", "; });
@@ -2061,7 +2061,7 @@ class ReferencedTypeFinder : public TypeVisitor<ReferencedTypeFinder> {
 
   void visitAnyFunctionType(AnyFunctionType *fnTy) {
     for (auto &param : fnTy->getParams())
-      visit(param.getType());
+      visit(param.getOldType());
     visit(fnTy->getResult());
   }
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -348,7 +348,7 @@ static SmallVector<CanType, 8>
 expandTupleTypes(AnyFunctionType::CanParamArrayRef params) {
   SmallVector<CanType, 8> results;
   for (auto param : params)
-    expandTupleTypes(param.getType(), results);
+    expandTupleTypes(param.getOldType(), results);
   return results;
 }
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -35,7 +35,7 @@ static SILValue emitConstructorMetatypeArg(SILGenFunction &SGF,
   auto ctorFnType = ctor->getInterfaceType()->castTo<AnyFunctionType>();
   assert(ctorFnType->getParams().size() == 1 &&
          "more than one self parameter?");
-  Type metatype = ctorFnType->getParams()[0].getType();
+  Type metatype = ctorFnType->getParams()[0].getOldType();
   auto *DC = ctor->getInnermostDeclContext();
   auto &AC = SGF.getASTContext();
   auto VD =

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -156,7 +156,7 @@ static std::pair<unsigned, unsigned> getTypeDepthAndWidth(Type t) {
     for (auto &Param : Params) {
       unsigned TypeWidth;
       unsigned TypeDepth;
-      std::tie(TypeDepth, TypeWidth) = getTypeDepthAndWidth(Param.getType());
+      std::tie(TypeDepth, TypeWidth) = getTypeDepthAndWidth(Param.getOldType());
       if (TypeDepth > MaxTypeDepth)
         MaxTypeDepth = TypeDepth;
       Width += TypeWidth;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -547,7 +547,7 @@ namespace {
       if (wantsRValueInstanceType)
         return base.getPlainType()->getMetatypeInstanceType();
 
-      return base.getType();
+      return base.getOldType();
     }
 
   public:
@@ -1441,7 +1441,7 @@ namespace {
         // Dig the key path expression out of the arguments.
         auto indexKP = cast<TupleExpr>(index)->getElement(0);
         auto keyPathExprTy = cs.getType(indexKP);
-        auto keyPathTy = applicationTy->getParams().front().getType();
+        auto keyPathTy = applicationTy->getParams().front().getOldType();
 
         Type valueTy;
         Type baseTy;
@@ -5584,7 +5584,7 @@ Expr *ExprRewriter::coerceCallArguments(
         return nullptr;
 
       // Record this parameter.
-      auto paramBaseType = param.getType();
+      auto paramBaseType = param.getOldType();
       assert(sliceType.isNull() && "Multiple variadic parameters?");
       sliceType = tc.getArraySliceType(arg->getLoc(), paramBaseType);
       toSugarFields.push_back(
@@ -5632,8 +5632,8 @@ Expr *ExprRewriter::coerceCallArguments(
       toSugarFields.push_back(TupleTypeElt(
                                 param.isVariadic()
                                   ? tc.getArraySliceType(arg->getLoc(),
-                                                         param.getType())
-                                  : param.getType(),
+                                                         param.getOldType())
+                                  : param.getOldType(),
                                 param.getLabel(),
                                 param.getParameterFlags()));
 
@@ -5657,7 +5657,7 @@ Expr *ExprRewriter::coerceCallArguments(
     sources.push_back(argIdx);
 
     // If the types exactly match, this is easy.
-    auto paramType = param.getType();
+    auto paramType = param.getOldType();
     if (argType->isEqual(paramType)) {
       toSugarFields.push_back(
           TupleTypeElt(param.getPlainType(), getArgLabel(argIdx),
@@ -6298,7 +6298,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
             // This handles situations like argument: (()), parameter: ().
             if (params1.size() == 1 && params2.empty()) {
-              auto tupleTy = params1.front().getType()->getAs<TupleType>();
+              auto tupleTy = params1.front().getOldType()->getAs<TupleType>();
               if (tupleTy && tupleTy->getNumElements() == 0)
                 break;
             }
@@ -7127,7 +7127,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         
         auto escapable = new (tc.Context)
           OpaqueValueExpr(apply->getFn()->getLoc(), Type());
-        cs.setType(escapable, escapableParams[0].getType());
+        cs.setType(escapable, escapableParams[0].getOldType());
 
         auto getType = [&](const Expr *E) -> Type {
           return cs.getType(E);

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6271,7 +6271,7 @@ bool FailureDiagnosis::diagnoseClosureExpr(
       // Before doing so, strip attributes off the function type so that they
       // don't confuse the issue.
       fnType = FunctionType::get(fnType->getParams(), fnType->getResult(),
-                                 fnType->getExtInfo(), false);
+                                 fnType->getExtInfo());
       auto diag = diagnose(
           params->getStartLoc(), diag::closure_argument_list_tuple, fnType,
           inferredArgCount, actualArgCount, (actualArgCount == 1));

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3078,7 +3078,7 @@ typeCheckArgumentChildIndependently(Expr *argExpr, Type argType,
           options |= TCC_AllowLValue;
 
         // Look at each of the arguments assigned to this parameter.
-        auto currentParamType = param.getType();
+        auto currentParamType = param.getOldType();
         for (auto inArgNo : paramBindings[paramIdx]) {
           // Determine the argument type.
           auto currentArgType = TE->getElement(inArgNo);
@@ -3554,8 +3554,8 @@ static bool diagnoseTupleParameterMismatch(CalleeCandidateInfo &CCI,
   }
 
   if (params.size() == 1 && args.size() == 1) {
-    auto paramType = params.front().getType();
-    auto argType = args.front().getType();
+    auto paramType = params.front().getOldType();
+    auto argType = args.front().getOldType();
 
     if (auto *paramFnType = paramType->getAs<AnyFunctionType>()) {
       // Only if both of the parameter and argument types are functions
@@ -3571,10 +3571,10 @@ static bool diagnoseTupleParameterMismatch(CalleeCandidateInfo &CCI,
   if (params.size() != 1 || args.empty())
     return false;
 
-  auto paramType = params.front().getType();
+  auto paramType = params.front().getOldType();
 
   if (args.size() == 1) {
-    auto argType = args.front().getType();
+    auto argType = args.front().getOldType();
     if (auto *paramFnType = paramType->getAs<AnyFunctionType>()) {
       // Only if both of the parameter and argument types are functions
       // let's recur into diagnosing their arguments.
@@ -3737,14 +3737,14 @@ public:
       insertText << ", ";
     if (!name.empty())
       insertText << name.str() << ": ";
-    Type Ty = param.getType();
+    Type Ty = param.getOldType();
     // Explode inout type.
     if (param.isInOut()) {
       insertText << "&";
       Ty = param.getPlainType();
     }
     // @autoclosure; the type should be the result type.
-    if (auto FT = param.getType()->getAs<AnyFunctionType>())
+    if (auto FT = param.getOldType()->getAs<AnyFunctionType>())
       if (FT->isAutoClosure())
         Ty = FT->getResult();
     insertText << "<#" << Ty << "#>";
@@ -4029,7 +4029,7 @@ diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI, Expr *fnExpr,
     auto resTy =
         candidate.getResultType()->lookThroughAllOptionalTypes();
     auto rawTy = isRawRepresentable(resTy, CCI.CS);
-    if (rawTy && arg.getType() && resTy->isEqual(arg.getType())) {
+    if (rawTy && arg.getOldType() && resTy->isEqual(arg.getOldType())) {
       auto getInnerExpr = [](Expr *E) -> Expr * {
         auto *parenE = dyn_cast<ParenExpr>(E);
         if (!parenE)
@@ -4153,8 +4153,8 @@ static bool diagnoseRawRepresentableMismatch(CalleeCandidateInfo &CCI,
       continue;
 
     for (unsigned i = 0, n = parameters.size(); i != n; ++i) {
-      auto paramType = parameters[i].getType();
-      auto argType = arguments[i].getType();
+      auto paramType = parameters[i].getOldType();
+      auto argType = arguments[i].getOldType();
 
       for (auto kind : rawRepresentableProtocols) {
         // If trying to convert from raw type to raw representable,
@@ -4181,8 +4181,8 @@ static bool diagnoseRawRepresentableMismatch(CalleeCandidateInfo &CCI,
   expr = expr->getValueProvidingExpr();
 
   auto parameters = bestMatchCandidate->getParameters();
-  auto paramType = parameters[bestMatchIndex].getType();
-  auto singleArgType = arguments[bestMatchIndex].getType();
+  auto paramType = parameters[bestMatchIndex].getOldType();
+  auto singleArgType = arguments[bestMatchIndex].getOldType();
 
   auto diag = CS.TC.diagnose(expr->getLoc(),
                              diag::cannot_convert_argument_value,
@@ -4684,7 +4684,7 @@ bool FailureDiagnosis::diagnoseArgumentGenericRequirements(
     // this returns a non-singular value is when there are varargs in play.
     for (auto argNo : bindings[i]) {
       auto argType = args[argNo]
-                         .getType()
+                         .getOldType()
                          ->getWithoutSpecifierType();
 
       if (argType->is<ArchetypeType>()) {
@@ -4854,8 +4854,8 @@ static bool diagnoseClosureExplicitParameterMismatch(
     return false;
 
   for (unsigned i = 0, n = params.size(); i != n; ++i) {
-    auto paramType = params[i].getType();
-    auto argType = args[i].getType();
+    auto paramType = params[i].getOldType();
+    auto argType = args[i].getOldType();
 
     if (auto paramFnType = paramType->getAs<AnyFunctionType>()) {
       if (auto argFnType = argType->getAs<AnyFunctionType>())
@@ -4968,7 +4968,7 @@ bool FailureDiagnosis::diagnoseTrailingClosureErrors(ApplyExpr *callExpr) {
     if (params.size() != 1)
       return false;
 
-    Type paramType = params.front().getType();
+    Type paramType = params.front().getOldType();
     if (auto paramFnType = paramType->getAs<AnyFunctionType>()) {
       auto closureType = CS.getType(closureExpr);
       if (auto *argFnType = closureType->getAs<AnyFunctionType>()) {
@@ -5122,9 +5122,9 @@ bool FailureDiagnosis::diagnoseSubscriptMisuse(ApplyExpr *callExpr) {
       return {CC_GeneralMismatch, {}};
 
     for (unsigned i = 0, e = params.size(); i < e; i ++) {
-      if (CS.TC.isConvertibleTo(params[i].getType(),
-                                candParams[i].getType(), CS.DC) ||
-          candParams[i].getType()->is<GenericTypeParamType>())
+      if (CS.TC.isConvertibleTo(params[i].getOldType(),
+                                candParams[i].getOldType(), CS.DC) ||
+          candParams[i].getOldType()->is<GenericTypeParamType>())
         continue;
       return {CC_GeneralMismatch, {}};
     }
@@ -5643,8 +5643,8 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
         if (params.size() != 2)
           return false;
 
-        auto lhsCandidate = params[0].getType();
-        auto rhsCandidate = params[1].getType();
+        auto lhsCandidate = params[0].getOldType();
+        auto rhsCandidate = params[1].getOldType();
         auto lhsIsCandidate = lhsType->isEqual(lhsCandidate);
         auto rhsIsCandidate = rhsType->isEqual(rhsCandidate);
 
@@ -6128,7 +6128,7 @@ bool FailureDiagnosis::diagnoseClosureExpr(
       }
 
       if (inferredArgCount == 1 && actualArgCount > 1) {
-        auto *argTupleTy = inferredArgs.front().getType()->getAs<TupleType>();
+        auto *argTupleTy = inferredArgs.front().getOldType()->getAs<TupleType>();
         // Let's see if inferred argument is actually a tuple inside of Paren.
         if (argTupleTy) {
           // Looks like the number of closure parameters matches number

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5489,7 +5489,9 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
         if (locator->getAnchor() == callExpr) {
           auto calleeType = CS.simplifyType(constraint->getSecondType());
           if (auto *fnType = calleeType->getAs<FunctionType>())
-            argType = fnType->getInput();
+            argType = AnyFunctionType::composeInput(fnType->getASTContext(),
+                                                    fnType->getParams(),
+                                                    /*canonicalVararg=*/false);
         }
       }
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -216,7 +216,7 @@ bool MissingConformanceFailure::diagnoseAsError() {
     if (auto *fnType = ownerType->getAs<AnyFunctionType>()) {
       auto parameters = fnType->getParams();
       for (auto index : indices(parameters)) {
-        if (parameters[index].getType()->isEqual(nonConformingType)) {
+        if (parameters[index].getOldType()->isEqual(nonConformingType)) {
           atParameterPos = index;
           break;
         }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -913,8 +913,8 @@ namespace {
       if (params.size() != 2)
         return false;
 
-      auto firstParamTy = params[0].getType();
-      auto secondParamTy = params[1].getType();
+      auto firstParamTy = params[0].getOldType();
+      auto secondParamTy = params[1].getOldType();
 
       auto resultTy = fnTy->getResult();
       auto contextualTy = CS.getContextualType(expr);

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -357,13 +357,13 @@ static bool isProtocolExtensionAsSpecializedAs(TypeChecker &tc,
 
 /// Retrieve the adjusted parameter type for overloading purposes.
 static Type getAdjustedParamType(const AnyFunctionType::Param &param) {
-  if (auto funcTy = param.getType()->getAs<FunctionType>()) {
+  if (auto funcTy = param.getOldType()->getAs<FunctionType>()) {
     if (funcTy->isAutoClosure()) {
       return funcTy->getResult();
     }
   }
 
-  return param.getType();
+  return param.getOldType();
 }
 
 // Is a particular parameter of a function or subscript declaration
@@ -646,8 +646,8 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         // If they both have trailing closures, compare those separately.
         bool compareTrailingClosureParamsSeparately = false;
         if (numParams1 > 0 && numParams2 > 0 &&
-            params1.back().getType()->is<AnyFunctionType>() &&
-            params2.back().getType()->is<AnyFunctionType>()) {
+            params1.back().getOldType()->is<AnyFunctionType>() &&
+            params2.back().getOldType()->is<AnyFunctionType>()) {
           compareTrailingClosureParamsSeparately = true;
         }
 
@@ -1062,8 +1062,8 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
         auto params = fnTy->getParams();
         assert(params.size() == 2);
 
-        auto param1 = params[0].getType();
-        auto param2 = params[1].getType()->castTo<AnyFunctionType>();
+        auto param1 = params[0].getOldType();
+        auto param2 = params[1].getOldType()->castTo<AnyFunctionType>();
 
         assert(param1->getOptionalObjectType());
         assert(param2->isAutoClosure());

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -833,14 +833,14 @@ constraints::matchCallArguments(ConstraintSystem &cs, bool isOperator,
 
     // Determine the parameter type.
     const auto &param = params[paramIdx];
-    auto paramTy = param.getType();
+    auto paramTy = param.getOldType();
 
     // Compare each of the bound arguments for this parameter.
     for (auto argIdx : parameterBindings[paramIdx]) {
       auto loc = locator.withPathElement(LocatorPathElt::
                                             getApplyArgToParam(argIdx,
                                                                paramIdx));
-      auto argTy = argsWithLabels[argIdx].getType();
+      auto argTy = argsWithLabels[argIdx].getOldType();
 
       // FIXME: This should be revisited. If one of argTy or paramTy
       // is a type variable, matchTypes() will add a constraint, and
@@ -1191,7 +1191,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     if (last != path.rend()) {
       if (last->getKind() == ConstraintLocator::ApplyArgToParam) {
         if (isSingleParam(func1Params) &&
-            func1Params[0].getType()->isVoid()) {
+            func1Params[0].getOldType()->isVoid()) {
           if (func2Params.empty()) {
             func2Params.emplace_back(getASTContext().TheEmptyTupleType);
           }
@@ -1227,8 +1227,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     // trivial because of inout-to-pointer conversions.
 
     // Compare the parameter types.
-    auto result = matchTypes(func2Param.getType(),
-                             func1Param.getType(),
+    auto result = matchTypes(func2Param.getOldType(),
+                             func1Param.getOldType(),
                              subKind, subflags,
                              (func1Params.size() == 1
                               ? argumentLocator

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -400,11 +400,11 @@ CalleeCandidateInfo::evaluateCloseness(UncurriedCandidate candidate,
     // If parameter is marked as @autoclosure, we are
     // only interested in it's resulting type.
     if (param.isAutoClosure()) {
-      if (auto fnType = param.getType()->getAs<AnyFunctionType>())
+      if (auto fnType = param.getOldType()->getAs<AnyFunctionType>())
         return fnType->getResult();
     }
     
-    return param.getType();
+    return param.getOldType();
   };
   
   for (unsigned i = 0, e = paramBindings.size(); i != e; ++i) {
@@ -537,7 +537,7 @@ CalleeCandidateInfo::evaluateCloseness(UncurriedCandidate candidate,
   // Check to see if the first argument expects an inout argument, but is not
   // an lvalue.
   if (candArgs[0].isInOut() &&
-      !(actualArgs[0].getType()->hasLValueType() || actualArgs[0].isInOut())) {
+      !(actualArgs[0].getOldType()->hasLValueType() || actualArgs[0].isInOut())) {
     return { CC_NonLValueInOut, {}};
   }
   

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2111,7 +2111,7 @@ bool isSubscriptReturningString(const ValueDecl *D, ASTContext &Context) {
   if (param.hasLabel() || param.isVariadic())
     return false;
 
-  auto inputTy = param.getType()->getAs<BoundGenericStructType>();
+  auto inputTy = param.getOldType()->getAs<BoundGenericStructType>();
   if (!inputTy)
     return false;
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -166,7 +166,7 @@ public:
       });
 
       for (const auto &param : gft->getParams())
-        param.getType().walk(walker);
+        param.getOldType().walk(walker);
 
       gft->getResult().walk(walker);
     }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -227,7 +227,7 @@ static unsigned getNumArgs(ValueDecl *value) {
     if (param.hasLabel() || param.isVariadic())
       return 1;
 
-    if (auto *tuple = param.getType()->getAs<TupleType>())
+    if (auto *tuple = param.getOldType()->getAs<TupleType>())
       return tuple->getNumElements();
   }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -819,7 +819,7 @@ bool swift::isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason) {
   if (SubscriptType->getParams().size() != 1)
     return false;
 
-  Type IndicesType = SubscriptType->getParams()[0].getType();
+  Type IndicesType = SubscriptType->getParams()[0].getOldType();
   if (IndicesType->hasError())
     return false;
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -321,7 +321,7 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
   ReferencedGenericTypeWalker paramsAndResultWalker;
   auto *funcTy = decl->getInterfaceType()->castTo<GenericFunctionType>();
   for (const auto &param : funcTy->getParams())
-    param.getType().walk(paramsAndResultWalker);
+    param.getOldType().walk(paramsAndResultWalker);
   funcTy->getResult().walk(paramsAndResultWalker);
 
   // Set of generic params referenced in parameter types,

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1584,7 +1584,7 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
   bool hadError = false;
   for (const auto &param : FN->getParams()) {
     params.push_back(param);
-    hadError |= param.getType()->hasError();
+    hadError |= param.getOldType()->hasError();
   }
 
   // Local function to check if the given type is valid e.g. doesn't have

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -607,8 +607,8 @@ swift::matchWitness(
       // Gross hack: strip a level of unchecked-optionality off both
       // sides when matching against a protocol imported from Objective-C.
       auto types =
-          getTypesToCompare(req, reqParams[i].getType(), reqParamTypeIsIUO,
-                            witnessParams[i].getType(), witnessParamTypeIsIUO,
+          getTypesToCompare(req, reqParams[i].getOldType(), reqParamTypeIsIUO,
+                            witnessParams[i].getOldType(), witnessParamTypeIsIUO,
                             VarianceKind::Contravariant);
 
       // Record any optional adjustment that occurred.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1758,7 +1758,11 @@ static Type getTypeForDisplay(ModuleDecl *module, ValueDecl *decl) {
 
   // For a constructor, we only care about the parameter types.
   if (auto ctor = dyn_cast<ConstructorDecl>(decl)) {
-    return ctor->getArgumentInterfaceType();
+    return AnyFunctionType::composeInput(module->getASTContext(),
+                                         ctor->getMethodInterfaceType()
+                                             ->castTo<FunctionType>()
+                                             ->getParams(),
+                                         /*canonicalVararg=*/false);
   }
 
   // We have something function-like, so we want to strip off the 'self'.

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1080,7 +1080,11 @@ SwiftDeclCollector::constructTypeNode(Type T,
 
     // Still, return type first
     Root->addChild(constructTypeNode(Fun->getResult()));
-    Root->addChild(constructTypeNode(Fun->getInput()));
+
+    auto Input = AnyFunctionType::composeInput(Fun->getASTContext(),
+                                               Fun->getParams(),
+                                               /*canonicalVararg=*/false);
+    Root->addChild(constructTypeNode(Input));
     return Root;
   }
 


### PR DESCRIPTION
I switched the handful of remaining uses to explicitly call AnyFunctionType::composeInput(). We still don't want to do that for non-materializable tuple types, but surfacing it there allows the code to be refactored later, and means we don't have to store the input type inside the FunctionType anymore. Also, rename `AnyFunctionType::Param::getType()` to `getOldType()`, since InOutType will be removed at some point.