### PR TITLE
[CSRanking] Amend concrete-over-protocol logic to only do an is-a check

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -471,10 +471,10 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       //    }
       //
       if (tc.Context.isSwiftVersionAtLeast(5) && !isDynamicOverloadComparison) {
-        auto *proto1 = dyn_cast<ProtocolDecl>(outerDC1);
-        auto *proto2 = dyn_cast<ProtocolDecl>(outerDC2);
-        if (proto1 != proto2)
-          return proto2;
+        auto inProto1 = isa<ProtocolDecl>(outerDC1);
+        auto inProto2 = isa<ProtocolDecl>(outerDC2);
+        if (inProto1 != inProto2)
+          return inProto2;
       }
 
       Type type1 = decl1->getInterfaceType();


### PR DESCRIPTION
As discussed in #18951, we don't want to be comparing two different protocol decls here, as that could lead to spurious 'is as specialized' results. I'm not aware of any case that currently trips this logic up though, so no tests to accompany.
