### PR TITLE
try! error message should report the right location

### DIFF
--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -62,6 +62,7 @@ FUNC_DECL(BridgeAnyObjectToAny,
 
 FUNC_DECL(ConvertToAnyHashable, "_convertToAnyHashable")
 
+FUNC_DECL(DiagnoseUnexpectedError, "_unexpectedError")
 FUNC_DECL(DiagnoseUnexpectedNilOptional, "_diagnoseUnexpectedNilOptional")
 FUNC_DECL(DiagnoseUnexpectedEnumCase, "_diagnoseUnexpectedEnumCase")
 FUNC_DECL(DiagnoseUnexpectedEnumCaseValue, "_diagnoseUnexpectedEnumCaseValue")

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1903,11 +1903,11 @@ public:
 
   class ForceTryEmission {
     SILGenFunction &SGF;
-    Expr *Loc;
+    ForceTryExpr *Loc;
     JumpDest OldThrowDest;
 
   public:
-    ForceTryEmission(SILGenFunction &SGF, Expr *loc);
+    ForceTryEmission(SILGenFunction &SGF, ForceTryExpr *loc);
 
     ForceTryEmission(const ForceTryEmission &) = delete;
     ForceTryEmission &operator=(const ForceTryEmission &) = delete;

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -178,8 +178,20 @@ public func _bridgeErrorToNSError(_ error: __owned Error) -> AnyObject
 /// Invoked by the compiler when the subexpression of a `try!` expression
 /// throws an error.
 @_silgen_name("swift_unexpectedError")
-public func _unexpectedError(_ error: Error) {
-  preconditionFailure("'try!' expression unexpectedly raised an error: \(String(reflecting: error))")
+public func _unexpectedError(
+  _ error: __owned Error,
+  filenameStart: Builtin.RawPointer,
+  filenameLength: Builtin.Word,
+  filenameIsASCII: Builtin.Int1,
+  line: Builtin.Word
+) {
+  preconditionFailure(
+    "'try!' expression unexpectedly raised an error: \(String(reflecting: error))",
+    file: StaticString(
+      _start: filenameStart,
+      utf8CodeUnitCount: filenameLength,
+      isASCII: filenameIsASCII),
+    line: UInt(line))
 }
 
 /// Invoked by the compiler when code at top level throws an uncaught error.

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -214,7 +214,11 @@ void swift_willThrow(SWIFT_CONTEXT void *unused,
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API LLVM_ATTRIBUTE_NORETURN
 void swift_errorInMain(SwiftError *object);
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API LLVM_ATTRIBUTE_NORETURN
-void swift_unexpectedError(SwiftError *object);
+void swift_unexpectedError(SwiftError *object,
+                           OpaqueValue *filenameStart,
+                           long filenameLength,
+                           bool isAscii,
+                           unsigned long line);
 
 #if SWIFT_OBJC_INTEROP
 

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -326,7 +326,7 @@ func testForceTry(_ fn: () -> Int) {
 // CHECK: [[FUNC:%.*]] = function_ref @$s6errors9createIntyySiyXEKF : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @error Error
 // CHECK: try_apply [[FUNC]]([[ARG]])
 // CHECK: return
-// CHECK: builtin "unexpectedError"
+// CHECK: function_ref @swift_unexpectedError
 // CHECK: unreachable
 
 func testForceTryMultiple() {
@@ -346,7 +346,8 @@ func testForceTryMultiple() {
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
 // CHECK-NEXT: return [[VOID]] : $()
 // CHECK: [[FAILURE:.+]]([[ERROR:%.+]] : @owned $Error):
-// CHECK-NEXT: = builtin "unexpectedError"([[ERROR]] : $Error)
+// CHECK: [[UNEXPECTED_ERROR:%.+]] = function_ref @swift_unexpectedError
+// CHECK-NEXT: apply [[UNEXPECTED_ERROR]]([[ERROR]]
 // CHECK-NEXT: unreachable
 // CHECK: [[CLEANUPS_1]]([[ERROR:%.+]] : @owned $Error):
 // CHECK-NEXT: br [[FAILURE]]([[ERROR]] : $Error)

--- a/test/SILOptimizer/stack-nesting-wrong-scope.swift
+++ b/test/SILOptimizer/stack-nesting-wrong-scope.swift
@@ -3,10 +3,10 @@
 // RUN:   -sil-print-only-functions=$s3red19ThrowAddrOnlyStructV016throwsOptionalToG0ACyxGSgSi_tcfC \
 // RUN:   -Xllvm -sil-print-debuginfo -o /dev/null 2>&1 | %FileCheck %s
 
-// CHECK: bb5(%27 : @owned $Error):
+// CHECK: bb5(%33 : @owned $Error):
 // CHECK:   dealloc_stack %6 : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:27:68, scope 2
 // CHECK:   dealloc_stack %3 : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:27:68, scope 2
-// CHECK:   br bb4(%27 : $Error), loc {{.*}}:27:15, scope 2
+// CHECK:   br bb4(%33 : $Error), loc {{.*}}:27:15, scope 2
 
 protocol Patatino {
   init()

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -115,7 +115,18 @@ ErrorTests.test("try!")
   .code {
     expectCrashLater()
     let _: () = try! { throw SillyError.JazzHands }()
-  }
+}
+
+ErrorTests.test("try!/location")
+  .skip(.custom({ _isFastAssertConfiguration() },
+                reason: "trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration()
+                        ? "test/stdlib/Error.swift, line 128"
+                        : "")
+  .code {
+    expectCrashLater()
+    let _: () = try! { throw SillyError.JazzHands }()
+}
 
 ErrorTests.test("try?") {
   var value = try? { () throws -> Int in return 1 }()


### PR DESCRIPTION
At the moment the location being reported is inside the standard
library, which is not very helpful. Instead, the location should point
at the `try!` expression in the application code.

Fixes: rdar://problem/21407683