### PR TITLE
[CSDiagnostics] Don't try to fix conformances for `Void` and `Never`

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2701,6 +2701,11 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     return result;
   }
 
+  // Let's not try to fix missing conformance for Void
+  // and Never because that doesn't really make sense.
+  if (type->isVoid() || type->isUninhabited())
+    return SolutionKind::Error;
+
   // If this is a generic requirement let's try to record that
   // conformance is missing and consider this a success, which
   // makes it much easier to diagnose problems like that.

--- a/test/Constraints/rdar44770297.swift
+++ b/test/Constraints/rdar44770297.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  associatedtype A
+}
+
+func foo<T: P>(_: () throws -> T) -> T.A? { // expected-note {{in call to function 'foo'}}
+  fatalError()
+}
+
+let _ = foo() {fatalError()} & nil // expected-error {{generic parameter 'T' could not be inferred}}


### PR DESCRIPTION
There are cases when adding missing conformance fix doesn't really
make sense like in case of `Void` and `Never` types because that
wouldn't result in a useful diagnostic.

This is a follow-up for rdar://problem/44770297

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
