### PR TITLE
 [Runtime] Handle non-key generic parameters when demangling to metadata.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -959,10 +959,17 @@ public:
     // this type.
     std::vector<unsigned> genericParamCounts;
     (void)_gatherGenericParameterCounts(typeDecl, genericParamCounts);
+    unsigned numTotalGenericParams =
+        genericParamCounts.empty() ? 0 : genericParamCounts.back();
 
-    // Check whether we have the right number of innermost generic arguments.
-    if (genericArgs.size() != getLocalGenericParams(typeDecl).size())
+    // Check whether we have the right number of generic arguments.
+    if (genericArgs.size() == getLocalGenericParams(typeDecl).size()) {
+      // Okay: genericArgs is the innermost set of generic arguments.
+    } else if (genericArgs.size() == numTotalGenericParams && !parent) {
+      // Okay: genericArgs is the complete set of generic arguments.
+    } else {
       return BuiltType();
+    }
 
     std::vector<const void *> allGenericArgsVec;
 
@@ -978,7 +985,7 @@ public:
                                  allGenericArgs);
       }
 
-      // Add this level of arguments.
+      // Add the generic arguments we were given.
       allGenericArgs.insert(allGenericArgs.end(),
                             genericArgs.begin(), genericArgs.end());
 

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -342,6 +342,22 @@ public:
 
   void *allocateMetadata(size_t size, size_t align);
 
+  /// Gather the set of generic arguments that would be written in the
+  /// source, as a f
+  ///
+  /// This function computes generic arguments even when they are not
+  /// directly represented in the metadata, e.g., generic parameters that
+  /// are canonicalized away by same-type constraints and are therefore not
+  /// "key" parameters.
+  ///
+  /// \code
+  ///   extension Array where Element == String { }
+  ///   extension Dictionary where Key == Value { }
+  /// \endcode
+  void gatherWrittenGenericArgs(const Metadata *metadata,
+                                const TypeContextDescriptor *description,
+                                std::vector<const Metadata *> &allGenericArgs);
+
   Demangle::NodePointer
   _buildDemanglingForContext(const ContextDescriptor *context,
                              llvm::ArrayRef<NodePointer> demangledGenerics,

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -287,6 +287,39 @@ public:
   TypeInfo _getTypeByMangledName(StringRef typeName,
                                  SubstGenericParameterFn substGenericParam);
 
+  /// Function object that produces substitutions for the generic parameters
+  /// that occur within a mangled name, using the complete set of generic
+  /// arguments "as written".
+  ///
+  /// Use with \c _getTypeByMangledName to decode potentially-generic types.
+  class SWIFT_RUNTIME_LIBRARY_VISIBILITY SubstGenericParametersFromWrittenArgs {
+    /// The complete set of generic arguments.
+    const std::vector<const Metadata *> &allGenericArgs;
+
+    /// The counts of generic parameters at each level.
+    const std::vector<unsigned> &genericParamCounts;
+
+  public:
+    /// Initialize a new function object to handle substitutions. Both
+    /// parameters are references to vectors that must live longer than
+    /// this function object.
+    ///
+    /// \param allGenericArgs The complete set of generic arguments, as written.
+    /// This could come directly from "source" (where all generic arguments are
+    /// encoded) or from metadata via gatherWrittenGenericArgs().
+    ///
+    /// \param genericParamCounts The count of generic parameters at each
+    /// generic level, typically gathered by _gatherGenericParameterCounts.
+    explicit SubstGenericParametersFromWrittenArgs(
+        const std::vector<const Metadata *> &allGenericArgs,
+        const std::vector<unsigned> &genericParamCounts)
+      : allGenericArgs(allGenericArgs), genericParamCounts(genericParamCounts) {
+    }
+
+    const Metadata *operator()(unsigned flatIndex) const;
+    const Metadata *operator()(unsigned depth, unsigned index) const;
+  };
+
   /// Gather generic parameter counts from a context descriptor.
   ///
   /// \returns true if the innermost descriptor is generic.

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -367,7 +367,7 @@ DemangleToMetadataTests.test("Nested types in extensions") {
     _typeByMangledName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VA2A2P3Rd__rlE018InnermostUConformsfG0VyAA08ConformsfC0V_AA0jf5P2AndG0V_AA0jF3P4aVG")!)
 
   // Failure case: Dictionary's outer `Key: Hashable` constraint not sastified
-  // TODO: expectNil(_typeByMangledName("s10DictionaryV4mainE5InnerVyAC12ConformsToP1VSi_AC12ConformsToP1VG"))
+  expectNil(_typeByMangledName("s10DictionaryV4mainE5InnerVyAC12ConformsToP1VSi_AC12ConformsToP1VG"))
   // Failure case: Dictionary's inner `V: P1` constraint not satisfied
   expectNil(_typeByMangledName("s10DictionaryV4mainE5InnerVySSSi_AC12ConformsToP2VG"))
 
@@ -383,8 +383,6 @@ DemangleToMetadataTests.test("Nested types in extensions") {
 //
 // Nested types in same-type-constrained extensions
 //
-
-/* TODO
 
 struct SG12<T: P1, U: P2> {}
 
@@ -419,8 +417,6 @@ DemangleToMetadataTests.test("Nested types in same-type-constrained extensions")
   // T != ConformsToP1 in InnerTEqualsConformsToP1
   // V !: P3 in InnerTEqualsConformsToP1
 }
-
- */
 
 runAllTests()
 


### PR DESCRIPTION
When forming metadata for a nested generic type, gather all of the
generic arguments from the parent type “as written”, so that we can directly
map generic parameters to those generic arguments when they occur within
requirements. This allows us to demangle nested types within extensions
that have same-type constraints on generic parameters into type metadata.

Fixes rdar://problem/37170296.