### PR TITLE
[Runtime] Enable mangled type name roundtrip checking by default.

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -204,6 +204,10 @@ def debug_forbid_typecheck_prefix : Separate<["-"], "debug-forbid-typecheck-pref
 
 def debug_cycles : Flag<["-"], "debug-cycles">,
   HelpText<"Print out debug dumps when cycles are detected in evaluation">;
+def suppress_cycles : Flag<["-"], "suppress-cycles">,
+  HelpText<"Suppress diagnostics for cycles detected in evaluation">;
+def diagnose_cycles : Flag<["-"], "diagnose-cycles">,
+  HelpText<"Diagnose diagnostics for cycles detected in evaluation">;
 def output_request_graphviz : Separate<["-"], "output-request-graphviz">,
   HelpText<"Emit GraphViz output visualizing the request graph">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -309,8 +309,16 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.DebugForbidTypecheckPrefix = A->getValue();
   }
 
-  if (Args.getLastArg(OPT_debug_cycles)) {
-    Opts.EvaluatorCycleDiagnostics = CycleDiagnosticKind::DebugDiagnose;
+  if (const Arg *A = Args.getLastArg(OPT_debug_cycles, OPT_suppress_cycles,
+                                     OPT_diagnose_cycles)) {
+    if (A->getOption().matches(OPT_debug_cycles)) {
+      Opts.EvaluatorCycleDiagnostics = CycleDiagnosticKind::DebugDiagnose;
+    } else if (A->getOption().matches(OPT_diagnose_cycles)) {
+      Opts.EvaluatorCycleDiagnostics = CycleDiagnosticKind::FullDiagnose;
+    } else {
+      assert(A->getOption().matches(OPT_suppress_cycles));
+      Opts.EvaluatorCycleDiagnostics = CycleDiagnosticKind::NoDiagnose;
+    }
   }
 
   if (const Arg *A = Args.getLastArg(OPT_output_request_graphviz)) {

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -924,9 +924,17 @@ namespace {
       auto params = type.getParams();
       auto numParams = params.size();
 
+      // Retrieve the ABI parameter flags from the type-level parameter
+      // flags.
+      auto getABIParameterFlags = [](ParameterTypeFlags flags) {
+        return ParameterFlags()
+                 .withValueOwnership(flags.getValueOwnership())
+                 .withVariadic(flags.isVariadic());
+      };
+
       bool hasFlags = false;
       for (auto param : params) {
-        if (!param.getParameterFlags().isNone()) {
+        if (!getABIParameterFlags(param.getParameterFlags()).isNone()) {
           hasFlags = true;
           break;
         }
@@ -969,11 +977,7 @@ namespace {
               auto param = params[index];
               auto flags = param.getParameterFlags();
 
-              auto parameterFlags =
-                  ParameterFlags()
-                      .withValueOwnership(flags.getValueOwnership())
-                      .withVariadic(flags.isVariadic());
-
+              auto parameterFlags = getABIParameterFlags(flags);
               processor(index, getFunctionParameterRef(param), parameterFlags);
             }
           };

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -3085,9 +3085,17 @@ bool _swift_isClassOrObjCExistentialType(const Metadata *value,
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 const Metadata *swift::_swift_class_getSuperclass(const Metadata *theClass) {
-  if (const ClassMetadata *classType = theClass->getClassObject())
+  if (const ClassMetadata *classType = theClass->getClassObject()) {
     if (classHasSuperclass(classType))
       return getMetadataForClass(classType->Superclass);
+  }
+
+  if (const ForeignClassMetadata *foreignClassType
+        = dyn_cast<ForeignClassMetadata>(theClass)) {
+    if (const Metadata *superclass = foreignClassType->Superclass)
+      return superclass;
+  }
+
   return nullptr;
 }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4686,9 +4686,9 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
   auto result = _getTypeByMangledName(mangledName,
                                       [](unsigned, unsigned){ return nullptr; });
   if (metadata != result)
-    swift::warning(RuntimeErrorFlagNone,
-                   "Metadata mangled name failed to roundtrip: %p -> %s -> %p\n",
-                   metadata, mangledName.c_str(), (const Metadata *)result);
+    swift::fatalError(RuntimeErrorFlagNone,
+                      "Metadata mangled name failed to roundtrip: %p -> %s -> %p\n",
+                      metadata, mangledName.c_str(), (const Metadata *)result);
 }
 #endif
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4676,6 +4676,8 @@ static bool referencesAnonymousContext(Demangle::Node *node) {
 
 void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
   Demangle::Demangler Dem;
+  Dem.setSymbolicReferenceResolver(ResolveToDemanglingForContext(Dem));
+
   auto node = _swift_buildDemanglingForMetadata(metadata, Dem);
   // If the mangled node involves types in an AnonymousContext, then by design,
   // it cannot be looked up by name.

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4675,18 +4675,6 @@ static bool referencesAnonymousContext(Demangle::Node *node) {
 }
 
 void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
-  // Enable verification when a special environment variable is set.
-  // Some metatypes crash when going through the mangler or demangler. A
-  // lot of tests currently trigger those crashes, resulting in failing
-  // tests which are still usefully testing something else. This
-  // variable lets us easily turn on verification to find and fix these
-  // bugs. Remove this and leave it permanently on once everything works
-  // with it enabled.
-  bool verificationEnabled =
-    SWIFT_LAZY_CONSTANT((bool)getenv("SWIFT_ENABLE_MANGLED_NAME_VERIFICATION"));
-  
-  if (!verificationEnabled) return;
-  
   Demangle::Demangler Dem;
   auto node = _swift_buildDemanglingForMetadata(metadata, Dem);
   // If the mangled node involves types in an AnonymousContext, then by design,

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -463,12 +463,10 @@ recur:
     }
   }
 
-  // If the type is a class, try its superclass.
-  if (const ClassMetadata *classType = type->getClassObject()) {
-    if (classHasSuperclass(classType)) {
-      type = getMetadataForClass(classType->Superclass);
-      goto recur;
-    }
+  // If there is a superclass, look there.
+  if (auto superclass = _swift_class_getSuperclass(type)) {
+    type = superclass;
+    goto recur;
   }
 
   // We did not find an up-to-date cache entry.
@@ -506,12 +504,10 @@ bool isRelatedType(const Metadata *type, const void *candidate,
         return true;
     }
 
-    // If the type is a class, try its superclass.
-    if (const ClassMetadata *classType = type->getClassObject()) {
-      if (classHasSuperclass(classType)) {
-        type = getMetadataForClass(classType->Superclass);
-        continue;
-      }
+    // If there is a superclass, look there.
+    if (auto superclass = _swift_class_getSuperclass(type)) {
+      type = superclass;
+      continue;
     }
 
     break;

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -51,4 +51,8 @@ func test_arch() {
   // CHECK: store %swift.type* @"$ss4Int8VN", %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 100663300, %swift.type** {{%.*}}, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags.{{.*}}, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @"$sytN", i32 0, i32 1))
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })
+
+  // CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden swiftcc %swift.metadata_response @"$syyyccMa"
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1(i64 67108865
+  arch({(x: @escaping () -> ()) -> () in })
 }

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -91,5 +91,10 @@ DemangleToMetadataTests.test("members of runtime-only Objective-C classes") {
     _typeByMangledName("So17OS_dispatch_queueC8DispatchE10AttributesV")!)
 }
 
+DemangleToMetadataTests.test("runtime conformance lookup via foreign superclasses") {
+  expectEqual(Set<CFMutableString>.self,
+    _typeByMangledName("ShySo18CFMutableStringRefaG")!)
+}
+
 runAllTests()
 


### PR DESCRIPTION
For an assertions-enabled runtime, enable the round-trip checking for
mangled type names <-> type metadata on metadata completion. This
checking was off-by-default due to various bugs, but could be enabled
by SWIFT_ENABLE_MANGLED_NAME_VERIFICATION. Turn it on always now.

Fixes rdar://problem/37551850.
