### PR TITLE
[stdlib] Rename _HashTable.Index in preparation of upcoming index validation enhancements

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1818,7 +1818,7 @@ extension Dictionary.Index: Hashable {
       hasher.combine(cocoaIndex.currentKeyIndex)
     }
   #else
-    hasher.combine(_asNative.bucket)
+    hasher.combine(_asNative.offset)
   #endif
   }
 }

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -413,34 +413,3 @@ extension _HashTable {
     words[hole.word].uncheckedRemove(hole.bit)
   }
 }
-
-extension _HashTable {
-  /// Check for consistency and return the count of occupied entries.
-  internal func _invariantCheck(with delegate: _HashTableDelegate) -> Int {
-#if INTERNAL_CHECKS_ENABLED
-    _sanityCheck(bucketCount > 0 && bucketCount & (bucketCount &- 1) == 0,
-      "Invalid bucketCount")
-    _sanityCheck(_isValidAddress(UInt(bitPattern: words)),
-      "Invalid words pointer")
-    _sanityCheck(_isValidAddress(UInt(bitPattern: words + wordCount - 1)),
-      "Invalid words buffer")
-
-    var occupiedCount = 0
-    for i in self {
-      occupiedCount += 1
-      let hashValue = delegate.hashValue(at: i)
-      var c = idealIndex(forHashValue: hashValue)
-      // There must be no holes between the ideal and actual buckets for this
-      // hash value.
-      while c != i {
-        _sanityCheck(_isOccupied(c),
-          "Some hash table elements are stored outside their collision chain")
-        c = index(wrappedAfter: c)
-      }
-    }
-    return occupiedCount
-#else
-    return 0
-#endif
-  }
-}

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -85,11 +85,19 @@ extension _HashTable {
 }
 
 extension _HashTable {
+  @usableFromInline
+  internal typealias Bucket = Index
+
   @_fixed_layout
   @usableFromInline
   internal struct Index {
     @usableFromInline
-    internal var bucket: Int
+    internal var offset: Int
+
+    internal var bucket: Int {
+      @inline(__always) get { return offset }
+      @inline(__always) set { offset = newValue }
+    }
 
     @inlinable
     @inline(__always)

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -12,8 +12,8 @@
 
 @usableFromInline
 internal protocol _HashTableDelegate {
-  func hashValue(at index: _HashTable.Index) -> Int
-  func moveEntry(from source: _HashTable.Index, to target: _HashTable.Index)
+  func hashValue(at bucket: _HashTable.Bucket) -> Int
+  func moveEntry(from source: _HashTable.Bucket, to target: _HashTable.Bucket)
 }
 
 @usableFromInline
@@ -85,64 +85,56 @@ extension _HashTable {
 }
 
 extension _HashTable {
-  @usableFromInline
-  internal typealias Bucket = Index
-
   @_fixed_layout
   @usableFromInline
-  internal struct Index {
+  internal struct Bucket {
     @usableFromInline
     internal var offset: Int
 
-    internal var bucket: Int {
-      @inline(__always) get { return offset }
-      @inline(__always) set { offset = newValue }
-    }
-
     @inlinable
     @inline(__always)
-    internal init(bucket: Int) {
-      _sanityCheck(bucket >= 0)
-      self.bucket = bucket
+    internal init(offset: Int) {
+      _sanityCheck(offset >= 0)
+      self.offset = offset
     }
 
     @inlinable
     @inline(__always)
     internal init(word: Int, bit: Int) {
-      self.bucket = _UnsafeBitset.join(word: word, bit: bit)
+      self.offset = _UnsafeBitset.join(word: word, bit: bit)
     }
 
     @inlinable
     internal var word: Int {
       @inline(__always) get {
-        return _UnsafeBitset.word(for: bucket)
+        return _UnsafeBitset.word(for: offset)
       }
     }
 
     @inlinable
     internal var bit: Int {
       @inline(__always) get {
-        return _UnsafeBitset.bit(for: bucket)
+        return _UnsafeBitset.bit(for: offset)
       }
     }
   }
 }
 
-extension _HashTable.Index: Equatable {
+extension _HashTable.Bucket: Equatable {
   @inlinable
   @inline(__always)
   internal
-  static func == (lhs: _HashTable.Index, rhs: _HashTable.Index) -> Bool {
-    return lhs.bucket == rhs.bucket
+  static func == (lhs: _HashTable.Bucket, rhs: _HashTable.Bucket) -> Bool {
+    return lhs.offset == rhs.offset
   }
 }
 
-extension _HashTable.Index: Comparable {
+extension _HashTable.Bucket: Comparable {
   @inlinable
   @inline(__always)
   internal
-  static func < (lhs: _HashTable.Index, rhs: _HashTable.Index) -> Bool {
-    return lhs.bucket < rhs.bucket
+  static func < (lhs: _HashTable.Bucket, rhs: _HashTable.Bucket) -> Bool {
+    return lhs.offset < rhs.offset
   }
 }
 
@@ -169,15 +161,15 @@ extension _HashTable: Sequence {
 
     @inlinable
     @inline(__always)
-    internal mutating func next() -> Index? {
+    internal mutating func next() -> Bucket? {
       if let bit = word.next() {
-        return Index(word: wordIndex, bit: bit)
+        return Bucket(word: wordIndex, bit: bit)
       }
       while wordIndex + 1 < hashTable.wordCount {
         wordIndex += 1
         word = hashTable.words[wordIndex]
         if let bit = word.next() {
-          return Index(word: wordIndex, bit: bit)
+          return Bucket(word: wordIndex, bit: bit)
         }
       }
       return nil
@@ -193,64 +185,64 @@ extension _HashTable: Sequence {
 extension _HashTable {
   @inlinable
   @inline(__always)
-  internal func isValid(_ index: Index) -> Bool {
-    return index.bucket >= 0 && index.bucket < bucketCount
+  internal func isValid(_ bucket: Bucket) -> Bool {
+    return bucket.offset >= 0 && bucket.offset < bucketCount
   }
 
   @inlinable
   @inline(__always)
-  internal func _isOccupied(_ index: Index) -> Bool {
-    _sanityCheck(isValid(index))
-    return words[index.word].uncheckedContains(index.bit)
+  internal func _isOccupied(_ bucket: Bucket) -> Bool {
+    _sanityCheck(isValid(bucket))
+    return words[bucket.word].uncheckedContains(bucket.bit)
   }
 
   @inlinable
   @inline(__always)
-  internal func isOccupied(_ index: Index) -> Bool {
-    return isValid(index) && _isOccupied(index)
+  internal func isOccupied(_ bucket: Bucket) -> Bool {
+    return isValid(bucket) && _isOccupied(bucket)
   }
 
   @inlinable
   @inline(__always)
-  internal func checkOccupied(_ i: Index) {
-    _precondition(isOccupied(i),
+  internal func checkOccupied(_ bucket: Bucket) {
+    _precondition(isOccupied(bucket),
       "Attempting to access Collection elements using an invalid Index")
   }
 
   @inlinable
   @inline(__always)
-  internal func _firstOccupiedIndex(fromWord word: Int) -> Index {
+  internal func _firstOccupiedBucket(fromWord word: Int) -> Bucket {
     _sanityCheck(word >= 0 && word <= wordCount)
     var word = word
     while word < wordCount {
       if let bit = words[word].minimum {
-        return Index(word: word, bit: bit)
+        return Bucket(word: word, bit: bit)
       }
       word += 1
     }
-    return endIndex
+    return endBucket
   }
 
   @inlinable
-  internal func index(after index: Index) -> Index {
-    _sanityCheck(isValid(index))
-    let word = index.word
-    if let bit = words[word].intersecting(elementsAbove: index.bit).minimum {
-      return Index(word: word, bit: bit)
+  internal func occupiedBucket(after bucket: Bucket) -> Bucket {
+    _sanityCheck(isValid(bucket))
+    let word = bucket.word
+    if let bit = words[word].intersecting(elementsAbove: bucket.bit).minimum {
+      return Bucket(word: word, bit: bit)
     }
-    return _firstOccupiedIndex(fromWord: word + 1)
+    return _firstOccupiedBucket(fromWord: word + 1)
   }
 
   @inlinable
-  internal var startIndex: Index {
-    return _firstOccupiedIndex(fromWord: 0)
+  internal var startBucket: Bucket {
+    return _firstOccupiedBucket(fromWord: 0)
   }
 
   @inlinable
-  internal var endIndex: Index {
+  internal var endBucket: Bucket {
     @inline(__always)
     get {
-      return Index(bucket: bucketCount)
+      return Bucket(offset: bucketCount)
     }
   }
 }
@@ -258,33 +250,33 @@ extension _HashTable {
 extension _HashTable {
   @inlinable
   @inline(__always)
-  internal func idealIndex(forHashValue hashValue: Int) -> Index {
-    return Index(bucket: hashValue & bucketMask)
+  internal func idealBucket(forHashValue hashValue: Int) -> Bucket {
+    return Bucket(offset: hashValue & bucketMask)
   }
 
   /// The next bucket after `bucket`, with wraparound at the end of the table.
   @inlinable
   @inline(__always)
-  internal func index(wrappedAfter index: Index) -> Index {
+  internal func bucket(wrappedAfter bucket: Bucket) -> Bucket {
     // The bucket is less than bucketCount, which is power of two less than
     // Int.max. Therefore adding 1 does not overflow.
-    return Index(bucket: (index.bucket &+ 1) & bucketMask)
+    return Bucket(offset: (bucket.offset &+ 1) & bucketMask)
   }
 }
 
 extension _HashTable {
   @inlinable
-  internal func previousHole(before index: Index) -> Index {
-    _sanityCheck(isValid(index))
+  internal func previousHole(before bucket: Bucket) -> Bucket {
+    _sanityCheck(isValid(bucket))
     // Note that if we have only a single partial word, its out-of-bounds bits
     // are guaranteed to be all set, so the formula below gives correct results.
-    var word = index.word
+    var word = bucket.word
     if let bit =
       words[word]
         .complement
-        .intersecting(elementsBelow: index.bit)
+        .intersecting(elementsBelow: bucket.bit)
         .maximum {
-      return Index(word: word, bit: bit)
+      return Bucket(word: word, bit: bit)
     }
     var wrap = false
     while true {
@@ -295,23 +287,23 @@ extension _HashTable {
         word = wordCount - 1
       }
       if let bit = words[word].complement.maximum {
-        return Index(word: word, bit: bit)
+        return Bucket(word: word, bit: bit)
       }
     }
   }
 
   @inlinable
-  internal func nextHole(atOrAfter index: Index) -> Index {
-    _sanityCheck(isValid(index))
+  internal func nextHole(atOrAfter bucket: Bucket) -> Bucket {
+    _sanityCheck(isValid(bucket))
     // Note that if we have only a single partial word, its out-of-bounds bits
     // are guaranteed to be all set, so the formula below gives correct results.
-    var word = index.word
+    var word = bucket.word
     if let bit =
       words[word]
         .complement
-        .subtracting(elementsBelow: index.bit)
+        .subtracting(elementsBelow: bucket.bit)
         .minimum {
-      return Index(word: word, bit: bit)
+      return Bucket(word: word, bit: bit)
     }
     var wrap = false
     while true {
@@ -322,7 +314,7 @@ extension _HashTable {
         word = 0
       }
       if let bit = words[word].complement.minimum {
-        return Index(word: word, bit: bit)
+        return Bucket(word: word, bit: bit)
       }
     }
   }
@@ -341,8 +333,8 @@ extension _HashTable {
   /// The entry must not already exist in the table -- duplicates are ignored.
   @inlinable
   @inline(__always)
-  internal func insertNew(hashValue: Int) -> Index {
-    let hole = nextHole(atOrAfter: idealIndex(forHashValue: hashValue))
+  internal func insertNew(hashValue: Int) -> Bucket {
+    let hole = nextHole(atOrAfter: idealBucket(forHashValue: hashValue))
     insert(hole)
     return hole
   }
@@ -350,9 +342,9 @@ extension _HashTable {
   /// Insert a new entry for an element at `index`.
   @inlinable
   @inline(__always)
-  internal func insert(_ index: Index) {
-    _sanityCheck(!isOccupied(index))
-    words[index.word].uncheckedInsert(index.bit)
+  internal func insert(_ bucket: Bucket) {
+    _sanityCheck(!isOccupied(bucket))
+    words[bucket.word].uncheckedInsert(bucket.bit)
   }
 
   @inlinable
@@ -360,8 +352,8 @@ extension _HashTable {
   internal func clear() {
     if bucketCount < Word.capacity {
       // We have only a single partial word. Set all out of bounds bits, so that
-      // `index(after:)` and `nextHole(atOrAfter:)` works correctly without a
-      // special case.
+      // `occupiedBucket(after:)` and `nextHole(atOrAfter:)` works correctly
+      // without a special case.
       words[0] = Word.allBits.subtracting(elementsBelow: bucketCount)
     } else {
       words.assign(repeating: .empty, count: wordCount)
@@ -371,16 +363,16 @@ extension _HashTable {
   @inline(__always)
   @inlinable
   internal func delete<D: _HashTableDelegate>(
-    at index: Index,
+    at bucket: Bucket,
     with delegate: D
   ) {
-    _sanityCheck(isOccupied(index))
+    _sanityCheck(isOccupied(bucket))
 
     // If we've put a hole in a chain of contiguous elements, some element after
     // the hole may belong where the new hole is.
 
-    var hole = index
-    var candidate = self.index(wrappedAfter: hole)
+    var hole = bucket
+    var candidate = self.bucket(wrappedAfter: hole)
 
     guard _isOccupied(candidate) else {
       // Fast path: Don't get the first bucket when there's nothing to do.
@@ -390,13 +382,13 @@ extension _HashTable {
 
     // Find the first bucket in the contiguous chain that contains the entry
     // we've just deleted.
-    let start = self.index(wrappedAfter: previousHole(before: index))
+    let start = self.bucket(wrappedAfter: previousHole(before: bucket))
 
     // Relocate out-of-place elements in the chain, repeating until we get to
     // the end of the chain.
     while _isOccupied(candidate) {
       let candidateHash = delegate.hashValue(at: candidate)
-      let ideal = idealIndex(forHashValue: candidateHash)
+      let ideal = idealBucket(forHashValue: candidateHash)
 
       // Does this element belong between start and hole?  We need two
       // separate tests depending on whether [start, hole] wraps around the
@@ -407,7 +399,7 @@ extension _HashTable {
         delegate.moveEntry(from: candidate, to: hole)
         hole = candidate
       }
-      candidate = self.index(wrappedAfter: candidate)
+      candidate = self.bucket(wrappedAfter: candidate)
     }
 
     words[hole.word].uncheckedRemove(hole.bit)

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -130,24 +130,24 @@ internal final class _BridgingHashBuffer
   }
 
   deinit {
-    for index in header.hashTable {
-      (firstElementAddress + index.bucket).deinitialize(count: 1)
+    for bucket in header.hashTable {
+      (firstElementAddress + bucket.offset).deinitialize(count: 1)
     }
     _fixLifetime(self)
   }
 
-  internal subscript(index: _HashTable.Index) -> AnyObject {
+  internal subscript(bucket: _HashTable.Bucket) -> AnyObject {
     @inline(__always) get {
-      _sanityCheck(header.hashTable.isOccupied(index))
+      _sanityCheck(header.hashTable.isOccupied(bucket))
       defer { _fixLifetime(self) }
-      return firstElementAddress[index.bucket]
+      return firstElementAddress[bucket.offset]
     }
   }
 
   @inline(__always)
-  internal func initialize(at index: _HashTable.Index, to object: AnyObject) {
-    _sanityCheck(header.hashTable.isOccupied(index))
-    (firstElementAddress + index.bucket).initialize(to: object)
+  internal func initialize(at bucket: _HashTable.Bucket, to object: AnyObject) {
+    _sanityCheck(header.hashTable.isOccupied(bucket))
+    (firstElementAddress + bucket.offset).initialize(to: object)
     _fixLifetime(self)
   }
 }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -111,8 +111,8 @@ extension _NativeDictionary { // Low-level unchecked operations
   @inline(__always)
   internal func uncheckedInitialize(
     at bucket: Bucket,
-    toKey key: Key,
-    value: Value) {
+    toKey key: __owned Key,
+    value: __owned Value) {
     defer { _fixLifetime(self) }
     _sanityCheck(hashTable.isValid(bucket))
     (_keys + bucket.offset).initialize(to: key)

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -35,11 +35,9 @@ internal struct _NativeDictionary<Key: Hashable, Value> {
     self._storage = storage
   }
 
-  @usableFromInline
-  @_effects(releasenone)
+  @inlinable
   internal init(capacity: Int) {
-    let scale = _HashTable.scale(forCapacity: capacity)
-    self._storage = _DictionaryStorage<Key, Value>.allocate(scale: scale)
+    self._storage = _DictionaryStorage<Key, Value>.allocate(capacity: capacity)
   }
 
 #if _runtime(_ObjC)

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -62,6 +62,9 @@ internal struct _NativeDictionary<Key: Hashable, Value> {
 }
 
 extension _NativeDictionary { // Primitive fields
+  @usableFromInline
+  internal typealias Bucket = _HashTable.Bucket
+
   @inlinable
   internal var capacity: Int {
     @inline(__always)
@@ -92,39 +95,39 @@ extension _NativeDictionary { // Primitive fields
 extension _NativeDictionary { // Low-level unchecked operations
   @inlinable
   @inline(__always)
-  internal func uncheckedKey(at index: Index) -> Key {
+  internal func uncheckedKey(at bucket: Bucket) -> Key {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(index))
-    return _keys[index.bucket]
+    _sanityCheck(hashTable.isOccupied(bucket))
+    return _keys[bucket.offset]
   }
 
   @inlinable
   @inline(__always)
-  internal func uncheckedValue(at index: Index) -> Value {
+  internal func uncheckedValue(at bucket: Bucket) -> Value {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(index))
-    return _values[index.bucket]
+    _sanityCheck(hashTable.isOccupied(bucket))
+    return _values[bucket.offset]
   }
 
   @usableFromInline
   @inline(__always)
   internal func uncheckedInitialize(
-    at index: Index,
+    at bucket: Bucket,
     toKey key: Key,
     value: Value) {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isValid(index))
-    (_keys + index.bucket).initialize(to: key)
-    (_values + index.bucket).initialize(to: value)
+    _sanityCheck(hashTable.isValid(bucket))
+    (_keys + bucket.offset).initialize(to: key)
+    (_values + bucket.offset).initialize(to: value)
   }
 
   @usableFromInline
   @inline(__always)
-  internal func uncheckedDestroy(at index: Index) {
+  internal func uncheckedDestroy(at bucket: Bucket) {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(index))
-    (_keys + index.bucket).deinitialize(count: 1)
-    (_values + index.bucket).deinitialize(count: 1)
+    _sanityCheck(hashTable.isOccupied(bucket))
+    (_keys + bucket.offset).deinitialize(count: 1)
+    (_values + bucket.offset).deinitialize(count: 1)
   }
 }
 
@@ -137,7 +140,7 @@ extension _NativeDictionary { // Low-level lookup operations
 
   @inlinable
   @inline(__always)
-  internal func find(_ key: Key) -> (index: Index, found: Bool) {
+  internal func find(_ key: Key) -> (bucket: Bucket, found: Bool) {
     return find(key, hashValue: self.hashValue(for: key))
   }
 
@@ -150,16 +153,16 @@ extension _NativeDictionary { // Low-level lookup operations
   internal func find(
     _ key: Key,
     hashValue: Int
-  ) -> (index: Index, found: Bool) {
+  ) -> (bucket: Bucket, found: Bool) {
     let hashTable = self.hashTable
-    var index = hashTable.idealIndex(forHashValue: hashValue)
-    while hashTable._isOccupied(index) {
-      if uncheckedKey(at: index) == key {
-        return (index, true)
+    var bucket = hashTable.idealBucket(forHashValue: hashValue)
+    while hashTable._isOccupied(bucket) {
+      if uncheckedKey(at: bucket) == key {
+        return (bucket, true)
       }
-      index = hashTable.index(wrappedAfter: index)
+      bucket = hashTable.bucket(wrappedAfter: bucket)
     }
-    return (index, false)
+    return (bucket, false)
   }
 }
 
@@ -170,9 +173,9 @@ extension _NativeDictionary { // ensureUnique
     let result = _NativeDictionary(
       _DictionaryStorage<Key, Value>.allocate(capacity: capacity))
     if count > 0 {
-      for index in hashTable {
-        let key = (_keys + index.bucket).move()
-        let value = (_values + index.bucket).move()
+      for bucket in hashTable {
+        let key = (_keys + bucket.offset).move()
+        let value = (_values + bucket.offset).move()
         result._unsafeInsertNew(key: key, value: value)
       }
       // Clear out old storage, ensuring that its deinit won't overrelease the
@@ -192,18 +195,18 @@ extension _NativeDictionary { // ensureUnique
     let result = _NativeDictionary(newStorage)
     if count > 0 {
       if rehash {
-        for index in hashTable {
+        for bucket in hashTable {
           result._unsafeInsertNew(
-            key: self.uncheckedKey(at: index),
-            value: self.uncheckedValue(at: index))
+            key: self.uncheckedKey(at: bucket),
+            value: self.uncheckedValue(at: bucket))
         }
       } else {
         result.hashTable.copyContents(of: hashTable)
         result._storage._count = self.count
-        for index in hashTable {
-          let key = uncheckedKey(at: index)
-          let value = uncheckedValue(at: index)
-          result.uncheckedInitialize(at: index, toKey: key, value: value)
+        for bucket in hashTable {
+          let key = uncheckedKey(at: bucket)
+          let value = uncheckedValue(at: bucket)
+          result.uncheckedInitialize(at: bucket, toKey: key, value: value)
         }
       }
     }
@@ -234,21 +237,21 @@ extension _NativeDictionary { // ensureUnique
 
 extension _NativeDictionary: _DictionaryBuffer {
   @usableFromInline
-  internal typealias Index = _HashTable.Index
+  internal typealias Index = Bucket
 
   @inlinable
   internal var startIndex: Index {
-    return hashTable.startIndex
+    return hashTable.startBucket
   }
 
   @inlinable
   internal var endIndex: Index {
-    return hashTable.endIndex
+    return hashTable.endBucket
   }
 
   @inlinable
   internal func index(after index: Index) -> Index {
-    return hashTable.index(after: index)
+    return hashTable.occupiedBucket(after: index)
   }
 
   @inlinable
@@ -257,8 +260,9 @@ extension _NativeDictionary: _DictionaryBuffer {
       // Fast path that avoids computing the hash of the key.
       return nil
     }
-    let (index, found) = find(key)
-    return found ? index : nil
+    let (bucket, found) = find(key)
+    guard found else { return nil }
+    return bucket
   }
 
   @inlinable
@@ -281,8 +285,9 @@ extension _NativeDictionary: _DictionaryBuffer {
       // Fast path that avoids computing the hash of the key.
       return nil
     }
-    let (index, found) = self.find(key)
-    return found ? self.uncheckedValue(at: index) : nil
+    let (bucket, found) = self.find(key)
+    guard found else { return nil }
+    return self.uncheckedValue(at: bucket)
   }
 
   @inlinable
@@ -341,15 +346,15 @@ extension _NativeDictionary { // Insertions
       // elements -- these imply that the Element type violates Hashable
       // requirements. This is generally more costly than a direct insertion,
       // because we'll need to compare elements in case of hash collisions.
-      let (index, found) = find(key, hashValue: hashValue)
+      let (bucket, found) = find(key, hashValue: hashValue)
       guard !found else {
         KEY_TYPE_OF_DICTIONARY_VIOLATES_HASHABLE_REQUIREMENTS(Key.self)
       }
-      hashTable.insert(index)
-      uncheckedInitialize(at: index, toKey: key, value: value)
+      hashTable.insert(bucket)
+      uncheckedInitialize(at: bucket, toKey: key, value: value)
     } else {
-      let index = hashTable.insertNew(hashValue: hashValue)
-      uncheckedInitialize(at: index, toKey: key, value: value)
+      let bucket = hashTable.insertNew(hashValue: hashValue)
+      uncheckedInitialize(at: bucket, toKey: key, value: value)
     }
     _storage._count += 1
   }
@@ -373,8 +378,8 @@ extension _NativeDictionary { // Insertions
   internal mutating func mutatingFind(
     _ key: Key,
     isUnique: Bool
-  ) -> (index: Index, found: Bool) {
-    let (index, found) = find(key)
+  ) -> (bucket: Bucket, found: Bool) {
+    let (bucket, found) = find(key)
 
     // Prepare storage.
     // If `key` isn't in the dictionary yet, assume that this access will end
@@ -384,22 +389,22 @@ extension _NativeDictionary { // Insertions
     let rehashed = ensureUnique(
       isUnique: isUnique,
       capacity: count + (found ? 0 : 1))
-    guard rehashed else { return (index, found) }
-    let (i, f) = find(key)
+    guard rehashed else { return (bucket, found) }
+    let (b, f) = find(key)
     if f != found {
       KEY_TYPE_OF_DICTIONARY_VIOLATES_HASHABLE_REQUIREMENTS(Key.self)
     }
-    return (i, found)
+    return (b, found)
   }
 
   @inlinable
   internal func _insert(
-    at index: Index,
+    at bucket: Bucket,
     key: __owned Key,
     value: __owned Value) {
     _sanityCheck(count < capacity)
-    hashTable.insert(index)
-    uncheckedInitialize(at: index, toKey: key, value: value)
+    hashTable.insert(bucket)
+    uncheckedInitialize(at: bucket, toKey: key, value: value)
     _storage._count += 1
   }
 
@@ -409,17 +414,17 @@ extension _NativeDictionary { // Insertions
     forKey key: Key,
     isUnique: Bool
   ) -> Value? {
-    let (index, found) = mutatingFind(key, isUnique: isUnique)
+    let (bucket, found) = mutatingFind(key, isUnique: isUnique)
     if found {
-      let oldValue = (_values + index.bucket).move()
-      (_values + index.bucket).initialize(to: value)
+      let oldValue = (_values + bucket.offset).move()
+      (_values + bucket.offset).initialize(to: value)
       // FIXME: Replacing the old key with the new is unnecessary, unintuitive,
       // and actively harmful to some usecases. We shouldn't do it.
       // rdar://problem/32144087
-      (_keys + index.bucket).pointee = key
+      (_keys + bucket.offset).pointee = key
       return oldValue
     }
-    _insert(at: index, key: key, value: value)
+    _insert(at: bucket, key: key, value: value)
     return nil
   }
 
@@ -429,15 +434,15 @@ extension _NativeDictionary { // Insertions
     forKey key: Key,
     isUnique: Bool
   ) {
-    let (index, found) = mutatingFind(key, isUnique: isUnique)
+    let (bucket, found) = mutatingFind(key, isUnique: isUnique)
     if found {
-      (_values + index.bucket).pointee = value
+      (_values + bucket.offset).pointee = value
       // FIXME: Replacing the old key with the new is unnecessary, unintuitive,
       // and actively harmful to some usecases. We shouldn't do it.
       // rdar://problem/32144087
-      (_keys + index.bucket).pointee = key
+      (_keys + bucket.offset).pointee = key
     } else {
-      _insert(at: index, key: key, value: value)
+      _insert(at: bucket, key: key, value: value)
     }
   }
 }
@@ -445,24 +450,24 @@ extension _NativeDictionary { // Insertions
 extension _NativeDictionary: _HashTableDelegate {
   @inlinable
   @inline(__always)
-  internal func hashValue(at index: Index) -> Int {
-    return hashValue(for: uncheckedKey(at: index))
+  internal func hashValue(at bucket: Bucket) -> Int {
+    return hashValue(for: uncheckedKey(at: bucket))
   }
 
   @inlinable
   @inline(__always)
-  internal func moveEntry(from source: Index, to target: Index) {
-    (_keys + target.bucket)
-      .moveInitialize(from: _keys + source.bucket, count: 1)
-    (_values + target.bucket)
-      .moveInitialize(from: _values + source.bucket, count: 1)
+  internal func moveEntry(from source: Bucket, to target: Bucket) {
+    (_keys + target.offset)
+      .moveInitialize(from: _keys + source.offset, count: 1)
+    (_values + target.offset)
+      .moveInitialize(from: _values + source.offset, count: 1)
   }
 }
 
 extension _NativeDictionary { // Deletion
   @inlinable
-  internal func _delete(at index: Index) {
-    hashTable.delete(at: index, with: self)
+  internal func _delete(at bucket: Bucket) {
+    hashTable.delete(at: bucket, with: self)
     _storage._count -= 1
     _sanityCheck(_storage._count >= 0)
   }
@@ -470,15 +475,15 @@ extension _NativeDictionary { // Deletion
   @inlinable
   @inline(__always)
   internal mutating func uncheckedRemove(
-    at index: Index,
+    at bucket: Bucket,
     isUnique: Bool
   ) -> Element {
-    _sanityCheck(hashTable.isOccupied(index))
+    _sanityCheck(hashTable.isOccupied(bucket))
     let rehashed = ensureUnique(isUnique: isUnique, capacity: capacity)
     _sanityCheck(!rehashed)
-    let oldKey = (_keys + index.bucket).move()
-    let oldValue = (_values + index.bucket).move()
-    _delete(at: index)
+    let oldKey = (_keys + bucket.offset).move()
+    let oldValue = (_values + bucket.offset).move()
+    _delete(at: bucket)
     return (oldKey, oldValue)
   }
 
@@ -496,9 +501,9 @@ extension _NativeDictionary { // Deletion
       _storage = _DictionaryStorage<Key, Value>.allocate(scale: scale)
       return
     }
-    for index in hashTable {
-      (_keys + index.bucket).deinitialize(count: 1)
-      (_values + index.bucket).deinitialize(count: 1)
+    for bucket in hashTable {
+      (_keys + bucket.offset).deinitialize(count: 1)
+      (_values + bucket.offset).deinitialize(count: 1)
     }
     hashTable.clear()
     _storage._count = 0
@@ -514,10 +519,10 @@ extension _NativeDictionary { // High-level operations
     // Because the keys in the current and new buffer are the same, we can
     // initialize to the same locations in the new buffer, skipping hash value
     // recalculations.
-    for index in hashTable {
-      let key = self.uncheckedKey(at: index)
-      let value = self.uncheckedValue(at: index)
-      try result._insert(at: index, key: key, value: transform(value))
+    for bucket in hashTable {
+      let key = self.uncheckedKey(at: bucket)
+      let value = self.uncheckedValue(at: bucket)
+      try result._insert(at: bucket, key: key, value: transform(value))
     }
     return result
   }
@@ -530,18 +535,18 @@ extension _NativeDictionary { // High-level operations
   ) rethrows where S.Element == (Key, Value) {
     var isUnique = isUnique
     for (key, value) in keysAndValues {
-      let (index, found) = mutatingFind(key, isUnique: isUnique)
+      let (bucket, found) = mutatingFind(key, isUnique: isUnique)
       isUnique = true
       if found {
         do {
-          let v = (_values + index.bucket).move()
+          let v = (_values + bucket.offset).move()
           let newValue = try combine(v, value)
-          (_values + index.bucket).initialize(to: newValue)
+          (_values + bucket.offset).initialize(to: newValue)
         } catch _MergeError.keyCollision {
           fatalError("Duplicate values for key: '\(key)'")
         }
       } else {
-        _insert(at: index, key: key, value: value)
+        _insert(at: bucket, key: key, value: value)
       }
     }
   }
@@ -555,11 +560,11 @@ extension _NativeDictionary { // High-level operations
     self.init()
     for value in values {
       let key = try keyForValue(value)
-      let (index, found) = mutatingFind(key, isUnique: true)
+      let (bucket, found) = mutatingFind(key, isUnique: true)
       if found {
-        _values[index.bucket].append(value)
+        _values[bucket.offset].append(value)
       } else {
-        _insert(at: index, key: key, value: [value])
+        _insert(at: bucket, key: key, value: [value])
       }
     }
   }

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -60,6 +60,9 @@ internal struct _NativeSet<Element: Hashable> {
 }
 
 extension _NativeSet { // Primitive fields
+  @usableFromInline
+  internal typealias Bucket = _HashTable.Bucket
+
   @inlinable
   internal var capacity: Int {
     @inline(__always)
@@ -85,17 +88,17 @@ extension _NativeSet { // Primitive fields
 extension _NativeSet { // Low-level unchecked operations
   @inlinable
   @inline(__always)
-  internal func uncheckedElement(at index: Index) -> Element {
+  internal func uncheckedElement(at bucket: Bucket) -> Element {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(index))
-    return _elements[index.bucket]
+    _sanityCheck(hashTable.isOccupied(bucket))
+    return _elements[bucket.offset]
   }
 
   @inlinable
   @inline(__always)
-  internal func uncheckedInitialize(at index: Index, to element: Element) {
-    _sanityCheck(hashTable.isValid(index))
-    (_elements + index.bucket).initialize(to: element)
+  internal func uncheckedInitialize(at bucket: Bucket, to element: Element) {
+    _sanityCheck(hashTable.isValid(bucket))
+    (_elements + bucket.offset).initialize(to: element)
   }
 }
 
@@ -108,7 +111,7 @@ extension _NativeSet { // Low-level lookup operations
 
   @inlinable
   @inline(__always)
-  internal func find(_ element: Element) -> (index: Index, found: Bool) {
+  internal func find(_ element: Element) -> (bucket: Bucket, found: Bool) {
     return find(element, hashValue: self.hashValue(for: element))
   }
 
@@ -121,16 +124,16 @@ extension _NativeSet { // Low-level lookup operations
   internal func find(
     _ element: Element,
     hashValue: Int
-  ) -> (index: Index, found: Bool) {
+  ) -> (bucket: Bucket, found: Bool) {
     let hashTable = self.hashTable
-    var index = hashTable.idealIndex(forHashValue: hashValue)
-    while hashTable._isOccupied(index) {
-      if uncheckedElement(at: index) == element {
-        return (index, true)
+    var bucket = hashTable.idealBucket(forHashValue: hashValue)
+    while hashTable._isOccupied(bucket) {
+      if uncheckedElement(at: bucket) == element {
+        return (bucket, true)
       }
-      index = hashTable.index(wrappedAfter: index)
+      bucket = hashTable.bucket(wrappedAfter: bucket)
     }
-    return (index, false)
+    return (bucket, false)
   }
 }
 
@@ -140,8 +143,8 @@ extension _NativeSet { // ensureUnique
     let capacity = Swift.max(capacity, self.capacity)
     let result = _NativeSet(_SetStorage<Element>.allocate(capacity: capacity))
     if count > 0 {
-      for index in hashTable {
-        let element = (self._elements + index.bucket).move()
+      for bucket in hashTable {
+        let element = (self._elements + bucket.offset).move()
         result._unsafeInsertNew(element)
       }
       // Clear out old storage, ensuring that its deinit won't overrelease the
@@ -161,15 +164,15 @@ extension _NativeSet { // ensureUnique
     let result = _NativeSet(newStorage)
     if count > 0 {
       if rehash {
-        for index in hashTable {
-          result._unsafeInsertNew(self.uncheckedElement(at: index))
+        for bucket in hashTable {
+          result._unsafeInsertNew(self.uncheckedElement(at: bucket))
         }
       } else {
         result.hashTable.copyContents(of: hashTable)
         result._storage._count = self.count
-        for index in hashTable {
-          let element = uncheckedElement(at: index)
-          result.uncheckedInitialize(at: index, to: element)
+        for bucket in hashTable {
+          let element = uncheckedElement(at: bucket)
+          result.uncheckedInitialize(at: bucket, to: element)
         }
       }
     }
@@ -200,21 +203,21 @@ extension _NativeSet { // ensureUnique
 
 extension _NativeSet: _SetBuffer {
   @usableFromInline
-  internal typealias Index = _HashTable.Index
+  internal typealias Index = Bucket
 
   @inlinable
   internal var startIndex: Index {
-    return hashTable.startIndex
+    return hashTable.startBucket
   }
 
   @inlinable
   internal var endIndex: Index {
-    return hashTable.endIndex
+    return hashTable.endBucket
   }
 
   @inlinable
   internal func index(after index: Index) -> Index {
-    return hashTable.index(after: index)
+    return hashTable.occupiedBucket(after: index)
   }
 
   @inlinable
@@ -224,8 +227,9 @@ extension _NativeSet: _SetBuffer {
       // Fast path that avoids computing the hash of the key.
       return nil
     }
-    let (index, found) = find(element)
-    return found ? index : nil
+    let (bucket, found) = find(element)
+    guard found else { return nil }
+    return bucket
   }
 
   @inlinable
@@ -247,7 +251,7 @@ extension _NativeSet: _SetBuffer {
   @inline(__always)
   internal func element(at index: Index) -> Element {
     hashTable.checkOccupied(index)
-    return _elements[index.bucket]
+    return _elements[index.offset]
   }
 }
 
@@ -280,15 +284,15 @@ extension _NativeSet { // Insertions
       // elements -- these imply that the Element type violates Hashable
       // requirements. This is generally more costly than a direct insertion,
       // because we'll need to compare elements in case of hash collisions.
-      let (index, found) = find(element, hashValue: hashValue)
+      let (bucket, found) = find(element, hashValue: hashValue)
       guard !found else {
         ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
       }
-      hashTable.insert(index)
-      uncheckedInitialize(at: index, to: element)
+      hashTable.insert(bucket)
+      uncheckedInitialize(at: bucket, to: element)
     } else {
-      let index = hashTable.insertNew(hashValue: hashValue)
-      uncheckedInitialize(at: index, to: element)
+      let bucket = hashTable.insertNew(hashValue: hashValue)
+      uncheckedInitialize(at: bucket, to: element)
     }
     _storage._count += 1
   }
@@ -303,28 +307,29 @@ extension _NativeSet { // Insertions
   }
 
   @inlinable
-  internal func _unsafeInsertNew(_ element: __owned Element, at index: Index) {
-    hashTable.insert(index)
-    uncheckedInitialize(at: index, to: element)
+  internal func _unsafeInsertNew(_ element: __owned Element, at bucket: Bucket) {
+    hashTable.insert(bucket)
+    uncheckedInitialize(at: bucket, to: element)
     _storage._count += 1
   }
 
   @inlinable
   internal mutating func insertNew(
     _ element: __owned Element,
-    at index: Index,
+    at bucket: Bucket,
     isUnique: Bool
   ) {
-    _sanityCheck(!hashTable.isOccupied(index))
-    var index = index
-    if ensureUnique(isUnique: isUnique, capacity: count + 1) {
-      let (i, f) = find(element)
+    _sanityCheck(!hashTable.isOccupied(bucket))
+    var bucket = bucket
+    let rehashed = ensureUnique(isUnique: isUnique, capacity: count + 1)
+    if rehashed {
+      let (b, f) = find(element)
       if f {
         ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
       }
-      index = i
+      bucket = b
     }
-    _unsafeInsertNew(element, at: index)
+    _unsafeInsertNew(element, at: bucket)
   }
 
   @inlinable
@@ -332,23 +337,23 @@ extension _NativeSet { // Insertions
     with element: __owned Element,
     isUnique: Bool
   ) -> Element? {
-    var (index, found) = find(element)
+    var (bucket, found) = find(element)
     let rehashed = ensureUnique(
       isUnique: isUnique,
       capacity: count + (found ? 0 : 1))
     if rehashed {
-      let (i, f) = find(element)
+      let (b, f) = find(element)
       if f != found {
         ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
       }
-      index = i
+      bucket = b
     }
     if found {
-      let old = (_elements + index.bucket).move()
-      uncheckedInitialize(at: index, to: element)
+      let old = (_elements + bucket.offset).move()
+      uncheckedInitialize(at: bucket, to: element)
       return old
     }
-    _unsafeInsertNew(element, at: index)
+    _unsafeInsertNew(element, at: bucket)
     return nil
   }
 }
@@ -356,35 +361,35 @@ extension _NativeSet { // Insertions
 extension _NativeSet: _HashTableDelegate {
   @inlinable
   @inline(__always)
-  internal func hashValue(at index: Index) -> Int {
-    return hashValue(for: uncheckedElement(at: index))
+  internal func hashValue(at bucket: Bucket) -> Int {
+    return hashValue(for: uncheckedElement(at: bucket))
   }
 
   @inlinable
   @inline(__always)
-  internal func moveEntry(from source: Index, to target: Index) {
-    (_elements + target.bucket)
-      .moveInitialize(from: _elements + source.bucket, count: 1)
+  internal func moveEntry(from source: Bucket, to target: Bucket) {
+    (_elements + target.offset)
+      .moveInitialize(from: _elements + source.offset, count: 1)
   }
 }
 
 extension _NativeSet { // Deletion
   @inlinable
-  internal mutating func _delete(at index: Index) {
-    hashTable.delete(at: index, with: self)
+  internal mutating func _delete(at bucket: Bucket) {
+    hashTable.delete(at: bucket, with: self)
     _storage._count -= 1
   }
 
   @inlinable
   @inline(__always)
   internal mutating func uncheckedRemove(
-    at index: Index,
+    at bucket: Bucket,
     isUnique: Bool) -> Element {
-    _sanityCheck(hashTable.isOccupied(index))
+    _sanityCheck(hashTable.isOccupied(bucket))
     let rehashed = ensureUnique(isUnique: isUnique, capacity: capacity)
     _sanityCheck(!rehashed)
-    let old = (_elements + index.bucket).move()
-    _delete(at: index)
+    let old = (_elements + bucket.offset).move()
+    _delete(at: bucket)
     return old
   }
 
@@ -402,8 +407,8 @@ extension _NativeSet { // Deletion
       _storage = _SetStorage<Element>.allocate(scale: scale)
       return
     }
-    for index in hashTable {
-      (_elements + index.bucket).deinitialize(count: 1)
+    for bucket in hashTable {
+      (_elements + bucket.offset).deinitialize(count: 1)
     }
     hashTable.clear()
     _storage._count = 0

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -34,11 +34,9 @@ internal struct _NativeSet<Element: Hashable> {
     self._storage = storage
   }
 
-  @usableFromInline
-  @_effects(releasenone)
+  @inlinable
   internal init(capacity: Int) {
-    let scale = _HashTable.scale(forCapacity: capacity)
-    self._storage = _SetStorage<Element>.allocate(scale: scale)
+    self._storage = _SetStorage<Element>.allocate(capacity: capacity)
   }
 
 #if _runtime(_ObjC)

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -94,7 +94,9 @@ extension _NativeSet { // Low-level unchecked operations
 
   @inlinable
   @inline(__always)
-  internal func uncheckedInitialize(at bucket: Bucket, to element: Element) {
+  internal func uncheckedInitialize(
+    at bucket: Bucket,
+    to element: __owned Element) {
     _sanityCheck(hashTable.isValid(bucket))
     (_elements + bucket.offset).initialize(to: element)
   }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -222,12 +222,12 @@ extension Set: ExpressibleByArrayLiteral {
     }
     let native = _NativeSet<Element>(capacity: elements.count)
     for element in elements {
-      let (index, found) = native.find(element)
+      let (bucket, found) = native.find(element)
       if found {
         // FIXME: Shouldn't this trap?
         continue
       }
-      native._unsafeInsertNew(element, at: index)
+      native._unsafeInsertNew(element, at: bucket)
     }
     self.init(_native: native)
   }
@@ -441,8 +441,8 @@ extension Set: Equatable {
       }
 
       defer { _fixLifetime(lhsNative) }
-      for i in lhsNative.hashTable {
-        let key = lhsNative.element(at: i)
+      for bucket in lhsNative.hashTable {
+        let key = lhsNative.uncheckedElement(at: bucket)
         let bridgedKey = _bridgeAnythingToObjectiveC(key)
         if rhsCocoa.contains(bridgedKey) {
           continue
@@ -1422,7 +1422,7 @@ extension Set.Index: Hashable {
     switch _variant {
     case .native(let nativeIndex):
       hasher.combine(0 as UInt8)
-      hasher.combine(nativeIndex.bucket)
+      hasher.combine(nativeIndex.offset)
     case .cocoa(let cocoaIndex):
       _cocoaPath()
       hasher.combine(1 as UInt8)

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1429,7 +1429,7 @@ extension Set.Index: Hashable {
       hasher.combine(cocoaIndex.currentKeyIndex)
     }
   #else
-    hasher.combine(_asNative.bucket)
+    hasher.combine(_asNative.offset)
   #endif
   }
 }

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -63,8 +63,8 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
 
   @nonobjc internal var base: _NativeSet<Element>
   @nonobjc internal var bridgedElements: _BridgingHashBuffer?
-  @nonobjc internal var nextIndex: _NativeSet<Element>.Index
-  @nonobjc internal var endIndex: _NativeSet<Element>.Index
+  @nonobjc internal var nextBucket: _NativeSet<Element>.Bucket
+  @nonobjc internal var endBucket: _NativeSet<Element>.Bucket
 
   @objc
   internal override required init() {
@@ -75,8 +75,8 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     _sanityCheck(_isBridgedVerbatimToObjectiveC(Element.self))
     self.base = base
     self.bridgedElements = nil
-    self.nextIndex = base.startIndex
-    self.endIndex = base.endIndex
+    self.nextBucket = base.hashTable.startBucket
+    self.endBucket = base.hashTable.endBucket
   }
 
   @nonobjc
@@ -84,16 +84,16 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     _sanityCheck(!_isBridgedVerbatimToObjectiveC(Element.self))
     self.base = deferred.native
     self.bridgedElements = deferred.bridgeElements()
-    self.nextIndex = base.startIndex
-    self.endIndex = base.endIndex
+    self.nextBucket = base.hashTable.startBucket
+    self.endBucket = base.hashTable.endBucket
   }
 
-  private func bridgedElement(at index: _HashTable.Index) -> AnyObject {
-    _sanityCheck(base.hashTable.isOccupied(index))
+  private func bridgedElement(at bucket: _HashTable.Bucket) -> AnyObject {
+    _sanityCheck(base.hashTable.isOccupied(bucket))
     if let bridgedElements = self.bridgedElements {
-      return bridgedElements[index]
+      return bridgedElements[bucket]
     }
-    return _bridgeAnythingToObjectiveC(base.element(at: index))
+    return _bridgeAnythingToObjectiveC(base.uncheckedElement(at: bucket))
   }
 
   //
@@ -104,12 +104,12 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
 
   @objc
   internal func nextObject() -> AnyObject? {
-    if nextIndex == endIndex {
+    if nextBucket == endBucket {
       return nil
     }
-    let index = nextIndex
-    nextIndex = base.index(after: nextIndex)
-    return self.bridgedElement(at: index)
+    let bucket = nextBucket
+    nextBucket = base.hashTable.occupiedBucket(after: nextBucket)
+    return self.bridgedElement(at: bucket)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -125,7 +125,7 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
     }
 
-    if nextIndex == endIndex {
+    if nextBucket == endBucket {
       state.pointee = theState
       return 0
     }
@@ -133,8 +133,8 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     // Return only a single element so that code can start iterating via fast
     // enumeration, terminate it, and continue via NSEnumerator.
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects)
-    unmanagedObjects[0] = self.bridgedElement(at: nextIndex)
-    nextIndex = base.index(after: nextIndex)
+    unmanagedObjects[0] = self.bridgedElement(at: nextBucket)
+    nextBucket = base.hashTable.occupiedBucket(after: nextBucket)
     state.pointee = theState
     return 1
   }
@@ -198,9 +198,10 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     let bridged = _BridgingHashBuffer.allocate(
       owner: native._storage,
       hashTable: native.hashTable)
-    for index in native.hashTable {
-      let object = _bridgeAnythingToObjectiveC(native.element(at: index))
-      bridged.initialize(at: index, to: object)
+    for bucket in native.hashTable {
+      let object = _bridgeAnythingToObjectiveC(
+        native.uncheckedElement(at: bucket))
+      bridged.initialize(at: bucket, to: object)
     }
 
     // Atomically put the bridged elements in place.
@@ -225,10 +226,10 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     guard let element = _conditionallyBridgeFromObjectiveC(object, Element.self)
     else { return nil }
 
-    let (index, found) = native.find(element)
+    let (bucket, found) = native.find(element)
     guard found else { return nil }
     let bridged = bridgeElements()
-    return bridged[index]
+    return bridged[bucket]
   }
 
   @objc
@@ -247,12 +248,15 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     objects: UnsafeMutablePointer<AnyObject>?,
     count: Int
   ) -> Int {
+    defer { _fixLifetime(self) }
+    let hashTable = native.hashTable
+
     var theState = state.pointee
     if theState.state == 0 {
       theState.state = 1 // Arbitrary non-zero value.
       theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
-      theState.extra.0 = CUnsignedLong(native.startIndex.bucket)
+      theState.extra.0 = CUnsignedLong(hashTable.startBucket.offset)
     }
 
     // Test 'objects' rather than 'count' because (a) this is very rare anyway,
@@ -263,21 +267,21 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     }
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
-    var index = _NativeSet<Element>.Index(bucket: Int(theState.extra.0))
-    let endIndex = native.endIndex
-    _precondition(index == endIndex || native.hashTable.isValid(index))
+    var bucket = _HashTable.Bucket(offset: Int(theState.extra.0))
+    let endBucket = hashTable.endBucket
+    _precondition(bucket == endBucket || native.hashTable.isValid(bucket))
 
     // Only need to bridge once, so we can hoist it out of the loop.
     let bridgedElements = bridgeElements()
 
     var stored = 0
     for i in 0..<count {
-      if index == endIndex { break }
-      unmanagedObjects[i] = bridgedElements[index]
+      if bucket == endBucket { break }
+      unmanagedObjects[i] = bridgedElements[bucket]
       stored += 1
-      index = native.index(after: index)
+      bucket = hashTable.occupiedBucket(after: bucket)
     }
-    theState.extra.0 = CUnsignedLong(index.bucket)
+    theState.extra.0 = CUnsignedLong(bucket.offset)
     state.pointee = theState
     return stored
   }

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -271,12 +271,12 @@ extension Set._Variant {
   ) -> (inserted: Bool, memberAfterInsert: Element) {
     switch self {
     case .native:
-      let (index, found) = asNative.find(element)
+      let (bucket, found) = asNative.find(element)
       if found {
-        return (false, asNative.uncheckedElement(at: index))
+        return (false, asNative.uncheckedElement(at: bucket))
       }
       let isUnique = self.isUniquelyReferenced()
-      asNative.insertNew(element, at: index, isUnique: isUnique)
+      asNative.insertNew(element, at: bucket, isUnique: isUnique)
       return (true, element)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
@@ -318,10 +318,10 @@ extension Set._Variant {
   internal mutating func remove(_ member: Element) -> Element? {
     switch self {
     case .native:
-      let (index, found) = asNative.find(member)
+      let (bucket, found) = asNative.find(member)
       guard found else { return nil }
       let isUnique = isUniquelyReferenced()
-      return asNative.uncheckedRemove(at: index, isUnique: isUnique)
+      return asNative.uncheckedRemove(at: bucket, isUnique: isUnique)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -341,9 +341,9 @@ extension Set._Variant {
     // FIXME(performance): fuse data migration and element deletion into one
     // operation.
     var native = _NativeSet<Element>(cocoa)
-    let (index, found) = native.find(member)
+    let (bucket, found) = native.find(member)
     _precondition(found, "Bridging did not preserve equality")
-    let old = native.remove(at: index, isUnique: true)
+    let old = native.uncheckedRemove(at: bucket, isUnique: true)
     _precondition(member == old, "Bridging did not preserve equality")
     self = .native(native)
     return old


### PR DESCRIPTION
I want to use the Index name for the upcoming extended index that includes a mutation count.

Prepare for this by renaming `_HashTable.Index` to `_HashTable.Bucket`. Also rename its `bucket` field to `offset`. Update local variable names and members to match the new terminology.