### PR TITLE
[stdlib] Set, Dictionary: Radically improved index validation

### DIFF
--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -43,7 +43,10 @@ struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
 struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
-  __swift_intptr_t scale;
+  __swift_int8_t scale;
+  __swift_int8_t reservedScale;
+  __swift_int16_t extra;
+  __swift_int32_t age;
   __swift_intptr_t seed;
   void *rawKeys;
   void *rawValues;
@@ -52,7 +55,10 @@ struct _SwiftDictionaryBodyStorage {
 struct _SwiftSetBodyStorage {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
-  __swift_intptr_t scale;
+  __swift_int8_t scale;
+  __swift_int8_t reservedScale;
+  __swift_int16_t extra;
+  __swift_int32_t age;
   __swift_intptr_t seed;
   void *rawElements;
 };
@@ -85,6 +91,16 @@ SWIFT_RUNTIME_STDLIB_API
 struct _SwiftHashingParameters _swift_stdlib_Hashing_parameters;
 
 #ifdef __cplusplus
+
+static_assert(
+  sizeof(_SwiftDictionaryBodyStorage) ==
+    5 * sizeof(__swift_intptr_t) + sizeof(__swift_int64_t),
+  "_SwiftDictionaryBodyStorage has unexpected size");
+
+static_assert(
+  sizeof(_SwiftSetBodyStorage) ==
+    4 * sizeof(__swift_intptr_t) + sizeof(__swift_int64_t),
+  "_SwiftSetBodyStorage has unexpected size");
 
 static_assert(std::is_pod<_SwiftEmptyArrayStorage>::value,
               "empty array type should be POD");

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1776,7 +1776,8 @@ extension Dictionary.Index {
       return nativeIndex
 #if _runtime(_ObjC)
     case .cocoa:
-      _sanityCheckFailure("internal error: does not contain a native index")
+      _preconditionFailure(
+        "Attempting to access Dictionary elements using an invalid index")
 #endif
     }
   }
@@ -1786,7 +1787,8 @@ extension Dictionary.Index {
   internal var _asCocoa: _CocoaDictionary.Index {
     switch _variant {
     case .native:
-      _sanityCheckFailure("internal error: does not contain a Cocoa index")
+      _preconditionFailure(
+        "Attempting to access Dictionary elements using an invalid index")
     case .cocoa(let cocoaIndex):
       return cocoaIndex
     }

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1464,6 +1464,7 @@ extension Dictionary {
       }
       _modify {
         let index = _variant.ensureUniqueNative(preserving: position)
+        _variant.asNative.validate(index)
         let address = _variant.asNative._values + index.bucket.offset
         yield &address.pointee
         _fixLifetime(self)

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -47,6 +47,7 @@
 //   | _count                                                    |
 //   | _capacity                                                 |
 //   | _scale                                                    |
+//   | _age                                                      |
 //   | _seed                                                     |
 //   | _rawKeys                                                  |
 //   | _rawValue                                                 |
@@ -149,6 +150,13 @@
 // dictionary storage are bounds-checked, this scheme never compromises memory
 // safety.
 //
+// As a safeguard against using invalid indices, Set and Dictionary maintain a
+// mutation counter in their storage header (`_age`). This counter gets bumped
+// every time an element is removed and whenever the contents are
+// rehashed. Native indices include a copy of this counter so that index
+// validation can verify it matches with current storage. This can't catch all
+// misuse, because counters may match by accident; but it does make indexing a
+// lot more reliable.
 //
 // Bridging
 // ========

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1721,7 +1721,7 @@ extension Dictionary {
     @_frozen
     @usableFromInline
     internal enum _Variant {
-      case native(_NativeDictionary<Key, Value>.Index)
+      case native(_HashTable.Index)
 #if _runtime(_ObjC)
       case cocoa(_CocoaDictionary.Index)
 #endif
@@ -1738,7 +1738,7 @@ extension Dictionary {
 
     @inlinable
     @inline(__always)
-    internal init(_native index: _NativeDictionary<Key, Value>.Index) {
+    internal init(_native index: _HashTable.Index) {
       self.init(_variant: .native(index))
     }
 
@@ -1770,7 +1770,7 @@ extension Dictionary.Index {
 #endif
 
   @usableFromInline @_transparent
-  internal var _asNative: _NativeDictionary<Key, Value>.Index {
+  internal var _asNative: _HashTable.Index {
     switch _variant {
     case .native(let nativeIndex):
       return nativeIndex

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1464,7 +1464,7 @@ extension Dictionary {
       }
       _modify {
         let index = _variant.ensureUniqueNative(preserving: position)
-        let address = _variant.asNative._values + index.offset
+        let address = _variant.asNative._values + index.bucket.offset
         yield &address.pointee
         _fixLifetime(self)
       }
@@ -1819,14 +1819,14 @@ extension Dictionary.Index: Hashable {
     switch _variant {
     case .native(let nativeIndex):
       hasher.combine(0 as UInt8)
-      hasher.combine(nativeIndex.offset)
+      hasher.combine(nativeIndex.bucket.offset)
     case .cocoa(let cocoaIndex):
       _cocoaPath()
       hasher.combine(1 as UInt8)
       hasher.combine(cocoaIndex.currentKeyIndex)
     }
   #else
-    hasher.combine(_asNative.offset)
+    hasher.combine(_asNative.bucket.offset)
   #endif
   }
 }

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1494,6 +1494,33 @@ extension Dictionary {
     public var debugDescription: String {
       return _makeCollectionDescription(withTypeName: "Dictionary.Values")
     }
+
+    @inlinable
+    public mutating func swapAt(_ i: Index, _ j: Index) {
+      guard i != j else { return }
+#if _runtime(_ObjC)
+      if case .cocoa(let cocoa) = _variant {
+        _variant.cocoaPath()
+        let cocoaKey1 = cocoa.key(at: i._asCocoa)
+        let cocoaKey2 = cocoa.key(at: j._asCocoa)
+        var native = _NativeDictionary<Key, Value>(cocoa)
+        let nativeKey1 = _forceBridgeFromObjectiveC(cocoaKey1, Key.self)
+        let nativeKey2 = _forceBridgeFromObjectiveC(cocoaKey2, Key.self)
+        guard
+          let index1 = native.index(forKey: nativeKey1),
+          let index2 = native.index(forKey: nativeKey2)
+        else {
+          _preconditionFailure("Invalid index")
+        }
+        _variant = .native(native)
+      }
+#endif
+      let isUnique = _variant.isUniquelyReferenced()
+      _variant.asNative.swapValuesAt(
+        i._asNative,
+        j._asNative,
+        isUnique: isUnique)
+    }
   }
 }
 

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -529,7 +529,7 @@ extension _CocoaDictionary: _DictionaryBuffer {
   @inline(__always)
   func key(at index: Index) -> Key {
     _precondition(index.base.object === self.object, "Invalid index")
-    return index.allKeys[index.currentKeyIndex]
+    return index.key
   }
 
   @inlinable
@@ -605,6 +605,16 @@ extension _CocoaDictionary {
       self.allKeys = allKeys
       self.currentKeyIndex = currentKeyIndex
     }
+  }
+}
+
+extension _CocoaDictionary.Index {
+  @inlinable
+  @nonobjc
+  internal var key: AnyObject {
+    _precondition(currentKeyIndex < allKeys.value,
+      "Attempting to access Dictionary elements using an invalid index")
+    return allKeys[currentKeyIndex]
   }
 }
 

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -616,6 +616,15 @@ extension _CocoaDictionary.Index {
       "Attempting to access Dictionary elements using an invalid index")
     return allKeys[currentKeyIndex]
   }
+
+  @usableFromInline
+  @nonobjc
+  internal var age: Int32 {
+    @_effects(releasenone)
+    get {
+      return _HashTable.age(for: base.object)
+    }
+  }
 }
 
 extension _CocoaDictionary.Index: Equatable {

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -403,7 +403,8 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
     var bucket = _HashTable.Bucket(offset: Int(theState.extra.0))
     let endBucket = hashTable.endBucket
-    _precondition(bucket == endBucket || hashTable.isOccupied(bucket))
+    _precondition(bucket == endBucket || hashTable.isOccupied(bucket),
+      "Invalid fast enumeration state")
     var stored = 0
 
     // Only need to bridge once, so we can hoist it out of the loop.

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -16,16 +16,14 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
-//
-// See the docs at the top of the file for more details on this type
-//
-// NOTE: The precise layout of this type is relied on in the runtime
-// to provide a statically allocated empty singleton.
-// See stdlib/public/stubs/GlobalObjects.cpp for details.
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 @_objc_non_lazy_realization
 internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
+  // NOTE: The precise layout of this type is relied on in the runtime to
+  // provide a statically allocated empty singleton.  See
+  // stdlib/public/stubs/GlobalObjects.cpp for details.
+
   /// The current number of occupied entries in this dictionary.
   @usableFromInline
   @nonobjc
@@ -61,13 +59,17 @@ internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
   @nonobjc
   internal final var _age: Int32
 
+  /// The hash seed used to hash elements in this dictionary instance.
   @usableFromInline
   internal final var _seed: Int
 
+  /// A raw pointer to the start of the tail-allocated hash buffer holding keys.
   @usableFromInline
   @nonobjc
   internal final var _rawKeys: UnsafeMutableRawPointer
 
+  /// A raw pointer to the start of the tail-allocated hash buffer holding
+  /// values.
   @usableFromInline
   @nonobjc
   internal final var _rawValues: UnsafeMutableRawPointer

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -43,6 +43,19 @@ internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
   @nonobjc
   internal final var _scale: Int8
 
+  /// The scale corresponding to the highest `reserveCapacity(_:)` call so far,
+  /// or 0 if there were none. This may be used later to allow removals to
+  /// resize storage.
+  ///
+  /// FIXME: <rdar://problem/18114559> Shrink storage on deletion
+  @usableFromInline
+  @nonobjc
+  internal final var _reservedScale: Int8
+
+  // Currently unused, set to zero.
+  @nonobjc
+  internal final var _extra: Int16
+
   /// A mutation count, enabling stricter index validation.
   @usableFromInline
   @nonobjc
@@ -391,6 +404,8 @@ extension _DictionaryStorage {
     storage._count = 0
     storage._capacity = _HashTable.capacity(forScale: scale)
     storage._scale = scale
+    storage._reservedScale = 0
+    storage._extra = 0
 
     if let age = age {
       storage._age = age

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -381,6 +381,7 @@ extension _DictionaryStorage {
     return allocate(scale: scale, age: nil)
   }
 
+#if _runtime(_ObjC)
   @usableFromInline
   @_effects(releasenone)
   static internal func convert(
@@ -391,6 +392,7 @@ extension _DictionaryStorage {
     let age = _HashTable.age(for: cocoa.object)
     return allocate(scale: scale, age: age)
   }
+#endif
 
   static internal func allocate(
     scale: Int8,

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -292,7 +292,8 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
     var bucket = _HashTable.Bucket(offset: Int(theState.extra.0))
     let endBucket = hashTable.endBucket
-    _precondition(bucket == endBucket || _hashTable.isOccupied(bucket))
+    _precondition(bucket == endBucket || hashTable.isOccupied(bucket),
+      "Invalid fast enumeration state")
     var stored = 0
     for i in 0..<count {
       if bucket == endBucket { break }

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -381,6 +381,17 @@ extension _DictionaryStorage {
     return allocate(scale: scale, age: nil)
   }
 
+  @usableFromInline
+  @_effects(releasenone)
+  static internal func convert(
+    _ cocoa: _CocoaDictionary,
+    capacity: Int
+  ) -> _DictionaryStorage {
+    let scale = _HashTable.scale(forCapacity: capacity)
+    let age = _HashTable.age(for: cocoa.object)
+    return allocate(scale: scale, age: age)
+  }
+
   static internal func allocate(
     scale: Int8,
     age: Int32?

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -154,8 +154,8 @@ extension Dictionary._Variant: _DictionaryBuffer {
   @inlinable
   internal var startIndex: Index {
     switch self {
-    case .native:
-      return Index(_native: asNative.startIndex)
+    case .native(let native):
+      return native.startIndex
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -167,8 +167,8 @@ extension Dictionary._Variant: _DictionaryBuffer {
   @inlinable
   internal var endIndex: Index {
     switch self {
-    case .native:
-      return Index(_native: asNative.endIndex)
+    case .native(let native):
+      return native.endIndex
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -178,14 +178,14 @@ extension Dictionary._Variant: _DictionaryBuffer {
   }
 
   @inlinable
-  internal func index(after i: Index) -> Index {
+  internal func index(after index: Index) -> Index {
     switch self {
-    case .native:
-      return Index(_native: asNative.index(after: i._asNative))
+    case .native(let native):
+      return native.index(after: index)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
-      return Index(_cocoa: cocoa.index(after: i._asCocoa))
+      return Index(_cocoa: cocoa.index(after: index._asCocoa))
 #endif
     }
   }
@@ -194,9 +194,8 @@ extension Dictionary._Variant: _DictionaryBuffer {
   @inline(__always)
   internal func index(forKey key: Key) -> Index? {
     switch self {
-    case .native:
-      guard let index = asNative.index(forKey: key) else { return nil }
-      return Index(_native: index)
+    case .native(let native):
+      return native.index(forKey: key)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -212,8 +211,8 @@ extension Dictionary._Variant: _DictionaryBuffer {
     @inline(__always)
     get {
       switch self {
-      case .native:
-        return asNative.count
+      case .native(let native):
+        return native.count
 #if _runtime(_ObjC)
       case .cocoa(let cocoa):
         cocoaPath()
@@ -227,8 +226,8 @@ extension Dictionary._Variant: _DictionaryBuffer {
   @inline(__always)
   func contains(_ key: Key) -> Bool {
     switch self {
-    case .native:
-      return asNative.contains(key)
+    case .native(let native):
+      return native.contains(key)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -242,8 +241,8 @@ extension Dictionary._Variant: _DictionaryBuffer {
   @inline(__always)
   func lookup(_ key: Key) -> Value? {
     switch self {
-    case .native:
-      return asNative.lookup(key)
+    case .native(let native):
+      return native.lookup(key)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -258,8 +257,8 @@ extension Dictionary._Variant: _DictionaryBuffer {
   @inline(__always)
   func lookup(_ index: Index) -> (key: Key, value: Value) {
     switch self {
-    case .native:
-      return asNative.lookup(index._asNative)
+    case .native(let native):
+      return native.lookup(index)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -275,8 +274,8 @@ extension Dictionary._Variant: _DictionaryBuffer {
   @inline(__always)
   func key(at index: Index) -> Key {
     switch self {
-    case .native:
-      return asNative.key(at: index._asNative)
+    case .native(let native):
+      return native.key(at: index)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -290,8 +289,8 @@ extension Dictionary._Variant: _DictionaryBuffer {
   @inline(__always)
   func value(at index: Index) -> Value {
     switch self {
-    case .native:
-      return asNative.value(at: index._asNative)
+    case .native(let native):
+      return native.value(at: index)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -356,7 +356,9 @@ extension Dictionary._Variant {
       let nativeKey = _forceBridgeFromObjectiveC(cocoaKey, Key.self)
       let (bucket, found) = native.find(nativeKey)
       _precondition(found, "Bridging did not preserve equality")
-      return bucket
+      return _NativeDictionary<Key, Value>.Index(
+        bucket: bucket,
+        age: native.age)
 #endif
     }
   }

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -60,12 +60,12 @@ extension _HashTable {
     @inline(__always) get { return 3 / 4 }
   }
 
-  internal static func capacity(forScale scale: Int) -> Int {
-    let bucketCount = 1 &<< scale
+  internal static func capacity(forScale scale: Int8) -> Int {
+    let bucketCount = (1 as Int) &<< scale
     return Int(Double(bucketCount) * maxLoadFactor)
   }
 
-  internal static func scale(forCapacity capacity: Int) -> Int {
+  internal static func scale(forCapacity capacity: Int) -> Int8 {
     let capacity = Swift.max(capacity, 1)
     // Calculate the minimum number of entries we need to allocate to satisfy
     // the maximum load factor. `capacity + 1` below ensures that we always
@@ -78,9 +78,10 @@ extension _HashTable {
     // exponent.
     let exponent = (Swift.max(minimumEntries, 2) - 1)._binaryLogarithm() + 1
     _sanityCheck(exponent >= 0 && exponent < Int.bitWidth)
-    _sanityCheck(self.capacity(forScale: exponent) >= capacity)
     // The scale is the exponent corresponding to the bucket count.
-    return exponent
+    let scale = Int8(truncatingIfNeeded: exponent)
+    _sanityCheck(self.capacity(forScale: scale) >= capacity)
+    return scale
   }
 }
 

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -139,6 +139,51 @@ extension _HashTable.Bucket: Comparable {
   }
 }
 
+extension _HashTable {
+  @usableFromInline
+  @_fixed_layout
+  internal struct Index {
+    @usableFromInline
+    let bucket: Bucket
+
+    @usableFromInline
+    let age: Int32
+
+    @inlinable
+    @inline(__always)
+    internal init(bucket: Bucket, age: Int32) {
+      self.bucket = bucket
+      self.age = age
+    }
+  }
+}
+
+extension _HashTable.Index: Equatable {
+  @inlinable
+  @inline(__always)
+  internal static func ==(
+    lhs: _HashTable.Index,
+    rhs: _HashTable.Index
+  ) -> Bool {
+    _precondition(lhs.age == rhs.age,
+      "Can't compare indices belonging to different collections")
+    return lhs.bucket == rhs.bucket
+  }
+}
+
+extension _HashTable.Index: Comparable {
+  @inlinable
+  @inline(__always)
+  internal static func <(
+    lhs: _HashTable.Index,
+    rhs: _HashTable.Index
+  ) -> Bool {
+    _precondition(lhs.age == rhs.age,
+      "Can't compare indices belonging to different collections")
+    return lhs.bucket < rhs.bucket
+  }
+}
+
 extension _HashTable: Sequence {
   @usableFromInline
   @_fixed_layout

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -83,6 +83,12 @@ extension _HashTable {
     _sanityCheck(self.capacity(forScale: scale) >= capacity)
     return scale
   }
+
+  // The initial age to use for native copies of a Cocoa NSSet/NSDictionary.
+  internal static func age(for cocoa: AnyObject) -> Int32 {
+    let hash = ObjectIdentifier(cocoa).hashValue
+    return Int32(truncatingIfNeeded: hash)
+  }
 }
 
 extension _HashTable {

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -251,7 +251,7 @@ extension _NativeDictionary {
   @inline(__always)
   func validate(_ index: Index) {
     _precondition(hashTable.isOccupied(index.bucket) && index.age == age,
-      "Attempting to access Dictionary elements using an invalid Index")
+      "Attempting to access Dictionary elements using an invalid index")
   }
 
   @inlinable
@@ -269,7 +269,7 @@ extension _NativeDictionary {
       let key = _forceBridgeFromObjectiveC(cocoa.key, Key.self)
       guard let index = self.index(forKey: key) else {
         _preconditionFailure(
-          "Attempting to access Dictionary elements using an invalid Index")
+          "Attempting to access Dictionary elements using an invalid index")
       }
       return index.bucket
 #endif

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -249,9 +249,10 @@ extension _NativeDictionary { // ensureUnique
 extension _NativeDictionary {
   @inlinable
   @inline(__always)
-  func validate(_ index: Index) {
+  func validatedBucket(for index: Index) -> Bucket {
     _precondition(hashTable.isOccupied(index.bucket) && index.age == age,
       "Attempting to access Dictionary elements using an invalid index")
+    return index.bucket
   }
 
   @inlinable
@@ -259,8 +260,7 @@ extension _NativeDictionary {
   func validatedBucket(for index: Dictionary<Key, Value>.Index) -> Bucket {
     switch index._variant {
     case .native(let native):
-      validate(native)
-      return native.bucket
+      return validatedBucket(for: native)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       // Accept Cocoa indices as long as they contain a key that exists in
@@ -295,9 +295,9 @@ extension _NativeDictionary: _DictionaryBuffer {
 
   @inlinable
   internal func index(after index: Index) -> Index {
-    validate(index)
-    let bucket = hashTable.occupiedBucket(after: index.bucket)
-    return Index(bucket: bucket, age: age)
+    let bucket = validatedBucket(for: index)
+    let next = hashTable.occupiedBucket(after: bucket)
+    return Index(bucket: next, age: age)
   }
 
   @inlinable
@@ -339,24 +339,24 @@ extension _NativeDictionary: _DictionaryBuffer {
   @inlinable
   @inline(__always)
   func lookup(_ index: Index) -> (key: Key, value: Value) {
-    validate(index)
-    let key = self.uncheckedKey(at: index.bucket)
-    let value = self.uncheckedValue(at: index.bucket)
+    let bucket = validatedBucket(for: index)
+    let key = self.uncheckedKey(at: bucket)
+    let value = self.uncheckedValue(at: bucket)
     return (key, value)
   }
 
   @inlinable
   @inline(__always)
   func key(at index: Index) -> Key {
-    validate(index)
-    return self.uncheckedKey(at: index.bucket)
+    let bucket = validatedBucket(for: index)
+    return self.uncheckedKey(at: bucket)
   }
 
   @inlinable
   @inline(__always)
   func value(at index: Index) -> Value {
-    validate(index)
-    return self.uncheckedValue(at: index.bucket)
+    let bucket = validatedBucket(for: index)
+    return self.uncheckedValue(at: bucket)
   }
 }
 

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -273,6 +273,7 @@ extension _NativeDictionary: _DictionaryBuffer {
 
   @inlinable
   internal func index(after index: Index) -> Index {
+    validate(index)
     let bucket = hashTable.occupiedBucket(after: index.bucket)
     return Index(bucket: bucket, age: age)
   }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -493,16 +493,17 @@ extension _NativeDictionary { // Insertions
 extension _NativeDictionary {
   @inlinable
   @inline(__always)
-  internal mutating func swapValuesAt(_ i: Index, _ j: Index, isUnique: Bool) {
+  internal mutating func swapValuesAt(
+    _ a: Bucket,
+    _ b: Bucket,
+    isUnique: Bool
+  ) {
     let rehashed = ensureUnique(isUnique: isUnique, capacity: capacity)
     _sanityCheck(!rehashed)
-    validate(i)
-    validate(j)
-    let a = i.bucket.offset
-    let b = j.bucket.offset
-    let value = (_values + a).move()
-    (_values + a).moveInitialize(from: _values + b, count: 1)
-    (_values + b).initialize(to: value)
+    _sanityCheck(hashTable.isOccupied(a) && hashTable.isOccupied(b))
+    let value = (_values + a.offset).move()
+    (_values + a.offset).moveInitialize(from: _values + b.offset, count: 1)
+    (_values + b.offset).initialize(to: value)
   }
 }
 
@@ -545,13 +546,6 @@ extension _NativeDictionary { // Deletion
     let oldValue = (_values + bucket.offset).move()
     _delete(at: bucket)
     return (oldKey, oldValue)
-  }
-
-  @inlinable
-  @inline(__always)
-  internal mutating func remove(at index: Index, isUnique: Bool) -> Element {
-    validate(index)
-    return uncheckedRemove(at: index.bucket, isUnique: isUnique)
   }
 
   @usableFromInline

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -468,6 +468,22 @@ extension _NativeDictionary { // Insertions
   }
 }
 
+extension _NativeDictionary {
+  @inlinable
+  @inline(__always)
+  internal mutating func swapValuesAt(_ i: Index, _ j: Index, isUnique: Bool) {
+    let rehashed = ensureUnique(isUnique: isUnique, capacity: capacity)
+    _sanityCheck(!rehashed)
+    validate(i)
+    validate(j)
+    let a = i.bucket.offset
+    let b = j.bucket.offset
+    let value = (_values + a).move()
+    (_values + a).moveInitialize(from: _values + b, count: 1)
+    (_values + b).initialize(to: value)
+  }
+}
+
 extension _NativeDictionary: _HashTableDelegate {
   @inlinable
   @inline(__always)

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -241,6 +241,7 @@ extension _NativeSet: _SetBuffer {
 
   @inlinable
   internal func index(after index: Index) -> Index {
+    validate(index)
     let bucket = hashTable.occupiedBucket(after: index.bucket)
     return Index(bucket: bucket, age: age)
   }

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -217,9 +217,10 @@ extension _NativeSet { // ensureUnique
 extension _NativeSet {
   @inlinable
   @inline(__always)
-  func validate(_ index: Index) {
+  func validatedBucket(for index: Index) -> Bucket {
     _precondition(hashTable.isOccupied(index.bucket) && index.age == age,
       "Attempting to access Set elements using an invalid index")
+    return index.bucket
   }
 
   @inlinable
@@ -227,8 +228,7 @@ extension _NativeSet {
   func validatedBucket(for index: Set<Element>.Index) -> Bucket {
     switch index._variant {
     case .native(let native):
-      validate(native)
-      return native.bucket
+      return validatedBucket(for: native)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       // Accept Cocoa indices as long as they contain an element that exists in
@@ -263,9 +263,9 @@ extension _NativeSet: _SetBuffer {
 
   @inlinable
   internal func index(after index: Index) -> Index {
-    validate(index)
-    let bucket = hashTable.occupiedBucket(after: index.bucket)
-    return Index(bucket: bucket, age: age)
+    let bucket = validatedBucket(for: index)
+    let next = hashTable.occupiedBucket(after: bucket)
+    return Index(bucket: next, age: age)
   }
 
   @inlinable
@@ -298,8 +298,8 @@ extension _NativeSet: _SetBuffer {
   @inlinable
   @inline(__always)
   internal func element(at index: Index) -> Element {
-    validate(index)
-    return uncheckedElement(at: index.bucket)
+    let bucket = validatedBucket(for: index)
+    return uncheckedElement(at: bucket)
   }
 }
 
@@ -446,8 +446,8 @@ extension _NativeSet { // Deletion
   @inlinable
   @inline(__always)
   internal mutating func remove(at index: Index, isUnique: Bool) -> Element {
-    validate(index)
-    return uncheckedRemove(at: index.bucket, isUnique: isUnique)
+    let bucket = validatedBucket(for: index)
+    return uncheckedRemove(at: bucket, isUnique: isUnique)
   }
 
   @usableFromInline

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -391,6 +391,7 @@ extension _NativeSet { // Deletion
   internal mutating func _delete(at bucket: Bucket) {
     hashTable.delete(at: bucket, with: self)
     _storage._count -= 1
+    _sanityCheck(_storage._count >= 0)
     invalidateIndices()
   }
 

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -219,7 +219,7 @@ extension _NativeSet {
   @inline(__always)
   func validate(_ index: Index) {
     _precondition(hashTable.isOccupied(index.bucket) && index.age == age,
-      "Attempting to access Set elements using an invalid Index")
+      "Attempting to access Set elements using an invalid index")
   }
 
   @inlinable
@@ -237,7 +237,7 @@ extension _NativeSet {
       let element = _forceBridgeFromObjectiveC(cocoa.element, Element.self)
       guard let index = self.index(for: element) else {
         _preconditionFailure(
-          "Attempting to access Set elements using an invalid Index")
+          "Attempting to access Set elements using an invalid index")
       }
       return index.bucket
 #endif

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1422,14 +1422,14 @@ extension Set.Index: Hashable {
     switch _variant {
     case .native(let nativeIndex):
       hasher.combine(0 as UInt8)
-      hasher.combine(nativeIndex.offset)
+      hasher.combine(nativeIndex.bucket.offset)
     case .cocoa(let cocoaIndex):
       _cocoaPath()
       hasher.combine(1 as UInt8)
       hasher.combine(cocoaIndex.currentKeyIndex)
     }
   #else
-    hasher.combine(_asNative.offset)
+    hasher.combine(_asNative.bucket.offset)
   #endif
   }
 }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1296,7 +1296,7 @@ extension Set {
     @_frozen
     @usableFromInline
     internal enum _Variant {
-      case native(_NativeSet<Element>.Index)
+      case native(_HashTable.Index)
 #if _runtime(_ObjC)
       case cocoa(_CocoaSet.Index)
 #endif
@@ -1313,7 +1313,7 @@ extension Set {
 
     @inlinable
     @inline(__always)
-    internal init(_native index: _NativeSet<Element>.Index) {
+    internal init(_native index: _HashTable.Index) {
       self.init(_variant: .native(index))
     }
 
@@ -1346,7 +1346,7 @@ extension Set.Index {
 #endif
 
   @usableFromInline @_transparent
-  internal var _asNative: _NativeSet<Element>.Index {
+  internal var _asNative: _HashTable.Index {
     switch _variant {
     case .native(let nativeIndex):
       return nativeIndex

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1352,7 +1352,8 @@ extension Set.Index {
       return nativeIndex
 #if _runtime(_ObjC)
     case .cocoa:
-      _sanityCheckFailure("internal error: does not contain a native index")
+      _preconditionFailure(
+        "Attempting to access Set elements using an invalid index")
 #endif
     }
   }
@@ -1362,7 +1363,8 @@ extension Set.Index {
   internal var _asCocoa: _CocoaSet.Index {
     switch _variant {
     case .native:
-      _sanityCheckFailure("internal error: does not contain a Cocoa index")
+      _preconditionFailure(
+        "Attempting to access Set elements using an invalid index")
     case .cocoa(let cocoaIndex):
       return cocoaIndex
     }

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -304,7 +304,7 @@ extension _CocoaSet {
   @usableFromInline
   @_effects(releasenone)
   internal func member(for index: Index) -> AnyObject {
-    return index.allKeys[index.currentKeyIndex]
+    return index.element
   }
 
   @inlinable
@@ -385,9 +385,9 @@ extension _CocoaSet: _SetBuffer {
 
   @usableFromInline
   internal func element(at i: Index) -> AnyObject {
-    let value: AnyObject? = i.allKeys[i.currentKeyIndex]
-    _sanityCheck(value != nil, "Item not found in underlying NSSet")
-    return value!
+    let element: AnyObject? = i.element
+    _sanityCheck(element != nil, "Item not found in underlying NSSet")
+    return element!
   }
 }
 
@@ -440,6 +440,16 @@ extension _CocoaSet {
       self.allKeys = allKeys
       self.currentKeyIndex = currentKeyIndex
     }
+  }
+}
+
+extension _CocoaSet.Index {
+  @inlinable
+  @nonobjc
+  internal var element: AnyObject {
+    _precondition(currentKeyIndex < allKeys.value,
+      "Attempting to access Set elements using an invalid index")
+    return allKeys[currentKeyIndex]
   }
 }
 

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -269,7 +269,8 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
     var bucket = _HashTable.Bucket(offset: Int(theState.extra.0))
     let endBucket = hashTable.endBucket
-    _precondition(bucket == endBucket || native.hashTable.isValid(bucket))
+    _precondition(bucket == endBucket || hashTable.isOccupied(bucket),
+      "Invalid fast enumeration state")
 
     // Only need to bridge once, so we can hoist it out of the loop.
     let bridgedElements = bridgeElements()

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -451,6 +451,15 @@ extension _CocoaSet.Index {
       "Attempting to access Set elements using an invalid index")
     return allKeys[currentKeyIndex]
   }
+
+  @usableFromInline
+  @nonobjc
+  internal var age: Int32 {
+    @_effects(releasenone)
+    get {
+      return _HashTable.age(for: base.object)
+    }
+  }
 }
 
 extension _CocoaSet.Index: Equatable {

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -307,6 +307,7 @@ extension _SetStorage {
     return allocate(scale: scale, age: nil)
   }
 
+#if _runtime(_ObjC)
   @usableFromInline
   @_effects(releasenone)
   static internal func convert(
@@ -317,6 +318,7 @@ extension _SetStorage {
     let age = _HashTable.age(for: cocoa.object)
     return allocate(scale: scale, age: age)
   }
+#endif
 
   static internal func allocate(
     scale: Int8,

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -43,6 +43,19 @@ internal class _RawSetStorage: __SwiftNativeNSSet {
   @nonobjc
   internal final var _scale: Int8
 
+  /// The scale corresponding to the highest `reserveCapacity(_:)` call so far,
+  /// or 0 if there were none. This may be used later to allow removals to
+  /// resize storage.
+  ///
+  /// FIXME: <rdar://problem/18114559> Shrink storage on deletion
+  @usableFromInline
+  @nonobjc
+  internal final var _reservedScale: Int8
+
+  // Currently unused, set to zero.
+  @nonobjc
+  internal final var _extra: Int16
+
   /// A mutation count, enabling stricter index validation.
   @usableFromInline
   @nonobjc
@@ -314,6 +327,8 @@ extension _SetStorage {
     storage._count = 0
     storage._capacity = _HashTable.capacity(forScale: scale)
     storage._scale = scale
+    storage._reservedScale = 0
+    storage._extra = 0
 
     if let age = age {
       storage._age = age

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -16,16 +16,14 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
-//
-// See the docs at the top of the file for more details on this type
-//
-// NOTE: The precise layout of this type is relied on in the runtime
-// to provide a statically allocated empty singleton.
-// See stdlib/public/stubs/GlobalObjects.cpp for details.
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 @_objc_non_lazy_realization
 internal class _RawSetStorage: __SwiftNativeNSSet {
+  // NOTE: The precise layout of this type is relied on in the runtime to
+  // provide a statically allocated empty singleton.  See
+  // stdlib/public/stubs/GlobalObjects.cpp for details.
+
   /// The current number of occupied entries in this set.
   @usableFromInline
   @nonobjc
@@ -61,9 +59,12 @@ internal class _RawSetStorage: __SwiftNativeNSSet {
   @nonobjc
   internal final var _age: Int32
 
+  /// The hash seed used to hash elements in this set instance.
   @usableFromInline
   internal final var _seed: Int
 
+  /// A raw pointer to the start of the tail-allocated hash buffer holding set
+  /// members.
   @usableFromInline
   @nonobjc
   internal final var _rawElements: UnsafeMutableRawPointer

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -255,7 +255,8 @@ final internal class _SetStorage<Element: Hashable>
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
     var bucket = _HashTable.Bucket(offset: Int(theState.extra.0))
     let endBucket = hashTable.endBucket
-    _precondition(bucket == endBucket || _hashTable.isValid(bucket))
+    _precondition(bucket == endBucket || hashTable.isOccupied(bucket),
+      "Invalid fast enumeration state")
     var stored = 0
     for i in 0..<count {
       if bucket == endBucket { break }

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -307,6 +307,17 @@ extension _SetStorage {
     return allocate(scale: scale, age: nil)
   }
 
+  @usableFromInline
+  @_effects(releasenone)
+  static internal func convert(
+    _ cocoa: _CocoaSet,
+    capacity: Int
+  ) -> _SetStorage {
+    let scale = _HashTable.scale(forCapacity: capacity)
+    let age = _HashTable.age(for: cocoa.object)
+    return allocate(scale: scale, age: age)
+  }
+
   static internal func allocate(
     scale: Int8,
     age: Int32?

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -147,8 +147,8 @@ extension Set._Variant: _SetBuffer {
   @inlinable
   internal var startIndex: Index {
     switch self {
-    case .native:
-      return Index(_native: asNative.startIndex)
+    case .native(let native):
+      return native.startIndex
 #if _runtime(_ObjC)
     case .cocoa(let cocoaSet):
       cocoaPath()
@@ -160,8 +160,8 @@ extension Set._Variant: _SetBuffer {
   @inlinable
   internal var endIndex: Index {
     switch self {
-    case .native:
-      return Index(_native: asNative.endIndex)
+    case .native(let native):
+      return native.endIndex
 #if _runtime(_ObjC)
     case .cocoa(let cocoaSet):
       cocoaPath()
@@ -171,14 +171,14 @@ extension Set._Variant: _SetBuffer {
   }
 
   @inlinable
-  internal func index(after i: Index) -> Index {
+  internal func index(after index: Index) -> Index {
     switch self {
-    case .native:
-      return Index(_native: asNative.index(after: i._asNative))
+    case .native(let native):
+      return native.index(after: index)
 #if _runtime(_ObjC)
     case .cocoa(let cocoaSet):
       cocoaPath()
-      return Index(_cocoa: cocoaSet.index(after: i._asCocoa))
+      return Index(_cocoa: cocoaSet.index(after: index._asCocoa))
 #endif
     }
   }
@@ -187,9 +187,8 @@ extension Set._Variant: _SetBuffer {
   @inline(__always)
   internal func index(for element: Element) -> Index? {
     switch self {
-    case .native:
-      guard let index = asNative.index(for: element) else { return nil }
-      return Index(_native: index)
+    case .native(let native):
+      return native.index(for: element)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -205,8 +204,8 @@ extension Set._Variant: _SetBuffer {
     @inline(__always)
     get {
       switch self {
-      case .native:
-        return asNative.count
+      case .native(let native):
+        return native.count
 #if _runtime(_ObjC)
       case .cocoa(let cocoa):
         cocoaPath()
@@ -220,8 +219,8 @@ extension Set._Variant: _SetBuffer {
   @inline(__always)
   internal func contains(_ member: Element) -> Bool {
     switch self {
-    case .native:
-      return asNative.contains(member)
+    case .native(let native):
+      return native.contains(member)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
@@ -232,14 +231,14 @@ extension Set._Variant: _SetBuffer {
 
   @inlinable
   @inline(__always)
-  internal func element(at i: Index) -> Element {
+  internal func element(at index: Index) -> Element {
     switch self {
-    case .native:
-      return asNative.element(at: i._asNative)
+    case .native(let native):
+      return native.element(at: index)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()
-      let cocoaMember = cocoa.element(at: i._asCocoa)
+      let cocoaMember = cocoa.element(at: index._asCocoa)
       return _forceBridgeFromObjectiveC(cocoaMember, Element.self)
 #endif
     }
@@ -300,7 +299,8 @@ extension Set._Variant {
     switch self {
     case .native:
       let isUnique = isUniquelyReferenced()
-      return asNative.remove(at: index._asNative, isUnique: isUnique)
+      let bucket = asNative.validatedBucket(for: index)
+      return asNative.uncheckedRemove(at: bucket, isUnique: isUnique)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       cocoaPath()

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -65,7 +65,10 @@ swift::_SwiftEmptyDictionarySingleton swift::_swiftEmptyDictionarySingleton = {
     // 0 so that any insertion will lead to real storage being allocated.
     0, // int count;
     0, // int capacity;                                    
-    0, // int scale;
+    0, // int8 scale;
+    0, // int8 reservedScale;
+    0, // int16 extra;
+    0, // int32 age;
     0, // int seed;
     (void *)1, // void* keys; (non-null garbage)
     (void *)1  // void* values; (non-null garbage)
@@ -89,7 +92,10 @@ swift::_SwiftEmptySetSingleton swift::_swiftEmptySetSingleton = {
     // 0 so that any insertion will lead to real storage being allocated.
     0, // int count;
     0, // int capacity;                                    
-    0, // int scale;
+    0, // int8 scale;
+    0, // int8 reservedScale;
+    0, // int16 extra;
+    0, // int32 age;
     0, // int seed;
     (void *)1, // void *rawElements; (non-null garbage)
   },


### PR DESCRIPTION
(This part 2 of a resubmission of https://github.com/apple/swift/pull/19537; part 1 with the boring parts has landed already in https://github.com/apple/swift/pull/19574.)

Set and Dictionary invalidate all previously vended indices whenever one of these two operations occur:

- The removal of any element
- Resizing of the hash table

Currently, we attempt to detect if someone reuses an invalid index or uses an index from an unrelated collection by simply verifying that it points to an occupied bucket. This isn't nearly enough.

We can detect invalid indices with a much higher degree of confidence by including a mutation counter in the storage header of every set/dictionary, and inside every native index. 

- The hash value of the storage object identifier is a nice way to generate an initial value for the counter.
- The counter in the header needs to be changed whenever the above operations occur. 
- For validation, the counter in the index needs to be compared to the one in the header. 

Obviously this isn't a 100% foolproof method -- mutation counters can wrap around, or they can just happen to be initialized to the same value. However, checking the counter is a cheap and reasonably reliable way to catch accidental misuse:

```swift
var set = Set(0..<100)
let index = set.index(of: 42)!
set.remove(7)

// Before:
print(set[index]) // May print 42, some other number, or trap

// After:
print(set[index]) // ⚡️ "Attempting to access Dictionary elements using an invalid Index"
```

rdar://problem/18191576