### PR TITLE
remove some tf-specific stuff from constexpr code

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -221,6 +221,7 @@ WARNING(designated_init_in_cross_module_extension,none,
 NOTE(designated_init_c_struct_fix,none,
      "use \"self.init()\" to initialize the struct with zero values", ())
 
+NOTE(constexpr_unknown_reason, none, "%0", (StringRef))
 NOTE(constexpr_called_from, none, "when called from here", ())
 NOTE(constexpr_not_evaluable, none,
      "expression not evaluable as constant here", ())

--- a/include/swift/SIL/GraphOperationBuilder.h
+++ b/include/swift/SIL/GraphOperationBuilder.h
@@ -20,17 +20,12 @@
 #define SWIFT_SIL_GRAPH_OPERATION_BUILDER_H
 
 #include "swift/SIL/SILConstants.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace swift {
-class ASTContext;
-class GraphOperationInst;
-class SILBuilder;
-class SILLocation;
-class SILType;
-
 namespace tf {
 
 class GraphOperationBuilder {

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -444,15 +444,6 @@ private:
   SymbolicValueMemoryObject(const SymbolicValueMemoryObject &) = delete;
   void operator=(const SymbolicValueMemoryObject &) = delete;
 };
-
-/// SWIFT_ENABLE_TENSORFLOW
-/// A graph operation attribute, used by GraphOperationInst.
-/// Attributes have a name and a constant value.
-struct GraphOperationAttribute {
-  Identifier name;
-  SymbolicValue value;
-};
-
 } // end namespace swift
 
 #endif

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -31,6 +31,7 @@
 #include "swift/Basic/Range.h"
 #include "swift/SIL/Consumption.h"
 #include "swift/SIL/SILAllocated.h"
+#include "swift/SIL/SILConstants.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunctionConventions.h"
 #include "swift/SIL/SILLocation.h"
@@ -8056,6 +8057,13 @@ inline DestructureTupleInst *DestructureTupleResult::getParent() {
 }
 
 /// SWIFT_ENABLE_TENSORFLOW
+/// A graph operation attribute, used by GraphOperationInst.
+/// Attributes have a name and a constant value.
+struct GraphOperationAttribute {
+  Identifier name;
+  SymbolicValue value;
+};
+
 /// A result for the graph_op instruction. See documentation for
 /// graph_op for more information.
 class GraphOperationResult final : public MultipleValueInstructionResult {
@@ -8079,7 +8087,6 @@ public:
   }
 };
 
-/// SWIFT_ENABLE_TENSORFLOW
 /// A graph operation. This instruction will be extracted to a graph program
 /// via graph program extraction passes.
 class GraphOperationInst final

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -800,8 +800,8 @@ static bool emitNoteDiagnostic(SILInstruction *badInst, UnknownReason reason,
   }
 
   auto &module = badInst->getModule();
-  diagnose(module.getASTContext(), loc.getSourceLoc(), diag::tf_op_misuse_note,
-           error)
+  diagnose(module.getASTContext(), loc.getSourceLoc(),
+           diag::constexpr_unknown_reason, error)
       .highlight(loc.getSourceRange());
   return true;
 }

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -25,7 +25,6 @@
 #include "llvm/Support/TrailingObjects.h"
 
 using namespace swift;
-using namespace tf;
 
 static llvm::cl::opt<unsigned>
     ConstExprLimit("constexpr-limit", llvm::cl::init(512),

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -38,8 +38,6 @@ class SILValue;
 class SymbolicValue;
 enum class UnknownReason;
 
-namespace tf {
-
 /// This class is the main entrypoint for evaluating constant expressions.  It
 /// also handles caching of previously computed constexpr results.
 class ConstExprEvaluator {
@@ -99,6 +97,5 @@ public:
                                 SmallPtrSet<SILInstruction*, 8> *arrayInsts);
 };
 
-} // end namespace tf
 } // end namespace swift
 #endif

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1474,7 +1474,7 @@ struct ArrayElementDecoder {
     uint64_t numElements =
         cast<IntegerLiteralInst>(numElementsVal)->getValue().getLimitedValue();
 
-    return !tf::ConstExprEvaluator::decodeAllocUninitializedArray(
+    return !ConstExprEvaluator::decodeAllocUninitializedArray(
         apply, numElements, elementsAtInit, &arrayInsts);
   }
 


### PR DESCRIPTION
This should make for slightly fewer conflicts when we send the constexpr patch upstream.