### PR TITLE
SIL: Stop imploding parameter list into a single value with opaque abstraction pattern

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -41,43 +41,6 @@ namespace swift {
 
 namespace Lowering {
 
-/// Should this tuple type always be expanded into its elements, even
-/// when emitted against an opaque abstraction pattern?
-///
-/// FIXME: Remove this once function signature lowering always explodes
-/// the top-level argument list.
-inline bool shouldExpandTupleType(TupleType *type) {
-  // Tuples with inout, __shared and __owned elements cannot be lowered
-  // to SIL types.
-  if (type->hasElementWithOwnership())
-    return true;
-
-  // A one-element tuple with a vararg element is essentially
-  // equivalent to the element itself, and we also can't lower it, since
-  // that would strip off the vararg-ness and produce a non-tuple type.
-  if (type->getNumElements() == 1 &&
-      type->getElement(0).isVararg()) {
-    return true;
-  }
-
-  // Everything else is OK.
-  return false;
-}
-
-/// A version of the above for parameter lists.
-///
-/// FIXME: Should also remove this soon.
-inline bool shouldExpandParams(AnyFunctionType::CanParamArrayRef params) {
-  for (auto param : params)
-    if (param.getValueOwnership() != ValueOwnership::Default)
-      return true;
-
-  if (params.size() == 1)
-    return params[0].isVariadic();
-
-  return false;
-}
-
 /// The default convention for handling the callee object on thick
 /// callees.
 const ParameterConvention DefaultThickCalleeConvention =

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1712,13 +1712,11 @@ static unsigned getFlattenedValueCount(AbstractionPattern origType,
 
   // The count is always 1 unless the substituted type is a tuple.
   auto substTuple = dyn_cast<TupleType>(substType);
-  if (!substTuple) return 1;
+  if (!substTuple)
+    return 1;
 
-  // If the original type is opaque and the substituted type is
-  // materializable, the count is 1 anyway.
-  //
-  // FIXME: Should always be materializable here.
-  if (origType.isTypeParameter() && substTuple->isMaterializable())
+  // If the original type is opaque, the count is 1 anyway.
+  if (origType.isTypeParameter())
     return 1;
 
   // Otherwise, add up the elements.

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -25,7 +25,7 @@ func test_arch() {
   arch({(x: (Int, Float)) -> () in })
 
   // CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden swiftcc %swift.metadata_response @"$sySiz_SitcMa"
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 100663298, %swift.type** {{%.*}}, i32* getelementptr inbounds ([2 x i32], [2 x i32]* @parameter-flags.17, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @"$sytN", i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 100663298, %swift.type** {{%.*}}, i32* getelementptr inbounds ([2 x i32], [2 x i32]* @parameter-flags.16, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @"$sytN", i32 0, i32 1))
   arch({(x: inout Int, y: Int) -> () in })
 
   // CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden swiftcc %swift.metadata_response @"$sySf_SitcMa"
@@ -33,7 +33,7 @@ func test_arch() {
   arch({(a: Float, b: Int) -> () in })
 
   // CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden swiftcc %swift.metadata_response @"$sySiz_SfSStcMa"
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 100663299, %swift.type** {{%.*}}, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @parameter-flags.24, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @"$sytN", i32 0, i32 1))
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 100663299, %swift.type** {{%.*}}, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @parameter-flags.23, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @"$sytN", i32 0, i32 1))
   arch({(x: inout Int, y: Float, z: String) -> () in })
 
   // CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden swiftcc %swift.metadata_response @"$sySf_SfSitcMa"

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -260,7 +260,7 @@ entry:
 
   %k = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @k_id : $@convention(thin) () -> (), getter @k_get : $@convention(thin) (@in_guaranteed S) -> @out Int)
   %l = keypath $KeyPath<C, Int>, (root $C; settable_property $Int, id #C.w!getter.1, getter @l_get : $@convention(thin) (@in_guaranteed C) -> @out Int, setter @l_set : $@convention(thin) (@in_guaranteed Int, @in_guaranteed C) -> ())
-  %m = keypath $KeyPath<S, () -> ()>, (root $S; settable_property $() -> (), id ##S.reabstracted, getter @m_get : $@convention(thin) (@in_guaranteed S) -> @out @callee_guaranteed (@in_guaranteed ()) -> @out (), setter @m_set : $@convention(thin) (@in_guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out (), @inout S) -> ())
+  %m = keypath $KeyPath<S, () -> ()>, (root $S; settable_property $() -> (), id ##S.reabstracted, getter @m_get : $@convention(thin) (@in_guaranteed S) -> @out @callee_guaranteed () -> @out (), setter @m_set : $@convention(thin) (@in_guaranteed @callee_guaranteed () -> @out (), @inout S) -> ())
 
   return undef : $()
 }
@@ -271,8 +271,8 @@ sil @k_get : $@convention(thin) (@in_guaranteed S) -> @out Int
 sil @l_get : $@convention(thin) (@in_guaranteed C) -> @out Int
 sil @l_set : $@convention(thin) (@in_guaranteed Int, @in_guaranteed C) -> ()
 
-sil @m_get : $@convention(thin) (@in_guaranteed S) -> @out @callee_guaranteed (@in_guaranteed ()) -> @out ()
-sil @m_set : $@convention(thin) (@in_guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out (), @inout S) -> ()
+sil @m_get : $@convention(thin) (@in_guaranteed S) -> @out @callee_guaranteed () -> @out ()
+sil @m_set : $@convention(thin) (@in_guaranteed @callee_guaranteed () -> @out (), @inout S) -> ()
 
 struct Gen<T, U> {
   var x: T

--- a/test/IRGen/lowered_optional_self_metadata.sil
+++ b/test/IRGen/lowered_optional_self_metadata.sil
@@ -15,8 +15,8 @@ public protocol Protocol {
 
 sil @optional_method : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
 
-sil @call_optional_method_with_lowered_function : $@convention(thin) (@in_guaranteed Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>) -> () {
-entry(%x : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>):
+sil @call_optional_method_with_lowered_function : $@convention(thin) (@in_guaranteed Optional<@callee_guaranteed () -> @out ()>) -> () {
+entry(%x : $*Optional<@callee_guaranteed () -> @out ()>):
   %f = function_ref @optional_method : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
   apply %f<() -> ()>(%x) : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
   %p = partial_apply [callee_guaranteed] %f<() -> ()>() : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -120,8 +120,8 @@ sil_property #ExternalReabstractions.ro <T> (
 sil_property #ExternalReabstractions.reabstracted <T> (
   settable_property $() -> (),
     id ##ExternalReabstractions.reabstracted,
-    getter @get_reabstracted : $@convention(thin) <T> (@in_guaranteed ExternalReabstractions<T>) -> @out @callee_guaranteed (@in_guaranteed ()) -> @out (),
-    setter @set_reabstracted : $@convention(thin) <T> (@in_guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out (), @inout ExternalReabstractions<T>) -> ())
+    getter @get_reabstracted : $@convention(thin) <T> (@in_guaranteed ExternalReabstractions<T>) -> @out @callee_guaranteed () -> @out (),
+    setter @set_reabstracted : $@convention(thin) <T> (@in_guaranteed @callee_guaranteed () -> @out (), @inout ExternalReabstractions<T>) -> ())
 
 // All trivial descriptors should share a definition by aliasing to the common
 // definition
@@ -147,5 +147,5 @@ sil @set_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed T
 sil @get_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed ExternalGeneric<T>, UnsafeRawPointer) -> @out T
 sil @set_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed T, @inout ExternalGeneric<T>, UnsafeRawPointer) -> ()
 
-sil @get_reabstracted : $@convention(thin) <T> (@in_guaranteed ExternalReabstractions<T>) -> @out @callee_guaranteed (@in_guaranteed ()) -> @out ()
-sil @set_reabstracted : $@convention(thin) <T> (@in_guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out (), @inout ExternalReabstractions<T>) -> ()
+sil @get_reabstracted : $@convention(thin) <T> (@in_guaranteed ExternalReabstractions<T>) -> @out @callee_guaranteed () -> @out ()
+sil @set_reabstracted : $@convention(thin) <T> (@in_guaranteed @callee_guaranteed () -> @out (), @inout ExternalReabstractions<T>) -> ()

--- a/test/SIL/Parser/apply_with_substitution.sil
+++ b/test/SIL/Parser/apply_with_substitution.sil
@@ -7,46 +7,46 @@ sil_stage raw
 import Builtin
 import Swift
 
-// CHECK-LABEL: sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>) -> ()
-sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>) -> () {
-bb0(%0 : @guaranteed $Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>>  // var f    // users: %2, %6, %32
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>>, 0
-  store %0 to [init] %1a : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>         // id: %2
+// CHECK-LABEL: sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed () -> @out ()>) -> ()
+sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed () -> @out ()>) -> () {
+bb0(%0 : @guaranteed $Optional<@callee_guaranteed () -> @out ()>):
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed () -> @out ()>>  // var f    // users: %2, %6, %32
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed () -> @out ()>>, 0
+  store %0 to [init] %1a : $*Optional<@callee_guaranteed () -> @out ()>         // id: %2
   %3 = alloc_stack $Optional<()>                  // users: %22, %28, %30, %31
   %4 = alloc_stack $()                            // users: %12, %22, %25
-  %5 = alloc_stack $Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>            // users: %6, %8, %10, %11, %16, %24
-  copy_addr %1a to [initialization] %5 : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()> // id: %6
+  %5 = alloc_stack $Optional<@callee_guaranteed () -> @out ()>            // users: %6, %8, %10, %11, %16, %24
+  copy_addr %1a to [initialization] %5 : $*Optional<@callee_guaranteed () -> @out ()> // id: %6
   %7 = function_ref @_TFs22_doesOptionalHaveValueU__FT1vRGSqQ___Bi1_ : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1 // user: %8
   %8 = apply %7<() -> ()>(%5) : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1 // user: %9
   br bb2                                          // id: %13
 
 bb2:                                              // Preds: bb0
   %14 = function_ref @_TFs17_getOptionalValueU__FT1vGSqQ___Q_ : $@convention(thin) <τ_0_0> (@in_guaranteed Optional<τ_0_0>) -> @out τ_0_0 // user: %16
-  %15 = alloc_stack $@callee_guaranteed (@in_guaranteed ()) -> @out () // users: %16, %17, %23
+  %15 = alloc_stack $@callee_guaranteed () -> @out () // users: %16, %17, %23
   // CHECK: apply %{{[0-9]+}}<() -> ()>(%{{[0-9]+}}, %{{[0-9]+}}) : $@convention(thin) <τ_0_0> (@in_guaranteed Optional<τ_0_0>) -> @out τ_0_0
   %16 = apply %14<() -> ()>(%15, %5) : $@convention(thin) <τ_0_0> (@in_guaranteed Optional<τ_0_0>) -> @out τ_0_0
-  %17 = load [take] %15 : $*@callee_guaranteed (@in_guaranteed ()) -> @out () // user: %19
-  %18 = function_ref @_TTRXFo_iT__iT__XFo__dT__ : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out ()) -> () // user: %19
-  %19 = partial_apply [callee_guaranteed] %18(%17) : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out ()) -> () // user: %20
+  %17 = load [take] %15 : $*@callee_guaranteed () -> @out () // user: %19
+  %18 = function_ref @_TTRXFo_iT__iT__XFo__dT__ : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out ()) -> () // user: %19
+  %19 = partial_apply [callee_guaranteed] %18(%17) : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out ()) -> () // user: %20
   %20 = apply %19() : $@callee_guaranteed () -> ()
   %21 = function_ref @_TFs24_injectValueIntoOptionalU__FT1vQ__GSqQ__ : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0> // user: %22
   // CHECK: apply %{{[0-9]+}}<()>(%{{[0-9]+}}, %{{[0-9]+}}) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
   %22 = apply %21<()>(%3, %4) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
-  dealloc_stack %15 : $*@callee_guaranteed (@in_guaranteed ()) -> @out () // id: %23
-  dealloc_stack %5 : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()> // id: %24
+  dealloc_stack %15 : $*@callee_guaranteed () -> @out () // id: %23
+  dealloc_stack %5 : $*Optional<@callee_guaranteed () -> @out ()> // id: %24
   dealloc_stack %4 : $*()        // id: %25
   br bb4                                          // id: %26
 
 bb4:                                              // Preds: bb2 bb3
   %30 = load [trivial] %3 : $*Optional<()>
   dealloc_stack %3 : $*Optional<()> // id: %31
-  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed () -> @out ()>>
   %33 = tuple ()                                  // user: %34
   return %33 : $()                                // id: %34
 }
 
 sil [transparent] @_TFs22_doesOptionalHaveValueU__FT1vRGSqQ___Bi1_ : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1
 sil [transparent] @_TFs17_getOptionalValueU__FT1vGSqQ___Q_ : $@convention(thin) <τ_0_0> (@in_guaranteed Optional<τ_0_0>) -> @out τ_0_0
-sil [transparent] @_TTRXFo_iT__iT__XFo__dT__ : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out ()) -> ()
+sil [transparent] @_TTRXFo_iT__iT__XFo__dT__ : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out ()) -> ()
 sil [transparent] @_TFs24_injectValueIntoOptionalU__FT1vQ__GSqQ__ : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>

--- a/test/SIL/Parser/bound_generic.sil
+++ b/test/SIL/Parser/bound_generic.sil
@@ -7,16 +7,16 @@ sil_stage raw
 import Builtin
 import Swift
 
-// CHECK-LABEL: sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>) -> ()
-sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>) -> () {
-bb0(%0 : @guaranteed $Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>>, 0
-  store %0 to [init] %1a : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>
+// CHECK-LABEL: sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed () -> @out ()>) -> ()
+sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed () -> (@out ())>) -> () {
+bb0(%0 : @guaranteed $Optional<@callee_guaranteed () -> (@out ())>):
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed () -> (@out ())>>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed () -> (@out ())>>, 0
+  store %0 to [init] %1a : $*Optional<@callee_guaranteed () -> (@out ())>
   %3 = alloc_stack $Optional<()>
   %4 = alloc_stack $()
-  %5 = alloc_stack $Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>
-  copy_addr %1a to [initialization] %5 : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>
+  %5 = alloc_stack $Optional<@callee_guaranteed () -> (@out ())>
+  copy_addr %1a to [initialization] %5 : $*Optional<@callee_guaranteed () -> (@out ())>
   // function_ref Swift._doesOptionalHaveValue <A>(v : @inout Swift.Optional<A>) -> Builtin.Int1
   %7 = function_ref @_TFs22_doesOptionalHaveValueU__FT1vRGSqQ___Bi1_ : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1
   // CHECK: apply %{{[0-9]+}}<() -> ()>(%{{[0-9]+}}) : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1
@@ -24,8 +24,8 @@ bb0(%0 : @guaranteed $Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out (
   br bb1
 
 bb1:
-  destroy_addr %5 : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>
-  dealloc_stack %5 : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>
+  destroy_addr %5 : $*Optional<@callee_guaranteed () -> (@out ())>
+  dealloc_stack %5 : $*Optional<@callee_guaranteed () -> (@out ())>
   dealloc_stack %4 : $*()
   br bb3
 
@@ -38,7 +38,7 @@ bb3:
 bb4:
   %30 = load [trivial] %3 : $*Optional<()>
   dealloc_stack %3 : $*Optional<()>
-  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed () -> (@out ())>>
   %33 = tuple ()
   return %33 : $()
 }

--- a/test/SILGen/array_literal_abstraction.swift
+++ b/test/SILGen/array_literal_abstraction.swift
@@ -5,13 +5,13 @@
 // <rdar://problem/16039286>
 
 // CHECK-LABEL: sil hidden @$s25array_literal_abstraction0A9_of_funcsSayyycGyF
-// CHECK:         pointer_to_address {{.*}} $*@callee_guaranteed (@in_guaranteed ()) -> @out ()
+// CHECK:         pointer_to_address {{.*}} $*@callee_guaranteed () -> @out ()
 func array_of_funcs() -> [(() -> ())] {
   return [{}, {}]
 }
 
 // CHECK-LABEL: sil hidden @$s25array_literal_abstraction13dict_of_funcsSDySiyycGyF
-// CHECK:         pointer_to_address {{.*}} $*(Int, @callee_guaranteed (@in_guaranteed ()) -> @out ())
+// CHECK:         pointer_to_address {{.*}} $*(Int, @callee_guaranteed () -> @out ())
 func dict_of_funcs() -> Dictionary<Int, () -> ()> {
   return [0: {}, 1: {}]
 }
@@ -19,7 +19,7 @@ func dict_of_funcs() -> Dictionary<Int, () -> ()> {
 func vararg_funcs(_ fs: (() -> ())...) {}
 
 // CHECK-LABEL: sil hidden @$s25array_literal_abstraction17call_vararg_funcsyyF
-// CHECK:         pointer_to_address {{.*}} $*@callee_guaranteed (@in_guaranteed ()) -> @out ()
+// CHECK:         pointer_to_address {{.*}} $*@callee_guaranteed () -> @out ()
 func call_vararg_funcs() {
   vararg_funcs({}, {})
 }

--- a/test/SILGen/downcast_reabstraction.swift
+++ b/test/SILGen/downcast_reabstraction.swift
@@ -2,10 +2,10 @@
 // RUN: %target-swift-emit-silgen -module-name downcast_reabstraction -enable-sil-ownership %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @$s22downcast_reabstraction19condFunctionFromAnyyyypF
-// CHECK:         checked_cast_addr_br take_always Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_guaranteed (@in_guaranteed ()) -> @out (), [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK:         checked_cast_addr_br take_always Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_guaranteed () -> @out (), [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 // CHECK:       [[YES]]:
 // CHECK:         [[ORIG_VAL:%.*]] = load [take] [[OUT]]
-// CHECK:         [[REABSTRACT:%.*]] = function_ref @$sytytIegnr_Ieg_TR
+// CHECK:         [[REABSTRACT:%.*]] = function_ref @$sytIegr_Ieg_TR
 // CHECK:         [[SUBST_VAL:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]([[ORIG_VAL]])
 
 func condFunctionFromAny(_ x: Any) {
@@ -15,9 +15,9 @@ func condFunctionFromAny(_ x: Any) {
 }
 
 // CHECK-LABEL: sil hidden @$s22downcast_reabstraction21uncondFunctionFromAnyyyypF : $@convention(thin) (@in_guaranteed Any) -> () {
-// CHECK:         unconditional_checked_cast_addr Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_guaranteed (@in_guaranteed ()) -> @out ()
+// CHECK:         unconditional_checked_cast_addr Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_guaranteed () -> @out ()
 // CHECK:         [[ORIG_VAL:%.*]] = load [take] [[OUT]]
-// CHECK:         [[REABSTRACT:%.*]] = function_ref @$sytytIegnr_Ieg_TR
+// CHECK:         [[REABSTRACT:%.*]] = function_ref @$sytIegr_Ieg_TR
 // CHECK:         [[SUBST_VAL:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]([[ORIG_VAL]])
 // CHECK:         [[BORROW:%.*]] = begin_borrow [[SUBST_VAL]]
 // CHECK:         apply [[BORROW]]()

--- a/test/SILGen/erasure_reabstraction.swift
+++ b/test/SILGen/erasure_reabstraction.swift
@@ -12,7 +12,7 @@ let x: Any = Foo.self
 
 // CHECK: [[CLOSURE:%.*]] = function_ref
 // CHECK: [[CLOSURE_THICK:%.*]] = thin_to_thick_function [[CLOSURE]]
-// CHECK: [[REABSTRACTION_THUNK:%.*]] = function_ref @$sIeg_ytytIegnr_TR
+// CHECK: [[REABSTRACTION_THUNK:%.*]] = function_ref @$sIeg_ytIegr_TR
 // CHECK: [[CLOSURE_REABSTRACTED:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACTION_THUNK]]([[CLOSURE_THICK]])
 // CHECK: [[CONCRETE:%.*]] = init_existential_addr [[EXISTENTIAL:%.*]] : $*Any, $() -> ()
 // CHECK: store [[CLOSURE_REABSTRACTED]] to [init] [[CONCRETE]]

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -131,7 +131,7 @@ class NestedGeneric<U> {
   }
 
   // CHECK-LABEL: sil hidden @$s16generic_closures13NestedGenericC20nested_reabstraction{{[_0-9a-zA-Z]*}}F
-  //   CHECK:       [[REABSTRACT:%.*]] = function_ref @$sIeg_ytytIegnr_TR
+  //   CHECK:       [[REABSTRACT:%.*]] = function_ref @$sIeg_ytIegr_TR
   //   CHECK:       partial_apply [callee_guaranteed] [[REABSTRACT]]
   func nested_reabstraction<T>(_ x: T) -> Optionable<() -> ()> {
     return .some({})

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -105,8 +105,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: settable_property $() -> (), 
   // CHECK-SAME:   id ##C.reabstracted,
-  // CHECK-SAME:   getter @$s8keypaths1CC12reabstractedyycvpAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed C<τ_0_0>) -> @out @callee_guaranteed (@in_guaranteed ()) -> @out (),
-  // CHECK-SAME:   setter @$s8keypaths1CC12reabstractedyycvpAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out (), @in_guaranteed C<τ_0_0>) -> ()
+  // CHECK-SAME:   getter @$s8keypaths1CC12reabstractedyycvpAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed C<τ_0_0>) -> @out @callee_guaranteed () -> @out (),
+  // CHECK-SAME:   setter @$s8keypaths1CC12reabstractedyycvpAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed @callee_guaranteed () -> @out (), @in_guaranteed C<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \C<T>.reabstracted
 
@@ -134,8 +134,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:  root $S<τ_0_0>;
   // CHECK-SAME:  settable_property $() -> (),
   // CHECK-SAME:    id ##S.reabstracted,
-  // CHECK-SAME:    getter @$s8keypaths1SV12reabstractedyycvpAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed S<τ_0_0>) -> @out @callee_guaranteed (@in_guaranteed ()) -> @out (),
-  // CHECK-SAME:    setter @$s8keypaths1SV12reabstractedyycvpAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out (), @inout S<τ_0_0>) -> ()
+  // CHECK-SAME:    getter @$s8keypaths1SV12reabstractedyycvpAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed S<τ_0_0>) -> @out @callee_guaranteed () -> @out (),
+  // CHECK-SAME:    setter @$s8keypaths1SV12reabstractedyycvpAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed @callee_guaranteed () -> @out (), @inout S<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \S<T>.reabstracted
 

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -664,9 +664,9 @@ class AnyHashableClass : NSObject {
 
 // CHECK-LABEL: sil hidden @$s17objc_bridging_any33bridgeOptionalFunctionToAnyObject2fnyXlyycSg_tF : $@convention(thin) (@guaranteed Optional<@callee_guaranteed () -> ()>) -> @owned AnyObject
 // CHECK: [[BRIDGE:%.*]] = function_ref @$sSq19_bridgeToObjectiveCyXlyF
-// CHECK: [[FN:%.*]] = function_ref @$sIeg_ytytIegnr_TR
+// CHECK: [[FN:%.*]] = function_ref @$sIeg_ytIegr_TR
 // CHECK: partial_apply [callee_guaranteed] [[FN]]
-// CHECK: [[SELF:%.*]] = alloc_stack $Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>
+// CHECK: [[SELF:%.*]] = alloc_stack $Optional<@callee_guaranteed () -> @out ()>
 // CHECK: apply [[BRIDGE]]<() -> ()>([[SELF]])
 func bridgeOptionalFunctionToAnyObject(fn: (() -> ())?) -> AnyObject {
   return fn as AnyObject

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -268,7 +268,7 @@ func functionInoutToPointer() {
   // CHECK: [[BOX:%.*]] = alloc_box ${ var @callee_guaranteed () -> () }
   var f: () -> () = {}
 
-  // CHECK: [[REABSTRACT_BUF:%.*]] = alloc_stack $@callee_guaranteed (@in_guaranteed ()) -> @out ()
+  // CHECK: [[REABSTRACT_BUF:%.*]] = alloc_stack $@callee_guaranteed () -> @out ()
   // CHECK: address_to_pointer [[REABSTRACT_BUF]]
   takesMutableVoidPointer(&f)
 }

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -115,7 +115,7 @@ struct T20341012 {
     private var options: ArrayLike<Test20341012> { get {} set {} }
 
     // CHECK-LABEL: sil hidden @$s20property_abstraction9T20341012V1t{{[_0-9a-zA-Z]*}}F
-    // CHECK:         [[TMP1:%.*]] = alloc_stack $(title: (), action: @callee_guaranteed (@in_guaranteed ()) -> @out ())
+    // CHECK:         [[TMP1:%.*]] = alloc_stack $(title: (), action: @callee_guaranteed () -> @out ())
     // CHECK:         apply {{.*}}<(title: (), action: () -> ())>([[TMP1]],
     mutating func t() {
         _ = self.options[()].title

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -18,19 +18,19 @@ class Box<T> {
 // CHECK:   [[THICK:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
 // CHECK:   [[TUPLEA:%.*]] = tuple (%{{.*}} : $Int, [[THICK]] : $@callee_guaranteed () -> ())
 // CHECK:   ([[ELTA_0:%.*]], [[ELTA_1:%.*]]) = destructure_tuple [[TUPLEA]] : $(Int, @callee_guaranteed () -> ())
-// CHECK:   [[THUNK1:%.*]] = function_ref @$sIeg_ytytIegnr_TR : $@convention(thin) (@in_guaranteed (), @guaranteed @callee_guaranteed () -> ()) -> @out ()
-// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK1]]([[ELTA_1]]) : $@convention(thin) (@in_guaranteed (), @guaranteed @callee_guaranteed () -> ()) -> @out ()
-// CHECK:   [[TUPLEB:%.*]] = tuple ([[ELTA_0]] : $Int, [[PA]] : $@callee_guaranteed (@in_guaranteed ()) -> @out ())
+// CHECK:   [[THUNK1:%.*]] = function_ref @$sIeg_ytIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out ()
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK1]]([[ELTA_1]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out ()
+// CHECK:   [[TUPLEB:%.*]] = tuple ([[ELTA_0]] : $Int, [[PA]] : $@callee_guaranteed () -> @out ())
 // CHECK:   ([[TUPLEB_0:%.*]], [[TUPLEB_1:%.*]]) = destructure_tuple [[TUPLEB]]
 // CHECK:   // function_ref Box.__allocating_init(_:)
 // CHECK:   [[INIT_F:%.*]] = function_ref @$s4main3BoxCyACyxGxcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0>
 // CHECK:   [[CALL:%.*]] = apply [[INIT_F]]<(Int, () -> ())>(%{{.*}}, %{{.*}}) : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0>
 // CHECK:   [[BORROW_CALL:%.*]] = begin_borrow [[CALL]] : $Box<(Int, () -> ())> 
 // CHECK:   [[REF:%.*]] = ref_element_addr [[BORROW_CALL]] : $Box<(Int, () -> ())>, #Box.value
-// CHECK:   [[TUPLEC:%.*]] = load [copy] [[REF]] : $*(Int, @callee_guaranteed (@in_guaranteed ()) -> @out ())
+// CHECK:   [[TUPLEC:%.*]] = load [copy] [[REF]] : $*(Int, @callee_guaranteed () -> @out ())
 // CHECK:   ([[TUPLEC_0:%.*]], [[TUPLEC_1:%.*]]) = destructure_tuple [[TUPLEC]]
-// CHECK:   [[THUNK2:%.*]] = function_ref @$sytytIegnr_Ieg_TR : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out ()) -> ()
-// CHECK:   [[PA2:%.*]] = partial_apply [callee_guaranteed] [[THUNK2]]([[TUPLEC_1]]) : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out ()) -> ()
+// CHECK:   [[THUNK2:%.*]] = function_ref @$sytIegr_Ieg_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out ()) -> ()
+// CHECK:   [[PA2:%.*]] = partial_apply [callee_guaranteed] [[THUNK2]]([[TUPLEC_1]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out ()) -> ()
 // CHECK:   destroy_value [[PA2]] : $@callee_guaranteed () -> ()    
 // CHECK:   end_borrow [[BORROW_CALL]] : $Box<(Int, () -> ())>
 // CHECK-LABEL: } // end sil function '$s4main7testBoxyyF'

--- a/test/SILGen/reabstract.swift
+++ b/test/SILGen/reabstract.swift
@@ -57,8 +57,8 @@ func test0() {
 // CHECK-NEXT: return
 
 // CHECK-LABEL: sil hidden @$s10reabstract10testThrowsyyypF
-// CHECK:         function_ref @$sytytIegnr_Ieg_TR
-// CHECK:         function_ref @$sytyts5Error_pIegnrzo_sAA_pIegzo_TR
+// CHECK:         function_ref @$sytIegr_Ieg_TR
+// CHECK:         function_ref @$syts5Error_pIegrzo_sAA_pIegzo_TR
 func testThrows(_ x: Any) {
   _ = x as? () -> ()
   _ = x as? () throws -> ()

--- a/test/SILGen/tuple_attribute_reabstraction.swift
+++ b/test/SILGen/tuple_attribute_reabstraction.swift
@@ -16,7 +16,7 @@ public func f() {
 
 // We shouldn't have @autoclosure and @escaping attributes in the lowered tuple type:
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$sIg_Ieg_Iegyg_ytytIgnr__ytytIegnr_tytIegnr_TR : $@convention(thin) (@in_guaranteed (@noescape @callee_guaranteed (@in_guaranteed ()) -> @out (), @callee_guaranteed (@in_guaranteed ()) -> @out ()), @guaranteed @callee_guaranteed (@noescape @callee_guaranteed () -> (), @guaranteed @callee_guaranteed () -> ()) -> ()) -> @out ()
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$sIg_Ieg_Iegyg_ytIgr_ytIegr_ytIegnnr_TR : $@convention(thin) (@in_guaranteed @noescape @callee_guaranteed () -> @out (), @in_guaranteed @callee_guaranteed () -> @out (), @guaranteed @callee_guaranteed (@noescape @callee_guaranteed () -> (), @guaranteed @callee_guaranteed () -> ()) -> ()) -> @out ()
 
 // The one-element vararg tuple ([Int]...) should be exploded and not treated as opaque,
 // even though its materializable:


### PR DESCRIPTION
The constraint solver support for the Swift 3 function type behavior
has been removed, so it's no longer possible to pun the same value as
both a function taking multiple parameters and a function taking a
single tuple argument.

This means the entire parameter list is no longer a target for
substitution as a single value, so the most general form of a function
value passes each parameter indirectly instead of passing a single
tuple parameter indirectly.