### PR TITLE
[stdlib] Set, Dictionary: Prepare for per-instance hash seeds

### DIFF
--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -366,11 +366,13 @@ extension _DictionaryStorage {
     _sanityCheck(capacity >= original._count)
     let scale = _HashTable.scale(forCapacity: capacity)
     let rehash = (scale != original._scale)
-    let newStorage = _DictionaryStorage<Key, Value>.allocate(
-      scale: scale,
-      // Invalidate indices if we're rehashing.
-      age: rehash ? nil : original._age
-    )
+    if rehash {
+      return (.allocate(scale: scale, age: nil, seed: nil), rehash)
+    }
+    return (
+      .allocate(scale: scale, age: original._age, seed: original._seed),
+      rehash)
+    }
     return (newStorage, rehash)
   }
 
@@ -378,7 +380,7 @@ extension _DictionaryStorage {
   @_effects(releasenone)
   static internal func allocate(capacity: Int) -> _DictionaryStorage {
     let scale = _HashTable.scale(forCapacity: capacity)
-    return allocate(scale: scale, age: nil)
+    return allocate(scale: scale, age: nil, seed: nil)
   }
 
 #if _runtime(_ObjC)
@@ -396,7 +398,8 @@ extension _DictionaryStorage {
 
   static internal func allocate(
     scale: Int8,
-    age: Int32?
+    age: Int32?,
+    seed: Int?
   ) -> _DictionaryStorage {
     // The entry count must be representable by an Int value; hence the scale's
     // peculiar upper bound.
@@ -432,18 +435,9 @@ extension _DictionaryStorage {
         truncatingIfNeeded: ObjectIdentifier(storage).hashValue)
     }
 
+    storage._seed = seed ?? _HashTable.hashSeed(for: storage, scale: scale)
     storage._rawKeys = UnsafeMutableRawPointer(keysAddr)
     storage._rawValues = UnsafeMutableRawPointer(valuesAddr)
-
-    // We use a slightly different hash seed whenever we change the size of the
-    // hash table, so that we avoid certain copy operations becoming quadratic,
-    // without breaking value semantics. (For background details, see
-    // https://bugs.swift.org/browse/SR-3268)
-
-    // FIXME: Use true per-instance seeding instead. Per-capacity seeding still
-    // leaves hash values the same in same-sized tables, which may affect
-    // operations on two tables at once. (E.g., union.)
-    storage._seed = Int(scale)
 
     // Initialize hash table metadata.
     storage._hashTable.clear()

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -359,21 +359,24 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
 extension _DictionaryStorage {
   @usableFromInline
   @_effects(releasenone)
-  internal static func reallocate(
+  internal static func copy(
+    original: _RawDictionaryStorage
+  ) -> _DictionaryStorage {
+    return allocate(
+      scale: original._scale,
+      age: original._age,
+      seed: original._seed)
+  }
+
+  @usableFromInline
+  @_effects(releasenone)
+  static internal func resize(
     original: _RawDictionaryStorage,
-    capacity: Int
-  ) -> (storage: _DictionaryStorage, rehash: Bool) {
-    _sanityCheck(capacity >= original._count)
+    capacity: Int,
+    move: Bool
+  ) -> _DictionaryStorage {
     let scale = _HashTable.scale(forCapacity: capacity)
-    let rehash = (scale != original._scale)
-    if rehash {
-      return (.allocate(scale: scale, age: nil, seed: nil), rehash)
-    }
-    return (
-      .allocate(scale: scale, age: original._age, seed: original._seed),
-      rehash)
-    }
-    return (newStorage, rehash)
+    return allocate(scale: scale, age: nil, seed: nil)
   }
 
   @usableFromInline
@@ -392,7 +395,7 @@ extension _DictionaryStorage {
   ) -> _DictionaryStorage {
     let scale = _HashTable.scale(forCapacity: capacity)
     let age = _HashTable.age(for: cocoa.object)
-    return allocate(scale: scale, age: age)
+    return allocate(scale: scale, age: age, seed: nil)
   }
 #endif
 

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -328,28 +328,22 @@ extension Dictionary._Variant {
     }
   }
 
-  /// Ensure uniquely held native storage, while preserving the given index.
-  /// (If the variant had bridged storage, then the returned index will be the
-  /// corresponding native representation. Otherwise it's kept the same.)
   @inlinable
   @inline(__always)
   internal mutating func ensureUniqueNative() -> _NativeDictionary<Key, Value> {
-    switch self {
-    case .native:
-      let isUnique = isUniquelyReferenced()
-      if !isUnique {
-        let rehashed = asNative.copy(capacity: asNative.capacity)
-        _sanityCheck(!rehashed)
-      }
-      return asNative
 #if _runtime(_ObjC)
-    case .cocoa(let cocoa):
+    if case .cocoa(let cocoa) = self {
       cocoaPath()
       let native = _NativeDictionary<Key, Value>(cocoa)
       self = .native(native)
       return native
-#endif
     }
+#endif
+    let isUnique = isUniquelyReferenced()
+    if !isUnique {
+      asNative.copy()
+    }
+    return asNative
   }
 
   @inlinable

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -89,6 +89,37 @@ extension _HashTable {
     let hash = ObjectIdentifier(cocoa).hashValue
     return Int32(truncatingIfNeeded: hash)
   }
+
+  internal static func hashSeed(
+    for object: AnyObject,
+    scale: Int
+  ) -> Int {
+#if false // FIXME: Enable per-instance seeding
+    // We generate a new hash seed whenever a new hash table is allocated and
+    // whenever an existing table is resized, so that we avoid certain copy
+    // operations becoming quadratic.  (For background details, see
+    // https://bugs.swift.org/browse/SR-3268)
+    //
+    // Note that we do reuse the existing seed when making copy-on-write copies
+    // so that we avoid breaking value semantics.
+    if Hasher._isDeterministic {
+      // When we're using deterministic hashing, the scale value as the seed is
+      // still allowed, and it covers most cases. (Unfortunately some operations
+      // that merge two similar-sized hash tables will still be quadratic.)
+      return scale
+    }
+    // Use the object address as the hash seed. This is cheaper than
+    // SystemRandomNumberGenerator, while it has the same practical effect.
+    // Addresses aren't entirely random, but that's not the goal here -- the
+    // 128-bit execution seed takes care of randomization. We only need to
+    // guarantee that no two tables with the same seed can coexist at the same
+    // time (apart from copy-on-write derivatives of the same table).
+    return unsafeBitCast(object, to: Int.self)
+#else
+    // Use per-capacity seeding for now.
+    return scale
+#endif
+  }
 }
 
 extension _HashTable {

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -92,7 +92,7 @@ extension _HashTable {
 
   internal static func hashSeed(
     for object: AnyObject,
-    scale: Int
+    scale: Int8
   ) -> Int {
 #if false // FIXME: Enable per-instance seeding
     // We generate a new hash seed whenever a new hash table is allocated and
@@ -106,7 +106,7 @@ extension _HashTable {
       // When we're using deterministic hashing, the scale value as the seed is
       // still allowed, and it covers most cases. (Unfortunately some operations
       // that merge two similar-sized hash tables will still be quadratic.)
-      return scale
+      return Int(scale)
     }
     // Use the object address as the hash seed. This is cheaper than
     // SystemRandomNumberGenerator, while it has the same practical effect.
@@ -117,7 +117,7 @@ extension _HashTable {
     return unsafeBitCast(object, to: Int.self)
 #else
     // Use per-capacity seeding for now.
-    return scale
+    return Int(scale)
 #endif
   }
 }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -552,7 +552,8 @@ extension _NativeDictionary { // Deletion
       let scale = self._storage._scale
       _storage = _DictionaryStorage<Key, Value>.allocate(
         scale: scale,
-        age: nil)
+        age: nil,
+        seed: nil)
       return
     }
     for bucket in hashTable {

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -571,8 +571,13 @@ extension _NativeDictionary { // High-level operations
   internal func mapValues<T>(
     _ transform: (Value) throws -> T
   ) rethrows -> _NativeDictionary<Key, T> {
-    let result = _NativeDictionary<Key, T>(capacity: capacity)
-    // Because the keys in the current and new buffer are the same, we can
+    let (resultStorage, rehash) = _DictionaryStorage<Key, T>.reallocate(
+      original: _storage,
+      capacity: capacity)
+    _sanityCheck(!rehash)
+    _sanityCheck(resultStorage._seed == _storage._seed)
+    let result = _NativeDictionary<Key, T>(resultStorage)
+    // Because the current and new buffer have the same scale and seed, we can
     // initialize to the same locations in the new buffer, skipping hash value
     // recalculations.
     for bucket in hashTable {

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -451,7 +451,10 @@ extension _NativeSet { // Deletion
   internal mutating func removeAll(isUnique: Bool) {
     guard isUnique else {
       let scale = self._storage._scale
-      _storage = _SetStorage<Element>.allocate(scale: scale, age: nil)
+      _storage = _SetStorage<Element>.allocate(
+        scale: scale,
+        age: nil,
+        seed: nil)
       return
     }
     for bucket in hashTable {

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -154,7 +154,10 @@ extension _NativeSet { // ensureUnique
   @inlinable
   internal mutating func resize(capacity: Int) {
     let capacity = Swift.max(capacity, self.capacity)
-    let result = _NativeSet(_SetStorage<Element>.allocate(capacity: capacity))
+    let result = _NativeSet(_SetStorage<Element>.resize(
+        original: _storage,
+        capacity: capacity,
+        move: true))
     if count > 0 {
       for bucket in hashTable {
         let element = (self._elements + bucket.offset).move()
@@ -169,28 +172,36 @@ extension _NativeSet { // ensureUnique
   }
 
   @inlinable
-  internal mutating func copy(capacity: Int) -> Bool {
+  internal mutating func copyAndResize(capacity: Int) {
     let capacity = Swift.max(capacity, self.capacity)
-    let (newStorage, rehash) = _SetStorage<Element>.reallocate(
-      original: _storage,
-      capacity: capacity)
-    let result = _NativeSet(newStorage)
+    let result = _NativeSet(_SetStorage<Element>.resize(
+        original: _storage,
+        capacity: capacity,
+        move: false))
     if count > 0 {
-      if rehash {
-        for bucket in hashTable {
-          result._unsafeInsertNew(self.uncheckedElement(at: bucket))
-        }
-      } else {
-        result.hashTable.copyContents(of: hashTable)
-        result._storage._count = self.count
-        for bucket in hashTable {
-          let element = uncheckedElement(at: bucket)
-          result.uncheckedInitialize(at: bucket, to: element)
-        }
+      for bucket in hashTable {
+        result._unsafeInsertNew(self.uncheckedElement(at: bucket))
       }
     }
     _storage = result._storage
-    return rehash
+  }
+
+  @inlinable
+  internal mutating func copy() {
+    let newStorage = _SetStorage<Element>.copy(original: _storage)
+    _sanityCheck(newStorage._scale == _storage._scale)
+    _sanityCheck(newStorage._age == _storage._age)
+    _sanityCheck(newStorage._seed == _storage._seed)
+    let result = _NativeSet(newStorage)
+    if count > 0 {
+      result.hashTable.copyContents(of: hashTable)
+      result._storage._count = self.count
+      for bucket in hashTable {
+        let element = uncheckedElement(at: bucket)
+        result.uncheckedInitialize(at: bucket, to: element)
+      }
+    }
+    _storage = result._storage
   }
 
   /// Ensure storage of self is uniquely held and can hold at least `capacity`
@@ -201,10 +212,15 @@ extension _NativeSet { // ensureUnique
     if _fastPath(capacity <= self.capacity && isUnique) {
       return false
     }
-    guard isUnique else {
-      return copy(capacity: capacity)
+    if isUnique {
+      resize(capacity: capacity)
+      return true
     }
-    resize(capacity: capacity)
+    if capacity <= self.capacity {
+      copy()
+      return false
+    }
+    copyAndResize(capacity: capacity)
     return true
   }
 

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -285,19 +285,22 @@ final internal class _SetStorage<Element: Hashable>
 extension _SetStorage {
   @usableFromInline
   @_effects(releasenone)
-  internal static func reallocate(
+  internal static func copy(original: _RawSetStorage) -> _SetStorage {
+    return .allocate(
+      scale: original._scale,
+      age: original._age,
+      seed: original._seed)
+  }
+
+  @usableFromInline
+  @_effects(releasenone)
+  static internal func resize(
     original: _RawSetStorage,
-    capacity: Int
-  ) -> (storage: _SetStorage, rehash: Bool) {
-    _sanityCheck(capacity >= original._count)
+    capacity: Int,
+    move: Bool
+  ) -> _SetStorage {
     let scale = _HashTable.scale(forCapacity: capacity)
-    let rehash = (scale != original._scale)
-    if rehash {
-      return .allocate(scale: scale, age: nil, seed: nil)
-    }
-    return (
-      .allocate(scale: scale, age: original._age, seed: original._seed),
-      rehash)
+    return allocate(scale: scale, age: nil, seed: nil)
   }
 
   @usableFromInline


### PR DESCRIPTION
Implement the per-instance seeding infrastructure without actually enabling per-instance seeding.

This is #19533 except for the crucial step of actually generating a new seed.

rdar://problem/44760778