### PR TITLE
[stdlib] Insert/remove same key in `SetTestSuite`

### DIFF
--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1172,7 +1172,7 @@ SetTestSuite.test("deleteChainCollisionRandomized") {
     if Int.random(in: 0 ..< (chainLength * 2), using: &generator) == 0 {
       s.remove(key)
     } else {
-      s.insert(TestKeyTy(key.value))
+      s.insert(key)
     }
     check(s)
   }


### PR DESCRIPTION
This pull request reuses the `TestKeyTy` from the local `getKey(_:)` function,
which has a separately randomized `hashValue`.

Previously, `SetTestSuite.test("deleteChainCollisionRandomized")` created a
different key, i.e. `s.insert(TestKeyTy(key.value))` versus `s.remove(key)`.

Compare with `DictionaryTestSuite.test("deleteChainCollisionRandomized")`,
which uses the same key for both insertion and removal, i.e. `d[key] = ...`

Follow-up to https://github.com/apple/swift/pull/16650#discussion_r206867016

Cc: @lorentey