### PR TITLE
[stdlib] Dictionary.updateValue(_:,forKey:): Don’t overwrite the existing key

### DIFF
--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -416,10 +416,6 @@ extension _NativeDictionary { // Insertions
     if found {
       let oldValue = (_values + bucket.offset).move()
       (_values + bucket.offset).initialize(to: value)
-      // FIXME: Replacing the old key with the new is unnecessary, unintuitive,
-      // and actively harmful to some usecases. We shouldn't do it.
-      // rdar://problem/32144087
-      (_keys + bucket.offset).pointee = key
       return oldValue
     }
     _insert(at: bucket, key: key, value: value)
@@ -435,10 +431,6 @@ extension _NativeDictionary { // Insertions
     let (bucket, found) = mutatingFind(key, isUnique: isUnique)
     if found {
       (_values + bucket.offset).pointee = value
-      // FIXME: Replacing the old key with the new is unnecessary, unintuitive,
-      // and actively harmful to some usecases. We shouldn't do it.
-      // rdar://problem/32144087
-      (_keys + bucket.offset).pointee = key
     } else {
       _insert(at: bucket, key: key, value: value)
     }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -411,7 +411,7 @@ DictionaryTestSuite.test("COW.Fast.UpdateValueForKeyDoesNotReallocate") {
   }
 }
 
-DictionaryTestSuite.test("COW.Slow.AddDoesNotReallocate") {
+DictionaryTestSuite.test("COW.Slow.UpdateValueForKeyDoesNotReallocate") {
   do {
     var d1 = getCOWSlowDictionary()
     let identity1 = d1._rawIdentifier()
@@ -4640,6 +4640,32 @@ DictionaryTestSuite.test("removeAt") {
     let origKeys: [Int] = [10, 20, 30]
     expectEqual(origKeys.filter { $0 != (i*10) }, d.keys.sorted())
   }
+}
+
+DictionaryTestSuite.test("updateValue") {
+  let key1 = TestKeyTy(42)
+  let key2 = TestKeyTy(42)
+  let value1 = TestValueTy(1)
+  let value2 = TestValueTy(2)
+
+  var d: [TestKeyTy: TestValueTy] = [:]
+
+  expectNil(d.updateValue(value1, forKey: key1))
+
+  expectEqual(d.count, 1)
+  let index1 = d.index(forKey: key2)
+  expectNotNil(index1)
+  expectTrue(d[index1!].key === key1)
+  expectTrue(d[index1!].value === value1)
+
+  expectTrue(d.updateValue(value2, forKey: key2) === value1)
+
+  expectEqual(d.count, 1)
+  let index2 = d.index(forKey: key2)
+  expectEqual(index1, index2)
+  // We expect updateValue to keep the original key in place.
+  expectTrue(d[index2!].key === key1) // Not key2
+  expectTrue(d[index2!].value === value2)
 }
 
 DictionaryTestSuite.test("localHashSeeds") {


### PR DESCRIPTION
(This is the second attempt, after #19500 was reverted.)

`updateValue(_:, forKey:)` currently replaces the old key, which is undocumented, unnecessary and somewhat surprising. The previous incarnation of Dictionary implemented updates this way because of a technical detail; this wrinkle is now eliminated.

rdar://problem/32144087

I know of no use cases where the old behavior was actually desirable; most/all practical code that would care about this seem to prefer to leave the old key in place.