### PR TITLE
fix double-deabstraction bug

### DIFF
--- a/include/swift/SIL/GraphOperationBuilder.h
+++ b/include/swift/SIL/GraphOperationBuilder.h
@@ -49,6 +49,10 @@ public:
   void addListArgument(llvm::ArrayRef<SILValue> arguments,
                        llvm::StringRef name = llvm::StringRef());
 
+  /// Add a list argument to the GraphOperationInst, with an optional name.
+  void addListArgument(OperandValueArrayRef arguments,
+                       llvm::StringRef name = llvm::StringRef());
+
   /// Add an attribute with known constant value to the GraphOperationInst.
   /// Returns a reference to the attribute, valid for the lifetime of the
   /// GraphOperationBuilder, that you can use to mutate the attribute before

--- a/lib/AST/GraphOperationBuilder.cpp
+++ b/lib/AST/GraphOperationBuilder.cpp
@@ -43,6 +43,17 @@ void GraphOperationBuilder::addListArgument(ArrayRef<SILValue> arguments,
   }
 }
 
+/// Add a list argument to the GraphOperationInst, with an optional name.
+void GraphOperationBuilder::addListArgument(OperandValueArrayRef arguments,
+                                            StringRef name) {
+  MangledName += ",L";
+  MangledName += name;
+  for (auto argument : arguments) {
+    MangledName += ",e";
+    Operands.push_back(argument);
+  }
+}
+
 /// Add an attribute with known constant value to the GraphOperationInst.
 /// Returns a reference to the attribute, valid for the lifetime of the
 /// GraphOperationBuilder, that you can use to mutate the attribute before

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -372,3 +372,21 @@ public func SR8419(iterationCount: Int) {
     }
   }
 }
+
+// If `deabstractedCallee` gets deabstracted before `inlineDeabstracted_*`,
+// then the insts in `deabstractedCallee` get deabstracted twice. There was
+// a bug where the compiler crashed when deabstracting certain graph_ops twice.
+// There is no guaranteed deabstraction order, so this test isn't guaranteed to
+// catch the problem. Sandwiching `deabstractedCallee` between two callers
+// makes this test catch the problem as long as the order happens to be linear
+// up or down.
+public func inlineDeabstracted_a() -> Tensor<Float> {
+  return deabstractedCallee([1, 2, 3])
+}
+// expected-warning @+1 {{implicitly copied}}
+public func deabstractedCallee(_ t: Tensor<Float>) -> Tensor<Float> {
+  return t ++ Tensor<Float>([1, 2, 3]) // expected-note {{value used here}}
+}
+public func inlineDeabstracted_b() -> Tensor<Float> {
+  return deabstractedCallee([1, 2, 3])
+}


### PR DESCRIPTION
https://github.com/apple/swift/pull/19528 introduces a bug because it incorrectly assumes that deabstraction sees each `graph_op` once.

This PR teaches deabstraction to handle `graph_op`s that have already gone through deabstraction.