### PR TITLE
[ModuleInterface] Trap when trying to print a null type

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -189,6 +189,10 @@ struct PrintOptions {
   /// ([] and ?), even if there are no sugar type nodes.
   bool SynthesizeSugarOnTypes = false;
 
+  /// \brief If true, null types in the AST will be printed as "<null>". If
+  /// false, the compiler will trap.
+  bool AllowNullTypes = true;
+
   /// \brief If true, the printer will explode a pattern like this:
   /// \code
   ///   var (a, b) = f()

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -85,6 +85,7 @@ PrintOptions PrintOptions::printTextualInterfaceFile() {
   result.TypeDefinitions = true;
   result.PrintIfConfig = false;
   result.FullyQualifiedTypes = true;
+  result.AllowNullTypes = false;
   result.SkipImports = true;
   result.OmitNameOfInaccessibleProperties = true;
   result.FunctionDefinitions = true;
@@ -4020,10 +4021,15 @@ void Type::print(raw_ostream &OS, const PrintOptions &PO) const {
   print(Printer, PO);
 }
 void Type::print(ASTPrinter &Printer, const PrintOptions &PO) const {
-  if (isNull())
+  if (isNull()) {
+    if (!PO.AllowNullTypes) {
+      // Use report_fatal_error instead of assert to trap in release builds too.
+      llvm::report_fatal_error("Cannot pretty-print a null type");
+    }
     Printer << "<null>";
-  else
-    TypePrinter(Printer, PO).visit(*this);
+    return;
+  }
+  TypePrinter(Printer, PO).visit(*this);
 }
 
 void AnyFunctionType::printParams(raw_ostream &OS, const


### PR DESCRIPTION
We want to catch these bugs sooner rather than later, like the one Harlan fixed in #19175. Trapping deterministically is the best way to do so, and it's better than generating nonsense.