### PR TITLE
[stdlib] Set, Dictionary: Make Cocoa indices resilient for now

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1897,7 +1897,7 @@ extension Dictionary.Index: Comparable {
 }
 
 extension Dictionary.Index: Hashable {
-  @inlinable
+  @_effects(readonly) // FIXME(cocoa-index): Make inlinable
   public func hash(into hasher: inout Hasher) {
   #if _runtime(_ObjC)
     switch _variant {

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1907,7 +1907,7 @@ extension Dictionary.Index: Hashable {
     case .cocoa(let cocoaIndex):
       _cocoaPath()
       hasher.combine(1 as UInt8)
-      hasher.combine(cocoaIndex.currentKeyIndex)
+      hasher.combine(cocoaIndex.storage.currentKeyIndex)
     }
   #else
     hasher.combine(_asNative.bucket.offset)

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -450,24 +450,31 @@ extension _CocoaDictionary: _DictionaryBuffer {
   @usableFromInline
   internal typealias Value = AnyObject
 
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
   internal var startIndex: Index {
-    return Index(self, startIndex: ())
+    @_effects(releasenone)
+    get {
+      return Index(self, startIndex: ())
+    }
   }
 
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
   internal var endIndex: Index {
-    return Index(self, endIndex: ())
+    @_effects(releasenone)
+    get {
+      return Index(self, endIndex: ())
+    }
   }
 
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
+  @_effects(releasenone)
   internal func index(after i: Index) -> Index {
     var i = i
     formIndex(after: &i)
     return i
   }
 
-  @usableFromInline
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
   @_effects(releasenone)
   internal func formIndex(after i: inout Index) {
     _precondition(i.base.object === self.object, "Invalid index")
@@ -476,7 +483,8 @@ extension _CocoaDictionary: _DictionaryBuffer {
     i.currentKeyIndex += 1
   }
 
-  @usableFromInline
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
+  @_effects(releasenone)
   internal func index(forKey key: Key) -> Index? {
     // Fast path that does not involve creating an array of all keys.  In case
     // the key is present, this lookup is a penalty for the slow path, but the
@@ -516,8 +524,8 @@ extension _CocoaDictionary: _DictionaryBuffer {
     return object.object(forKey: key)
   }
 
-  @inlinable
-  @inline(__always)
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
+  @_effects(releasenone)
   internal func lookup(_ index: Index) -> (key: Key, value: Value) {
     _precondition(index.base.object === self.object, "Invalid index")
     let key: Key = index.allKeys[index.currentKeyIndex]
@@ -525,15 +533,15 @@ extension _CocoaDictionary: _DictionaryBuffer {
     return (key, value)
   }
 
-  @inlinable
-  @inline(__always)
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
+  @_effects(releasenone)
   func key(at index: Index) -> Key {
     _precondition(index.base.object === self.object, "Invalid index")
     return index.key
   }
 
-  @inlinable
-  @inline(__always)
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
+  @_effects(releasenone)
   func value(at index: Index) -> Value {
     _precondition(index.base.object === self.object, "Invalid index")
     let key = index.allKeys[index.currentKeyIndex]
@@ -557,7 +565,7 @@ extension _CocoaDictionary {
 }
 
 extension _CocoaDictionary {
-  @_fixed_layout // FIXME(sil-serialize-all)
+  // FIXME(cocoa-index): Overhaul and make @_fixed_layout
   @usableFromInline
   internal struct Index {
     // Assumption: we rely on NSDictionary.getObjects when being
@@ -567,35 +575,29 @@ extension _CocoaDictionary {
 
     /// A reference to the NSDictionary, which owns members in `allObjects`,
     /// or `allKeys`, for NSSet and NSDictionary respectively.
-    @usableFromInline // FIXME(sil-serialize-all)
     internal let base: _CocoaDictionary
     // FIXME: swift-3-indexing-model: try to remove the cocoa reference, but
     // make sure that we have a safety check for accessing `allKeys`.  Maybe
     // move both into the dictionary/set itself.
 
     /// An unowned array of keys.
-    @usableFromInline // FIXME(sil-serialize-all)
     internal var allKeys: _HeapBuffer<Int, AnyObject>
 
     /// Index into `allKeys`
-    @usableFromInline // FIXME(sil-serialize-all)
     internal var currentKeyIndex: Int
 
-    @inlinable // FIXME(sil-serialize-all)
     internal init(_ base: __owned _CocoaDictionary, startIndex: ()) {
       self.base = base
       self.allKeys = _stdlib_NSDictionary_allKeys(base.object)
       self.currentKeyIndex = 0
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     internal init(_ base: __owned _CocoaDictionary, endIndex: ()) {
       self.base = base
       self.allKeys = _stdlib_NSDictionary_allKeys(base.object)
       self.currentKeyIndex = allKeys.value
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     internal init(
       _ base: __owned _CocoaDictionary,
       _ allKeys: __owned _HeapBuffer<Int, AnyObject>,
@@ -628,7 +630,8 @@ extension _CocoaDictionary.Index {
 }
 
 extension _CocoaDictionary.Index: Equatable {
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
+  @_effects(readonly)
   internal static func == (
     lhs: _CocoaDictionary.Index,
     rhs: _CocoaDictionary.Index
@@ -640,7 +643,8 @@ extension _CocoaDictionary.Index: Equatable {
 }
 
 extension _CocoaDictionary.Index: Comparable {
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
+  @_effects(readonly)
   internal static func < (
     lhs: _CocoaDictionary.Index,
     rhs: _CocoaDictionary.Index

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -611,18 +611,21 @@ extension _CocoaDictionary {
 }
 
 extension _CocoaDictionary.Index {
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
   @nonobjc
   internal var key: AnyObject {
-    _precondition(currentKeyIndex < allKeys.value,
-      "Attempting to access Dictionary elements using an invalid index")
-    return allKeys[currentKeyIndex]
+    @_effects(readonly)
+    get {
+      _precondition(currentKeyIndex < allKeys.value,
+        "Attempting to access Dictionary elements using an invalid index")
+      return allKeys[currentKeyIndex]
+    }
   }
 
-  @usableFromInline
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
   @nonobjc
   internal var age: Int32 {
-    @_effects(releasenone)
+    @_effects(readonly)
     get {
       return _HashTable.age(for: base.object)
     }

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -454,7 +454,8 @@ extension _CocoaDictionary: _DictionaryBuffer {
   internal var startIndex: Index {
     @_effects(releasenone)
     get {
-      return Index(self, startIndex: ())
+      let allKeys = _stdlib_NSDictionary_allKeys(self.object)
+      return Index(Index.Storage(self, allKeys, 0))
     }
   }
 
@@ -462,25 +463,33 @@ extension _CocoaDictionary: _DictionaryBuffer {
   internal var endIndex: Index {
     @_effects(releasenone)
     get {
-      return Index(self, endIndex: ())
+      let allKeys = _stdlib_NSDictionary_allKeys(self.object)
+      return Index(Index.Storage(self, allKeys, allKeys.value))
     }
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
   @_effects(releasenone)
-  internal func index(after i: Index) -> Index {
-    var i = i
-    formIndex(after: &i)
-    return i
+  internal func index(after index: Index) -> Index {
+    var result = index
+    formIndex(after: &result)
+    return result
+  }
+
+  internal func validate(_ index: Index) {
+    _precondition(index.storage.base.object === self.object, "Invalid index")
+    _precondition(index.storage.currentKeyIndex < index.storage.allKeys.value,
+      "Attempt to access endIndex")
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
   @_effects(releasenone)
-  internal func formIndex(after i: inout Index) {
-    _precondition(i.base.object === self.object, "Invalid index")
-    _precondition(i.currentKeyIndex < i.allKeys.value,
-      "Cannot increment endIndex")
-    i.currentKeyIndex += 1
+  internal func formIndex(after index: inout Index) {
+    validate(index)
+    let isUnique = index.isUniquelyReferenced()
+    if !isUnique { index.storage = index.copy() }
+    let storage = index.storage // FIXME: rdar://problem/44863751
+    storage.currentKeyIndex += 1
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
@@ -495,16 +504,13 @@ extension _CocoaDictionary: _DictionaryBuffer {
     }
 
     let allKeys = _stdlib_NSDictionary_allKeys(object)
-    var keyIndex = -1
     for i in 0..<allKeys.value {
       if _stdlib_NSObject_isEqual(key, allKeys[i]) {
-        keyIndex = i
-        break
+        return Index(Index.Storage(self, allKeys, i))
       }
     }
-    _sanityCheck(keyIndex >= 0,
-        "Key was found in fast path, but not found later?")
-    return Index(self, allKeys, keyIndex)
+    _sanityCheckFailure(
+      "An NSDictionary key wassn't listed amongst its enumerated contents")
   }
 
   @inlinable
@@ -527,25 +533,25 @@ extension _CocoaDictionary: _DictionaryBuffer {
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
   @_effects(releasenone)
   internal func lookup(_ index: Index) -> (key: Key, value: Value) {
-    _precondition(index.base.object === self.object, "Invalid index")
-    let key: Key = index.allKeys[index.currentKeyIndex]
-    let value: Value = index.base.object.object(forKey: key)!
+    _precondition(index.storage.base.object === self.object, "Invalid index")
+    let key: Key = index.storage.allKeys[index.storage.currentKeyIndex]
+    let value: Value = index.storage.base.object.object(forKey: key)!
     return (key, value)
   }
 
   @usableFromInline // FIXME(cocoa-index): Make inlinable
   @_effects(releasenone)
   func key(at index: Index) -> Key {
-    _precondition(index.base.object === self.object, "Invalid index")
+    _precondition(index.storage.base.object === self.object, "Invalid index")
     return index.key
   }
 
   @usableFromInline // FIXME(cocoa-index): Make inlinable
   @_effects(releasenone)
   func value(at index: Index) -> Value {
-    _precondition(index.base.object === self.object, "Invalid index")
-    let key = index.allKeys[index.currentKeyIndex]
-    return index.base.object.object(forKey: key)!
+    _precondition(index.storage.base.object === self.object, "Invalid index")
+    let key = index.storage.allKeys[index.storage.currentKeyIndex]
+    return index.storage.base.object.object(forKey: key)!
   }
 }
 
@@ -565,10 +571,23 @@ extension _CocoaDictionary {
 }
 
 extension _CocoaDictionary {
-  // FIXME(cocoa-index): Overhaul and make @_fixed_layout
+  @_fixed_layout
   @usableFromInline
   internal struct Index {
-    // Assumption: we rely on NSDictionary.getObjects when being
+    @usableFromInline
+    internal var storage: Storage
+
+    internal init(_ storage: Storage) {
+      self.storage = storage
+    }
+  }
+}
+
+extension _CocoaDictionary.Index {
+  // FIXME(cocoa-index): Try using an NSEnumerator to speed this up.
+  @usableFromInline
+  internal class Storage {
+  // Assumption: we rely on NSDictionary.getObjects when being
     // repeatedly called on the same NSDictionary, returning items in the same
     // order every time.
     // Similarly, the same assumption holds for NSSet.allObjects.
@@ -586,18 +605,6 @@ extension _CocoaDictionary {
     /// Index into `allKeys`
     internal var currentKeyIndex: Int
 
-    internal init(_ base: __owned _CocoaDictionary, startIndex: ()) {
-      self.base = base
-      self.allKeys = _stdlib_NSDictionary_allKeys(base.object)
-      self.currentKeyIndex = 0
-    }
-
-    internal init(_ base: __owned _CocoaDictionary, endIndex: ()) {
-      self.base = base
-      self.allKeys = _stdlib_NSDictionary_allKeys(base.object)
-      self.currentKeyIndex = allKeys.value
-    }
-
     internal init(
       _ base: __owned _CocoaDictionary,
       _ allKeys: __owned _HeapBuffer<Int, AnyObject>,
@@ -611,14 +618,27 @@ extension _CocoaDictionary {
 }
 
 extension _CocoaDictionary.Index {
+  @inlinable
+  internal mutating func isUniquelyReferenced() -> Bool {
+    return _isUnique_native(&storage)
+  }
+
+  @usableFromInline
+  internal mutating func copy() -> Storage {
+    let storage = self.storage
+    return Storage(storage.base, storage.allKeys, storage.currentKeyIndex)
+  }
+}
+
+extension _CocoaDictionary.Index {
   @usableFromInline // FIXME(cocoa-index): Make inlinable
   @nonobjc
   internal var key: AnyObject {
     @_effects(readonly)
     get {
-      _precondition(currentKeyIndex < allKeys.value,
+      _precondition(storage.currentKeyIndex < storage.allKeys.value,
         "Attempting to access Dictionary elements using an invalid index")
-      return allKeys[currentKeyIndex]
+      return storage.allKeys[storage.currentKeyIndex]
     }
   }
 
@@ -627,7 +647,7 @@ extension _CocoaDictionary.Index {
   internal var age: Int32 {
     @_effects(readonly)
     get {
-      return _HashTable.age(for: base.object)
+      return _HashTable.age(for: storage.base.object)
     }
   }
 }
@@ -639,9 +659,9 @@ extension _CocoaDictionary.Index: Equatable {
     lhs: _CocoaDictionary.Index,
     rhs: _CocoaDictionary.Index
   ) -> Bool {
-    _precondition(lhs.base.object === rhs.base.object,
+    _precondition(lhs.storage.base.object === rhs.storage.base.object,
       "Comparing indexes from different dictionaries")
-    return lhs.currentKeyIndex == rhs.currentKeyIndex
+    return lhs.storage.currentKeyIndex == rhs.storage.currentKeyIndex
   }
 }
 
@@ -652,9 +672,9 @@ extension _CocoaDictionary.Index: Comparable {
     lhs: _CocoaDictionary.Index,
     rhs: _CocoaDictionary.Index
   ) -> Bool {
-    _precondition(lhs.base.object === rhs.base.object,
+    _precondition(lhs.storage.base.object === rhs.storage.base.object,
       "Comparing indexes from different dictionaries")
-    return lhs.currentKeyIndex < rhs.currentKeyIndex
+    return lhs.storage.currentKeyIndex < rhs.storage.currentKeyIndex
   }
 }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1428,7 +1428,7 @@ extension Set.Index: Hashable {
     case .cocoa(let cocoaIndex):
       _cocoaPath()
       hasher.combine(1 as UInt8)
-      hasher.combine(cocoaIndex.currentKeyIndex)
+      hasher.combine(cocoaIndex.storage.currentKeyIndex)
     }
   #else
     hasher.combine(_asNative.bucket.offset)

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1418,7 +1418,7 @@ extension Set.Index: Hashable {
   ///
   /// - Parameter hasher: The hasher to use when combining the components
   ///   of this instance.
-  @inlinable
+  @_effects(readonly) // FIXME(cocoa-index): Make inlinable
   public func hash(into hasher: inout Hasher) {
   #if _runtime(_ObjC)
     switch _variant {

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -324,24 +324,31 @@ extension _CocoaSet: _SetBuffer {
   @usableFromInline
   internal typealias Element = AnyObject
 
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
   internal var startIndex: Index {
-    return Index(self, startIndex: ())
+    @_effects(releasenone)
+    get {
+      return Index(self, startIndex: ())
+    }
   }
 
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
   internal var endIndex: Index {
-    return Index(self, endIndex: ())
+    @_effects(releasenone)
+    get {
+      return Index(self, endIndex: ())
+    }
   }
 
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
+  @_effects(releasenone)
   internal func index(after i: Index) -> Index {
     var i = i
     formIndex(after: &i)
     return i
   }
 
-  @usableFromInline
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
   @_effects(releasenone)
   internal func formIndex(after i: inout Index) {
     _precondition(i.base.object === self.object, "Invalid index")
@@ -350,7 +357,8 @@ extension _CocoaSet: _SetBuffer {
     i.currentKeyIndex += 1
   }
 
-  @usableFromInline
+  @usableFromInline // FIXME(cocoa-index): Should be inlinable
+  @_effects(releasenone)
   internal func index(for element: AnyObject) -> Index? {
     // Fast path that does not involve creating an array of all keys.  In case
     // the key is present, this lookup is a penalty for the slow path, but the
@@ -384,6 +392,7 @@ extension _CocoaSet: _SetBuffer {
   }
 
   @usableFromInline
+  @_effects(releasenone)
   internal func element(at i: Index) -> AnyObject {
     let element: AnyObject? = i.element
     _sanityCheck(element != nil, "Item not found in underlying NSSet")
@@ -392,7 +401,7 @@ extension _CocoaSet: _SetBuffer {
 }
 
 extension _CocoaSet {
-  @_fixed_layout // FIXME(sil-serialize-all)
+  // FIXME(cocoa-index): Overhaul and make @_fixed_layout
   @usableFromInline
   internal struct Index {
     // Assumption: we rely on NSDictionary.getObjects when being
@@ -402,35 +411,29 @@ extension _CocoaSet {
 
     /// A reference to the NSSet, which owns members in `allObjects`,
     /// or `allKeys`, for NSSet and NSDictionary respectively.
-    @usableFromInline // FIXME(sil-serialize-all)
     internal let base: _CocoaSet
     // FIXME: swift-3-indexing-model: try to remove the cocoa reference, but
     // make sure that we have a safety check for accessing `allKeys`.  Maybe
     // move both into the dictionary/set itself.
 
     /// An unowned array of keys.
-    @usableFromInline // FIXME(sil-serialize-all)
     internal var allKeys: _HeapBuffer<Int, AnyObject>
 
     /// Index into `allKeys`
-    @usableFromInline // FIXME(sil-serialize-all)
     internal var currentKeyIndex: Int
 
-    @inlinable // FIXME(sil-serialize-all)
     internal init(_ base: __owned _CocoaSet, startIndex: ()) {
       self.base = base
       self.allKeys = _stdlib_NSSet_allObjects(base.object)
       self.currentKeyIndex = 0
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     internal init(_ base: __owned _CocoaSet, endIndex: ()) {
       self.base = base
       self.allKeys = _stdlib_NSSet_allObjects(base.object)
       self.currentKeyIndex = allKeys.value
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     internal init(
       _ base: __owned _CocoaSet,
       _ allKeys: __owned _HeapBuffer<Int, AnyObject>,
@@ -463,7 +466,8 @@ extension _CocoaSet.Index {
 }
 
 extension _CocoaSet.Index: Equatable {
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
+  @_effects(readonly)
   internal static func == (lhs: _CocoaSet.Index, rhs: _CocoaSet.Index) -> Bool {
     _precondition(lhs.base.object === rhs.base.object,
       "Comparing indexes from different sets")
@@ -472,7 +476,8 @@ extension _CocoaSet.Index: Equatable {
 }
 
 extension _CocoaSet.Index: Comparable {
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
+  @_effects(readonly)
   internal static func < (lhs: _CocoaSet.Index, rhs: _CocoaSet.Index) -> Bool {
     _precondition(lhs.base.object === rhs.base.object,
       "Comparing indexes from different sets")

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -391,7 +391,7 @@ extension _CocoaSet: _SetBuffer {
     return object.member(element) != nil
   }
 
-  @usableFromInline
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
   @_effects(releasenone)
   internal func element(at i: Index) -> AnyObject {
     let element: AnyObject? = i.element
@@ -447,15 +447,18 @@ extension _CocoaSet {
 }
 
 extension _CocoaSet.Index {
-  @inlinable
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
   @nonobjc
   internal var element: AnyObject {
-    _precondition(currentKeyIndex < allKeys.value,
-      "Attempting to access Set elements using an invalid index")
-    return allKeys[currentKeyIndex]
+    @_effects(readonly)
+    get {
+      _precondition(currentKeyIndex < allKeys.value,
+        "Attempting to access Set elements using an invalid index")
+      return allKeys[currentKeyIndex]
+    }
   }
 
-  @usableFromInline
+  @usableFromInline // FIXME(cocoa-index): Make inlinable
   @nonobjc
   internal var age: Int32 {
     @_effects(releasenone)


### PR DESCRIPTION
This makes `_CocoaSet.Index` and `_CocoaDictionary.Index` fully resilient for now, allowing us to replace/fix its internals at any point in the future.