### PR TITLE
Add sextOrBitCast to conversions of Builtin.Word

### DIFF
--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1617,7 +1617,7 @@ ${assignmentOperatorComment(x.operator, True)}
 % if BuiltinName == 'Int32':
     self._value = Builtin.truncOrBitCast_Word_Int32(_v)
 % elif BuiltinName == 'Int64':
-    self._value = Builtin.zextOrBitCast_Word_Int64(_v)
+    self._value = Builtin.${z}extOrBitCast_Word_Int64(_v)
 % end
   }
 
@@ -1625,7 +1625,7 @@ ${assignmentOperatorComment(x.operator, True)}
   public // @testable
   var _builtinWordValue: Builtin.Word {
 % if BuiltinName == 'Int32':
-    return Builtin.zextOrBitCast_Int32_Word(_value)
+    return Builtin.${z}extOrBitCast_Int32_Word(_value)
 % elif BuiltinName == 'Int64':
     return Builtin.truncOrBitCast_Int64_Word(_value)
 % end


### PR DESCRIPTION
<!-- What's in this pull request? -->
An error was hit when attempting to build Swift on a 32-bit Linux host. It was asserting when attempting to run ‘RedunantLoadElim” during the optimizer. The reason why is a bit messy.

First, Builtin.Word is always considered to be 64-bit when it is a SILType. This means the optimizer, when working with a Builtin.Word, will create 64-bit APInts when converting from other types.

Second, the SIL being output for a particular literal looked like this:
Int2048 (integer_literal) : Int32 (Signed Truncation) : Word (zextOrBitCast)

The constant fold behavior would convert this into an integer_literal of the Builtin.Word type. But because of the zext cast, if the original literal was -1, it would become +4 billion during folding.

This normally isn’t a problem **except** when SIL is still attempting to optimize. (See First)

Third, The Redundant Load Elimination pass was attempting to make sense of an index_addr instruction which was indexing at -1. This happens when you perform “-= 1” on an UnsafePointer. Because SIL was interpreting Word’s size incorrectly, it caused the RLE pass to ask “what is at ptr[4billion]?” Since there’s no feasible answer for such a question, the answer was “nothing”, which tripped the assert.

This fix uses sign extension when converting “upward” and the Integer type is signed, otherwise it will still use zero extension.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8870](https://bugs.swift.org/browse/SR-8870).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->