### PR TITLE
[DON'T MERGE][stdlib] Set, Dictionary: Make storage classes resilient

### DIFF
--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -16,7 +16,6 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
-@_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 @_objc_non_lazy_realization
 internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
@@ -109,7 +108,6 @@ internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
 
 /// The storage class for the singleton empty set.
 /// The single instance of this class is created by the runtime.
-@_fixed_layout
 @usableFromInline
 internal class _EmptyDictionarySingleton: _RawDictionaryStorage {
   @nonobjc
@@ -192,7 +190,6 @@ extension _RawDictionaryStorage {
   }
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 final internal class _DictionaryStorage<Key: Hashable, Value>
   : _RawDictionaryStorage, _NSDictionaryCore {

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -500,25 +500,19 @@ internal class __SwiftNativeNSArray {
   deinit {}
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@usableFromInline
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSDictionaryBase)
 internal class __SwiftNativeNSDictionary {
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal init() {}
-  @inlinable // FIXME(sil-serialize-all)
   deinit {}
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@usableFromInline
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSSetBase)
 internal class __SwiftNativeNSSet {
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal init() {}
-  @inlinable // FIXME(sil-serialize-all)
   deinit {}
 }
 

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -16,7 +16,6 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
-@_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 @_objc_non_lazy_realization
 internal class _RawSetStorage: __SwiftNativeNSSet {
@@ -104,7 +103,6 @@ internal class _RawSetStorage: __SwiftNativeNSSet {
 
 /// The storage class for the singleton empty set.
 /// The single instance of this class is created by the runtime.
-@_fixed_layout
 @usableFromInline
 internal class _EmptySetSingleton: _RawSetStorage {
   @nonobjc
@@ -175,7 +173,6 @@ extension _EmptySetSingleton: _NSSetCore {
 #endif
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 final internal class _SetStorage<Element: Hashable>
   : _RawSetStorage, _NSSetCore {


### PR DESCRIPTION
Let's try removing `@_fixed_layout` from `Set` and `Dictionary` storage classes.