### PR TITLE
[stdlib] Set, Dictionary: Make reserveCapacity non-inlinable

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -442,8 +442,8 @@ public struct Dictionary<Key: Hashable, Value> {
   /// - Parameter minimumCapacity: The minimum number of key-value pairs that
   ///   the newly created dictionary should be able to store without
   ///   reallocating its storage buffer.
-  @inlinable
-  public init(minimumCapacity: Int) {
+  public // FIXME(reserveCapacity): Should be inlinable
+  init(minimumCapacity: Int) {
     _variant = .native(_NativeDictionary(capacity: minimumCapacity))
   }
 
@@ -2074,8 +2074,8 @@ extension Dictionary {
   ///
   /// - Parameter minimumCapacity: The requested number of key-value pairs to
   ///   store.
-  @inlinable
-  public mutating func reserveCapacity(_ minimumCapacity: Int) {
+  public // FIXME(reserveCapacity): Should be inlinable
+  mutating func reserveCapacity(_ minimumCapacity: Int) {
     _variant.reserveCapacity(minimumCapacity)
     _sanityCheck(self.capacity >= minimumCapacity)
   }

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -109,7 +109,6 @@ extension Dictionary._Variant {
 
   /// Reserves enough space for the specified number of elements to be stored
   /// without reallocating additional storage.
-  @inlinable
   internal mutating func reserveCapacity(_ capacity: Int) {
     switch self {
     case .native:

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -241,7 +241,6 @@ extension _NativeDictionary { // ensureUnique
     return true
   }
 
-  @inlinable
   internal mutating func reserveCapacity(_ capacity: Int, isUnique: Bool) {
     _ = ensureUnique(isUnique: isUnique, capacity: capacity)
   }

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -208,7 +208,6 @@ extension _NativeSet { // ensureUnique
     return true
   }
 
-  @inlinable
   internal mutating func reserveCapacity(_ capacity: Int, isUnique: Bool) {
     _ = ensureUnique(isUnique: isUnique, capacity: capacity)
   }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -161,8 +161,8 @@ public struct Set<Element: Hashable> {
   /// - Parameter minimumCapacity: The minimum number of elements that the
   ///   newly created set should be able to store without reallocating its
   ///   storage buffer.
-  @inlinable
-  public init(minimumCapacity: Int) {
+  public // FIXME(reserveCapacity): Should be inlinable
+  init(minimumCapacity: Int) {
     _variant = .native(_NativeSet(capacity: minimumCapacity))
   }
 
@@ -1590,8 +1590,8 @@ extension Set {
   ///
   /// - Parameter minimumCapacity: The requested number of elements to
   ///   store.
-  @inlinable
-  public mutating func reserveCapacity(_ minimumCapacity: Int) {
+  public // FIXME(reserveCapacity): Should be inlinable
+  mutating func reserveCapacity(_ minimumCapacity: Int) {
     _variant.reserveCapacity(minimumCapacity)
     _sanityCheck(self.capacity >= minimumCapacity)
   }

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -104,7 +104,6 @@ extension Set._Variant {
 
   /// Reserves enough space for the specified number of elements to be stored
   /// without reallocating additional storage.
-  @inlinable
   internal mutating func reserveCapacity(_ capacity: Int) {
     switch self {
     case .native:


### PR DESCRIPTION
This allows us to record the reserved capacity in storage later, which will enable removals to resize the hash table.
