### PR TITLE
fix another double-deabstraction bug

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8087,8 +8087,25 @@ public:
   }
 };
 
-/// A graph operation. This instruction will be extracted to a graph program
-/// via graph program extraction passes.
+/// A graph operation, which takes operands and attributes and returns results.
+///
+/// Operands have values that are possibly unknown at compile time. Operands
+/// are grouped into `GraphOperationInfo::StructuredArgument`s. See there for
+/// more documentation. This structure is mangled into `Name`.
+///
+/// Attributes have values that are known at compile time, and these values are
+/// stored in the GraphOperationInst.
+///
+/// Results can be represented in 3 different ways:
+/// 1. As an output parameter with type that is a TensorFlow value or aggregate
+///    of TensorFlow values.
+/// 2. As a single result that is a TensorFlow value or aggregate of TensorFlow
+///    values.
+/// 3. As multiple results, where each result is a TensorFlow value (not an
+///    aggregate of TensorFlow values!).
+/// The later result representations are "better" than the earlier ones because
+/// code performing the operations has to do less work to deal with the results.
+/// Various compiler passes try to improve the result representations.
 class GraphOperationInst final
   : public InstructionBase<
                SILInstructionKind::GraphOperationInst,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8097,8 +8097,8 @@ public:
 /// stored in the GraphOperationInst.
 ///
 /// Results can be represented in 3 different ways:
-/// 1. As an output parameter with type that is a TensorFlow value or aggregate
-///    of TensorFlow values.
+/// 1. As a single output parameter with type that is a TensorFlow value or
+///    aggregate of TensorFlow values.
 /// 2. As a single result that is a TensorFlow value or aggregate of TensorFlow
 ///    values.
 /// 3. As multiple results, where each result is a TensorFlow value (not an
@@ -8106,6 +8106,8 @@ public:
 /// The later result representations are "better" than the earlier ones because
 /// code performing the operations has to do less work to deal with the results.
 /// Various compiler passes try to improve the result representations.
+/// Successful deabstraction currently guarantees that the result will be in
+/// form 3.
 class GraphOperationInst final
   : public InstructionBase<
                SILInstructionKind::GraphOperationInst,

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -375,17 +375,28 @@ public func SR8419(iterationCount: Int) {
 
 // If `deabstractedCallee` gets deabstracted before `inlineDeabstracted_*`,
 // then the insts in `deabstractedCallee` get deabstracted twice. There was
-// a bug where the compiler crashed when deabstracting certain graph_ops twice.
+// a bug where the compiler crashed when deabstracting certain graph_ops twice:
+//  - graph_ops with InputLists
+//  - graph_ops that pack results into aggregate structs
 // There is no guaranteed deabstraction order, so this test isn't guaranteed to
 // catch the problem. Sandwiching `deabstractedCallee` between two callers
 // makes this test catch the problem as long as the order happens to be linear
 // up or down.
+struct AggregateStruct {
+  let a, b: Tensor<Float>
+}
 public func inlineDeabstracted_a() -> Tensor<Float> {
   return deabstractedCallee([1, 2, 3])
 }
 // expected-warning @+1 {{implicitly copied}}
 public func deabstractedCallee(_ t: Tensor<Float>) -> Tensor<Float> {
-  return t ++ Tensor<Float>([1, 2, 3]) // expected-note {{value used here}}
+  // expected-error @+3 {{op named 'Dummy' is not registered in TensorFlow}}
+  // expected-error @+2 {{op named 'Dummy' is not registered in TensorFlow}}
+  // expected-error @+1 {{op named 'Dummy' is not registered in TensorFlow}}
+  let aggregate: AggregateStruct = #tfop("Dummy") // packs results
+
+  // expected-note @+1 {{value used here}}
+  return t ++ aggregate.a // concat uses an InputList
 }
 public func inlineDeabstracted_b() -> Tensor<Float> {
   return deabstractedCallee([1, 2, 3])


### PR DESCRIPTION
This is pretty much the same thing as https://github.com/apple/swift/pull/19593, but with results instead of inputs.

I also added some documentation to GraphOperationInst describing how results work.