### PR TITLE
AST: Use named lazy member loading to find constructors in deserialized types

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1640,11 +1640,11 @@ TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
   bool includeAttrImplements =
       flags.contains(LookupDirectFlags::IncludeAttrImplements);
 
-  // FIXME: At present, lazy member loading conflicts with a bunch of other code
-  // that appears to special-case initializers (clang-imported initializer
-  // sorting, implicit initializer synthesis), so for the time being we have to
-  // turn it off for them entirely.
-  if (name.getBaseName() == DeclBaseName::createConstructor())
+  // FIXME: At present, lazy member is not able to find inherited constructors
+  // in imported classes, because SwiftDeclConverter::importInheritedConstructors()
+  // is only called via ClangImporter::Implementation::loadAllMembers().
+  if (hasClangNode() &&
+      name.getBaseName() == DeclBaseName::createConstructor())
     useNamedLazyMemberLoading = false;
 
   LLVM_DEBUG(llvm::dbgs() << getNameStr() << ".lookupDirect(" << name << ")"

--- a/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.swift
+++ b/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.swift
@@ -38,6 +38,11 @@ public struct BaseStruct {
   public func memberFunc3() -> Int { return 1; }
   public func memberFunc4() -> Int { return 1; }
   public func memberFunc5() -> Int { return 1; }
+  public func memberFunc6() -> Int { return 1; }
+  public func memberFunc7() -> Int { return 1; }
+  public func memberFunc8() -> Int { return 1; }
+  public func memberFunc9() -> Int { return 1; }
+  public init() {}
 }
 
 public enum BaseEnum {

--- a/test/NameBinding/named_lazy_member_loading_swift_struct.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct.swift
@@ -6,10 +6,14 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -4' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -7' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 
 public func test(b: BaseStruct) {
   let _ = b.memberFunc1()
+}
+
+public func test2() {
+  let _ = BaseStruct()
 }


### PR DESCRIPTION
Only imported types require the exception here.