### PR TITLE
[stdlib] Set, Dictionary: Resilient Cocoa indices, vol 2

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1897,8 +1897,8 @@ extension Dictionary.Index: Comparable {
 }
 
 extension Dictionary.Index: Hashable {
-  @_effects(readonly) // FIXME(cocoa-index): Make inlinable
-  public func hash(into hasher: inout Hasher) {
+  public // FIXME(cocoa-index): Make inlinable
+  func hash(into hasher: inout Hasher) {
   #if _runtime(_ObjC)
     switch _variant {
     case .native(let nativeIndex):

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -647,6 +647,11 @@ extension Dictionary: Collection {
     return _variant.index(after: i)
   }
 
+  @inlinable
+  public func formIndex(after i: inout Index) {
+    _variant.formIndex(after: &i)
+  }
+
   /// Returns the index for the given key.
   ///
   /// If the given key is found in the dictionary, this method returns an index
@@ -1351,6 +1356,11 @@ extension Dictionary {
     }
 
     @inlinable
+    public func formIndex(after i: inout Index) {
+      _variant.formIndex(after: &i)
+    }
+
+    @inlinable
     public subscript(position: Index) -> Element {
       return _variant.key(at: position)
     }
@@ -1454,6 +1464,11 @@ extension Dictionary {
     @inlinable
     public func index(after i: Index) -> Index {
       return _variant.index(after: i)
+    }
+
+    @inlinable
+    public func formIndex(after i: inout Index) {
+      _variant.formIndex(after: &i)
     }
 
     @inlinable

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1827,6 +1827,14 @@ extension Dictionary.Index {
       _conditionallyUnreachable()
     }
   }
+
+  @inlinable
+  @inline(__always)
+  internal mutating func _isUniquelyReferenced() -> Bool {
+    defer { _fixLifetime(self) }
+    var handle = _asCocoa.handleBitPattern
+    return handle == 0 || _isUnique_native(&handle)
+  }
 #endif
 
   @usableFromInline @_transparent
@@ -1843,14 +1851,27 @@ extension Dictionary.Index {
   }
 
 #if _runtime(_ObjC)
-  @usableFromInline @_transparent
+  @usableFromInline
   internal var _asCocoa: _CocoaDictionary.Index {
-    switch _variant {
-    case .native:
-      _preconditionFailure(
-        "Attempting to access Dictionary elements using an invalid index")
-    case .cocoa(let cocoaIndex):
-      return cocoaIndex
+    @_transparent
+    get {
+      switch _variant {
+      case .native:
+        _preconditionFailure(
+          "Attempting to access Dictionary elements using an invalid index")
+      case .cocoa(let cocoaIndex):
+        return cocoaIndex
+      }
+    }
+    _modify {
+      guard case .cocoa(var cocoa) = _variant else {
+        _preconditionFailure(
+          "Attempting to access Dictionary elements using an invalid index")
+      }
+      let dummy = _HashTable.Index(bucket: _HashTable.Bucket(offset: 0), age: 0)
+      _variant = .native(dummy)
+      yield &cocoa
+      _variant = .cocoa(cocoa)
     }
   }
 #endif

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -483,7 +483,6 @@ extension _CocoaDictionary: _DictionaryBuffer {
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
-  @_effects(releasenone)
   internal func formIndex(after index: inout Index, isUnique: Bool) {
     validate(index)
     if !isUnique { index = index.copy() }

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -487,7 +487,8 @@ extension _CocoaDictionary: _DictionaryBuffer {
   internal func formIndex(after index: inout Index) {
     validate(index)
     let isUnique = index.isUniquelyReferenced()
-    if !isUnique { index.storage = index.copy() }
+    if !isUnique { index = index.copy() }
+    _sanityCheck(index.isUniquelyReferenced())
     let storage = index.storage // FIXME: rdar://problem/44863751
     storage.currentKeyIndex += 1
   }
@@ -575,17 +576,34 @@ extension _CocoaDictionary {
   @usableFromInline
   internal struct Index {
     @usableFromInline
-    internal var storage: Storage
+    internal var _object: Builtin.BridgeObject
+    @usableFromInline
+    internal var _storage: Builtin.BridgeObject
+
+    internal var object: AnyObject {
+      @inline(__always)
+      get {
+        return _bridgeObject(toNonTaggedObjC: _object)
+      }
+    }
+
+    internal var storage: Storage {
+      @inline(__always)
+      get {
+        let storage = _bridgeObject(toNative: _storage)
+        return unsafeDowncast(storage, to: Storage.self)
+      }
+    }
 
     internal init(_ storage: Storage) {
-      self.storage = storage
+      self._object = _bridgeObject(fromNonTaggedObjC: storage.base.object)
+      self._storage = _bridgeObject(fromNative: storage)
     }
   }
 }
 
 extension _CocoaDictionary.Index {
   // FIXME(cocoa-index): Try using an NSEnumerator to speed this up.
-  @usableFromInline
   internal class Storage {
   // Assumption: we rely on NSDictionary.getObjects when being
     // repeatedly called on the same NSDictionary, returning items in the same
@@ -620,13 +638,21 @@ extension _CocoaDictionary.Index {
 extension _CocoaDictionary.Index {
   @inlinable
   internal mutating func isUniquelyReferenced() -> Bool {
+    defer { _fixLifetime(self) }
+    guard _isNativePointer(_storage) else {
+      return false
+    }
+    unowned(unsafe) var storage = _bridgeObject(toNative: _storage)
     return _isUnique_native(&storage)
   }
 
   @usableFromInline
-  internal mutating func copy() -> Storage {
+  internal mutating func copy() -> _CocoaDictionary.Index {
     let storage = self.storage
-    return Storage(storage.base, storage.allKeys, storage.currentKeyIndex)
+    return _CocoaDictionary.Index(Storage(
+        storage.base,
+        storage.allKeys,
+        storage.currentKeyIndex))
   }
 }
 
@@ -647,7 +673,7 @@ extension _CocoaDictionary.Index {
   internal var age: Int32 {
     @_effects(readonly)
     get {
-      return _HashTable.age(for: storage.base.object)
+      return _HashTable.age(for: object)
     }
   }
 }

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -190,6 +190,20 @@ extension Dictionary._Variant: _DictionaryBuffer {
   }
 
   @inlinable
+  internal func formIndex(after index: inout Index) {
+    switch self {
+    case .native(let native):
+      index = native.index(after: index)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoa):
+      cocoaPath()
+      let isUnique = index._isUniquelyReferenced()
+      cocoa.formIndex(after: &index._asCocoa, isUnique: isUnique)
+#endif
+    }
+  }
+
+  @inlinable
   @inline(__always)
   internal func index(forKey key: Key) -> Index? {
     switch self {

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1418,8 +1418,8 @@ extension Set.Index: Hashable {
   ///
   /// - Parameter hasher: The hasher to use when combining the components
   ///   of this instance.
-  @_effects(readonly) // FIXME(cocoa-index): Make inlinable
-  public func hash(into hasher: inout Hasher) {
+  public // FIXME(cocoa-index): Make inlinable
+  func hash(into hasher: inout Hasher) {
   #if _runtime(_ObjC)
     switch _variant {
     case .native(let nativeIndex):

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -340,6 +340,11 @@ extension Set: Collection {
     return _variant.index(after: i)
   }
 
+  @inlinable
+  public func formIndex(after i: inout Index) {
+    _variant.formIndex(after: &i)
+  }
+
   // APINAMING: complexity docs are broadly missing in this file.
 
   /// Returns the index of the given element in the set, or `nil` if the

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -345,8 +345,8 @@ extension _CocoaSet: _SetBuffer {
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
   @_effects(releasenone)
   internal func index(after index: Index) -> Index {
-    var result = index
-    formIndex(after: &result)
+    var result = index.copy()
+    formIndex(after: &result, isUnique: true)
     return result
   }
 
@@ -359,9 +359,8 @@ extension _CocoaSet: _SetBuffer {
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
   @_effects(releasenone)
-  internal func formIndex(after index: inout Index) {
+  internal func formIndex(after index: inout Index, isUnique: Bool) {
     validate(index)
-    let isUnique = index.isUniquelyReferenced()
     if !isUnique { index = index.copy() }
     let storage = index.storage // FIXME: rdar://problem/44863751
     storage.currentKeyIndex += 1
@@ -472,18 +471,15 @@ extension _CocoaSet.Index {
 }
 
 extension _CocoaSet.Index {
-  @inlinable
-  internal mutating func isUniquelyReferenced() -> Bool {
-    defer { _fixLifetime(self) }
-    guard _isNativePointer(_storage) else {
-      return false
+  @usableFromInline
+  internal var handleBitPattern: UInt {
+    @_effects(readonly)
+    get {
+      return unsafeBitCast(storage, to: UInt.self)
     }
-    unowned(unsafe) var storage = _bridgeObject(toNative: _storage)
-    return _isUnique_native(&storage)
   }
 
-  @usableFromInline
-  internal mutating func copy() -> _CocoaSet.Index {
+  internal func copy() -> _CocoaSet.Index {
     let storage = self.storage
     return _CocoaSet.Index(Storage(
         storage.base,

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -362,7 +362,7 @@ extension _CocoaSet: _SetBuffer {
   internal func formIndex(after index: inout Index) {
     validate(index)
     let isUnique = index.isUniquelyReferenced()
-    if !isUnique { index.storage = index.copy() }
+    if !isUnique { index = index.copy() }
     let storage = index.storage // FIXME: rdar://problem/44863751
     storage.currentKeyIndex += 1
   }
@@ -412,17 +412,34 @@ extension _CocoaSet {
   @usableFromInline
   internal struct Index {
     @usableFromInline
-    internal var storage: Storage
+    internal var _object: Builtin.BridgeObject
+    @usableFromInline
+    internal var _storage: Builtin.BridgeObject
+
+    internal var object: AnyObject {
+      @inline(__always)
+      get {
+        return _bridgeObject(toNonTaggedObjC: _object)
+      }
+    }
+
+    internal var storage: Storage {
+      @inline(__always)
+      get {
+        let storage = _bridgeObject(toNative: _storage)
+        return unsafeDowncast(storage, to: Storage.self)
+      }
+    }
 
     internal init(_ storage: __owned Storage) {
-      self.storage = storage
+      self._object = _bridgeObject(fromNonTaggedObjC: storage.base.object)
+      self._storage = _bridgeObject(fromNative: storage)
     }
   }
 }
 
 extension _CocoaSet.Index {
   // FIXME(cocoa-index): Try using an NSEnumerator to speed this up.
-  @usableFromInline
   internal class Storage {
     // Assumption: we rely on NSDictionary.getObjects when being
     // repeatedly called on the same NSDictionary, returning items in the same
@@ -457,13 +474,21 @@ extension _CocoaSet.Index {
 extension _CocoaSet.Index {
   @inlinable
   internal mutating func isUniquelyReferenced() -> Bool {
+    defer { _fixLifetime(self) }
+    guard _isNativePointer(_storage) else {
+      return false
+    }
+    unowned(unsafe) var storage = _bridgeObject(toNative: _storage)
     return _isUnique_native(&storage)
   }
 
   @usableFromInline
-  internal mutating func copy() -> Storage {
+  internal mutating func copy() -> _CocoaSet.Index {
     let storage = self.storage
-    return Storage(storage.base, storage.allKeys, storage.currentKeyIndex)
+    return _CocoaSet.Index(Storage(
+        storage.base,
+        storage.allKeys,
+        storage.currentKeyIndex))
   }
 }
 
@@ -484,7 +509,7 @@ extension _CocoaSet.Index {
   internal var age: Int32 {
     @_effects(releasenone)
     get {
-      return _HashTable.age(for: storage.base.object)
+      return _HashTable.age(for: object)
     }
   }
 }

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -358,7 +358,6 @@ extension _CocoaSet: _SetBuffer {
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
-  @_effects(releasenone)
   internal func formIndex(after index: inout Index, isUnique: Bool) {
     validate(index)
     if !isUnique { index = index.copy() }

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -183,6 +183,20 @@ extension Set._Variant: _SetBuffer {
   }
 
   @inlinable
+  internal func formIndex(after index: inout Index) {
+    switch self {
+    case .native(let native):
+      index = native.index(after: index)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoa):
+      cocoaPath()
+      let isUnique = index._isUniquelyReferenced()
+      cocoa.formIndex(after: &index._asCocoa, isUnique: isUnique)
+#endif
+    }
+  }
+
+  @inlinable
   @inline(__always)
   internal func index(for element: Element) -> Index? {
     switch self {


### PR DESCRIPTION
- Fix effects annotations
- Replace typed storage reference with two BridgeObjects. This covers all future variants I can think of.