### PR TITLE
Make `__consuming` meaningful for code generation.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3646,23 +3646,6 @@ public:
       llvm_unreachable("Unhandled Representation in switch.");
     }
 
-    bool hasGuaranteedSelfParam() const {
-      switch (getRepresentation()) {
-      case Representation::Thick:
-      case Representation::Block:
-      case Representation::Thin:
-      case Representation::CFunctionPointer:
-      case Representation::ObjCMethod:
-      case Representation::Closure:
-        return false;
-      case Representation::Method:
-      case Representation::WitnessMethod:
-        return true;
-      }
-
-      llvm_unreachable("Unhandled Representation in switch.");
-    }
-
     /// True if the function representation carries context.
     bool hasContext() const {
       switch (getRepresentation()) {

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -689,11 +689,8 @@ private:
     if (ownership == ValueOwnership::InOut) {
       convention = ParameterConvention::Indirect_Inout;
     } else if (isFormallyPassedIndirectly(origType, substType, substTL)) {
-      if (forSelf && rep == SILFunctionTypeRepresentation::WitnessMethod)
-        convention = ParameterConvention::Indirect_In_Guaranteed;
-      else
-        convention = Convs.getIndirect(ownership, forSelf, origParamIndex,
-                                       origType, substTL);
+      convention = Convs.getIndirect(ownership, forSelf, origParamIndex,
+                                     origType, substTL);
       assert(isIndirectFormalParameter(convention));
     } else if (substTL.isTrivial()) {
       convention = ParameterConvention::Direct_Unowned;

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1517,8 +1517,9 @@ bool LifetimeChecker::diagnoseMethodCall(const DIMemoryUse &Use,
     // the generic error that we would emit before.
     //
     // That is the only case where we support pattern matching a release.
-    if (Release && AI &&
-        !AI->getSubstCalleeType()->getExtInfo().hasGuaranteedSelfParam())
+    if (Release && AI /*
+        && (!AI->getSubstCalleeType()->hasSelfParam()
+            || !AI->getSubstCalleeType()->getSelfParameter().isGuaranteed())*/)
       MI = nullptr;
 
     if (AI && MI) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5753,6 +5753,17 @@ Expr *ExprRewriter::coerceCallArguments(
   // If we came from a scalar, create a scalar-to-tuple conversion.
   TupleShuffleExpr::TypeImpact typeImpact;
   if (argTuple == nullptr) {
+    // Deal with a difference in only scalar ownership.
+    if (auto paramParenTy = dyn_cast<ParenType>(paramType.getPointer())) {
+      assert(paramParenTy->getUnderlyingType()
+              ->isEqual(cs.getType(arg)));
+      auto argParen = new (tc.Context) ParenExpr(arg->getStartLoc(),
+                                                 arg, arg->getEndLoc(), false,
+                                                 paramParenTy);
+      argParen->setImplicit();
+      return cs.cacheType(argParen);
+    }
+
     typeImpact = TupleShuffleExpr::ScalarToTuple;
     assert(isa<TupleType>(paramType.getPointer()));
   } else if (isa<TupleType>(paramType.getPointer())) {

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -110,8 +110,8 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<Int>> }, var, name "$x$generator"
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<Int>
-// CHECK:   store_borrow [[ARRAY]] to [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in_guaranteed τ_0_0) -> @out IndexingIterator<τ_0_0>
+// CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
 // CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[Int]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
@@ -213,8 +213,8 @@ func existentialBreak(_ xx: [P]) {
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<P>> }, var, name "$x$generator"
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<P>
-// CHECK:   store_borrow [[ARRAY]] to [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in_guaranteed τ_0_0) -> @out IndexingIterator<τ_0_0>
+// CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
 // CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[P]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<P>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
@@ -376,8 +376,8 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box $<τ_0_0> { var IndexingIterator<Array<GenericStruct<τ_0_0>>> } <T>, var, name "$x$generator"
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<GenericStruct<T>>
-// CHECK:   store_borrow [[ARRAY]] to [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in_guaranteed τ_0_0) -> @out IndexingIterator<τ_0_0>
+// CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
 // CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[GenericStruct<T>]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<GenericStruct<T>>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
@@ -486,8 +486,8 @@ func genericCollectionBreak<T : Collection>(_ xx: T) {
 // CHECK: bb0([[COLLECTION:%.*]] : @trivial $*T):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : Collection> { var τ_0_0.Iterator } <T>, var, name "$x$generator"
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $T, #Sequence.makeIterator!1 : <Self where Self : Sequence> (Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in_guaranteed τ_0_0) -> @out τ_0_0.Iterator
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<T>([[PROJECT_ITERATOR_BOX]], [[COLLECTION]])
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $T, #Sequence.makeIterator!1
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<T>([[PROJECT_ITERATOR_BOX]], [[COLLECTION_COPY:%.*]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<T.Element>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //

--- a/test/SILGen/value_ownership.swift
+++ b/test/SILGen/value_ownership.swift
@@ -4,39 +4,56 @@ protocol OwnershipProto {
   __consuming func elided(_ default: String, _ shared: __shared String, _ owned: __owned String)
 
   __consuming func explicit(_ default: String, _ shared: __shared String, _ owned: __owned String)
+
+  var elidedPropertyGet: String { __consuming get }
+  var explicitPropertyGet: String { __consuming get }
 }
 
 struct Witness: OwnershipProto {
+  var x: String
+
   func elided(_ default: String, _ shared: String, _ owned: String) { }
 
   __consuming func explicit(_ default: String, _ toShared: __shared String, _ toOwned: __owned String) { }
+
+  var elidedPropertyGet: String { return "" }
+  var explicitPropertyGet: String { __consuming get { return "" } }
 }
 
 // Check the conventions of the witnesses
 
-// CHECK-LABEL: sil hidden @$s15value_ownership7WitnessV6elidedyySS_S2StF : $@convention(method) (@guaranteed String, @guaranteed String, @guaranteed String, Witness) -> () {
-// CHECK:       } // end sil function '$s15value_ownership7WitnessV6elidedyySS_S2StF'
-
-// CHECK-LABEL: sil hidden @$s15value_ownership7WitnessV8explicityySS_SShSSntF : $@convention(method) (@guaranteed String, @guaranteed String, @owned String, Witness) -> () {
-// CHECK:       } // end sil function '$s15value_ownership7WitnessV8explicityySS_SShSSntF'
+// CHECK-LABEL: sil hidden @$s15value_ownership7WitnessV6elidedyySS_S2StF : $@convention(method) (@guaranteed String, @guaranteed String, @guaranteed String, @guaranteed Witness) -> () {
+// CHECK-LABEL: sil hidden @$s15value_ownership7WitnessV8explicityySS_SShSSntF : $@convention(method) (@guaranteed String, @guaranteed String, @owned String, @owned Witness) -> () {
+// CHECK-LABEL: sil hidden @$s15value_ownership7WitnessV17elidedPropertyGetSSvg : $@convention(method) (@guaranteed Witness) -> @owned String
+// CHECK-LABEL: sil hidden @$s15value_ownership7WitnessV19explicitPropertyGetSSvg : $@convention(method) (@owned Witness) -> @owned String
 
 // Check the elided witness' thunk has the right conventions and borrows where necessary
 
-// CHECK-LABEL: @$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP6elidedyySS_SShSSntFTW : $@convention(witness_method: OwnershipProto) (@guaranteed String, @guaranteed String, @owned String, @in_guaranteed Witness) -> ()
+// CHECK-LABEL: @$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP6elidedyySS_SShSSntFTW : $@convention(witness_method: OwnershipProto) (@guaranteed String, @guaranteed String, @owned String, @in Witness) -> ()
 // CHECK:       bb0([[DEFAULT2DEFAULT:%.*]] : @guaranteed $String, [[SHARED2DEFAULT:%.*]] : @guaranteed $String, [[OWNED2DEFAULT:%.*]] : @owned $String, [[WITNESS_VALUE:%.*]] : @trivial $*Witness):
-// CHECK:         [[LOAD_WITNESS:%.*]] = load [trivial] [[WITNESS_VALUE]] : $*Witness
+// CHECK:         [[LOAD_WITNESS:%.*]] = load [take] [[WITNESS_VALUE]] : $*Witness
+// CHECK:         [[BORROW_WITNESS:%.*]] = begin_borrow [[LOAD_WITNESS]]
 // CHECK:         [[WITNESS_FUNC:%.*]] = function_ref @$s15value_ownership7WitnessV6elidedyySS_S2StF
 // CHECK:         [[BORROWOWNED2DEFAULT:%.*]] = begin_borrow [[OWNED2DEFAULT]] : $String
-// CHECK:         apply [[WITNESS_FUNC]]([[DEFAULT2DEFAULT]], [[SHARED2DEFAULT]], [[BORROWOWNED2DEFAULT]], [[LOAD_WITNESS]])
+// CHECK:         apply [[WITNESS_FUNC]]([[DEFAULT2DEFAULT]], [[SHARED2DEFAULT]], [[BORROWOWNED2DEFAULT]], [[BORROW_WITNESS]])
 // CHECK:         end_borrow [[BORROWOWNED2DEFAULT]] : $String
+// CHECK:         end_borrow [[BORROW_WITNESS]]
+// CHECK:         destroy_value [[LOAD_WITNESS]]
 // CHECK:       } // end sil function '$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP6elidedyySS_SShSSntFTW'
 
 // Check that the explicit witness' thunk doesn't copy or borrow
 
-// CHECK-LABEL: @$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP8explicityySS_SShSSntFTW : $@convention(witness_method: OwnershipProto) (@guaranteed String, @guaranteed String, @owned String, @in_guaranteed Witness) -> () {
+// CHECK-LABEL: @$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP8explicityySS_SShSSntFTW : $@convention(witness_method: OwnershipProto) (@guaranteed String, @guaranteed String, @owned String, @in Witness) -> () {
 // CHECK:       bb0([[ARG0:%.*]] : @guaranteed $String, [[ARG1:%.*]] : @guaranteed $String, [[ARG2:%.*]] : @owned $String, [[WITNESS_VALUE:%.*]] : @trivial $*Witness):
-// CHECK-NEXT:    [[LOAD_WITNESS:%.*]] = load [trivial] [[WITNESS_VALUE]] : $*Witness
+// CHECK-NEXT:    [[LOAD_WITNESS:%.*]] = load [take] [[WITNESS_VALUE]] : $*Witness
 // CHECK-NEXT:    // function_ref Witness.explicit(_:_:_:)
 // CHECK-NEXT:    [[WITNESS_FUNC:%.*]] = function_ref @$s15value_ownership7WitnessV8explicityySS_SShSSntF
 // CHECK-NEXT:    apply [[WITNESS_FUNC]]([[ARG0]], [[ARG1]], [[ARG2]], [[LOAD_WITNESS]])
 // CHECK:       } // end sil function '$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP8explicityySS_SShSSntFTW'
+
+// Check the signature of the property accessor witness thunks.
+// If a protocol asks for a __consuming get it should get a +1-in +1-out
+// accessor entry point in its witness table.
+
+// CHECK-LABEL: sil private [transparent] [thunk] @$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP17elidedPropertyGetSSvgTW : $@convention(witness_method: OwnershipProto) (@in Witness) -> @owned String
+// CHECK-LABEL: sil private [transparent] [thunk] @$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP19explicitPropertyGetSSvgTW : $@convention(witness_method: OwnershipProto) (@in Witness) -> @owned String

--- a/test/SILGen/witness_same_type.swift
+++ b/test/SILGen/witness_same_type.swift
@@ -20,7 +20,7 @@ struct Foo: Fooable {
 }
 
 // rdar://problem/19049566
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @$s17witness_same_type14LazySequenceOfVyxq_GSTAAST12makeIterator0H0QzyFTW : $@convention(witness_method: Sequence) <τ_0_0, τ_0_1 where τ_0_0 : Sequence, τ_0_1 == τ_0_0.Element> (@in_guaranteed LazySequenceOf<τ_0_0, τ_0_1>) -> @out AnyIterator<τ_0_1>
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @$s17witness_same_type14LazySequenceOfVyxq_GSTAAST12makeIterator0H0QzyFTW : $@convention(witness_method: Sequence) <τ_0_0, τ_0_1 where τ_0_0 : Sequence, τ_0_1 == τ_0_0.Element> (@in LazySequenceOf<τ_0_0, τ_0_1>) -> @out AnyIterator<τ_0_1>
 public struct LazySequenceOf<SS : Sequence, A> : Sequence where SS.Iterator.Element == A {
   public func makeIterator() -> AnyIterator<A> { 
     var opt: AnyIterator<A>?

--- a/test/Sema/fixed_ambiguities/rdar27033993.swift
+++ b/test/Sema/fixed_ambiguities/rdar27033993.swift
@@ -4,7 +4,7 @@ class S {}
 let arr: [(S, Int)] = []
 let _: [S] = arr.sorted {
     $0.1 < $1.1
-// CHECK: function_ref @$sSlsE6prefixy11SubSequenceQzSiF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (Int, @in_guaranteed τ_0_0) -> @out τ_0_0.SubSequence
+// CHECK: function_ref @$sSlsE6prefixy11SubSequenceQzSiF
 }.prefix(1).map {
     return $0.0
 }

--- a/test/Sema/fixed_ambiguities/rdar27198177.swift
+++ b/test/Sema/fixed_ambiguities/rdar27198177.swift
@@ -3,5 +3,5 @@
 
 let arr = ["A", "B", "C"]
 let lazy: LazyMapCollection = arr.lazy.map { $0 }
-// CHECK: function_ref @$ss22LazyCollectionProtocolPsE6filterys0a6FilterB0Vy8ElementsQzGSb7ElementQzcF : $@convention(method) <τ_0_0 where τ_0_0 : LazyCollectionProtocol> (@guaranteed @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> Bool, @in_guaranteed τ_0_0) -> @out LazyFilterCollection<τ_0_0.Elements>
+// CHECK: function_ref @$ss22LazyCollectionProtocolPsE6filterys0a6FilterB0Vy8ElementsQzGSb7ElementQzcF
 _ = lazy.filter { $0 > "A" }.count

--- a/test/Sema/fixed_ambiguities/rdar33142386.swift
+++ b/test/Sema/fixed_ambiguities/rdar33142386.swift
@@ -2,5 +2,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s -swift-version 4 | %FileCheck %s
 
 let x: String = "ultimate question"
-// CHECK: function_ref @$sSmsE6filteryxSb7ElementQzKXEKF : $@convention(method) <τ_0_0 where τ_0_0 : RangeReplaceableCollection> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> (Bool, @error Error), @in_guaranteed τ_0_0) -> (@out τ_0_0, @error Error)
+// CHECK: function_ref @$sSmsE6filteryxSb7ElementQzKXEKF
 _ = x.filter({ $0 == " " }).count < 3

--- a/test/Sema/fixed_ambiguities/rdar35624855.swift
+++ b/test/Sema/fixed_ambiguities/rdar35624855.swift
@@ -2,7 +2,7 @@
 
 extension Collection {
   func foo() {
-    // CHECK: witness_method $Self.Indices, #Sequence.dropFirst!1 : <Self where Self : Sequence> (Self) -> (Int) -> Self.SubSequence : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (Int, @in_guaranteed τ_0_0) -> @out τ_0_0.SubSequence
+    // CHECK: witness_method $Self.Indices, #Sequence.dropFirst!1
     _ = zip(indices, indices.dropFirst(3))
   }
 }

--- a/test/Sema/fixed_ambiguities/rdar35625339.swift
+++ b/test/Sema/fixed_ambiguities/rdar35625339.swift
@@ -1,4 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
 let arr = Array(10...20)
-// CHECK: function_ref @$sSlsE6prefixy11SubSequenceQzSiF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (Int, @in_guaranteed τ_0_0) -> @out τ_0_0.SubSequence
+// CHECK: function_ref @$sSlsE6prefixy11SubSequenceQzSiF
 arr.prefix(3).forEach { (v: Int) in }

--- a/test/Sema/fixed_ambiguities/rdar35625473.swift
+++ b/test/Sema/fixed_ambiguities/rdar35625473.swift
@@ -1,4 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
 
-// CHECK: function_ref @$sSlsE9dropFirsty11SubSequenceQzSiF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (Int, @in_guaranteed τ_0_0) -> @out τ_0_0.SubSequence
+// CHECK: function_ref @$sSlsE9dropFirsty11SubSequenceQzSiF
 _ = [1, 2, 3].dropFirst(1).dropFirst(1)


### PR DESCRIPTION
Previously, the `__consuming` decl modifier failed to get propagated to the value ownership of the
method's `self` parameter, causing it to effectively be a no-op. Fix this, and address some of the
downstream issues this exposes:

- `coerceCallArguments` in the type checker failing to handle the single `__owned` parameter case
- Various places in SILGen and optimizer passes that made inappropriate assertions that `self`
  was always passed guaranteed

rdar://problem/44769874