### PR TITLE
[Build System: Presets] Disabled building libclang in the OSS toolchain preset.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1024,7 +1024,6 @@ test-installable-package
 reconfigure
 
 swift-install-components=compiler;clang-builtin-headers;stdlib;swift-syntax;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=libclang;libclang-headers
 
 # Path to the .tar.gz package we would create.
 installable-package=%(installable_package)s


### PR DESCRIPTION
rdar://42776715