### PR TITLE
[stdlib] Mark reversed as consuming

### DIFF
--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -257,7 +257,7 @@ extension ReversedCollection {
   /// - Complexity: O(1)
   @inlinable
   @available(swift, introduced: 4.2)
-  public func reversed() -> Base {
+  public __consuming func reversed() -> Base {
     return _base
   }
 }
@@ -289,7 +289,7 @@ extension BidirectionalCollection {
   ///
   /// - Complexity: O(1)
   @inlinable
-  public func reversed() -> ReversedCollection<Self> {
+  public __consuming func reversed() -> ReversedCollection<Self> {
     return ReversedCollection(_base: self)
   }
 }
@@ -303,7 +303,7 @@ extension LazyCollectionProtocol
   ///
   /// - Complexity: O(1)
   @inlinable
-  public func reversed() -> LazyCollection<ReversedCollection<Elements>> {
+  public __consuming func reversed() -> LazyCollection<ReversedCollection<Elements>> {
     return ReversedCollection(_base: elements).lazy
   }
 }

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -750,7 +750,7 @@ extension Sequence {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
-  public func reversed() -> [Element] {
+  public __consuming func reversed() -> [Element] {
     // FIXME(performance): optimize to 1 pass?  But Array(self) can be
     // optimized to a memcpy() sometimes.  Those cases are usually collections,
     // though.


### PR DESCRIPTION
Since either the elements go into an array, or the collection is wrapped, it's likely this would be the better choice. We'll see if the benchmarks agree (needs #19613 for any change to show up).