### PR TITLE
constexpr improvements suggested on the PR to master

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -139,12 +139,6 @@ private:
 
     SILFunction *function;
 
-    /// When this SymbolicValue is of "Inst" kind, this contains a
-    /// pointer to the instruction whose value this holds.  This is known to
-    /// be one of a closed set of constant instructions:
-    ///    IntegerLiteralInst, FloatLiteralInst, StringLiteralInst
-    SingleValueInstruction *inst;
-
     /// When this SymbolicValue is of "Integer" kind, this pointer stores
     /// the words of the APInt value it holds.
     uint64_t *integer;

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// SWIFT_ENABLE_TENSORFLOW
-
 #include "swift/SIL/SILConstants.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/Demangling/Demangle.h"

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -779,15 +779,6 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
 
   SILFunction *callee = calleeFn.getFunctionValue();
 
-  // If we reached an external function that hasn't been deserialized yet, make
-  // sure to pull it in so we can see its body.  If that fails, then we can't
-  // analyze the function.
-  if (callee->isExternalDeclaration()) {
-    callee->getModule().loadFunction(callee);
-    if (callee->isExternalDeclaration())
-      return computeOpaqueCallResult(apply, callee);
-  }
-
   // TODO: Verify that the callee was defined as a @constexpr function.
 
   // If this is a well-known function, do not step into it.
@@ -894,6 +885,15 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
                                                 evaluator.getAllocator()));
     return None;
   }
+  }
+
+  // If we reached an external function that hasn't been deserialized yet, make
+  // sure to pull it in so we can see its body.  If that fails, then we can't
+  // analyze the function.
+  if (callee->isExternalDeclaration()) {
+    callee->getModule().loadFunction(callee);
+    if (callee->isExternalDeclaration())
+      return computeOpaqueCallResult(apply, callee);
   }
 
   // Verify that we can fold all of the arguments to the call.

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -83,6 +83,8 @@ func test_loops() {
 
 //===----------------------------------------------------------------------===//
 // Reduced testcase propagating substitutions around.
+//===----------------------------------------------------------------------===//
+
 protocol SubstitutionsP {
   init<T: SubstitutionsP>(something: T)
 
@@ -194,3 +196,41 @@ func testCallStack() {
 }
 
 //===----------------------------------------------------------------------===//
+// Array functions.
+//===----------------------------------------------------------------------===//
+
+func testArrayInit() {
+  // We do not yet support functions that let us statically inspect the arrays
+  // we initialize, so we put them in structs (not tuples, which get expanded
+  // in SILGen) to force the evaluator to initialize them. Then we assert
+  // things about other components of the structs.
+
+  struct IntArrayPair {
+    let i: Int
+    let a: [Int]
+  }
+
+  #assert(IntArrayPair(i: 0, a: []).i == 0)
+  #assert(IntArrayPair(i: 0, a: [1]).i == 0)
+  #assert(IntArrayPair(i: 0, a: [1, 2]).i == 0)
+}
+
+//===----------------------------------------------------------------------===//
+// String functions.
+//===----------------------------------------------------------------------===//
+
+func testStringInit() {
+  // We do not yet support functions that let us statically inspect the strings
+  // we initialize, so we put them in structs (not tuples, which get expanded
+  // in SILGen) to force the evaluator to initialize them. Then we assert
+  // things about other components of the structs.
+
+  struct IntStringPair {
+    let i: Int
+    let s: String
+  }
+
+  #assert(IntStringPair(i: 0, s: "").i == 0)
+  #assert(IntStringPair(i: 0, s: String()).i == 0)
+  #assert(IntStringPair(i: 0, s: "hello world").i == 0)
+}

--- a/test/SILOptimizer/pound_assert_well_known_no_load.swift
+++ b/test/SILOptimizer/pound_assert_well_known_no_load.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-sil %s -verify | %FileCheck %s
+
+// Checks that the constant evaluator does not load WellKnownFunctions. This
+// test is in its own file because other test code might load
+// WellKnownFunctions for valid reasons.
+
+struct IntStringPair {
+  var i: Int
+  var s: String
+}
+
+func testStringInit() {
+  // String initialization is a WellKnownFunction.
+  #assert(IntStringPair(i: 0, s: "").i == 0)
+}
+
+// String.init should appear as a declaration, but not a definition.
+// CHECK-LABEL: // String.init
+// CHECK-NOT: bb0
+// The following check for empty line finds the end of the String.init decl/def,
+// preventing the bb0 check-not from finding a bb0 in a subsequent def.
+// CHECK: {{^$}}


### PR DESCRIPTION
These are some cleanups and improvements suggested in https://github.com/apple/swift/pull/19579.
* Move function deserialization after handling WellKnownFunctions, so that we don't deserialize WellKnownFunctions.
* Add tests for string and array initialization.
* Remove unused SILConstant union member.
* Remove SWIFT_ENABLE_TENSORFLOW comment from file that we're moving to master.