### PR TITLE
[vim] add skipempty

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -32,7 +32,7 @@ syn keyword swiftKeyword
 syn match swiftMultiwordKeyword
       \ "indirect case"
 
-syn keyword swiftImport skipwhite nextgroup=swiftImportModule
+syn keyword swiftImport skipwhite skipempty nextgroup=swiftImportModule
       \ import
 
 syn keyword swiftDefinitionModifier
@@ -52,7 +52,7 @@ syn keyword swiftDefinitionModifier
       \ throws
       \ weak
 
-syn keyword swiftInOutKeyword skipwhite nextgroup=swiftTypeName
+syn keyword swiftInOutKeyword skipwhite skipempty nextgroup=swiftTypeName
       \ inout
 
 syn keyword swiftIdentifierKeyword
@@ -61,7 +61,7 @@ syn keyword swiftIdentifierKeyword
       \ self
       \ super
 
-syn keyword swiftFuncKeywordGeneral skipwhite nextgroup=swiftTypeParameters
+syn keyword swiftFuncKeywordGeneral skipwhite skipempty nextgroup=swiftTypeParameters
       \ init
 
 syn keyword swiftFuncKeyword
@@ -71,12 +71,12 @@ syn keyword swiftFuncKeyword
 syn keyword swiftScope
       \ autoreleasepool
 
-syn keyword swiftMutating skipwhite nextgroup=swiftFuncDefinition
+syn keyword swiftMutating skipwhite skipempty nextgroup=swiftFuncDefinition
       \ mutating
-syn keyword swiftFuncDefinition skipwhite nextgroup=swiftTypeName,swiftOperator
+syn keyword swiftFuncDefinition skipwhite skipempty nextgroup=swiftTypeName,swiftOperator
       \ func
 
-syn keyword swiftTypeDefinition skipwhite nextgroup=swiftTypeName
+syn keyword swiftTypeDefinition skipwhite skipempty nextgroup=swiftTypeName
       \ class
       \ enum
       \ extension
@@ -84,10 +84,10 @@ syn keyword swiftTypeDefinition skipwhite nextgroup=swiftTypeName
       \ struct
       \ typealias
 
-syn match swiftMultiwordTypeDefinition skipwhite nextgroup=swiftTypeName
+syn match swiftMultiwordTypeDefinition skipwhite skipempty nextgroup=swiftTypeName
       \ "indirect enum"
 
-syn keyword swiftVarDefinition skipwhite nextgroup=swiftVarName
+syn keyword swiftVarDefinition skipwhite skipempty nextgroup=swiftVarName
       \ let
       \ var
 
@@ -109,20 +109,20 @@ syn match swiftImportModule contained nextgroup=swiftImportComponent
 syn match swiftImportComponent contained nextgroup=swiftImportComponent
       \ /\.\<[A-Za-z_][A-Za-z_0-9]*\>/
 
-syn match swiftTypeName contained skipwhite nextgroup=swiftTypeParameters
+syn match swiftTypeName contained skipwhite skipempty nextgroup=swiftTypeParameters
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>/
-syn match swiftVarName contained skipwhite nextgroup=swiftTypeDeclaration
+syn match swiftVarName contained skipwhite skipempty nextgroup=swiftTypeDeclaration
       \ /\<[A-Za-z_][A-Za-z_0-9]*\>/
 syn match swiftImplicitVarName
       \ /\$\<[A-Za-z_0-9]\+\>/
 
 " TypeName[Optionality]?
-syn match swiftType contained skipwhite nextgroup=swiftTypeParameters
+syn match swiftType contained skipwhite skipempty nextgroup=swiftTypeParameters
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " [Type:Type] (dictionary) or [Type] (array)
 syn region swiftType contained contains=swiftTypePair,swiftType
       \ matchgroup=Delimiter start=/\[/ end=/\]/
-syn match swiftTypePair contained skipwhite nextgroup=swiftTypeParameters,swiftTypeDeclaration
+syn match swiftTypePair contained skipwhite skipempty nextgroup=swiftTypeParameters,swiftTypeDeclaration
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " (Type[, Type]) (tuple)
 " FIXME: we should be able to use skip="," and drop swiftParamDelim
@@ -136,9 +136,9 @@ syn region swiftTypeParameters contained contains=swiftVarName,swiftConstraint
 syn keyword swiftConstraint contained
       \ where
 
-syn match swiftTypeDeclaration skipwhite nextgroup=swiftType,swiftInOutKeyword
+syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftType,swiftInOutKeyword
       \ /:/
-syn match swiftTypeDeclaration skipwhite nextgroup=swiftType
+syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftType
       \ /->/
 
 syn region swiftParenthesisRegion matchgroup=NONE start=/(/ end=/)/ contains=TOP
@@ -153,8 +153,8 @@ syn match swiftHex /[+\-]\?\<0x[0-9A-Fa-f][0-9A-Fa-f_]*\(\([.][0-9A-Fa-f_]*\)\?[
 syn match swiftOct /[+\-]\?\<0o[0-7][0-7_]*\>/
 syn match swiftBin /[+\-]\?\<0b[01][01_]*\>/
 
-syn match swiftOperator +\.\@<!\.\.\.\@!\|[/=\-+*%<>!&|^~]\@<!\(/[/*]\@![/=\-+*%<>!&|^~]*\|*/\@![/=\-+*%<>!&|^~]*\|->\@![/=\-+*%<>!&|^~]*\|[=+%<>!&|^~][/=\-+*%<>!&|^~]*\)+ skipwhite nextgroup=swiftTypeParameters
-syn match swiftOperator "\.\.[<.]" skipwhite nextgroup=swiftTypeParameters
+syn match swiftOperator +\.\@<!\.\.\.\@!\|[/=\-+*%<>!&|^~]\@<!\(/[/*]\@![/=\-+*%<>!&|^~]*\|*/\@![/=\-+*%<>!&|^~]*\|->\@![/=\-+*%<>!&|^~]*\|[=+%<>!&|^~][/=\-+*%<>!&|^~]*\)+ skipwhite skipempty nextgroup=swiftTypeParameters
+syn match swiftOperator "\.\.[<.]" skipwhite skipempty nextgroup=swiftTypeParameters
 
 syn match swiftChar /'\([^'\\]\|\\\(["'tnr0\\]\|x[0-9a-fA-F]\{2}\|u[0-9a-fA-F]\{4}\|U[0-9a-fA-F]\{8}\)\)'/
 
@@ -167,12 +167,12 @@ syn match swiftPreproc /#\(\<file\>\|\<line\>\|\<function\>\)/
 syn match swiftPreproc /^\s*#\(\<if\>\|\<else\>\|\<elseif\>\|\<endif\>\|\<error\>\|\<warning\>\)/
 syn region swiftPreprocFalse start="^\s*#\<if\>\s\+\<false\>" end="^\s*#\(\<else\>\|\<elseif\>\|\<endif\>\)"
 
-syn match swiftAttribute /@\<\w\+\>/ skipwhite nextgroup=swiftType
+syn match swiftAttribute /@\<\w\+\>/ skipwhite skipempty nextgroup=swiftType
 
 syn keyword swiftTodo MARK TODO FIXME contained
 
-syn match swiftCastOp "\<is\>" skipwhite nextgroup=swiftType
-syn match swiftCastOp "\<as\>[!?]\?" skipwhite nextgroup=swiftType
+syn match swiftCastOp "\<is\>" skipwhite skipempty nextgroup=swiftType
+syn match swiftCastOp "\<as\>[!?]\?" skipwhite skipempty nextgroup=swiftType
 
 syn match swiftNilOps "??"
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

**Update only utils/vim/syntax/swift.vim**

Swift compiler allows some newlines instead of white spaces. Therefore, I added `skipempty` after` skipwhite`.

## Problematic patterns

![2018-09-29 11 10 51](https://user-images.githubusercontent.com/629993/46239797-967e1e00-c3d8-11e8-9325-a84340a9630c.png)

## Expects

![2018-09-29 11 08 53](https://user-images.githubusercontent.com/629993/46239798-9aaa3b80-c3d8-11e8-8689-9f04e53491e0.png)
