### PR TITLE
Remove concrete inits from integer types

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -56,13 +56,6 @@ public struct CGFloat {
     self.native = value.native
   }
 
-% for src_ty in all_integer_types(word_bits):
-  @_transparent public init(_ value: ${src_ty.stdlib_name}) {
-    self.native = NativeType(value)
-  }
-
-% end
-
   /// The native value.
   public var native: NativeType
 }

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -66,7 +66,7 @@ set(SWIFTLIB_ESSENTIAL
   FixedArray.swift.gyb
   FlatMap.swift
   Flatten.swift
-  FloatingPoint.swift.gyb
+  FloatingPoint.swift
   FloatingPointParsing.swift.gyb
   FloatingPointTypes.swift.gyb
   Hashable.swift

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1581,53 +1581,6 @@ extension ${Self} {
 // Explicit conversions between types.
 //===----------------------------------------------------------------------===//
 
-// Construction from integers.
-extension ${Self} {
-
-% for self_ty in all_integer_types(word_bits):
-%   That = self_ty.stdlib_name
-%   ThatBuiltinName = self_ty.builtin_name
-%   sign = 's' if self_ty.is_signed else 'u'
-%   srcBits = self_ty.bits
-%
-%   max_required_exponent = srcBits - 1
-%   max_available_exponent = (1 << (ExponentBitCount - 1)) - 1
-%   max_required_precision = srcBits - 1 if self_ty.is_signed else srcBits
-%   max_available_precision = SignificandBitCount + 1
-%   is_always_represented_exactly = \
-%     (max_required_exponent <= max_available_exponent and \
-%       max_required_precision <= max_available_precision)
-
-  /// Creates the closest representable value to the given integer.
-  ///
-  /// - Parameter value: The integer to represent as a floating-point value.
-  @_transparent
-  public init(_ v: ${That}) {
-    _value = Builtin.${sign}itofp_${ThatBuiltinName}_FPIEEE${bits}(v._value)
-  }
-  
-  /// Creates a value that exactly represents the given integer.
-  ///
-  /// If the given integer is outside the representable range of this type or
-  /// can't be represented exactly, the result is `nil`.
-  ///
-  /// - Parameter value: The integer to represent as a floating-point value.
-%   if is_always_represented_exactly:
-  @available(*, message: "Converting ${That} to ${Self} will always succeed.")
-%   end
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
-  public init?(exactly value: ${That}) {
-    _value = Builtin.${sign}itofp_${ThatBuiltinName}_FPIEEE${bits}(value._value)
-%   if not is_always_represented_exactly:
-    guard let roundTrip = ${That}(exactly: self), roundTrip == value else {
-      return nil
-    }
-%   end
-  }
-% end # all_integer_types
-}
-
 // Construction from other floating point numbers.
 extension ${Self} {
 % for src_type in all_floating_point_types():

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1591,6 +1591,23 @@ extension ${Self} {
     _value = Builtin.sitofp_Int${word_bits}_FPIEEE${bits}(v._value)
   }
 
+  // Fast-path for conversion when the source is representable as a 64-bit int,
+  // falling back on the generic _convert operation otherwise.
+  @_transparent
+  public init<Source : BinaryInteger>(_ value: Source) {
+    if value.bitWidth <= 64 {
+      if Source.isSigned {
+        let asI64 = Int64(truncatingIfNeeded: value)
+        _value = Builtin.sitofp_Int64_FPIEEE${bits}(asI64._value)
+      } else {
+        let asU64 = Int64(truncatingIfNeeded: value)
+        _value = Builtin.uitofp_Int64_FPIEEE${bits}(asU64._value)
+      }
+    } else {
+      self = ${Self}._convert(from: value).value
+    }
+  }
+
 % for src_type in all_floating_point_types():
 %   srcBits = src_type.bits
 %   That = src_type.stdlib_name

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1581,8 +1581,16 @@ extension ${Self} {
 // Explicit conversions between types.
 //===----------------------------------------------------------------------===//
 
-// Construction from other floating point numbers.
+// Construction from other concrete types.
 extension ${Self} {
+
+  // We "shouldn't" need this, but the typechecker barfs on an expression
+  // in the test suite without it.
+  @_transparent
+  public init(_ v: Int) {
+    _value = Builtin.sitofp_Int${word_bits}_FPIEEE${bits}(v._value)
+  }
+
 % for src_type in all_floating_point_types():
 %   srcBits = src_type.bits
 %   That = src_type.stdlib_name

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -5,6 +5,12 @@ Protocol BinaryInteger has generic signature change from <Self : CustomStringCon
 /* RawRepresentable Changes */
 
 /* Removed Decls */
+Constructor Double.init(_:) has been removed
+Constructor Double.init(exactly:) has been removed
+Constructor Float.init(_:) has been removed
+Constructor Float.init(exactly:) has been removed
+Constructor Float80.init(_:) has been removed
+Constructor Float80.init(exactly:) has been removed
 Constructor Int.init(truncatingBitPattern:) has been removed
 Constructor Int16.init(truncatingBitPattern:) has been removed
 Constructor Int32.init(truncatingBitPattern:) has been removed

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -1,5 +1,10 @@
 
 /* Generic Signature Changes */
+Constructor BinaryFloatingPoint.init(_:) has generic signature change from <Self, Source where Self : BinaryFloatingPoint, Source : BinaryInteger> to <Self, Source where Self : BinaryFloatingPoint, Source : BinaryInteger, Self.RawSignificand : FixedWidthInteger>
+Constructor BinaryFloatingPoint.init(exactly:) has generic signature change from <Self, Source where Self : BinaryFloatingPoint, Source : BinaryInteger> to <Self, Source where Self : BinaryFloatingPoint, Source : BinaryInteger, Self.RawSignificand : FixedWidthInteger>
+Constructor Double.init(_:) has generic signature change from to <Source where Source : BinaryInteger>
+Constructor Float.init(_:) has generic signature change from to <Source where Source : BinaryInteger>
+Constructor Float80.init(_:) has generic signature change from to <Source where Source : BinaryInteger>
 Func Substring.replaceSubrange(_:with:) has generic signature change from <C where C : Collection, C.Element == Character> to <C where C : Collection, C.Element == Substring.Iterator.Element>
 Protocol BinaryInteger has generic signature change from <Self : CustomStringConvertible, Self : Hashable, Self : Numeric, Self : Strideable, Self.Magnitude : BinaryInteger, Self.Magnitude == Self.Magnitude.Magnitude, Self.Words : Sequence, Self.Words.Element == UInt> to <Self : CustomStringConvertible, Self : Hashable, Self : Numeric, Self : Strideable, Self.Magnitude : BinaryInteger, Self.Magnitude == Self.Magnitude.Magnitude, Self.Words : RandomAccessCollection, Self.Words.Element == UInt, Self.Words.Index == Int>
 /* RawRepresentable Changes */

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -5,12 +5,10 @@ Protocol BinaryInteger has generic signature change from <Self : CustomStringCon
 /* RawRepresentable Changes */
 
 /* Removed Decls */
-Constructor Double.init(_:) has been removed
 Constructor Double.init(exactly:) has been removed
-Constructor Float.init(_:) has been removed
 Constructor Float.init(exactly:) has been removed
-Constructor Float80.init(_:) has been removed
 Constructor Float80.init(exactly:) has been removed
+Constructor FloatingPoint.init(_:) has been removed
 Constructor Int.init(truncatingBitPattern:) has been removed
 Constructor Int16.init(truncatingBitPattern:) has been removed
 Constructor Int32.init(truncatingBitPattern:) has been removed
@@ -83,6 +81,9 @@ Func Dictionary.filter(_:obsoletedInSwift4:) has been renamed to Func Dictionary
 Func Set.filter(_:obsoletedInSwift4:) has been renamed to Func Set.filter(_:)
 
 /* Type Changes */
+Constructor Double.init(_:) has parameter 0 type change from UInt8 to Source
+Constructor Float.init(_:) has parameter 0 type change from UInt8 to Source
+Constructor Float80.init(_:) has parameter 0 type change from UInt8 to Source
 Constructor Mirror.init(_:children:displayStyle:ancestorRepresentation:) has parameter 1 type change from DictionaryLiteral<String, Any> to KeyValuePairs<String, Any>
 Constructor String.init(_:) has return type change from String? to String
 Func Dictionary.filter(_:obsoletedInSwift4:) has return type change from [Dictionary<Key, Value>.Element] to [Dictionary<Key, Value>.Key : Dictionary<Key, Value>.Value]


### PR DESCRIPTION
We should no longer need these with the protocol-based integer support we now have. Some small work may be needed to fix performance regressions, but that will come in a follow-on update.

I *did* have to keep the concrete init from Int around to keep the type checker from failing in some new cases; I hope we can remove that too in the future.

Fixes <rdar://problem/33199966>