### PR TITLE
[AutoDiff] Support general differentiable manifolds and move tangent space definition to AST

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -102,6 +102,8 @@ namespace swift {
   class TypeAliasDecl;
   class VarDecl;
   class UnifiedStatsReporter;
+  // SWIFT_ENABLE_TENSORFLOW
+  class TangentSpace;
 
   enum class KnownProtocolKind : uint8_t;
 
@@ -902,6 +904,11 @@ public:
   bool isSwiftVersionAtLeast(unsigned major, unsigned minor = 0) const {
     return LangOpts.isSwiftVersionAtLeast(major, minor);
   }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Compute the tangent space of this manifold, if the given type represents a
+  /// differentiable manifold.
+  Optional<TangentSpace> getTangentSpace(CanType type, ModuleDecl *module);
 
 private:
   friend Decl;

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -88,12 +88,13 @@ struct SILReverseAutoDiffIndices {
   /// Indices of independent parameters to differentiate with respect to.
   llvm::SmallBitVector parameters;
   
+
   /// Creates a set of AD indices from the given source index and a bit vector
   /// representing parameter indices.
   /*implicit*/ SILReverseAutoDiffIndices(unsigned source,
                                          llvm::SmallBitVector parameters)
     : source(source), parameters(parameters) {}
-  
+
   /// Creates a set of AD indices from the given source index and an array of
   /// parameter indices. Elements in `parameters` must be acending integers.
   /*implicit*/ SILReverseAutoDiffIndices(unsigned source,
@@ -206,6 +207,112 @@ struct SILReverseAutoDiffConfig {
   bool operator==(const SILReverseAutoDiffConfig &other) const {
     return indices == other.indices &&
            options.toRaw() == other.options.toRaw();
+  }
+};
+
+/// A type that represents the tangent space of a differentiable type.
+class TangentSpace {
+public:
+  /// A tangent space kind.
+  enum class Kind {
+    /// `Builtin.FP<...>`.
+    BuiltinRealScalar,
+    /// A type that conforms to `FloatingPoint`.
+    RealScalar,
+    /// A type that conforms to `VectorNumeric` where the associated
+    /// `ScalarElement` conforms to `FloatingPoint`.
+    RealVector,
+    /// A product of tangent spaces as a struct.
+    ProductStruct,
+    /// A product of tangent spaces as a tuple.
+    ProductTuple,
+    /// A sum of tangent spaces.
+    Sum
+  };
+
+private:
+  Kind kind;
+  union Value {
+    // BuiltinRealScalar
+    BuiltinFloatType *builtinFPType;
+    // RealScalar or RealVector
+    NominalTypeDecl *realNominalType;
+    // ProductStruct
+    StructDecl *structDecl;
+    // ProductTuple
+    TupleType *tupleType;
+    // Sum
+    EnumDecl *enumDecl;
+
+    Value(BuiltinFloatType *builtinFP) : builtinFPType(builtinFP) {}
+    Value(NominalTypeDecl *nominal) : realNominalType(nominal) {}
+    Value(StructDecl *structDecl) : structDecl(structDecl) {}
+    Value(TupleType *tupleType) : tupleType(tupleType) {}
+    Value(EnumDecl *enumDecl) : enumDecl(enumDecl) {}
+  } value;
+
+  TangentSpace(Kind kind, Value value)
+      : kind(kind), value(value) {}
+
+public:
+  TangentSpace() = delete;
+
+  static TangentSpace
+  getBuiltinRealScalarSpace(BuiltinFloatType *builtinFP) {
+    return {Kind::BuiltinRealScalar, builtinFP};
+  }
+  static TangentSpace getRealScalarSpace(NominalTypeDecl *typeDecl) {
+    return {Kind::RealScalar, typeDecl};
+  }
+  static TangentSpace getRealVectorSpace(NominalTypeDecl *typeDecl) {
+    return {Kind::RealVector, typeDecl};
+  }
+  static TangentSpace getProductStruct(StructDecl *structDecl) {
+    return {Kind::ProductStruct, structDecl};
+  }
+  static TangentSpace getProductTuple(TupleType *tupleTy) {
+    return {Kind::ProductTuple, tupleTy};
+  }
+  static TangentSpace getSum(EnumDecl *enumDecl) {
+    return {Kind::Sum, enumDecl};
+  }
+
+  bool isBuiltinRealScalarSpace() const {
+    return kind == Kind::BuiltinRealScalar;
+  }
+  bool isRealScalarSpace() const { return kind == Kind::RealScalar; }
+  bool isRealVectorSpace() const { return kind == Kind::RealVector; }
+  bool isProductStruct() const { return kind == Kind::ProductStruct; }
+  bool isProductTuple() const { return kind == Kind::ProductTuple; }
+
+  Kind getKind() const { return kind; }
+  BuiltinFloatType *getBuiltinRealScalarSpace() const {
+    assert(kind == Kind::BuiltinRealScalar);
+    return value.builtinFPType;
+  }
+  NominalTypeDecl *getRealScalarSpace() const {
+    assert(kind == Kind::RealScalar);
+    return value.realNominalType;
+  }
+  NominalTypeDecl *getRealVectorSpace() const {
+    assert(kind == Kind::RealVector);
+    return value.realNominalType;
+  }
+  NominalTypeDecl *getRealScalarOrVectorSpace() const {
+    assert(kind == Kind::RealScalar || kind == Kind::RealVector);
+    return value.realNominalType;
+  }
+  StructDecl *getProductStruct() const {
+    assert(kind == Kind::ProductStruct);
+    return value.structDecl;
+  }
+  TupleType *getProductTuple() const {
+    assert(kind == Kind::ProductTuple);
+    return value.tupleType;
+  }
+  EnumDecl *getSum() const {
+    assert(kind == Kind::Sum);
+    return value.enumDecl;
   }
 };
 

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -210,6 +210,12 @@ struct SILReverseAutoDiffConfig {
   }
 };
 
+class BuiltinFloatType;
+class NominalTypeDecl;
+class StructDecl;
+class TupleType;
+class EnumDecl;
+
 /// A type that represents the tangent space of a differentiable type.
 class TangentSpace {
 public:

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -75,6 +75,7 @@ PROTOCOL(Parameterized)
 PROTOCOL(TensorProtocol)
 PROTOCOL(TensorSendableReceivable)
 PROTOCOL(VectorNumeric)
+PROTOCOL(Differentiable)
 
 PROTOCOL_(ObjectiveCBridgeable)
 PROTOCOL_(DestructorSafeContainer)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -17,8 +17,6 @@
 #ifndef SWIFT_TYPES_H
 #define SWIFT_TYPES_H
 
-// SWIFT_ENABLE_TENSORFLOW
-#include "swift/AST/AutoDiff.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/Identifier.h"
@@ -74,6 +72,8 @@ namespace swift {
   class ProtocolConformance;
   enum PointerTypeKind : unsigned;
   struct ValueOwnershipKind;
+  // SWIFT_ENABLE_TENSORFLOW
+  struct SILReverseAutoDiffConfig;
 
   enum class TypeKind : uint8_t {
 #define TYPE(id, parent) id,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -358,6 +358,10 @@ FOR_KNOWN_FOUNDATION_TYPES(CACHE_FOUNDATION_DECL)
   llvm::FoldingSet<DeclName::CompoundDeclName> CompoundNames;
   llvm::DenseMap<UUID, ArchetypeType *> OpenedExistentialArchetypes;
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// A cache of tangent spaces per type.
+  llvm::DenseMap<CanType, Optional<TangentSpace>> TangentSpaces;
+
   /// List of Objective-C member conflicts we have found during type checking.
   std::vector<ObjCMethodConflict> ObjCMethodConflicts;
 
@@ -4997,4 +5001,85 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
   return LayoutConstraint(New);
 }
 
-
+// SWIFT_ENABLE_TENSORFLOW
+Optional<TangentSpace> ASTContext::getTangentSpace(CanType type,
+                                                   ModuleDecl *module) {
+  auto lookup = getImpl().TangentSpaces.find(type);
+  if (lookup != getImpl().TangentSpaces.end())
+    return lookup->getSecond();
+  // A helper that is used to cache the computed tangent space for the
+  // specified type and retuns the same tangent space.
+  auto cache = [&](Optional<TangentSpace> tangentSpace) {
+    getImpl().TangentSpaces.insert({type, tangentSpace});
+    return tangentSpace;
+  };
+  // `Builtin.FP<...>` is a builtin real scalar space.
+  if (auto *fpType = type->getAs<BuiltinFloatType>())
+    return cache(TangentSpace::getBuiltinRealScalarSpace(fpType));
+  // Look up conformance to `FloatingPoint`.
+  auto *fpProto = getProtocol(KnownProtocolKind::FloatingPoint);
+  if (auto maybeFPConf = module->lookupConformance(type, fpProto)) {
+    auto *typeDecl = type->getAnyNominal();
+    assert(typeDecl);
+    return cache(TangentSpace::getRealScalarSpace(typeDecl));
+  }
+  // Look up conformance to `Differentiable`.
+  auto *diffableProto = getProtocol(KnownProtocolKind::Differentiable);
+  if (auto maybeDiffableConf = module->lookupConformance(type, diffableProto)) {
+    auto tangentLookup =
+        diffableProto->lookupDirect(getIdentifier("TangentVector"));
+    auto *tangentAssocDecl = cast<AssociatedTypeDecl>(tangentLookup[0]);
+    auto subMap = type->getMemberSubstitutionMap(module, tangentAssocDecl);
+    auto tangent = tangentAssocDecl->getDeclaredInterfaceType().subst(subMap);
+    auto *tangentDecl = tangent->getAnyNominal();
+    assert(tangentDecl &&
+           "Tangent must be a nominal type because it has protocol contraints");
+    return cache(TangentSpace::getRealVectorSpace(tangentDecl));
+  }
+  // Nominal types can be either a struct or an enum.
+  if (auto *nominal = type->getAnyNominal()) {
+    // Fixed-layout struct types, each of whose elements has a tangent space,
+    // are a product of those tangent spaces.
+    if (auto *structDecl = dyn_cast<StructDecl>(nominal)) {
+      if (structDecl->getFormalAccess() >= AccessLevel::Public &&
+          !structDecl->getAttrs().hasAttribute<FixedLayoutAttr>())
+        return cache(None);
+      auto allMembersHaveTangentSpace =
+          llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
+            return (bool)getTangentSpace(v->getType()->getCanonicalType(),
+                                         module);
+          });
+      if (allMembersHaveTangentSpace)
+        return cache(TangentSpace::getProductStruct(structDecl));
+    }
+    // Frozen enum types, all of whose payloads have a tangent space, are a
+    // sum of the product of payloads in each case.
+    if (auto *enumDecl = dyn_cast<EnumDecl>(nominal)) {
+      if (enumDecl->getFormalAccess() >= AccessLevel::Public &&
+          !enumDecl->getAttrs().hasAttribute<FrozenAttr>())
+        return cache(None);
+      if (enumDecl->isIndirect())
+        return cache(None);
+      auto allMembersHaveTangentSpace =
+        llvm::all_of(enumDecl->getAllCases(), [&](EnumCaseDecl *cd) {
+          return llvm::all_of(cd->getElements(), [&](EnumElementDecl *eed) {
+            return llvm::all_of(*eed->getParameterList(), [&](ParamDecl *pd) {
+              return (bool)
+                  getTangentSpace(pd->getType()->getCanonicalType(), module);
+            });
+          });
+        });
+      if (allMembersHaveTangentSpace)
+        return cache(TangentSpace::getSum(enumDecl));
+    }
+  }
+  // Tuple types, each of whose elements has a tangent space, are a product of
+  // those tangent space.
+  if (TupleType *tupleType = type->getAs<TupleType>())
+    if (llvm::all_of(tupleType->getElementTypes(), [&](Type t) {
+            return (bool)getTangentSpace(t->getCanonicalType(), module); }))
+      return cache(TangentSpace::getProductTuple(tupleType));
+  // Otherwise, the type does not have a tangent space. That is, it does not
+  // support differentiation.
+  return cache(None);
+}

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/AST/AutoDiff.h"
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace swift;
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3865,6 +3865,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::TensorProtocol:
   case KnownProtocolKind::TensorSendableReceivable:
   case KnownProtocolKind::VectorNumeric:
+  case KnownProtocolKind::Differentiable:
     return SpecialProtocol::None;
   }
 

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -826,112 +826,6 @@ enum class PrimalValueKind {
   TapeCheckpoint
 };
 
-/// A conceptual cotangent space representing the type of the adjoint.
-class CotangentSpace {
-public:
-  /// A cotangent space kind.
-  enum class Kind {
-    /// `Builtin.FP<...>`.
-    BuiltinRealScalar,
-    /// A type that conforms to `FloatingPoint`.
-    RealScalar,
-    /// A type that conforms to `VectorNumeric` where the associated
-    /// `ScalarElement` conforms to `FloatingPoint`.
-    RealVector,
-    /// A product of cotangent spaces as a struct.
-    ProductStruct,
-    /// A product of cotangent spaces as a tuple.
-    ProductTuple,
-    /// A sum of cotangent spaces.
-    Sum
-  };
-  
-private:
-  Kind kind;
-  union Value {
-    // BuiltinRealScalar
-    BuiltinFloatType *builtinFPType;
-    // RealScalar or RealVector
-    NominalTypeDecl *realNominalType;
-    // ProductStruct
-    StructDecl *structDecl;
-    // ProductTuple
-    TupleType *tupleType;
-    // Sum
-    EnumDecl *enumDecl;
-    
-    Value(BuiltinFloatType *builtinFP) : builtinFPType(builtinFP) {}
-    Value(NominalTypeDecl *nominal) : realNominalType(nominal) {}
-    Value(StructDecl *structDecl) : structDecl(structDecl) {}
-    Value(TupleType *tupleType) : tupleType(tupleType) {}
-    Value(EnumDecl *enumDecl) : enumDecl(enumDecl) {}
-  } value;
-  
-  CotangentSpace(Kind kind, Value value)
-      : kind(kind), value(value) {}
-  
-public:
-  CotangentSpace() = delete;
-  
-  static CotangentSpace
-  getBuiltinRealScalarSpace(BuiltinFloatType *builtinFP) {
-    return {Kind::BuiltinRealScalar, builtinFP};
-  }
-  static CotangentSpace getRealScalarSpace(NominalTypeDecl *typeDecl) {
-    return {Kind::RealScalar, typeDecl};
-  }
-  static CotangentSpace getRealVectorSpace(NominalTypeDecl *typeDecl) {
-    return {Kind::RealVector, typeDecl};
-  }
-  static CotangentSpace getProductStruct(StructDecl *structDecl) {
-    return {Kind::ProductStruct, structDecl};
-  }
-  static CotangentSpace getProductTuple(TupleType *tupleTy) {
-    return {Kind::ProductTuple, tupleTy};
-  }
-  static CotangentSpace getSum(EnumDecl *enumDecl) {
-    return {Kind::Sum, enumDecl};
-  }
-  
-  bool isBuiltinRealScalarSpace() const {
-    return kind == Kind::BuiltinRealScalar;
-  }
-  bool isRealScalarSpace() const { return kind == Kind::RealScalar; }
-  bool isRealVectorSpace() const { return kind == Kind::RealVector; }
-  bool isProductStruct() const { return kind == Kind::ProductStruct; }
-  bool isProductTuple() const { return kind == Kind::ProductTuple; }
-  
-  Kind getKind() const { return kind; }
-  BuiltinFloatType *getBuiltinRealScalarSpace() const {
-    assert(kind == Kind::BuiltinRealScalar);
-    return value.builtinFPType;
-  }
-  NominalTypeDecl *getRealScalarSpace() const {
-    assert(kind == Kind::RealScalar);
-    return value.realNominalType;
-  }
-  NominalTypeDecl *getRealVectorSpace() const {
-    assert(kind == Kind::RealVector);
-    return value.realNominalType;
-  }
-  NominalTypeDecl *getRealScalarOrVectorSpace() const {
-    assert(kind == Kind::RealScalar || kind == Kind::RealVector);
-    return value.realNominalType;
-  }
-  StructDecl *getProductStruct() const {
-    assert(kind == Kind::ProductStruct);
-    return value.structDecl;
-  }
-  TupleType *getProductTuple() const {
-    assert(kind == Kind::ProductTuple);
-    return value.tupleType;
-  }
-  EnumDecl *getSum() const {
-    assert(kind == Kind::Sum);
-    return value.enumDecl;
-  }
-};
-
 using GradientLookupKey = std::pair<SILFunction *, SILReverseAutoDiffConfig>;
 
 //===----------------------------------------------------------------------===//
@@ -979,9 +873,6 @@ private:
   mutable FuncDecl *cachedVectorPlusFn = nullptr;
   /// `Numeric.+` declaration.
   mutable FuncDecl *cachedNumericPlusFn = nullptr;
-  
-  /// Cache of computed cotangent spaces for types.
-  mutable DenseMap<CanType, Optional<CotangentSpace>> cachedCotangentSpaces;
 
 public:
   /// Construct an ADContext for the given module.
@@ -1026,9 +917,6 @@ public:
     }
     return cachedNumericPlusFn;
   }
-
-  /// Determines the cotangent space (or none) of the specified type.
-  Optional<CotangentSpace> getCotangentSpace(CanType type) const;
 
   /// Retrieves the file unit that contains implicit declarations in the
   /// current Swift module. If it does not exist, create one.
@@ -1248,118 +1136,6 @@ void ADContext::emitNondifferentiabilityError(SILInstruction *inst,
     break;
   }
   }
-}
-
-/// Determines whether the type supports vector differentiation. We say that a
-/// type supports vector differentiation if it conforms to `VectorNumeric` and
-/// the associated type `ScalarElement` conforms to `FloatingPoint`.
-static NominalTypeDecl *getAnyRealVectorTypeDecl(CanType type,
-                                                 const ADContext &context) {
-  auto *swiftModule = context.getModule().getSwiftModule();
-  auto *floatingPointProtocol = context.getFloatingPointProtocol();
-  auto *vectorNumericProtocol = context.getVectorNumericProtocol();
-  // Look up conformance.
-  auto maybeConf = swiftModule->lookupConformance(type, vectorNumericProtocol);
-  if (!maybeConf)
-    return nullptr;
-  auto conf = *maybeConf;
-  // See if the `ScalarElement` associated type conforms to `FloatingPoint`.
-  DeclName scalarDeclName(
-      context.getASTContext().getIdentifier("ScalarElement"));
-  auto lookup = vectorNumericProtocol->lookupDirect(scalarDeclName);
-  auto scalarAssocTy =
-      cast<AssociatedTypeDecl>(lookup[0])->getDeclaredInterfaceType();
-  auto scalarTy = conf.getAssociatedType(type, scalarAssocTy);
-  auto scalarConf =
-      swiftModule->lookupConformance(scalarTy, floatingPointProtocol);
-  if (!scalarConf.hasValue())
-    return nullptr;
-  auto *nominal = type->getAnyNominal();
-  assert(nominal && "Should've been nominal since it conforms to protocols");
-  return nominal;
-}
-
-/// Determines whether the type supports scalar differentiation. We say that a
-/// type supports scalar differentiation if it conforms to `FloatingPoint` and
-/// the associated type `ScalarElement` conforms to `FloatingPoint`.
-static NominalTypeDecl *getAnyRealScalarTypeDecl(CanType type,
-                                                 const ADContext &context) {
-  auto *swiftModule = context.getModule().getSwiftModule();
-  if (!swiftModule->lookupConformance(type, context.getFloatingPointProtocol()))
-    return nullptr;
-  auto *nominal = type->getAnyNominal();
-  assert(nominal && "Should've been nominal since it conforms to protocols");
-  return nominal;
-}
-
-/// Determines the cotangent space of a type.
-Optional<CotangentSpace> ADContext::getCotangentSpace(CanType type) const {
-  LLVM_DEBUG(getADDebugStream() << "Classifying cotangent space for "
-             << type << '\n');
-  auto lookup = cachedCotangentSpaces.find(type);
-  if (lookup != cachedCotangentSpaces.end())
-    return lookup->getSecond();
-  // A helper that is used to cache the computed cotangent space for the
-  // specified type and retuns the same cotangent space.
-  auto cache = [&](Optional<CotangentSpace> cotangentSpace) {
-    cachedCotangentSpaces.insert({type, cotangentSpace});
-    return cotangentSpace;
-  };
-  // `Builtin.FP<...>` is a builtin real scalar space.
-  if (auto *fpType = type->getAs<BuiltinFloatType>())
-    return cache(CotangentSpace::getBuiltinRealScalarSpace(fpType));
-  // Types that conform to `FloatingPoint` are a real scalar space.
-  if (auto *nomTy = getAnyRealScalarTypeDecl(type, *this))
-    return cache(CotangentSpace::getRealScalarSpace(nomTy));
-  // Types that conform to `VectorNumeric` where the associated `ScalarElement`
-  // conforms to `FloatingPoint` are a real vector space.
-  if (auto *nomTy = getAnyRealVectorTypeDecl(type, *this))
-    return cache(CotangentSpace::getRealVectorSpace(nomTy));
-  // Nominal types can be either a struct or an enum.
-  if (auto *nominal = type->getAnyNominal()) {
-    // Fixed-layout struct types, each of whose elements has a cotangent space,
-    // are a product of those cotangent spaces.
-    if (auto *structDecl = dyn_cast<StructDecl>(nominal)) {
-      if (structDecl->getFormalAccess() >= AccessLevel::Public &&
-          !structDecl->getAttrs().hasAttribute<FixedLayoutAttr>())
-        return cache(None);
-      auto allMembersHaveCotangentSpace =
-          llvm::all_of(structDecl->getStoredProperties(), [&](VarDecl *v) {
-            return (bool)getCotangentSpace(v->getType()->getCanonicalType());
-          });
-      if (allMembersHaveCotangentSpace)
-        return cache(CotangentSpace::getProductStruct(structDecl));
-    }
-    // Frozen enum types, all of whose payloads have a cotangent space, are a
-    // sum of the product of payloads in each case.
-    if (auto *enumDecl = dyn_cast<EnumDecl>(nominal)) {
-      if (enumDecl->getFormalAccess() >= AccessLevel::Public &&
-          !enumDecl->getAttrs().hasAttribute<FrozenAttr>())
-        return cache(None);
-      if (enumDecl->isIndirect())
-        return cache(None);
-      auto allMembersHaveCotangentSpace =
-        llvm::all_of(enumDecl->getAllCases(), [&](EnumCaseDecl *cd) {
-          return llvm::all_of(cd->getElements(), [&](EnumElementDecl *eed) {
-            return llvm::all_of(*eed->getParameterList(), [&](ParamDecl *pd) {
-              return (bool)
-                  getCotangentSpace(pd->getType()->getCanonicalType());
-            });
-          });
-        });
-      if (allMembersHaveCotangentSpace)
-        return cache(CotangentSpace::getSum(enumDecl));
-    }
-  }
-  // Tuple types, each of whose elements has a cotangent space, are a product of
-  // those cotangent space.
-  if (TupleType *tupleType = type->getAs<TupleType>())
-    if (llvm::all_of(tupleType->getElementTypes(), [&](Type t) {
-            return (bool)getCotangentSpace(t->getCanonicalType()); }))
-      return cache(CotangentSpace::getProductTuple(tupleType));
-  // Otherwise, the type does not have a cotangent space. That is, it does not
-  // support differentiation.
-  return cache(None);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1905,13 +1681,15 @@ static void convertIntToIndirectExpressible(intmax_t scalar,
 static void createScalarValueIndirect(intmax_t scalar, CanType type,
                                       SILValue seedBufAccess, SILLocation loc,
                                       SILBuilder &builder, ADContext &context) {
-  auto cotangentSpace = context.getCotangentSpace(type);
-  assert(cotangentSpace && "No cotangent space for this type");
+  auto &astCtx = context.getASTContext();
+  auto *swiftMod = context.getModule().getSwiftModule();
+  auto tangentSpace = astCtx.getTangentSpace(type, swiftMod);
+  assert(tangentSpace && "No tangent space for this type");
   // See if the type is a builtin float. If so, we don't do protocol
   // conformance-based conversion.
-  switch (cotangentSpace->getKind()) {
+  switch (tangentSpace->getKind()) {
   // Builtin scalar is just a `float_literal` instruction.
-  case CotangentSpace::Kind::BuiltinRealScalar: {
+  case TangentSpace::Kind::BuiltinRealScalar: {
     auto *fpType = type->castTo<BuiltinFloatType>();
     auto scalarVal =
         createBuiltinFPScalar(scalar, fpType->getCanonicalType(), loc, builder);
@@ -1922,8 +1700,8 @@ static void createScalarValueIndirect(intmax_t scalar, CanType type,
   // Real scalar gets initialized through
   // `<target_type>.IntegerLiteralType.init(_builtinIntegerLiteral:)` and
   // `<target_type>.init(integerLiteral:)`.
-  case CotangentSpace::Kind::RealScalar: {
-    auto *decl = cotangentSpace->getRealScalarSpace();
+  case TangentSpace::Kind::RealScalar: {
+    auto *decl = tangentSpace->getRealScalarSpace();
     convertIntToIndirectExpressible(scalar, decl, seedBufAccess, loc, builder,
                                     context);
     return;
@@ -1933,8 +1711,8 @@ static void createScalarValueIndirect(intmax_t scalar, CanType type,
   //     .init(_builtinIntegerLiteral:)`,
   // `<target_type>.ScalarElement.init(integerLiteral:)` and
   // `<target_type>.init(_:)`.
-  case CotangentSpace::Kind::RealVector: {
-    auto *targetTypeDecl = cotangentSpace->getRealVectorSpace();
+  case TangentSpace::Kind::RealVector: {
+    auto *targetTypeDecl = tangentSpace->getRealVectorSpace();
     auto &astCtx = context.getASTContext();
     auto &module = context.getModule();
     // Create a scalar value from the specified integer literal.
@@ -2026,8 +1804,8 @@ static void createScalarValueIndirect(intmax_t scalar, CanType type,
     return;
   }
   // Struct gets member-wise initialized.
-  case CotangentSpace::Kind::ProductStruct: {
-    auto *decl = cotangentSpace->getProductStruct();
+  case TangentSpace::Kind::ProductStruct: {
+    auto *decl = tangentSpace->getProductStruct();
     SmallVector<SILValue, 8> elements;
     for (auto *field : decl->getStoredProperties()) {
       auto *eltAddr =
@@ -2038,8 +1816,8 @@ static void createScalarValueIndirect(intmax_t scalar, CanType type,
     return;
   }
   // Tuple gets member-wise initialized.
-  case CotangentSpace::Kind::ProductTuple: {
-    auto tupleType = cotangentSpace->getProductTuple();
+  case TangentSpace::Kind::ProductTuple: {
+    auto tupleType = tangentSpace->getProductTuple();
     SmallVector<SILValue, 8> elements;
     for (auto i : indices(tupleType->getElementTypes())) {
       auto *eltAddr = builder.createTupleElementAddr(loc, seedBufAccess, i);
@@ -2048,27 +1826,29 @@ static void createScalarValueIndirect(intmax_t scalar, CanType type,
     }
     return;
   }
-  case CotangentSpace::Kind::Sum: {
+  case TangentSpace::Kind::Sum: {
     llvm_unreachable("Differentiating sum types is not supported yet");
   }
   }
 }
 
 /// Creates and returns a scalar value in the specified type. The specified type
-/// must be a loadable type and must have a cotangent space.
+/// must be a loadable type and must have a tangent space.
 static SILValue createScalarValueDirect(intmax_t scalar, CanType type,
                                         SILLocation loc,
                                         SILBuilder &builder,
                                         ADContext &context) {
   LLVM_DEBUG(getADDebugStream() << "Creating a scalar value " << scalar <<
         " of type " << type << '\n');
-  auto cotangentSpace = context.getCotangentSpace(type);
-  assert(cotangentSpace && "No cotangent space for this type");
-  switch (cotangentSpace->getKind()) {
-  case CotangentSpace::Kind::BuiltinRealScalar:
+  auto &astCtx = context.getASTContext();
+  auto *swiftMod = context.getModule().getSwiftModule();
+  auto tangentSpace = astCtx.getTangentSpace(type, swiftMod);
+  assert(tangentSpace && "No tangent space for this type");
+  switch (tangentSpace->getKind()) {
+  case TangentSpace::Kind::BuiltinRealScalar:
     return createBuiltinFPScalar(scalar, type, loc, builder);
-  case CotangentSpace::Kind::RealScalar:
-  case CotangentSpace::Kind::RealVector: {
+  case TangentSpace::Kind::RealScalar:
+  case TangentSpace::Kind::RealVector: {
     // Otherwise, initiailize the value through protocol calls.
     auto *buffer =
         builder.createAllocStack(loc, SILType::getPrimitiveObjectType(type));
@@ -2089,8 +1869,8 @@ static SILValue createScalarValueDirect(intmax_t scalar, CanType type,
     builder.createDeallocStack(loc, buffer);
     return loadedValue;
   }
-  case CotangentSpace::Kind::ProductStruct: {
-    auto *structDecl = cotangentSpace->getProductStruct();
+  case TangentSpace::Kind::ProductStruct: {
+    auto *structDecl = tangentSpace->getProductStruct();
     SmallVector<SILValue, 8> elements;
     for (auto *field : structDecl->getStoredProperties()) {
       auto eltVal = createScalarValueDirect(
@@ -2100,8 +1880,8 @@ static SILValue createScalarValueDirect(intmax_t scalar, CanType type,
     return builder.createStruct(
         loc, SILType::getPrimitiveObjectType(type), elements);
   }
-  case CotangentSpace::Kind::ProductTuple: {
-    auto tupleType = cotangentSpace->getProductTuple();
+  case TangentSpace::Kind::ProductTuple: {
+    auto tupleType = tangentSpace->getProductTuple();
     SmallVector<SILValue, 8> elements;
     for (auto eltType : tupleType->getElementTypes()) {
       auto eltVal = createScalarValueDirect(
@@ -2111,7 +1891,7 @@ static SILValue createScalarValueDirect(intmax_t scalar, CanType type,
     return builder.createTuple(
         loc, SILType::getPrimitiveObjectType(type), elements);
   }
-  case CotangentSpace::Kind::Sum: {
+  case TangentSpace::Kind::Sum: {
     llvm_unreachable("Differentiating sum types is not supported yet");
   }
   }
@@ -3908,10 +3688,12 @@ SILValue AdjointEmitter::materializeAdjointDirect(AdjointValue val,
                                                   SILLocation loc) {
   auto &builder = getBuilder();
   auto &ctx = getContext();
+  auto *swiftMod = ctx.getModule().getSwiftModule();
   LLVM_DEBUG(getADDebugStream() <<
              "Materializing adjoints for " << val << '\n');
-  auto cotangentSpace = ctx.getCotangentSpace(val.getType().getASTType());
-  assert(cotangentSpace && "No cotangent space for this type");
+  auto tangentSpace =
+      getASTContext().getTangentSpace(val.getType().getASTType(), swiftMod);
+  assert(tangentSpace && "No tangent space for this type");
   switch (val.getKind()) {
   case AdjointValue::Kind::Zero:
     return createScalarValueDirect(
@@ -4077,14 +3859,16 @@ SILValue AdjointEmitter::accumulateMaterializedAdjointsDirect(SILValue lhs,
   auto adjointASTTy = adjointTy.getASTType();
   auto loc = lhs.getLoc();
   auto &builder = getBuilder();
-  auto cotangentSpace = getContext().getCotangentSpace(adjointASTTy);
-  assert(cotangentSpace && "No cotangent space for this type");
-  switch (cotangentSpace->getKind()) {
-  case CotangentSpace::Kind::BuiltinRealScalar:
+  auto &astCtx = getContext().getASTContext();
+  auto *swiftMod = getModule().getSwiftModule();
+  auto tangentSpace = astCtx.getTangentSpace(adjointASTTy, swiftMod);
+  assert(tangentSpace && "No tangent space for this type");
+  switch (tangentSpace->getKind()) {
+  case TangentSpace::Kind::BuiltinRealScalar:
     return builder.createBuiltinBinaryFunction(
         loc, "fadd", adjointTy, adjointTy, {lhs, rhs});
-    case CotangentSpace::Kind::RealScalar:
-    case CotangentSpace::Kind::RealVector: {
+    case TangentSpace::Kind::RealScalar:
+    case TangentSpace::Kind::RealVector: {
       // Handle any nominal type value.
 
       // Allocate buffers for inputs and output.
@@ -4139,8 +3923,8 @@ SILValue AdjointEmitter::accumulateMaterializedAdjointsDirect(SILValue lhs,
 
       return val;
     }
-    case CotangentSpace::Kind::ProductStruct: {
-      auto *structDecl = cotangentSpace->getProductStruct();
+    case TangentSpace::Kind::ProductStruct: {
+      auto *structDecl = tangentSpace->getProductStruct();
       SmallVector<SILValue, 8> adjElements;
       for (auto *field : structDecl->getStoredProperties()) {
         auto *eltLHS = builder.createStructExtract(loc, lhs, field);
@@ -4150,8 +3934,8 @@ SILValue AdjointEmitter::accumulateMaterializedAdjointsDirect(SILValue lhs,
       }
       return builder.createStruct(loc, adjointTy, adjElements);
     }
-    case CotangentSpace::Kind::ProductTuple: {
-      auto tupleType = cotangentSpace->getProductTuple();
+    case TangentSpace::Kind::ProductTuple: {
+      auto tupleType = tangentSpace->getProductTuple();
       SmallVector<SILValue, 8> adjElements;
       for (unsigned i : range(tupleType->getNumElements())) {
         auto *eltLHS = builder.createTupleExtract(loc, lhs, i);
@@ -4161,7 +3945,7 @@ SILValue AdjointEmitter::accumulateMaterializedAdjointsDirect(SILValue lhs,
       }
       return builder.createTuple(loc, adjointTy, adjElements);
     }
-    case CotangentSpace::Kind::Sum: {
+    case TangentSpace::Kind::Sum: {
       llvm_unreachable("Differentiating sum types is not supported yet");
     }
   }
@@ -4179,10 +3963,12 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
   auto adjointTy = lhsBufAccess->getType();
   auto adjointASTTy = adjointTy.getASTType();
   auto &context = getContext();
-  auto cotangentSpace = context.getCotangentSpace(adjointASTTy);
-  assert(cotangentSpace && "No cotangent space for this type");
-  switch (cotangentSpace->getKind()) {
-  case CotangentSpace::Kind::BuiltinRealScalar: {
+  auto &astCtx = context.getASTContext();
+  auto *swiftMod = getModule().getSwiftModule();
+  auto tangentSpace = astCtx.getTangentSpace(adjointASTTy, swiftMod);
+  assert(tangentSpace && "No tangent space for this type");
+  switch (tangentSpace->getKind()) {
+  case TangentSpace::Kind::BuiltinRealScalar: {
     auto *sum = builder.createBuiltinBinaryFunction(
         loc, "fadd", lhsBufAccess->getType(), lhsBufAccess->getType(),
         {lhsBufAccess, rhsBufAccess});
@@ -4191,20 +3977,20 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
     builder.createEndAccess(loc, resultBufAccess, /*aborted*/ false);
     return;
   }
-  case CotangentSpace::Kind::RealScalar:
-  case CotangentSpace::Kind::RealVector: {
+  case TangentSpace::Kind::RealScalar:
+  case TangentSpace::Kind::RealVector: {
     FuncDecl *combinerFuncDecl = nullptr;
     ProtocolDecl *proto = nullptr;
-    auto *adjointTyDecl = cotangentSpace->getRealScalarOrVectorSpace();
+    auto *adjointTyDecl = tangentSpace->getRealScalarOrVectorSpace();
     // If the type conforms to `VectorNumeric`, then combine them using
     // `VectorNumeric.+`.
-    if (cotangentSpace->isRealVectorSpace()) {
+    if (tangentSpace->isRealVectorSpace()) {
       combinerFuncDecl = getContext().getVectorPlusDecl();
       proto = getContext().getVectorNumericProtocol();
     }
     // If the type conforms to `FloatingPoint`, then use `Numeric.+`.
     else {
-      assert(cotangentSpace->isRealScalarSpace());
+      assert(tangentSpace->isRealScalarSpace());
       combinerFuncDecl = getContext().getNumericPlusDecl();
       proto = getContext().getNumericProtocol();
     }
@@ -4231,8 +4017,8 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
                         /*isNonThrowing*/ false);
     return;
   }
-  case CotangentSpace::Kind::ProductTuple: {
-    auto tupleType = cotangentSpace->getProductTuple();
+  case TangentSpace::Kind::ProductTuple: {
+    auto tupleType = tangentSpace->getProductTuple();
     for (unsigned i : range(tupleType->getNumElements())) {
       auto *eltAddrLHS = builder.createTupleElementAddr(loc, lhsBufAccess, i);
       auto *eltAddrRHS = builder.createTupleElementAddr(loc, rhsBufAccess, i);
@@ -4241,8 +4027,8 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
     }
     return;
   }
-  case CotangentSpace::Kind::ProductStruct: {
-    auto *structDecl = cotangentSpace->getProductStruct();
+  case TangentSpace::Kind::ProductStruct: {
+    auto *structDecl = tangentSpace->getProductStruct();
     for (auto *field : structDecl->getStoredProperties()) {
       auto *eltAddrLHS =
           builder.createStructElementAddr(loc, lhsBufAccess, field);
@@ -4254,7 +4040,7 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
     }
     return;
   }
-  case CotangentSpace::Kind::Sum: {
+  case TangentSpace::Kind::Sum: {
     llvm_unreachable("Differentiating a sum type is not supported yet");
   }
   }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -134,10 +134,8 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
   }
 }
 
-extension Tensor : DifferentiableVectorNumeric
-  where ScalarElement : FloatingPoint {
-  public typealias Tangent = Tensor
-  public typealias Cotangent = Tensor
+extension Tensor : Differentiable where Scalar : FloatingPoint {
+  public typealias TangentVector = Tensor
 }
 
 public extension Tensor where Scalar : Numeric {

--- a/test/AutoDiff/simple_real_vector.swift
+++ b/test/AutoDiff/simple_real_vector.swift
@@ -1,10 +1,11 @@
 // RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
 
 @_fixed_layout
-public struct Vector : VectorNumeric {
+public struct Vector : VectorNumeric, Differentiable {
   public var x: Float
   public var y: Float
 
+  public typealias TangentVector = Vector
   public typealias ScalarElement = Float
   public typealias Dimensionality = ()
 


### PR DESCRIPTION
Three things in this patch:

1. Support general differentiable manifolds in differentiation API through a new `Differentiable` protocol. This enables user-define matrix types and differentiation of quantized networks. 
    ```swift
    public protocol Differentiable {
      /// The tangent vector space of this differentiable manifold.
      associatedtype TangentVector : VectorNumeric
        where TangentVector.ScalarElement : FloatingPoint

      /// Move `self` along the value space towards the given tangent vector. In
      /// Riemannian geometry (mathematics), this represents an exponential map.
      func moved(toward direction: TangentVector) -> Self
    }
    ```

   In `Differentiable`, `TangentVector` represents the tangent space of this manifold. This is the type of each elements in a Jacobian matrix. Note that mathematically reverse-mode automatic differentiation should produce cotangent vectors, but they are usually implicitly converted to tangent vectors since the cotangent space (`TangentVector -> ℝ`) is isomorphic to `TangentVector`. Method `moved(toward:)`, as explained in the doc comment, is used for (mathematical) optimization, and it is implemented as `+` when the type is also a vector space.

    `Differentiable` still won't generalize scalar differentiation, because we don't consider `FloatingPoint` a differentiable manifold. Scalar differentiation is treated separately in AD, and will hopefully be updated later.

2. Rename `swift::CotangentSpace` to `swift::TangentSpace` since we will be using `swift::TangentSpace` for both forward-mode AD and reverse-mode AD as explained above.
    Note: Since we don't consider `FloatingPoint` as differentiable manifold, it's a bit weird to call this data structure `TangentSpace`, and the name is too mathy for `ASTContext`. I'll rename it to something like `DerivativeClass` later.

3.  Move `swift::TangentSpace` from AD to `AutoDiff.h` and tangent space classification to `swift::ASTContext::getTangentSpace`. Sema will need this to type-check functions that are to be differentiated.