### PR TITLE
Fix sema for `@differentiable` and `@dynamicCallable`.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -942,6 +942,7 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *funcDecl, DeclContext *DC,
   //    `ExpressibleByStringLiteral`.
   //    `D.Value` and the return type can be arbitrary.
 
+  TC.validateDeclForNameLookup(funcDecl);
   auto paramList = funcDecl->getParameters();
   if (paramList->size() != 1 || paramList->get(0)->isVariadic()) return false;
   auto argType = paramList->get(0)->getType();
@@ -2540,10 +2541,9 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   };
 
   auto isValidAdjoint = [&](FuncDecl *adjointCandidate) {
-    // TENSORFLOW MERGE FIXME:
-    // `adjointCandidate->getInterfaceType()` returns null here.
-    auto adjointType = adjointCandidate
-        ->getInterfaceType()->getUnlabeledType(ctx);
+    TC.validateDeclForNameLookup(adjointCandidate);
+    auto adjointType = adjointCandidate->getInterfaceType()
+      ->getUnlabeledType(ctx);
     return adjointType->isEqual(expectedAdjointFnTy);
   };
 

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1829,6 +1829,7 @@ extension FloatingPoint {
   /// - Returns: The square root of the value.
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
+  @differentiable(reverse, wrt: (self), adjoint: _adjointSquareRoot)
   public func squareRoot( ) -> Self {
     var lhs = self
     lhs.formSquareRoot( )
@@ -1858,6 +1859,7 @@ extension FloatingPoint {
   /// - Returns: The product of `lhs` and `rhs`, added to this value.
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
+  @differentiable(reverse, wrt: (self, .0, .1), adjoint: _adjointAddingProduct)
   public func addingProduct(_ lhs: Self, _ rhs: Self) -> Self {
     var addend = self
     addend.addProduct(lhs, rhs)

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1717,6 +1717,7 @@ extension ${Self} {
 extension ${Self} {
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
+  @differentiable(reverse, adjoint: _adjointAdd)
   public static func + (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs += rhs
@@ -1725,6 +1726,7 @@ extension ${Self} {
 
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
+  @differentiable(reverse, adjoint: _adjointSubtract)
   public static func - (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs -= rhs
@@ -1733,6 +1735,7 @@ extension ${Self} {
 
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
+  @differentiable(reverse, adjoint: _adjointMultiply)
   public static func * (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs *= rhs
@@ -1741,6 +1744,7 @@ extension ${Self} {
 
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
+  @differentiable(reverse, adjoint: _adjointDivide)
   public static func / (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs /= rhs


### PR DESCRIPTION
The following commit reduced the number of declaration validations: https://github.com/apple/swift/commit/5e0a7fdab9117ae0fb1fd03085026a6be7c91076

This makes it necessary to call `TC.validateDeclForNameLookup` in some places.

Readd `@differentiable` to floating-point methods.