### PR TITLE
More backwards-deployment test fixes

### DIFF
--- a/test/SILGen/tsan_instrumentation.swift
+++ b/test/SILGen/tsan_instrumentation.swift
@@ -1,6 +1,10 @@
 // RUN: %target-swift-emit-silgen -sanitize=thread %s | %FileCheck %s
 // REQUIRES: tsan_runtime
 
+// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
+// don't support TSan.
+// UNSUPPORTED: remote_run
+
 func takesInout(_ p: inout Int) { }
 func takesInout(_ p: inout MyStruct) { }
 

--- a/test/Sanitizers/tsan-norace-block-release.swift
+++ b/test/Sanitizers/tsan-norace-block-release.swift
@@ -5,6 +5,10 @@
 // REQUIRES: objc_interop
 // REQUIRES: tsan_runtime
 
+// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
+// don't support TSan.
+// UNSUPPORTED: remote_run
+
 // Test that we do not report a race on block release operation.
 import Foundation
 

--- a/test/Sanitizers/tsan-norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan-norace-deinit-run-time.swift
@@ -5,6 +5,10 @@
 // REQUIRES: objc_interop
 // REQUIRES: tsan_runtime
 
+// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
+// don't support TSan.
+// UNSUPPORTED: remote_run
+
 // Test that we do not report a race on deinit; the synchronization is guaranteed by runtime.
 import Foundation
 

--- a/test/Sanitizers/tsan-static-exclusivity.swift
+++ b/test/Sanitizers/tsan-static-exclusivity.swift
@@ -1,6 +1,10 @@
 // RUN: %target-swift-frontend -enforce-exclusivity=checked -sanitize=thread -emit-sil -primary-file %s -o /dev/null -verify
 // REQUIRES: tsan_runtime
 
+// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
+// don't support TSan.
+// UNSUPPORTED: remote_run
+
 
 struct OtherStruct {
   mutating

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -5,6 +5,10 @@
 // REQUIRES: tsan_runtime
 // UNSUPPORTED: OS=tvos
 
+// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
+// don't support TSan.
+// UNSUPPORTED: remote_run
+
 // https://bugs.swift.org/browse/SR-6622
 // XFAIL: linux
 

--- a/test/stdlib/MapKit.swift
+++ b/test/stdlib/MapKit.swift
@@ -21,7 +21,9 @@ func spansEqual(_ x: MKCoordinateSpan, _ y: MKCoordinateSpan)
 
 if #available(tvOS 9.2, *) {
   mapKit.test("NSValue bridging")
-    .skip(.iOSMinor(9, 3, reason: "<rdar://problem/41440036>")).code {
+      .xfail(.iOSMinor(9, 3, reason: "<rdar://problem/41440036>"))
+      .xfail(.osxMinorRange(10, 9...10, reason: "<rdar://problem/44866579>"))
+      .code {
     expectBridgeToNSValue(CLLocationCoordinate2D(latitude: 17, longitude: 38),
                           nsValueInitializer: { NSValue(mkCoordinate: $0) },
                           nsValueGetter: { $0.mkCoordinateValue },

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -15,7 +15,8 @@
 // RUN: %target-clang %S/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m -c -o %t/SwiftObjectNSObject.o -g
 // RUN: %target-build-swift %s -I %S/Inputs/SwiftObjectNSObject/ -Xlinker %t/SwiftObjectNSObject.o -o %t/SwiftObjectNSObject
 // RUN: %target-codesign %t/SwiftObjectNSObject
-// RUN: %target-run %t/SwiftObjectNSObject 2>&1 | %FileCheck %s
+// RUN: %target-run %t/SwiftObjectNSObject 2> %t/log.txt
+// RUN: %FileCheck %s < %t/log.txt
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop

--- a/test/stdlib/TestLocale.swift
+++ b/test/stdlib/TestLocale.swift
@@ -94,7 +94,9 @@ class TestLocale : TestLocaleSuper {
         
         expectEqual(".", locale.decimalSeparator)
         expectEqual(",", locale.groupingSeparator)
-        expectEqual("HK$", locale.currencySymbol)
+        if #available(macOS 10.11, *) {
+          expectEqual("HK$", locale.currencySymbol)
+        }
         expectEqual("HKD", locale.currencyCode)
         
         expectTrue(Locale.availableIdentifiers.count > 0)


### PR DESCRIPTION
Tweak or disable a handful of tests when using remote-run to test on older OSs.

rdar://problem/44802353
rdar://problem/44866579