### PR TITLE
[CodeCompletion] Pre-remove argument labels from function types

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -973,6 +973,7 @@ calculateTypeRelationForDecl(const Decl *D, Type ExpectedType,
         !IsImplicitlyCurriedInstanceMethod)
       funcType = funcType->getResult()->getAs<AnyFunctionType>();
     if (funcType) {
+      funcType = funcType->removeArgumentLabels(1)->castTo<AnyFunctionType>();
       auto relation = calculateTypeRelation(funcType, ExpectedType, DC);
       if (UseFuncResultType)
         relation =

--- a/test/IDE/complete_func_reference.swift
+++ b/test/IDE/complete_func_reference.swift
@@ -122,7 +122,7 @@ do {
 }
 
 // ANY_INT: Begin completions
-// ANY_INT-DAG: Decl{{.*}}:      anyToInt({#a: Any#})[#Int#]; name=anyToInt(a: Any)
+// ANY_INT_DAG: Decl{{.*}}/TypeRelation[Identical]: anyToInt(a:); name=anyToInt(a:)
 // ANY_INT-DAG: Decl{{.*}}/NotRecommended/TypeRelation[Invalid]: intToVoid({#a: Int#})[#Void#];
 // ANY_INT-DAG: Decl{{.*}}/NotRecommended/TypeRelation[Invalid]: anyToVoid({#a: Any#})[#Void#];
 // ANY_INT-DAG: Decl{{.*}}/NotRecommended/TypeRelation[Invalid]: voidToVoid()[#Void#];
@@ -135,7 +135,7 @@ do {
 // ANY_INT: End completions
 
 // ANY_INT_STATIC_CURRY: Begin completions
-// ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal:   anyToInt({#self: S0#})[#(a: Any) -> Int#]; name=anyToInt(S0)
+// ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: anyToInt({#self: S0#})[#(a: Any) -> Int#];
 // ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: voidToVoid({#self: S0#})[#() -> Void#];
 // ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: intToVoid({#self: S0#})[#(a: Int) -> Void#];
 // ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: anyToVoid({#self: S0#})[#(a: Any) -> Void#];
@@ -153,12 +153,12 @@ do {
 }
 
 // INT_ANY: Begin completions
-// INT_ANY-DAG: Decl{{.*}}:      intToAny({#a: Int#})[#Any#]; name=intToAny(a: Int)
-// INT_ANY-DAG: Decl{{.*}}:      intToInt({#a: Int#})[#Int#]; name=intToInt(a: Int)
-// INT_ANY-DAG: Decl{{.*}}:      intToVoid({#a: Int#})[#Void#]; name=intToVoid(a: Int)
-// INT_ANY-DAG: Decl{{.*}}:      anyToAny({#a: Any#})[#Any#]; name=anyToAny(a: Any)
-// INT_ANY-DAG: Decl{{.*}}:      anyToInt({#a: Any#})[#Int#]; name=anyToInt(a: Any)
-// INT_ANY-DAG: Decl{{.*}}:      anyToVoid({#a: Any#})[#Void#]; name=anyToVoid(a: Any)
+// INT_ANY-DAG: Decl{{.*}}/TypeRelation[Identical]: intToAny(a:);
+// INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: intToInt(a:);
+// INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: intToVoid(a:);
+// INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: anyToAny(a:);
+// INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: anyToInt(a:);
+// INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: anyToVoid(a:);
 // INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: returnsIntToInt()[#(Int) -> Int#];
 // INT_ANY-DAG: Decl{{.*}}/NotRecommended/TypeRelation[Invalid]: voidToVoid()[#Void#];
 // INT_ANY-DAG: Decl{{.*}}:      voidToInt()[#Int#];
@@ -166,12 +166,12 @@ do {
 // INT_ANY: End completions
 
 // INT_ANY_STATIC_CURRY: Begin completions
-// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal:   intToInt({#self: S0#})[#(a: Int) -> Int#]; name=intToInt(S0)
-// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: intToVoid({#self: S0#})[#(a: Int) -> Void#]; name=intToVoid(S0)
-// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal:   anyToAny({#self: S0#})[#(a: Any) -> Any#]; name=anyToAny(S0)
-// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: anyToVoid({#self: S0#})[#(a: Any) -> Void#]; name=anyToVoid(S0)
-// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal:   intToAny({#self: S0#})[#(a: Int) -> Any#]; name=intToAny(S0)
-// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal:   anyToInt({#self: S0#})[#(a: Any) -> Int#]; name=anyToInt(S0)
+// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: intToInt({#self: S0#})[#(a: Int) -> Int#];
+// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: intToVoid({#self: S0#})[#(a: Int) -> Void#];
+// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: anyToAny({#self: S0#})[#(a: Any) -> Any#];
+// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: anyToVoid({#self: S0#})[#(a: Any) -> Void#];
+// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: intToAny({#self: S0#})[#(a: Int) -> Any#];
+// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: anyToInt({#self: S0#})[#(a: Any) -> Int#];
 // INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: returnsIntToInt({#self: S0#})[#() -> (Int) -> Int#];
 // INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal:   voidToAny({#self: S0#})[#() -> Any#];
 // INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal:   voidToInt({#self: S0#})[#() -> Int#];


### PR DESCRIPTION
before checking type relation between candidate types and expected types. In normal compilation, this removal is done in `CSGen`. However, since code-completion directly uses Constraint System, we have to manually remove argument labels before checking convertibility.

We can remove argument labels unconditionally because function types as value cannot have argument labels. (i.e. `var fn: (a: Int) -> Int` is illegal). That means, expected types shouldn't have any argument labels.

This fixes regression revealed in 5e75b1ad3b8a5287d46c3aeb4e326e1c4e268ba4
rdar://problem/41496748
