### PR TITLE
[stdlib] Dictionary.merge: Don’t leave storage in an inconsistent state when closure throws

### DIFF
--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -613,9 +613,8 @@ extension _NativeDictionary { // High-level operations
       isUnique = true
       if found {
         do {
-          let v = (_values + bucket.offset).move()
-          let newValue = try combine(v, value)
-          (_values + bucket.offset).initialize(to: newValue)
+          let newValue = try combine(uncheckedValue(at: bucket), value)
+          _values[bucket.offset] = newValue
         } catch _MergeError.keyCollision {
           fatalError("Duplicate values for key: '\(key)'")
         }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -734,6 +734,30 @@ DictionaryTestSuite.test("COW.Fast.MergeDictionaryDoesNotReallocate")
   }
 }
 
+
+DictionaryTestSuite.test("Merge.ThrowingIsSafe") {
+  var d: [TestKeyTy: TestValueTy] = [
+    TestKeyTy(10): TestValueTy(1),
+    TestKeyTy(20): TestValueTy(2),
+    TestKeyTy(30): TestValueTy(3),
+  ]
+
+  let d2: [TestKeyTy: TestValueTy] = [
+    TestKeyTy(40): TestValueTy(4),
+    TestKeyTy(50): TestValueTy(5),
+    TestKeyTy(10): TestValueTy(1),
+  ]
+
+  struct TE: Error {}
+  do {
+    // Throwing must not leave the dictionary in an inconsistent state.
+    try d.merge(d2) { v1, v2 in throw TE() }
+    expectTrue(false, "merge did not throw")
+  } catch {
+    expectTrue(error is TE)
+  }
+}
+
 DictionaryTestSuite.test("COW.Fast.DefaultedSubscriptDoesNotReallocate") {
   do {
     var d1 = getCOWFastDictionary()


### PR DESCRIPTION
The new merge implementation leaves behind an uninitialized value when the uniquing closure throws.