### PR TITLE
SourceKit: libdispatch swift requires swift stdlib

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -93,6 +93,12 @@ include_directories(BEFORE
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   set(SOURCEKIT_DEFAULT_TARGET_SDK "LINUX")
   if(SWIFT_BUILD_SOURCEKIT)
+    if(SWIFT_BUILD_STDLIB)
+      set(SOURCEKIT_LIBDISPATCH_ENABLE_SWIFT YES)
+    else()
+      set(SOURCEKIT_LIBDISPATCH_ENABLE_SWIFT NO)
+    endif()
+
     include(ExternalProject)
     ExternalProject_Add(libdispatch
                         SOURCE_DIR
@@ -106,7 +112,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                           -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
                           -DCMAKE_SWIFT_COMPILER=$<TARGET_FILE:swift>c
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                          -DENABLE_SWIFT=YES
+                          -DENABLE_SWIFT=${SOURCEKIT_LIBDISPATCH_ENABLE_SWIFT}
                         BUILD_BYPRODUCTS
                           ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
                           ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_STATIC_LIBRARY_PREFIX}BlocksRuntime${CMAKE_STATIC_LIBRARY_SUFFIX}
@@ -126,13 +132,16 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     include_directories(AFTER
                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime
                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
-    add_dependencies(libdispatch
-                       swift
-                       copy_shim_headers
-                       swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
-                       swiftSwiftOnoneSupport-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
-                       swiftCore-swiftmodule-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
-                       swiftSwiftOnoneSupport-swiftmodule-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+
+    if(SWIFT_BUILD_STDLIB)
+      add_dependencies(libdispatch
+                         swift
+                         copy_shim_headers
+                         swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
+                         swiftSwiftOnoneSupport-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
+                         swiftCore-swiftmodule-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}
+                         swiftSwiftOnoneSupport-swiftmodule-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+    endif()
   endif()
 
   ExternalProject_Get_Property(libdispatch install_dir)
@@ -142,9 +151,13 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                           IMPORTED_LOCATION
                             ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
                           INTERFACE_INCLUDE_DIRECTORIES
-                            ${install_dir}/include
-                          IMPORTED_LINK_INTERFACE_LIBRARIES
-                            swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+                            ${install_dir}/include)
+  if(SWIFT_BUILD_STDLIB)
+    set_target_properties(dispatch
+                          PROPERTIES
+                            IMPORTED_LINK_INTERFACE_LIBRARIES
+                              swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+  endif()
 
   add_library(BlocksRuntime STATIC IMPORTED)
   set_target_properties(BlocksRuntime


### PR DESCRIPTION
When building libdispatch for SourceKit, only enable the swift overlay
components if the swift standard library is being built.  This allows building
just the compiler and SourceKit.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
