### PR TITLE
SR-7724: Build SourceKit libdispatch into its own directory

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -96,28 +96,33 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     ExternalProject_Add(libdispatch
                         SOURCE_DIR
                           "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}"
-                        BINARY_DIR
-                          "${SWIFT_PATH_TO_LIBDISPATCH_BUILD}"
                         CMAKE_ARGS
                           -DCMAKE_C_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang
                           -DCMAKE_CXX_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang++
                           -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+                          -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                           -DCMAKE_SWIFT_COMPILER=$<TARGET_FILE:swift>c
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                           -DENABLE_SWIFT=YES
+                          -DENABLE_TESTING=NO
+                        BUILD_COMMAND
+                            ${CMAKE_COMMAND} --build <BINARY_DIR> --target install
                         BUILD_BYPRODUCTS
-                          ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
-                          ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_STATIC_LIBRARY_PREFIX}BlocksRuntime${CMAKE_STATIC_LIBRARY_SUFFIX}
+                          <BINARY_DIR>/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
+                          <INSTALL_DIR>/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
+                          <INSTALL_DIR>/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}/Dispatch.swiftmodule
+                          <INSTALL_DIR>/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}/Dispatch.swiftdoc
+                        INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Finished building libdispatch for SourceKit"
                         STEP_TARGETS
-                          configure
-                        BUILD_ALWAYS
-                          1)
+                          configure build
+                        )
 
     # CMake does not like the addition of INTERFACE_INCLUDE_DIRECTORIES without
     # the directory existing.  Just create the location which will be populated
     # during the installation.
     ExternalProject_Get_Property(libdispatch install_dir)
     file(MAKE_DIRECTORY ${install_dir}/include)
+    ExternalProject_Get_Property(libdispatch binary_dir)
 
     # TODO(compnerd) this should be taken care of by the
     # INTERFACE_INCLUDE_DIRECTORIES below
@@ -138,19 +143,11 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   set_target_properties(dispatch
                         PROPERTIES
                           IMPORTED_LOCATION
-                            ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
+                            ${install_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
                           INTERFACE_INCLUDE_DIRECTORIES
                             ${install_dir}/include
                           IMPORTED_LINK_INTERFACE_LIBRARIES
                             swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
-
-  add_library(BlocksRuntime STATIC IMPORTED)
-  set_target_properties(BlocksRuntime
-                        PROPERTIES
-                          IMPORTED_LOCATION
-                            ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_STATIC_LIBRARY_PREFIX}BlocksRuntime${CMAKE_STATIC_LIBRARY_SUFFIX}
-                          INTERFACE_INCLUDE_DIRECTORIES
-                            ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
 
   set(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH TRUE)
 endif()

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -70,15 +70,6 @@ function(add_sourcekit_default_compiler_flags target)
     # TODO(compnerd) this should really use target_compile_options but the use
     # of keyword and non-keyword flags prevents this
     list(APPEND c_compile_flags "-fblocks")
-    # TODO(compnerd) this should really use target_link_libraries but the use of
-    # explicit_llvm_config using target_link_libraries without keywords on
-    # executables causes conflicts here
-    list(APPEND link_flags "-L${SWIFT_PATH_TO_LIBDISPATCH_BUILD}")
-    list(APPEND link_flags "-lBlocksRuntime")
-    # NOTE(compnerd) since we do not use target_link_libraries, we do not get
-    # the implicit dependency tracking.  Add an explicit dependency until we can
-    # use target_link_libraries.
-    add_dependencies(${target} BlocksRuntime)
   endif()
 
   # Convert variables to space-separated strings.

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2561,11 +2561,6 @@ for host in "${ALL_HOSTS[@]}"; do
                   continue
                 ;;
                 *)
-                  # FIXME: Always re-build libdispatch on non-darwin platforms.
-                  # Remove this when products build in the CMake system.
-                  echo "Cleaning the libdispatch build directory"
-                  call rm -rf "${LIBDISPATCH_BUILD_DIR}"
-
                   cmake_options=(
                     ${cmake_options[@]}
                     -DCMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"


### PR DESCRIPTION
This is a partial fix for https://bugs.swift.org/browse/SR-7724. It changes the Swift build system to place the libdispatch that SourceKit is linked to in a different directory. This is still not ideal (SourceKit should link the same version of dispatch swift apps will link at runtime) but there's a dependency cycle between swift and corelibs-libdispatch (at least the way build-script is currently structured). A future change can  reduce the number of dispatch build directories from 2 to 1. This change is still valuable because it restores the ability to incrementally build libdispatch when calling build-script.

Partially resolves [SR-7724](https://bugs.swift.org/browse/SR-7724).