### PR TITLE
SourceKit: hoist decision for building InProc

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -34,6 +34,11 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND NOT CMAKE_CROSSCOMPILING)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "")
 endif()
 
+# If we were don't have XPC, just build inproc.
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND NOT HAVE_XPC_H)
+  set(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY TRUE)
+endif()
+
 # Now include AddSwiftSourceKit
 include(AddSwiftSourceKit)
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -1,7 +1,3 @@
-# If we were going to build for APPLE but don't have XPC, just build inproc.
-if(APPLE AND NOT HAVE_XPC_H)
-  set(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY TRUE)
-endif()
 
 set(sourcekitdAPI_sources
   CodeCompletionResultsArray.cpp


### PR DESCRIPTION
The decision to whether build InProc or as an XPC service is needed for the
test tools as well.  Rather than recompute it for the tests as well, hoist it to
the top level for the SourceKit project.  This repairs the build of the
SourceKit tests on non-Darwin hosts.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
