### PR TITLE
Improve the behavior of the custom @objc name in the available attribute when generates ObjC headers

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -936,24 +936,8 @@ private:
         if (!specificTypeLookup.getSingleTypeResult()) {
           return nullptr;
         }
-
-        if (typeDecl->getDeclaredInterfaceType()->matches(
-                specificTypeLookup.getSingleTypeResult()
-                    ->getDeclaredInterfaceType(),
-                TypeMatchFlags::AllowOverride)) {
-          // If the Context Name contain the name of the subclass then we would
-          // find the renamed in the superclass instead
-          typeDecl = specificTypeLookup.getSingleTypeResult();
-        } else if (!specificTypeLookup.getSingleTypeResult()
-                        ->getDeclaredInterfaceType()
-                        ->matches(typeDecl->getDeclaredInterfaceType(),
-                                  TypeMatchFlags::AllowOverride)) {
-          // Failed and print the raw renamed attributed when there is no
-          // relationship between those 2 types
-          return nullptr;
-        }
       }
-
+        
       const ValueDecl *renamedDecl = nullptr;
       SmallVector<ValueDecl *, 4> lookupResults;
       declContext->lookupQualified(typeDecl, renamedDeclName,
@@ -978,8 +962,7 @@ private:
           for (auto index : indices(*cParams)) {
             auto cParamsType = cParams->get(index)->getType();
             auto dParamsType = dParams->get(index)->getType();
-            if (!cParamsType->matchesParameter(dParamsType,
-                                               TypeMatchFlags::AllowOverride)) {
+            if (!cParamsType->matchesParameter(dParamsType, TypeMatchOptions())) {
               hasSameParameterTypes = false;
               break;
             }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -956,9 +956,9 @@ private:
              cast<ValueDecl>(D)->isInstanceMember()))
           continue;
         
-        if (isa<FuncDecl>(candidate)) {
-          auto cParams = cast<FuncDecl>(candidate)->getParameters();
-          auto dParams = cast<FuncDecl>(D)->getParameters();
+        if (isa<AbstractFunctionDecl>(candidate)) {
+          auto cParams = cast<AbstractFunctionDecl>(candidate)->getParameters();
+          auto dParams = cast<AbstractFunctionDecl>(D)->getParameters();
           
           if (cParams->size() != dParams->size())
             continue;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -915,7 +915,8 @@ private:
   
   const ValueDecl *getRenameDecl(const ValueDecl *D, const ParsedDeclName renamedParsedDeclName) {
     auto declContext = D->getDeclContext();
-    auto renamedDeclName = renamedParsedDeclName.formDeclName(D->getASTContext());
+    ASTContext &astContext = D->getASTContext();
+    auto renamedDeclName = renamedParsedDeclName.formDeclName(astContext);
     
     if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D)) {
       UnqualifiedLookup lookup(renamedDeclName.getBaseIdentifier(),
@@ -928,7 +929,7 @@ private:
       TypeDecl *typeDecl = declContext->getSelfNominalTypeDecl();
       
       if (!renamedParsedDeclName.ContextName.empty()) {
-        auto contextIdentifier = D->getASTContext().getIdentifier(renamedParsedDeclName.ContextName);
+        auto contextIdentifier = astContext.getIdentifier(renamedParsedDeclName.ContextName);
         UnqualifiedLookup specificTypeLookup(contextIdentifier,
                                              declContext->getModuleScopeContext(),
                                              nullptr,

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -971,11 +971,9 @@ private:
           
           bool hasSameParameterTypes = true;
           for (auto index : indices(*cParams)) {
-            TypeMatchOptions matchMode = TypeMatchFlags::AllowOverride;
-            matchMode |= TypeMatchFlags::AllowTopLevelOptionalMismatch;
             auto cParamsType = cParams->get(index)->getType();
             auto dParamsType = dParams->get(index)->getType();
-            if (!cParamsType->matchesParameter(dParamsType, matchMode)) {
+            if (!cParamsType->matchesParameter(dParamsType, TypeMatchFlags::AllowOverride)) {
               hasSameParameterTypes = false;
               break;
             }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -967,8 +967,11 @@ private:
           
           bool hasSameParameterTypes = true;
           for (auto index : indices(*cParams)) {
-            if (cParams->get(index)->getType()->getCanonicalType() !=
-                dParams->get(index)->getType()->getCanonicalType()) {
+            TypeMatchOptions matchMode = TypeMatchFlags::AllowOverride;
+            matchMode |= TypeMatchFlags::AllowTopLevelOptionalMismatch;
+            auto cParamsType = cParams->get(index)->getType();
+            auto dParamsType = dParams->get(index)->getType();
+            if (!cParamsType->matchesParameter(dParamsType, matchMode)) {
               hasSameParameterTypes = false;
               break;
             }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -137,7 +137,7 @@ namespace {
 using DelayedMemberSet = llvm::SmallSetVector<const ValueDecl *, 32>;
 
 class ObjCPrinter : private DeclVisitor<ObjCPrinter>,
-                    private TypeVisitor<ObjCPrinter, void, 
+                    private TypeVisitor<ObjCPrinter, void,
                                         Optional<OptionalTypeKind>>
 {
   friend ASTVisitor;
@@ -528,7 +528,7 @@ private:
     return sel.getNumArgs() == 0 &&
            sel.getSelectorPieces().front().str() == "init";
   }
-                                          
+  
   void printAbstractFunctionAsMethod(AbstractFunctionDecl *AFD,
                                      bool isClassMethod,
                                      bool isNSUIntegerSubscript = false) {
@@ -553,7 +553,7 @@ private:
     auto resultTy = getForeignResultType(AFD, methodTy, errorConvention);
 
     // Constructors and methods returning DynamicSelf return
-    // instancetype.    
+    // instancetype.
     if (isa<ConstructorDecl>(AFD) ||
         (isa<FuncDecl>(AFD) && cast<FuncDecl>(AFD)->hasDynamicSelf())) {
       if (errorConvention && errorConvention->stripsResultOptionality()) {
@@ -774,8 +774,8 @@ private:
     No = false,
     Yes = true
   };
- 
-    /// Returns \c true if anything was printed.
+
+  /// Returns \c true if anything was printed.
   bool printAvailability(const Decl *D, PrintLeadingSpace printLeadingSpace =
                                             PrintLeadingSpace::Yes) {
     bool hasPrintedAnything = false;
@@ -928,14 +928,15 @@ private:
                                UnqualifiedLookup::Flags::TypeLookup);
       return lookup.getSingleTypeResult();
     }
-    
+
     TypeDecl *typeDecl = declContext->getSelfNominalTypeDecl();
-    
+
     const ValueDecl *renamedDecl = nullptr;
     SmallVector<ValueDecl *, 4> lookupResults;
-    declContext->lookupQualified(typeDecl->getDeclaredInterfaceType(), renamedDeclName,
-                                 NL_QualifiedDefault, nullptr, lookupResults);
-    
+    declContext->lookupQualified(typeDecl->getDeclaredInterfaceType(),
+                                 renamedDeclName, NL_QualifiedDefault, nullptr,
+                                 lookupResults);
+
     if (lookupResults.size() == 1) {
       auto candidate = lookupResults[0];
       if (!shouldInclude(candidate))
@@ -944,40 +945,41 @@ private:
           (candidate->isInstanceMember() !=
            cast<ValueDecl>(D)->isInstanceMember()))
         return nullptr;
-      
+
       renamedDecl = candidate;
     } else {
       for (auto candidate : lookupResults) {
         if (!shouldInclude(candidate))
           continue;
-        
+
         if (candidate->getKind() != D->getKind() ||
             (candidate->isInstanceMember() !=
              cast<ValueDecl>(D)->isInstanceMember()))
           continue;
-        
+
         if (isa<AbstractFunctionDecl>(candidate)) {
           auto cParams = cast<AbstractFunctionDecl>(candidate)->getParameters();
           auto dParams = cast<AbstractFunctionDecl>(D)->getParameters();
-          
+
           if (cParams->size() != dParams->size())
             continue;
-          
+
           bool hasSameParameterTypes = true;
           for (auto index : indices(*cParams)) {
             auto cParamsType = cParams->get(index)->getType();
             auto dParamsType = dParams->get(index)->getType();
-            if (!cParamsType->matchesParameter(dParamsType, TypeMatchOptions())) {
+            if (!cParamsType->matchesParameter(dParamsType,
+                                               TypeMatchOptions())) {
               hasSameParameterTypes = false;
               break;
             }
           }
-          
+
           if (!hasSameParameterTypes) {
             continue;
           }
         }
-        
+
         if (renamedDecl) {
           // If we found a duplicated candidate then we would silently fail.
           renamedDecl = nullptr;
@@ -993,7 +995,7 @@ private:
                           bool includeQuotes) {
     assert(!AvAttr->Rename.empty());
 
-    const swift::ValueDecl *renamedDecl =
+    const ValueDecl *renamedDecl =
         getRenameDecl(D, parseDeclName(AvAttr->Rename));
 
     if (renamedDecl) {
@@ -1005,7 +1007,7 @@ private:
       printEncodedString(AvAttr->Rename, includeQuotes);
     }
   }
-    
+
   void printSwift3ObjCDeprecatedInference(ValueDecl *VD) {
     const LangOptions &langOpts = M.getASTContext().LangOpts;
     if (!langOpts.EnableSwift3ObjCInference ||
@@ -1514,9 +1516,9 @@ private:
       MAP(UnsafeMutableRawPointer, "void *", true);
 
       Identifier ID_ObjectiveC = ctx.Id_ObjectiveC;
-      specialNames[{ID_ObjectiveC, ctx.getIdentifier("ObjCBool")}] 
+      specialNames[{ID_ObjectiveC, ctx.getIdentifier("ObjCBool")}]
         = { "BOOL", false};
-      specialNames[{ID_ObjectiveC, ctx.getIdentifier("Selector")}] 
+      specialNames[{ID_ObjectiveC, ctx.getIdentifier("Selector")}]
         = { "SEL", true };
       specialNames[{ID_ObjectiveC,
                     ctx.getIdentifier(
@@ -1643,7 +1645,7 @@ private:
     os << clangDecl->getKindName() << " ";
   }
 
-  void visitStructType(StructType *ST, 
+  void visitStructType(StructType *ST,
                        Optional<OptionalTypeKind> optionalKind) {
     const StructDecl *SD = ST->getStructOrBoundGenericStruct();
 
@@ -1867,7 +1869,7 @@ private:
     visitExistentialType(PT, optionalKind, /*isMetatype=*/false);
   }
 
-  void visitProtocolCompositionType(ProtocolCompositionType *PCT, 
+  void visitProtocolCompositionType(ProtocolCompositionType *PCT,
                                     Optional<OptionalTypeKind> optionalKind) {
     visitExistentialType(PCT, optionalKind, /*isMetatype=*/false);
   }
@@ -1878,7 +1880,7 @@ private:
     visitExistentialType(instanceTy, optionalKind, /*isMetatype=*/true);
   }
 
-  void visitMetatypeType(MetatypeType *MT, 
+  void visitMetatypeType(MetatypeType *MT,
                          Optional<OptionalTypeKind> optionalKind) {
     Type instanceTy = MT->getInstanceType();
     if (auto classTy = instanceTy->getAs<ClassType>()) {
@@ -1913,7 +1915,7 @@ private:
     os << cast<clang::ObjCTypeParamDecl>(decl->getClangDecl())->getName();
     printNullability(optionalKind);
   }
-                      
+    
   void printFunctionType(FunctionType *FT, char pointerSigil,
                          Optional<OptionalTypeKind> optionalKind) {
     visitPart(FT->getResult(), OTK_None);
@@ -1922,7 +1924,7 @@ private:
     openFunctionTypes.push_back(FT);
   }
 
-  void visitFunctionType(FunctionType *FT, 
+  void visitFunctionType(FunctionType *FT,
                          Optional<OptionalTypeKind> optionalKind) {
     switch (FT->getRepresentation()) {
     case AnyFunctionType::Representation::Thin:
@@ -1966,18 +1968,18 @@ private:
     visitPart(PT->getSinglyDesugaredType(), optionalKind);
   }
 
-  void visitSyntaxSugarType(SyntaxSugarType *SST, 
+  void visitSyntaxSugarType(SyntaxSugarType *SST,
                             Optional<OptionalTypeKind> optionalKind) {
     visitPart(SST->getSinglyDesugaredType(), optionalKind);
   }
 
-  void visitDynamicSelfType(DynamicSelfType *DST, 
+  void visitDynamicSelfType(DynamicSelfType *DST,
                             Optional<OptionalTypeKind> optionalKind) {
     printNullability(optionalKind, NullabilityPrintKind::ContextSensitive);
     os << "instancetype";
   }
 
-  void visitReferenceStorageType(ReferenceStorageType *RST, 
+  void visitReferenceStorageType(ReferenceStorageType *RST,
                                  Optional<OptionalTypeKind> optionalKind) {
     visitPart(RST->getReferentType(), optionalKind);
   }
@@ -2015,7 +2017,7 @@ private:
   /// finishFunctionType()). If only a part of a type is being printed, use
   /// visitPart().
 public:
-  void print(Type ty, Optional<OptionalTypeKind> optionalKind, 
+  void print(Type ty, Optional<OptionalTypeKind> optionalKind,
              Identifier name = Identifier(),
              IsFunctionParam_t isFuncParam = IsNotFunctionParam) {
     PrettyStackTraceType trace(M.getASTContext(), "printing", ty);
@@ -2867,9 +2869,9 @@ public:
       // FIXME: This will end up taking linear time.
       auto lhsMembers = cast<ExtensionDecl>(*lhs)->getMembers();
       auto rhsMembers = cast<ExtensionDecl>(*rhs)->getMembers();
-      unsigned numLHSMembers = std::distance(lhsMembers.begin(), 
+      unsigned numLHSMembers = std::distance(lhsMembers.begin(),
                                              lhsMembers.end());
-      unsigned numRHSMembers = std::distance(rhsMembers.begin(), 
+      unsigned numRHSMembers = std::distance(rhsMembers.begin(),
                                              rhsMembers.end());
       if (numLHSMembers != numRHSMembers)
         return numLHSMembers < numRHSMembers ? Descending : Ascending;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -774,17 +774,17 @@ private:
     No = false,
     Yes = true
   };
-
-  /// Returns \c true if anything was printed.
+ 
+    /// Returns \c true if anything was printed.
   bool printAvailability(const Decl *D, PrintLeadingSpace printLeadingSpace =
-                         PrintLeadingSpace::Yes) {
+                                            PrintLeadingSpace::Yes) {
     bool hasPrintedAnything = false;
     auto maybePrintLeadingSpace = [&] {
       if (printLeadingSpace == PrintLeadingSpace::Yes || hasPrintedAnything)
         os << " ";
       hasPrintedAnything = true;
     };
-    
+
     for (auto AvAttr : D->getAttrs().getAttributes<AvailableAttr>()) {
       if (AvAttr->Platform == PlatformKind::none) {
         if (AvAttr->PlatformAgnostic ==
@@ -794,8 +794,8 @@ private:
             // rename
             maybePrintLeadingSpace();
             os << "SWIFT_UNAVAILABLE_MSG(\"'"
-            << cast<ValueDecl>(D)->getBaseName()
-            << "' has been renamed to '";
+               << cast<ValueDecl>(D)->getBaseName()
+               << "' has been renamed to '";
             printRenameForDecl(AvAttr, cast<ValueDecl>(D), false);
             os << '\'';
             if (!AvAttr->Message.empty()) {
@@ -831,7 +831,7 @@ private:
         }
         continue;
       }
-      
+
       // Availability for a specific platform
       if (!AvAttr->Introduced.hasValue() && !AvAttr->Deprecated.hasValue() &&
           !AvAttr->Obsoleted.hasValue() &&
@@ -839,37 +839,37 @@ private:
           !AvAttr->isUnconditionallyUnavailable()) {
         continue;
       }
-      
+
       const char *plat;
       switch (AvAttr->Platform) {
-        case PlatformKind::OSX:
-          plat = "macos";
-          break;
-        case PlatformKind::iOS:
-          plat = "ios";
-          break;
-        case PlatformKind::tvOS:
-          plat = "tvos";
-          break;
-        case PlatformKind::watchOS:
-          plat = "watchos";
-          break;
-        case PlatformKind::OSXApplicationExtension:
-          plat = "macos_app_extension";
-          break;
-        case PlatformKind::iOSApplicationExtension:
-          plat = "ios_app_extension";
-          break;
-        case PlatformKind::tvOSApplicationExtension:
-          plat = "tvos_app_extension";
-          break;
-        case PlatformKind::watchOSApplicationExtension:
-          plat = "watchos_app_extension";
-          break;
-        case PlatformKind::none:
-          llvm_unreachable("handled above");
+      case PlatformKind::OSX:
+        plat = "macos";
+        break;
+      case PlatformKind::iOS:
+        plat = "ios";
+        break;
+      case PlatformKind::tvOS:
+        plat = "tvos";
+        break;
+      case PlatformKind::watchOS:
+        plat = "watchos";
+        break;
+      case PlatformKind::OSXApplicationExtension:
+        plat = "macos_app_extension";
+        break;
+      case PlatformKind::iOSApplicationExtension:
+        plat = "ios_app_extension";
+        break;
+      case PlatformKind::tvOSApplicationExtension:
+        plat = "tvos_app_extension";
+        break;
+      case PlatformKind::watchOSApplicationExtension:
+        plat = "watchos_app_extension";
+        break;
+      case PlatformKind::none:
+        llvm_unreachable("handled above");
       }
-      
+
       maybePrintLeadingSpace();
       os << "SWIFT_AVAILABILITY(" << plat;
       if (AvAttr->isUnconditionallyUnavailable()) {
@@ -895,7 +895,7 @@ private:
       }
       if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
         os << ",message=\"'" << cast<ValueDecl>(D)->getBaseName()
-        << "' has been renamed to '";
+           << "' has been renamed to '";
         printRenameForDecl(AvAttr, cast<ValueDecl>(D), false);
         os << '\'';
         if (!AvAttr->Message.empty()) {
@@ -911,13 +911,13 @@ private:
     }
     return hasPrintedAnything;
   }
-  
+
   const ValueDecl *getRenameDecl(const ValueDecl *D,
                                  const ParsedDeclName renamedParsedDeclName) {
     auto declContext = D->getDeclContext();
     ASTContext &astContext = D->getASTContext();
     auto renamedDeclName = renamedParsedDeclName.formDeclName(astContext);
-    
+
     if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D)) {
       UnqualifiedLookup lookup(renamedDeclName.getBaseIdentifier(),
                                declContext->getModuleScopeContext(), nullptr,
@@ -926,34 +926,34 @@ private:
       return lookup.getSingleTypeResult();
     } else {
       TypeDecl *typeDecl = declContext->getSelfNominalTypeDecl();
-      
+
       if (!renamedParsedDeclName.ContextName.empty()) {
         auto contextIdentifier =
-        astContext.getIdentifier(renamedParsedDeclName.ContextName);
+            astContext.getIdentifier(renamedParsedDeclName.ContextName);
         UnqualifiedLookup specificTypeLookup(
-                                             contextIdentifier, declContext->getModuleScopeContext(), nullptr,
-                                             SourceLoc(), UnqualifiedLookup::Flags::TypeLookup);
+            contextIdentifier, declContext->getModuleScopeContext(), nullptr,
+            SourceLoc(), UnqualifiedLookup::Flags::TypeLookup);
         if (!specificTypeLookup.getSingleTypeResult()) {
           return nullptr;
         }
-        
+
         if (typeDecl->getDeclaredInterfaceType()->matches(
-                                                          specificTypeLookup.getSingleTypeResult()
-                                                          ->getDeclaredInterfaceType(),
-                                                          TypeMatchFlags::AllowOverride)) {
+                specificTypeLookup.getSingleTypeResult()
+                    ->getDeclaredInterfaceType(),
+                TypeMatchFlags::AllowOverride)) {
           // If the Context Name contain the name of the subclass then we would
           // find the renamed in the superclass instead
           typeDecl = specificTypeLookup.getSingleTypeResult();
         } else if (!specificTypeLookup.getSingleTypeResult()
-                   ->getDeclaredInterfaceType()
-                   ->matches(typeDecl->getDeclaredInterfaceType(),
-                             TypeMatchFlags::AllowOverride)) {
-                     // Failed and print the raw renamed attributed when there is no
-                     // relationship between those 2 types
-                     return nullptr;
-                   }
+                        ->getDeclaredInterfaceType()
+                        ->matches(typeDecl->getDeclaredInterfaceType(),
+                                  TypeMatchFlags::AllowOverride)) {
+          // Failed and print the raw renamed attributed when there is no
+          // relationship between those 2 types
+          return nullptr;
+        }
       }
-      
+
       const ValueDecl *renamedDecl = nullptr;
       SmallVector<ValueDecl *, 4> lookupResults;
       declContext->lookupQualified(typeDecl, renamedDeclName,
@@ -961,19 +961,19 @@ private:
       for (auto candidate : lookupResults) {
         if (!shouldInclude(candidate))
           continue;
-        
+
         if (candidate->getKind() != D->getKind() ||
             (candidate->isInstanceMember() !=
              cast<ValueDecl>(D)->isInstanceMember()))
           continue;
-        
+
         if (isa<FuncDecl>(candidate)) {
           auto cParams = cast<FuncDecl>(candidate)->getParameters();
           auto dParams = cast<FuncDecl>(D)->getParameters();
-          
+
           if (cParams->size() != dParams->size())
             continue;
-          
+
           bool hasSameParameterTypes = true;
           for (auto index : indices(*cParams)) {
             auto cParamsType = cParams->get(index)->getType();
@@ -984,12 +984,12 @@ private:
               break;
             }
           }
-          
+
           if (!hasSameParameterTypes) {
             continue;
           }
         }
-        
+
         if (renamedDecl) {
           // If we found a duplicated candidate then we would silently fail.
           renamedDecl = nullptr;
@@ -1000,24 +1000,24 @@ private:
       return renamedDecl;
     }
   }
-  
+
   void printRenameForDecl(const AvailableAttr *AvAttr, const ValueDecl *D,
                           bool includeQuotes) {
     assert(!AvAttr->Rename.empty());
-    
+
     const swift::ValueDecl *renamedDecl =
-    getRenameDecl(D, parseDeclName(AvAttr->Rename));
-    
+        getRenameDecl(D, parseDeclName(AvAttr->Rename));
+
     if (renamedDecl) {
       SmallString<128> scratch;
       auto renamedObjCRuntimeName =
-      renamedDecl->getObjCRuntimeName()->getString(scratch);
+          renamedDecl->getObjCRuntimeName()->getString(scratch);
       printEncodedString(renamedObjCRuntimeName, includeQuotes);
     } else {
       printEncodedString(AvAttr->Rename, includeQuotes);
     }
   }
-
+    
   void printSwift3ObjCDeprecatedInference(ValueDecl *VD) {
     const LangOptions &langOpts = M.getASTContext().LangOpts;
     if (!langOpts.EnableSwift3ObjCInference ||

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -931,9 +931,23 @@ private:
                                UnqualifiedLookup::Flags::TypeLookup);
       renamedDecl = lookup.getSingleTypeResult();
     } else {
+      TypeDecl *typeDecl = declContext->getSelfNominalTypeDecl();
+      
+      if (!renamedDeclName.isSpecial()) {
+        auto contextIdentifier = D->getASTContext().getIdentifier(renamedParsedDeclName.ContextName);
+        UnqualifiedLookup specificTypeLookup(contextIdentifier,
+                                             declContext->getModuleScopeContext(),
+                                             nullptr,
+                                             SourceLoc(),
+                                             UnqualifiedLookup::Flags::TypeLookup);
+        if (specificTypeLookup.getSingleTypeResult()) {
+          typeDecl = specificTypeLookup.getSingleTypeResult();
+        }
+      }
+      
       SmallVector<ValueDecl *, 4> lookupResults;
       declContext->lookupQualified(
-        declContext->getSelfNominalTypeDecl(),
+        typeDecl,
         renamedDeclName, NL_QualifiedDefault, lookupResults);
       for (auto candidate : lookupResults) {
         if (!shouldInclude(candidate))

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -933,9 +933,6 @@ private:
     } else {
       TypeDecl *typeDecl = declContext->getSelfNominalTypeDecl();
       
-      TypeMatchOptions matchMode = TypeMatchFlags::AllowOverride;
-      matchMode |= TypeMatchFlags::AllowTopLevelOptionalMismatch;
-      
       if (!renamedParsedDeclName.ContextName.empty()) {
         auto contextIdentifier = D->getASTContext().getIdentifier(renamedParsedDeclName.ContextName);
         UnqualifiedLookup specificTypeLookup(contextIdentifier,
@@ -948,10 +945,10 @@ private:
           goto printing_rename_attribute;
         }
         
-        if (typeDecl->getDeclaredInterfaceType()->matches(specificTypeLookup.getSingleTypeResult()->getDeclaredInterfaceType(), matchMode)) {
+        if (typeDecl->getDeclaredInterfaceType()->matches(specificTypeLookup.getSingleTypeResult()->getDeclaredInterfaceType(), TypeMatchFlags::AllowOverride)) {
           // If the Context Name contain the name of the subclass then we would find the renamed in the superclass instead
           typeDecl = specificTypeLookup.getSingleTypeResult();
-        } else if (!specificTypeLookup.getSingleTypeResult()->getDeclaredInterfaceType()->matches(typeDecl->getDeclaredInterfaceType(), matchMode)) {
+        } else if (!specificTypeLookup.getSingleTypeResult()->getDeclaredInterfaceType()->matches(typeDecl->getDeclaredInterfaceType(), TypeMatchFlags::AllowOverride)) {
           // Failed and print the raw renamed attributed when there is no relationship between those 2 types
           renamedDecl = nullptr;
           goto printing_rename_attribute;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -933,7 +933,7 @@ private:
     } else {
       TypeDecl *typeDecl = declContext->getSelfNominalTypeDecl();
       
-      if (!renamedDeclName.isSpecial()) {
+      if (!renamedParsedDeclName.ContextName.empty()) {
         auto contextIdentifier = D->getASTContext().getIdentifier(renamedParsedDeclName.ContextName);
         UnqualifiedLookup specificTypeLookup(contextIdentifier,
                                              declContext->getModuleScopeContext(),

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -958,10 +958,26 @@ private:
              cast<ValueDecl>(D)->isInstanceMember()))
           continue;
         
-        if (isa<FuncDecl>(candidate) &&
-            (cast<FuncDecl>(candidate)->getParameters()->size() !=
-             cast<FuncDecl>(D)->getParameters()->size()))
-          continue;
+        if (isa<FuncDecl>(candidate)) {
+          auto cParams = cast<FuncDecl>(candidate)->getParameters();
+          auto dParams = cast<FuncDecl>(D)->getParameters();
+          
+          if (cParams->size() != dParams->size())
+            continue;
+          
+          bool hasSameParameterTypes = true;
+          for (auto index : indices(*cParams)) {
+            if (cParams->get(index)->getType()->getCanonicalType() !=
+                dParams->get(index)->getType()->getCanonicalType()) {
+              hasSameParameterTypes = false;
+              break;
+            }
+          }
+
+          if (!hasSameParameterTypes) {
+            continue;
+          }
+        }
         
         if (renamedDecl) {
           // If we found a duplicated candidate then we would silently fail.

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -933,8 +933,8 @@ private:
     
     const ValueDecl *renamedDecl = nullptr;
     SmallVector<ValueDecl *, 4> lookupResults;
-    declContext->lookupQualified(typeDecl, renamedDeclName,
-                                 NL_QualifiedDefault, lookupResults);
+    declContext->lookupQualified(typeDecl->getDeclaredInterfaceType(), renamedDeclName,
+                                 NL_QualifiedDefault, nullptr, lookupResults);
     
     if (lookupResults.size() == 1) {
       auto candidate = lookupResults[0];

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -943,12 +943,6 @@ private:
                                              nullptr,
                                              SourceLoc(),
                                              UnqualifiedLookup::Flags::TypeLookup);
-        if (specificTypeLookup.getSingleTypeResult()) {
-          fprintf(stderr, "Declared type : %s\n", typeDecl->getDeclaredInterfaceType()->getStringAsComponent().data());
-          fprintf(stderr, "Looked up type : %s\n", specificTypeLookup.getSingleTypeResult()->getDeclaredInterfaceType()->getStringAsComponent().data());
-          fprintf(stderr, "Result %d\n", specificTypeLookup.getSingleTypeResult()->getDeclaredInterfaceType()->matches(typeDecl->getDeclaredInterfaceType(), matchMode));
-          fprintf(stderr, "Result %d\n", typeDecl->getDeclaredInterfaceType()->matches(specificTypeLookup.getSingleTypeResult()->getDeclaredInterfaceType(), matchMode));
-        }
         if (!specificTypeLookup.getSingleTypeResult()) {
           renamedDecl = nullptr;
           goto printing_rename_attribute;

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -124,7 +124,17 @@
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'__makeUnavailableOnMacOSAvailability' has been renamed to 'unavailableAvailabilityWithValue:': use something else");
 
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
+// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)x OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
+// CHECK-NEXT: - (nonnull instancetype)initWithFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "initWithFirst:second:");
+// CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedOnMacOSFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'init' has been renamed to 'initWithFirst:second:'");
+// CHECK-NEXT: - (nonnull instancetype)initWithUnavailableFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'init' has been renamed to 'initWithFirst:second:'");
+// CHECK-NEXT: - (nonnull instancetype)initWithUnavailableOnMacOSFirst:(NSInteger)first second:(NSInteger)second OBJC_DESIGNATED_INITIALIZER
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'init' has been renamed to 'initWithFirst:second:'");
+
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger simpleProperty;
 // CHECK-NEXT: @property (nonatomic) NSInteger alwaysUnavailableProperty SWIFT_UNAVAILABLE_MSG("'alwaysUnavailableProperty' has been renamed to 'baz': whatever");
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger alwaysDeprecatedProperty SWIFT_DEPRECATED_MSG("use something else", "quux");
@@ -163,9 +173,12 @@
 // CHECK-LABEL: @interface AvailabilitySub
 // CHECK-NEXT: - (nonnull instancetype)init SWIFT_UNAVAILABLE;
 // CHECK-NEXT: + (nonnull instancetype)new SWIFT_DEPRECATED_MSG("-init is unavailable");
-// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)x SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedZ:(NSInteger)deprecatedZ OBJC_DESIGNATED_INITIALIZER SWIFT_DEPRECATED_MSG("init(deprecatedZ:) was deprecated. Use the new one instead", "initWithNewZ:")
 // CHECK-NEXT: - (nonnull instancetype)initWithNewZ:(NSInteger)z OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedOnMacOSFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
@@ -431,8 +444,23 @@
 
     @objc init() {}
     @available(macOS 10.10, *)
-    @objc init(x _: Int) {}
-
+    @objc init(x: Int) {}
+    
+    @objc init(first: Int, second: Int) {}
+    init(first: Double, second: Double) {}
+    
+    @available(*, deprecated, renamed: "init(first:second:)")
+    @objc init(deprecatedFirst first: Int, second: Int) {}
+    
+    @available(macOS, deprecated, renamed: "init(first:second:)")
+    @objc init(deprecatedOnMacOSFirst first: Int, second: Int) {}
+    
+    @available(*, unavailable, renamed: "init(first:second:)")
+    @objc init(unavailableFirst first: Int, second: Int) {}
+    
+    @available(macOS, unavailable, renamed: "init(first:second:)")
+    @objc init(unavailableOnMacOSFirst first: Int, second: Int) {}
+    
     @objc var simpleProperty: Int {
         get {
             return 100
@@ -536,7 +564,6 @@
 extension Availability {
     @objc func extensionAvailability(_: WholeClassAvailability) {}
     
-    
     @available(macOS, deprecated: 10.10)
     @objc var propertyDeprecatedInsideExtension: Int {
         get {
@@ -548,7 +575,7 @@ extension Availability {
 @objc class AvailabilitySub: Availability {
     private override init() { super.init() }
     @available(macOS 10.10, *)
-    private override init(x _: Int) { super.init() }
+    private override init(x: Int) { super.init() }
     @available(*, deprecated, message: "init(deprecatedZ:) was deprecated. Use the new one instead", renamed: "init(z:)")
     @objc init(deprecatedZ: Int) { super.init() }
     @objc(initWithNewZ:) init(z: Int) { super.init() }

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -102,8 +102,6 @@
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToSimpleProperty' has been renamed to 'simpleProperty'");
 
 // CHECK-NEXT: - (NSInteger)methodReturningInt SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT: - (NSInteger)methodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "methodWithoutCustomObjCNameWithValue:")
 // CHECK-NEXT: - (NSInteger)methodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT;
 
 // CHECK-NEXT: - (NSInteger)deprecatedMethodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
@@ -395,9 +393,7 @@
     @objc public func unavailableOnMacOSMethodRenamedToSimpleProperty() {}
 
     @objc(methodReturningInt) public func simpleMethodReturningInt() -> Int { return -1 }
-  
-    @available(*, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func methodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
+
     @objc public func methodWithoutCustomObjCName(value: Int) -> Int { return -1 }
 
     @available(*, deprecated, renamed: "methodWithoutCustomObjCName(value:)")

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -46,22 +46,22 @@
 // CHECK-DAG: SWIFT_AVAILABILITY(tvos_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(watchos_app_extension,unavailable)
 // CHECK-SAME: ;
-// CHECK-NEXT: - (void)overloadingMethodWithFirst:(NSInteger)first second:(NSInteger)second;
-// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadingMethodWithFirst:second:");
-// CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadingMethodWithFirst:second:'");
-// CHECK-NEXT: - (void)unavailableMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethod' has been renamed to 'overloadingMethodWithFirst:second:'");
-// CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadingMethodWithFirst:second:'");
+// CHECK-NEXT: - (void)overloadMethodWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadMethodWithFirst:second:");
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadMethodWithFirst:second:'");
+// CHECK-NEXT: - (void)unavailableMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethod' has been renamed to 'overloadMethodWithFirst:second:'");
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadMethodWithFirst:second:'");
 
 // CHECK-NEXT: - (void)firstOverloadingMethodWithDiffernceNameWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: - (void)secondOverloadingMethodWithDiffernceNameWithFirst:(double)first second:(double)second;
 // CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "overloadMethodWithDifferenceObjCName(first:second:)");
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "firstOverloadingMethodWithDiffernceNameWithFirst:second:");
 // CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'overloadMethodWithDifferenceObjCName(first:second:)'");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'firstOverloadingMethodWithDiffernceNameWithFirst:second:'");
 // CHECK-NEXT: - (void)unavailableMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'overloadMethodWithDifferenceObjCName(first:second:)'");
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'firstOverloadingMethodWithDiffernceNameWithFirst:second:'");
 // CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'overloadMethodWithDifferenceObjCName(first:second:)'");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'firstOverloadingMethodWithDiffernceNameWithFirst:second:'");
 
 // CHECK-NEXT: + (void)deprecatedAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: - (void)deprecatedInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value
@@ -293,7 +293,7 @@
     @available(watchOSApplicationExtension, unavailable)
     @objc func extensionUnavailable() {}
   
-    @objc(overloadingMethodWithFirst:second:) func overloadMethod(first: Int, second: Int) {}
+    @objc func overloadMethod(first: Int, second: Int) {}
     func overloadMethod(first: Double, second: Double) {}
 
     @available(*, deprecated, renamed: "overloadMethod(first:second:)")

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -173,41 +173,60 @@
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface DeprecatedAvailability
 // CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "replacingMethodInReplacementClassWithFirst:second:")
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
 // CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'replacingMethodInReplacementClassWithFirst:second:': use method in another class instead");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol DeprecatedAvailabilityProtocol
 // CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "replacingMethodInReplacementClassWithFirst:second:")
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
 // CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'replacingMethodInReplacementProtocolWithFirst:second:': use method in another class instead");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SWTReplacementAvailable
 // CHECK-NEXT: - (void)replacingMethodInReplacementClassWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)deprecatedMethodReplacingInReplacementClassWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - ContextName is self",
+// CHECK-SAME: "replacingMethodInReplacementClassWithFirst:second:")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @protocol SWTReplacementAvailableProtocol
 // CHECK-NEXT: - (void)replacingMethodInReplacementProtocolWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: @end
 
+
+// CHECK-LABEL: @interface SWTSubclassOfReplacementAvailable : SWTReplacementAvailable
+// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSuperclassWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to superclass's method", "replacingMethodInReplacementClassWithFirst:second:");
+// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
+// CHECK-SAME: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfReplacementClass(first:second:)")
+// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
+// CHECK-SAME: "replacingMethodInReplacementClassWithFirst:second:")
+// CHECK-NEXT: @end
+
+// CHECK-LABEL: @interface SWTSubclassOfSubclassOfReplacementAvailable : SWTSubclassOfReplacementAvailable
+// CHECK-NEXT: - (void)methodReplacingInSubclassOfSubclassOfReplacementClassWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: @end
+
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface UnavailableAvailability
 // CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'replacingMethodInReplacementClassWithFirst:second:': use method in another class instead")
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead")
 // CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'replacingMethodInReplacementClassWithFirst:second:': use method in another class instead");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol UnavailableAvailabilityProtocol
 // CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'replacingMethodInReplacementClassWithFirst:second:': use method in another class instead")
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead")
 // CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'replacingMethodInReplacementProtocolWithFirst:second:': use method in another class instead");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_CLASS("{{.+}}WholeClassAvailability") 
@@ -550,16 +569,41 @@ extension Availability {
     func wholeProtoAvailability(_: WholeClassAvailability)
 }
 
-
 @objc(SWTReplacementAvailable) class ReplacementAvailable {
     @objc(replacingMethodInReplacementClassWithFirst:second:) func methodReplacingInReplacementClass(first: Int, second: Int) -> Void {}
+  
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - ContextName is self",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
+    @objc func deprecatedMethodReplacingInReplacementClass(first: Int, second: Int) -> Void {}
+}
+
+@objc(SWTSubclassOfReplacementAvailable) class SubclassOfReplacementAvailable : ReplacementAvailable {
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - Rename to superclass's method",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
+    @objc func deprecatedMethodInSubclassOfReplacedInSuperclass(first: Int, second: Int) -> Void {}
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
+    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfReplacementClass(first:second:)")
+    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButUnavilable(first: Int, second: Int) -> Void {}
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
+    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
+    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButAvilable(first: Int, second: Int) -> Void {}
+}
+
+@objc(SWTSubclassOfSubclassOfReplacementAvailable) class SubclassOfSubclassOfReplacementAvailable : SubclassOfReplacementAvailable {
+  @objc func methodReplacingInSubclassOfSubclassOfReplacementClass(first: Int, second: Int) -> Void {}
 }
 
 @available(macOS, deprecated, renamed: "ReplacementAvailable")
 @objc class DeprecatedAvailability {
-    @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
+    @available(*, deprecated, message: "use method in another class instead",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
     @objc func deprecatedMethodInDeprecatedClass(first: Int, second: Int) -> Void {}
-    @available(macOS, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
+    @available(macOS, deprecated, message: "use method in another class instead",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
     @objc func deprecatedOnMacOSMethodInDeprecatedClass(first: Int, second: Int) -> Void {}
 }
 

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -101,17 +101,19 @@
 // CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToSimpleProperty
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToSimpleProperty' has been renamed to 'simpleProperty'");
 
-// CHECK-NEXT: - (NSInteger)methodReturningInt
+// CHECK-NEXT: - (NSInteger)methodReturningInt SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (NSInteger)methodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "methodWithoutCustomObjCNameWithValue:")
 // CHECK-NEXT: - (NSInteger)methodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT;
 
-// CHECK-NEXT: - (NSInteger)deprecatedMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-NEXT: - (NSInteger)deprecatedMethodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("", "methodWithoutCustomObjCNameWithValue:");
-// CHECK-NEXT: - (NSInteger)deprecatedOnMacOSMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToMethodWithouCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
-// CHECK-NEXT: - (NSInteger)unavailableMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToMethodWithouCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
-// CHECK-NEXT: - (NSInteger)unavailableOnMacOSMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToMethodWithouCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
+// CHECK-NEXT: - (NSInteger)deprecatedOnMacOSMethodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToMethodWithoutCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
+// CHECK-NEXT: - (NSInteger)unavailableMethodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToMethodWithoutCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
+// CHECK-NEXT: - (NSInteger)unavailableOnMacOSMethodRenamedToMethodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToMethodWithoutCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
 
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value
@@ -171,17 +173,17 @@
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface DeprecatedAvailability
 // CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)");
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "replacingMethodInReplacementClassWithFirst:second:")
 // CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'replacingMethodInReplacementClassWithFirst:second:': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol DeprecatedAvailabilityProtocol
 // CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)");
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "replacingMethodInReplacementClassWithFirst:second:")
 // CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'replacingMethodInReplacementProtocolWithFirst:second:': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SWTReplacementAvailable
@@ -195,17 +197,17 @@
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface UnavailableAvailability
 // CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'replacingMethodInReplacementClassWithFirst:second:': use method in another class instead")
 // CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'replacingMethodInReplacementClassWithFirst:second:': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol UnavailableAvailabilityProtocol
 // CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'replacingMethodInReplacementClassWithFirst:second:': use method in another class instead")
 // CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'replacingMethodInReplacementProtocolWithFirst:second:': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_CLASS("{{.+}}WholeClassAvailability") 
@@ -375,17 +377,19 @@
 
     @objc(methodReturningInt) public func simpleMethodReturningInt() -> Int { return -1 }
   
+    @available(*, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
+    @objc public func methodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
     @objc public func methodWithoutCustomObjCName(value: Int) -> Int { return -1 }
 
     @available(*, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func deprecatedMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @objc public func deprecatedMethodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
     @available(macOS, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func deprecatedOnMacOSMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @objc public func deprecatedOnMacOSMethodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
 
     @available(*, unavailable, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func unavailableMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @objc public func unavailableMethodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
     @available(macOS, unavailable, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func unavailableOnMacOSMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @objc public func unavailableOnMacOSMethodRenamedToMethodWithoutCustomObjCName(value: Int) -> Int { return -1 }
 
 
     @objc(unavailableAvailabilityWithValue:)
@@ -573,7 +577,7 @@ extension Availability {
 
 @available(macOS, deprecated, renamed: "ReplacementAvailableProtocol")
 @objc protocol DeprecatedAvailabilityProtocol {
-  @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
+  @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
   @objc func deprecatedMethodInDeprecatedClass(first: Int, second: Int) -> Void
   @available(macOS, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
   @objc func deprecatedOnMacOSMethodInDeprecatedClass(first: Int, second: Int) -> Void
@@ -581,7 +585,7 @@ extension Availability {
 
 @available(macOS, unavailable, renamed: "ReplacementAvailableProtocol")
 @objc protocol UnavailableAvailabilityProtocol {
-  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
+  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
   @objc func unavailableMethodInUnavailableClass(first: Int, second: Int) -> Void
   @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
   @objc func unavailableOnMacOSMethodInUnavailableClass(first: Int, second: Int) -> Void

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -172,25 +172,35 @@
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface DeprecatedAvailability
-// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead");
+
+// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClassWithSuperclassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)': use method in another class instead");
+
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol DeprecatedAvailabilityProtocol
-// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SWTReplacementAvailable
-// CHECK-NEXT: - (void)replacingMethodInReplacementClassWithFirst:(NSInteger)first second:(NSInteger)second;
-// CHECK-NEXT: - (void)deprecatedMethodReplacingInReplacementClassWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-NEXT: - (void)replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:(SWTSubclassOfReplacementAvailable * _Nonnull)first second:(SWTSubclassOfReplacementAvailable * _Nonnull)second;
+// CHECK-NEXT: - (void)deprecatedMethodReplacingInReplacementClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - ContextName is self",
-// CHECK-SAME: "replacingMethodInReplacementClassWithFirst:second:")
+// CHECK-SAME: "replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:")
+// CHECK-NEXT: - (void)deprecatedmethodReplacingInReplacementClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - ContextName is self",
+// CHECK-SAME: "replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:second:")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @protocol SWTReplacementAvailableProtocol
@@ -199,14 +209,24 @@
 
 
 // CHECK-LABEL: @interface SWTSubclassOfReplacementAvailable : SWTReplacementAvailable
-// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSuperclassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to superclass's method", "replacingMethodInReplacementClassWithFirst:second:");
-// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSuperclassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to superclass's method", "replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:");
+// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
-// CHECK-SAME: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfReplacementClass(first:second:)")
-// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfReplacementClassWithPrimitiveParameters(first:second:)")
+// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
-// CHECK-SAME: "replacingMethodInReplacementClassWithFirst:second:")
+// CHECK-SAME: "replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:")
+
+// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSuperclassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to superclass's method", "replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:second:");
+// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
+// CHECK-SAME: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfObjectClass(first:second:)")
+// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
+// CHECK-SAME: "replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:second:")
+
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SWTSubclassOfSubclassOfReplacementAvailable : SWTSubclassOfReplacementAvailable
@@ -215,18 +235,23 @@
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface UnavailableAvailability
-// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead")
-// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead")
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead");
+
+// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClassWithSuperclassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)': use method in another class instead")
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClassWithSuperclassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol UnavailableAvailabilityProtocol
-// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead")
-// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead")
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_CLASS("{{.+}}WholeClassAvailability") 
@@ -570,27 +595,49 @@ extension Availability {
 }
 
 @objc(SWTReplacementAvailable) class ReplacementAvailable {
-    @objc(replacingMethodInReplacementClassWithFirst:second:) func methodReplacingInReplacementClass(first: Int, second: Int) -> Void {}
-  
+    @objc(replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:)
+    func methodReplacingInReplacementClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+    
+    @objc(replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:second:)
+    func methodReplacingInReplacementClassWithClassObjectParameters(first: SubclassOfReplacementAvailable, second: SubclassOfReplacementAvailable) -> Void {}
+    
     @available(*, deprecated,
     message: "Deprecated method with the Context name in the renamed attribute - ContextName is self",
-    renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-    @objc func deprecatedMethodReplacingInReplacementClass(first: Int, second: Int) -> Void {}
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedMethodReplacingInReplacementClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+    
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - ContextName is self",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func deprecatedmethodReplacingInReplacementClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @objc(SWTSubclassOfReplacementAvailable) class SubclassOfReplacementAvailable : ReplacementAvailable {
     @available(*, deprecated,
     message: "Deprecated method with the Context name in the renamed attribute - Rename to superclass's method",
-    renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-    @objc func deprecatedMethodInSubclassOfReplacedInSuperclass(first: Int, second: Int) -> Void {}
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedMethodInSubclassOfReplacedInSuperclassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
     @available(*, deprecated,
     message: "Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
-    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfReplacementClass(first:second:)")
-    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButUnavilable(first: Int, second: Int) -> Void {}
+    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithPrimitiveParameters(first: Int, second: Int) -> Void {}
     @available(*, deprecated,
     message: "Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
-    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButAvilable(first: Int, second: Int) -> Void {}
+    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+    
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - Rename to superclass's method",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func deprecatedMethodInSubclassOfReplacedInSuperclassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
+    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfObjectClass(first:second:)")
+    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    @available(*, deprecated,
+    message: "Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
+    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @objc(SWTSubclassOfSubclassOfReplacementAvailable) class SubclassOfSubclassOfReplacementAvailable : SubclassOfReplacementAvailable {
@@ -600,39 +647,52 @@ extension Availability {
 @available(macOS, deprecated, renamed: "ReplacementAvailable")
 @objc class DeprecatedAvailability {
     @available(*, deprecated, message: "use method in another class instead",
-    renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-    @objc func deprecatedMethodInDeprecatedClass(first: Int, second: Int) -> Void {}
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedMethodInDeprecatedClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
     @available(macOS, deprecated, message: "use method in another class instead",
-    renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-    @objc func deprecatedOnMacOSMethodInDeprecatedClass(first: Int, second: Int) -> Void {}
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+  
+    @available(*, deprecated, message: "use method in another class instead",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
+    @objc func deprecatedMethodInDeprecatedClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    @available(macOS, deprecated, message: "use method in another class instead",
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
+    @objc func deprecatedOnMacOSMethodInDeprecatedClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @available(macOS, unavailable, renamed: "ReplacementAvailable")
 @objc class UnavailableAvailability {
-  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-  @objc func unavailableMethodInUnavailableClass(first: Int, second: Int) -> Void {}
-  @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-  @objc func unavailableOnMacOSMethodInUnavailableClass(first: Int, second: Int) -> Void {}
+    @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func unavailableMethodInUnavailableClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+    @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
+  
+    @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
+    @objc func unavailableMethodInUnavailableClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
+    @objc func unavailableOnMacOSMethodInUnavailableClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @objc(SWTReplacementAvailableProtocol) protocol ReplacementAvailableProtocol {
-  @objc(replacingMethodInReplacementProtocolWithFirst:second:) func methodReplacingInReplacementProtocol(first: Int, second: Int) -> Void
+    @objc(replacingMethodInReplacementProtocolWithFirst:second:)
+    func methodReplacingInReplacementProtocol(first: Int, second: Int) -> Void
 }
 
 @available(macOS, deprecated, renamed: "ReplacementAvailableProtocol")
 @objc protocol DeprecatedAvailabilityProtocol {
-  @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-  @objc func deprecatedMethodInDeprecatedClass(first: Int, second: Int) -> Void
-  @available(macOS, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
-  @objc func deprecatedOnMacOSMethodInDeprecatedClass(first: Int, second: Int) -> Void
+    @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func deprecatedMethodInDeprecatedClassWithPrimitiveParameters(first: Int, second: Int) -> Void
+    @available(macOS, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
+    @objc func deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters(first: Int, second: Int) -> Void
 }
 
 @available(macOS, unavailable, renamed: "ReplacementAvailableProtocol")
 @objc protocol UnavailableAvailabilityProtocol {
-  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
-  @objc func unavailableMethodInUnavailableClass(first: Int, second: Int) -> Void
-  @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
-  @objc func unavailableOnMacOSMethodInUnavailableClass(first: Int, second: Int) -> Void
+    @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
+    @objc func unavailableMethodInUnavailableClassWithPrimitiveParameters(first: Int, second: Int) -> Void
+    @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
+    @objc func unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters(first: Int, second: Int) -> Void
 }
 
 

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -179,7 +179,7 @@
 // CHECK-NEXT: - (nonnull instancetype)initWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedOnMacOSFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
-// CHECK-NEXT: @end
+// CHECK: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface DeprecatedAvailability

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -177,10 +177,10 @@
 // CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead");
 
-// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
-// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClassWithSuperclassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClassWithClassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)': use method in another class instead");
 
 // CHECK-NEXT: @end
 
@@ -194,44 +194,19 @@
 
 // CHECK-LABEL: @interface SWTReplacementAvailable
 // CHECK-NEXT: - (void)replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second;
-// CHECK-NEXT: - (void)replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:(SWTSubclassOfReplacementAvailable * _Nonnull)first second:(SWTSubclassOfReplacementAvailable * _Nonnull)second;
+// CHECK-NEXT: - (void)replacingMethodInReplacementClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second;
 // CHECK-NEXT: - (void)deprecatedMethodReplacingInReplacementClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - ContextName is self",
 // CHECK-SAME: "replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:")
-// CHECK-NEXT: - (void)deprecatedmethodReplacingInReplacementClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-NEXT: - (void)deprecatedmethodReplacingInReplacementClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - ContextName is self",
-// CHECK-SAME: "replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:second:")
+// CHECK-SAME: "replacingMethodInReplacementClassWithClassObjectParametersWithFirst:second:")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @protocol SWTReplacementAvailableProtocol
 // CHECK-NEXT: - (void)replacingMethodInReplacementProtocolWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: @end
 
-
-// CHECK-LABEL: @interface SWTSubclassOfReplacementAvailable : SWTReplacementAvailable
-// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSuperclassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to superclass's method", "replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:");
-// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
-// CHECK-SAME: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfReplacementClassWithPrimitiveParameters(first:second:)")
-// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
-// CHECK-SAME: "replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:")
-
-// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSuperclassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to superclass's method", "replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:second:");
-// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
-// CHECK-SAME: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfObjectClass(first:second:)")
-// CHECK-NEXT: - (void)deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
-// CHECK-SAME: "replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:second:")
-
-// CHECK-NEXT: @end
-
-// CHECK-LABEL: @interface SWTSubclassOfSubclassOfReplacementAvailable : SWTSubclassOfReplacementAvailable
-// CHECK-NEXT: - (void)methodReplacingInSubclassOfSubclassOfReplacementClassWithFirst:(NSInteger)first second:(NSInteger)second;
-// CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface UnavailableAvailability
@@ -240,10 +215,10 @@
 // CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParametersWithFirst:(NSInteger)first second:(NSInteger)second
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)': use method in another class instead");
 
-// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClassWithSuperclassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)': use method in another class instead")
-// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithSuperclassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
-// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClassWithSuperclassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClassWithClassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)': use method in another class instead")
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithClassObjectParametersWithFirst:(SWTReplacementAvailable * _Nonnull)first second:(SWTReplacementAvailable * _Nonnull)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClassWithClassObjectParameters' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
@@ -598,8 +573,8 @@ extension Availability {
     @objc(replacingMethodInReplacementClassWithPrimitiveParametersWithFirst:second:)
     func methodReplacingInReplacementClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
     
-    @objc(replacingMethodInReplacementClassWithSuperclassObjectParametersWithFirst:second:)
-    func methodReplacingInReplacementClassWithClassObjectParameters(first: SubclassOfReplacementAvailable, second: SubclassOfReplacementAvailable) -> Void {}
+    @objc(replacingMethodInReplacementClassWithClassObjectParametersWithFirst:second:)
+    func methodReplacingInReplacementClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
     
     @available(*, deprecated,
     message: "Deprecated method with the Context name in the renamed attribute - ContextName is self",
@@ -609,39 +584,7 @@ extension Availability {
     @available(*, deprecated,
     message: "Deprecated method with the Context name in the renamed attribute - ContextName is self",
     renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
-    @objc func deprecatedmethodReplacingInReplacementClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
-}
-
-@objc(SWTSubclassOfReplacementAvailable) class SubclassOfReplacementAvailable : ReplacementAvailable {
-    @available(*, deprecated,
-    message: "Deprecated method with the Context name in the renamed attribute - Rename to superclass's method",
-    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
-    @objc func deprecatedMethodInSubclassOfReplacedInSuperclassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
-    @available(*, deprecated,
-    message: "Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
-    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfReplacementClassWithPrimitiveParameters(first:second:)")
-    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithPrimitiveParameters(first: Int, second: Int) -> Void {}
-    @available(*, deprecated,
-    message: "Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
-    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
-    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithPrimitiveParameters(first: Int, second: Int) -> Void {}
-    
-    @available(*, deprecated,
-    message: "Deprecated method with the Context name in the renamed attribute - Rename to superclass's method",
-    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
-    @objc func deprecatedMethodInSubclassOfReplacedInSuperclassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
-    @available(*, deprecated,
-    message: "Deprecated method with the Context name in the renamed attribute - Rename to unavilable subclass's method",
-    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInSubclassOfSubclassOfObjectClass(first:second:)")
-    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButUnavilableWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
-    @available(*, deprecated,
-    message: "Deprecated method with the Context name in the renamed attribute - Rename to available subclass's method",
-    renamed: "SubclassOfSubclassOfReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
-    @objc func deprecatedMethodInSubclassOfReplacedInSubclassButAvilableWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
-}
-
-@objc(SWTSubclassOfSubclassOfReplacementAvailable) class SubclassOfSubclassOfReplacementAvailable : SubclassOfReplacementAvailable {
-  @objc func methodReplacingInSubclassOfSubclassOfReplacementClass(first: Int, second: Int) -> Void {}
+    @objc func deprecatedmethodReplacingInReplacementClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @available(macOS, deprecated, renamed: "ReplacementAvailable")
@@ -654,11 +597,11 @@ extension Availability {
     @objc func deprecatedOnMacOSMethodInDeprecatedClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
   
     @available(*, deprecated, message: "use method in another class instead",
-    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
-    @objc func deprecatedMethodInDeprecatedClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func deprecatedMethodInDeprecatedClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
     @available(macOS, deprecated, message: "use method in another class instead",
-    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
-    @objc func deprecatedOnMacOSMethodInDeprecatedClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func deprecatedOnMacOSMethodInDeprecatedClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @available(macOS, unavailable, renamed: "ReplacementAvailable")
@@ -668,10 +611,10 @@ extension Availability {
     @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithPrimitiveParameters(first:second:)")
     @objc func unavailableOnMacOSMethodInUnavailableClassWithPrimitiveParameters(first: Int, second: Int) -> Void {}
   
-    @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
-    @objc func unavailableMethodInUnavailableClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
-    @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithSuperclassObjectParameters(first:second:)")
-    @objc func unavailableOnMacOSMethodInUnavailableClassWithSuperclassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func unavailableMethodInUnavailableClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
+    @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClassWithClassObjectParameters(first:second:)")
+    @objc func unavailableOnMacOSMethodInUnavailableClassWithClassObjectParameters(first: ReplacementAvailable, second: ReplacementAvailable) -> Void {}
 }
 
 @objc(SWTReplacementAvailableProtocol) protocol ReplacementAvailableProtocol {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR is an improvement of the #18081. It adds a few improvements for the custom `@objc` name in the available attribute when generates ObjC headers

Here's a list of the improvements
1. The compiler will follow the base type when the rename attribute references to the declaration in other Type
2. The compiler will try to look at the type of the method parameter when the rename attribute references to an overloading method

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->