### PR TITLE
SILOptimizer: fix non-deterministic behavior in RedundantLoadElimination and DeadStoreElimination.

### DIFF
--- a/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
@@ -289,7 +289,6 @@ static inline llvm::hash_code hash_value(const LSValue &V) {
 //===----------------------------------------------------------------------===//
 //                            Load Store Location
 //===----------------------------------------------------------------------===//
-using LSLocationSet = llvm::DenseSet<LSLocation>;
 using LSLocationList = llvm::SmallVector<LSLocation, 8>;
 using LSLocationIndexMap = llvm::SmallDenseMap<LSLocation, unsigned, 32>;
 using LSLocationBaseMap = llvm::DenseMap<SILValue, LSLocation>;
@@ -357,7 +356,7 @@ public:
 
   /// Given a set of locations derived from the same base, try to merge/reduce
   /// them into smallest number of LSLocations possible.
-  static bool reduce(LSLocation Base, SILModule *Mod, LSLocationSet &Locs);
+  static void reduce(LSLocation Base, SILModule *Mod, LSLocationList &Locs);
 
   /// Enumerate the given Mem LSLocation.
   static void enumerateLSLocation(SILModule *M, SILValue Mem,

--- a/lib/SILOptimizer/UtilityPasses/LSLocationPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LSLocationPrinter.cpp
@@ -181,7 +181,7 @@ public:
   void printMemReduction(SILFunction &Fn) {
     LSLocation L;
     LSLocationList Locs;
-    llvm::DenseSet<LSLocation> SLocs;
+    LSLocationList SLocs;
     unsigned Counter = 0;
     for (auto &BB : Fn) {
       for (auto &II : BB) {
@@ -212,7 +212,7 @@ public:
         // Reduction should not care about the order of the memory locations in
         // the set.
         for (auto I = Locs.begin(); I != Locs.end(); ++I) {
-          SLocs.insert(*I);
+          SLocs.push_back(*I);
         }
 
         // This should get the original (unexpanded) location back.


### PR DESCRIPTION
Replace some DenseSets, which are used for iteration, with vectors.
This also needed some rewrite in LSLocation::reduce() to rule out quadratic complexity.

SR-8844
rdar://problem/44762620