### PR TITLE
Double the timeout in EditTest

### DIFF
--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -137,7 +137,7 @@ public:
   }
 
   bool waitForDocUpdate(bool reset = false) {
-    std::chrono::seconds secondsToWait(10);
+    std::chrono::seconds secondsToWait(20);
     std::unique_lock<std::mutex> lk(DocUpdState->Mtx);
     auto when = std::chrono::system_clock::now() + secondsToWait;
     auto result = !DocUpdState->CV.wait_until(


### PR DESCRIPTION
These tests are occassionaly timing out in CI. I have been unable to
reproduce this even with TSan and varying the pauses between operations.
On the other hand, I can get this test to run slowly if the machine is
heavily loaded, so double the timeout to see if it resolves the CI
issues.

rdar://44842835