### PR TITLE
SourceKit: handle Windows codepaths better

### DIFF
--- a/tools/SourceKit/tools/complete-test/complete-test.cpp
+++ b/tools/SourceKit/tools/complete-test/complete-test.cpp
@@ -21,13 +21,25 @@
 #include "llvm/Support/FileSystem.h"
 #include <fstream>
 #include <regex>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #include <sys/param.h>
+#elif defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#endif
 
 // FIXME: Platform compatibility.
 #include <dispatch/dispatch.h>
 
 using namespace llvm;
+
+#if defined(_WIN32)
+namespace {
+int STDOUT_FILENO = _fileno(stdout);
+}
+#endif
 
 namespace {
 struct TestOptions {

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -27,8 +27,14 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <fstream>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #include <sys/param.h>
+#elif defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#endif
 
 // FIXME: Platform compatibility.
 #include <dispatch/dispatch.h>
@@ -36,6 +42,19 @@
 using namespace llvm;
 
 using namespace sourcekitd_test;
+
+#if defined(_WIN32)
+namespace {
+int STDOUT_FILENO = _fileno(stdout);
+const constexpr size_t MAXPATHLEN = MAX_PATH + 1;
+char *realpath(const char *path, const char *resolved_path) {
+  DWORD dwLength = GetFullPathNameA(path, 0, nullptr, nullptr);
+  if (resolved_path = malloc(dwLength + 1))
+    GetFullPathNameA(path, dwLength, resolved_path, nullptr);
+  return resolved_path;
+}
+}
+#endif
 
 static int handleTestInvocation(ArrayRef<const char *> Args, TestOptions &InitOpts);
 static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
@@ -80,9 +80,16 @@ UIdent sourcekitd::UIdentFromSKDUID(sourcekitd_uid_t uid) {
 }
 
 std::string sourcekitd::getRuntimeLibPath() {
-  // FIXME: Move to an LLVM API. Note that libclang does the same thing.
 #if defined(_WIN32)
-#error Not implemented
+  MEMORY_BASIC_INFORMATION mbi;
+  char path[MAX_PATH + 1];
+  if (!VirtualQuery(static_cast<void *>(sourcekitd_initialize), &mbi,
+                    sizeof(mbi)))
+    llvm_unreachable("call to VirtualQuery failed");
+  if (!GetModuleFileNameA(static_cast<HINSTANCE>(mbi.AllocationBase), path,
+                          MAX_PATH))
+    llvm_unreachable("call to GetModuleFileNameA failed");
+  return llvm::sys::path::parent_path(path);
 #else
   // This silly cast below avoids a C++ warning.
   Dl_info info;


### PR DESCRIPTION
Fill in some of the Windows codepaths that were previously missing.  This allows
us to at least compile the SourceKit sources.  More changes are required to the
build system to use the correct compiler when cross-compiling to get the
dependencies correct.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
