### PR TITLE
constant interpreter: addresses and memory

### DIFF
--- a/test/SILOptimizer/pound_assert.sil
+++ b/test/SILOptimizer/pound_assert.sil
@@ -29,3 +29,77 @@ bb0:
   %5 = builtin "poundAssert"(%3 : $Builtin.Int1, %4 : $Builtin.RawPointer) : $()
   return undef : $()
 }
+
+// Tests that piecewise initialization of memory works, by piecewise
+// initializing a tuple.
+sil @piecewiseInit : $@convention(thin) () -> Bool {
+bb0:
+  // Allocate and initialize the tuple to (1, 2).
+  %0 = alloc_stack $(Int64, Int64), var, name "tup"
+  %1 = tuple_element_addr %0 : $*(Int64, Int64), 0
+  %2 = tuple_element_addr %0 : $*(Int64, Int64), 1
+  %3 = integer_literal $Builtin.Int64, 1
+  %4 = struct $Int64 (%3 : $Builtin.Int64)
+  store %4 to %1 : $*Int64
+  %6 = integer_literal $Builtin.Int64, 2
+  %7 = struct $Int64 (%6 : $Builtin.Int64)
+  store %7 to %2 : $*Int64
+
+  // Read the first element from the tuple.
+  %9 = begin_access [read] [static] %0 : $*(Int64, Int64)
+  %10 = tuple_element_addr %9 : $*(Int64, Int64), 0
+  %11 = load %10 : $*Int64
+  end_access %9 : $*(Int64, Int64)
+
+  // Check that the first element is what we put in.
+  %13 = struct_extract %11 : $Int64, #Int64._value
+  %14 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, %13 : $Builtin.Int64) : $Builtin.Int1
+  %15 = struct $Bool (%14 : $Builtin.Int1)
+
+  // Deallocate and return.
+  dealloc_stack %0 : $*(Int64, Int64)
+  return %15 : $Bool
+}
+
+// Tests copy_addr interpretation.
+sil @copyAddr : $@convention(thin) () -> Bool {
+  // Allocate an initialize an Int64 to 1.
+  %0 = alloc_stack $Int64
+  %1 = integer_literal $Builtin.Int64, 1
+  %2 = struct $Int64 (%1 : $Builtin.Int64)
+  store %2 to %0 : $*Int64
+
+  // Allocate another Int64 and copy to it.
+  %4 = alloc_stack $Int64
+  copy_addr %0 to %4 : $*Int64
+
+  // Check that the value is what we put in the original Int64.
+  %5 = begin_access [read] [static] %4 : $*Int64
+  %6 = load %5 : $*Int64
+  end_access %5 : $*Int64
+  %8 = struct_extract %6 : $Int64, #Int64._value
+  %9 = builtin "cmp_eq_Int64"(%1 : $Builtin.Int64, %8 : $Builtin.Int64) : $Builtin.Int1
+  %10 = struct $Bool (%9 : $Builtin.Int1)
+
+  // Deallocate and return.
+  dealloc_stack %4 : $*Int64
+  dealloc_stack %0 : $*Int64
+  return %10 : $Bool
+}
+
+sil @invokeTests : $@convention(thin) () -> () {
+  %0 = function_ref @piecewiseInit : $@convention(thin) () -> Bool
+  %1 = apply %0() : $@convention(thin) () -> Bool
+  %2 = struct_extract %1 : $Bool, #Bool._value
+  %3 = string_literal utf8 ""
+  %4 = builtin "poundAssert"(%2 : $Builtin.Int1, %3 : $Builtin.RawPointer) : $()
+
+  %5 = function_ref @copyAddr : $@convention(thin) () -> Bool
+  %6 = apply %5() : $@convention(thin) () -> Bool
+  %7 = struct_extract %6 : $Bool, #Bool._value
+  %8 = string_literal utf8 ""
+  %9 = builtin "poundAssert"(%7 : $Builtin.Int1, %8 : $Builtin.RawPointer) : $()
+
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
This makes the interpreter able to evaluate functions that do mutation, and this also paves the way for generics support, array support, and string support.

This is a part of the #19579 mega-patch. See there if you're interested in what comes next.