### PR TITLE
[vim] remove swiftTypePair

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -120,10 +120,8 @@ syn match swiftImplicitVarName
 syn match swiftType contained skipwhite skipempty nextgroup=swiftTypeParameters
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " [Type:Type] (dictionary) or [Type] (array)
-syn region swiftType contained contains=swiftTypePair,swiftType
+syn region swiftType contained contains=swiftType
       \ matchgroup=Delimiter start=/\[/ end=/\]/
-syn match swiftTypePair contained skipwhite skipempty nextgroup=swiftTypeParameters,swiftTypeDeclaration
-      \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
 " (Type[, Type]) (tuple)
 " FIXME: we should be able to use skip="," and drop swiftParamDelim
 syn region swiftType contained contains=swiftType,swiftParamDelim
@@ -187,7 +185,6 @@ hi def link swiftMultiwordKeyword Statement
 hi def link swiftTypeDefinition Define
 hi def link swiftMultiwordTypeDefinition Define
 hi def link swiftType Type
-hi def link swiftTypePair Type
 hi def link swiftTypeName Function
 hi def link swiftConstraint Special
 hi def link swiftFuncDefinition Define


### PR DESCRIPTION
**Update only utils/vim/syntax/swift.vim**

I confirmed that `swiftTypePair` seems unnecessary now. This pattern is supported by `swiftType` and `swiftTypeDeclaration`.

I would like to remove this before creating other pull requests.

## Before removed

![2018-10-02 10 49 32](https://user-images.githubusercontent.com/629993/46325056-86ad4680-c631-11e8-9f2f-0977f94863de.png)

## After removed

![2018-10-02 10 53 20](https://user-images.githubusercontent.com/629993/46325057-88770a00-c631-11e8-8f6e-270199b632e9.png)
