### PR TITLE
[SR-8340]Improve fix-it for var and subscript in Protocol

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6226,7 +6226,7 @@ Parser::parseDeclSubscript(ParseDeclOptions Flags,
     if (!Status.isError()) {
       if (Flags.contains(PD_InProtocol)) {
         diagnose(Tok, diag::expected_lbrace_subscript_protocol)
-            .fixItInsertAfter(ElementTy.get()->getEndLoc(), " { get set }");
+            .fixItInsertAfter(ElementTy.get()->getEndLoc(), " { get <#set#> }");
       } else {
         diagnose(Tok, diag::expected_lbrace_subscript);
       }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2023,21 +2023,15 @@ void swift::maybeAddAccessorsToStorage(TypeChecker &TC,
   } else if (isa<ProtocolDecl>(dc)) {
     if (storage->hasStorage()) {
       auto var = cast<VarDecl>(storage);
-      auto braces = var->getBracesRange();
 
       if (var->isLet()) {
-        auto diag = TC.diagnose(var->getLoc(),
-                                diag::protocol_property_must_be_computed_var);
-        if (braces.isValid())
-          diag
-            .fixItReplace(var->getParentPatternBinding()->getLoc(), "var")
-            .fixItReplace(braces, " { get }");
-        else
-          diag
-            .fixItReplace(var->getParentPatternBinding()->getLoc(), "var")
-            .fixItInsertAfter(var->getTypeLoc().getLoc(), " { get }");
+        TC.diagnose(var->getLoc(),
+                   diag::protocol_property_must_be_computed_var)
+          .fixItReplace(var->getParentPatternBinding()->getLoc(), "var")
+          .fixItInsertAfter(var->getTypeLoc().getLoc(), " { get }");
       } else {
         auto diag = TC.diagnose(var->getLoc(), diag::protocol_property_must_be_computed);
+        auto braces = var->getBracesRange();
 
         if (braces.isValid())
           diag.fixItReplace(braces, "{ get <#set#> }");

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2040,7 +2040,7 @@ void swift::maybeAddAccessorsToStorage(TypeChecker &TC,
         auto diag = TC.diagnose(var->getLoc(), diag::protocol_property_must_be_computed);
 
         if (braces.isValid())
-          diag.fixItReplace(braces, " { get <#set#> }");
+          diag.fixItReplace(braces, "{ get <#set#> }");
         else
           diag.fixItInsertAfter(var->getTypeLoc().getLoc(), " { get <#set#> }");
       }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2023,11 +2023,27 @@ void swift::maybeAddAccessorsToStorage(TypeChecker &TC,
   } else if (isa<ProtocolDecl>(dc)) {
     if (storage->hasStorage()) {
       auto var = cast<VarDecl>(storage);
-      if (var->isLet())
-        TC.diagnose(var->getLoc(),
-                    diag::protocol_property_must_be_computed_var);
-      else
-        TC.diagnose(var->getLoc(), diag::protocol_property_must_be_computed);
+      auto braces = var->getBracesRange();
+
+      if (var->isLet()) {
+        auto diag = TC.diagnose(var->getLoc(),
+                                diag::protocol_property_must_be_computed_var);
+        if (braces.isValid())
+          diag
+            .fixItReplace(var->getParentPatternBinding()->getLoc(), "var")
+            .fixItReplace(braces, " { get }");
+        else
+          diag
+            .fixItReplace(var->getParentPatternBinding()->getLoc(), "var")
+            .fixItInsertAfter(var->getTypeLoc().getLoc(), " { get }");
+      } else {
+        auto diag = TC.diagnose(var->getLoc(), diag::protocol_property_must_be_computed);
+
+        if (braces.isValid())
+          diag.fixItReplace(braces, " { get <#set#> }");
+        else
+          diag.fixItInsertAfter(var->getTypeLoc().getLoc(), " { get <#set#> }");
+      }
     }
 
     setProtocolStorageImpl(TC, storage);

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -454,7 +454,7 @@ protocol ShouldntCrash {
   let fullName: String { get }  // expected-error {{'let' declarations cannot be computed properties}} {{3-6=var}}
   
   // <rdar://problem/17200672> Let in protocol causes unclear errors and crashes
-  let fullName2: String  // expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}} {{24-24= { get \}}}
+  let fullName2: String  // expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}} {{3-6=var}} {{24-24= { get \}}}
 
   // <rdar://problem/16789886> Assert on protocol property requirement without a type
   var propertyWithoutType { get } // expected-error {{type annotation missing in pattern}}

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -16,6 +16,9 @@ protocol Test {
   var minor : Int { get }
   var subminor : Int  // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{21-21= { get <#set#> \}}}
   static var staticProperty: Int // expected-error{{property in protocol must have explicit { get } or { get set } specifier}} {{33-33= { get <#set#> \}}}
+
+  let bugfix // expected-error {{type annotation missing in pattern}} expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
+  var comment // expected-error {{type annotation missing in pattern}} expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
 }
 
 protocol Test2 {

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -500,9 +500,8 @@ class C4 : P4 { // expected-error {{type 'C4' does not conform to protocol 'P4'}
 // <rdar://problem/25185722> Crash with invalid 'let' property in protocol
 protocol LetThereBeCrash {
   let x: Int
-  // expected-error@-1 {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
+  // expected-error@-1 {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}} {{13-13= { get \}}}
   // expected-note@-2 {{declared here}}
-  // {{13-13= { get \}}}
 }
 
 extension LetThereBeCrash {

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -14,15 +14,15 @@ protocol Test {
   var creator: String { get }
   var major : Int { get }
   var minor : Int { get }
-  var subminor : Int  // expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
-  static var staticProperty: Int // expected-error{{property in protocol must have explicit { get } or { get set } specifier}}
+  var subminor : Int  // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{21-21= { get <#set#> \}}}
+  static var staticProperty: Int // expected-error{{property in protocol must have explicit { get } or { get set } specifier}} {{33-33= { get <#set#> \}}}
 }
 
 protocol Test2 {
   var property: Int { get }
 
-  var title: String = "The Art of War" { get } // expected-error{{initial value is not allowed here}} expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
-  static var title2: String = "The Art of War" // expected-error{{initial value is not allowed here}} expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
+  var title: String = "The Art of War" { get } // expected-error{{initial value is not allowed here}} expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{20-20= { get <#set#> \}}}
+  static var title2: String = "The Art of War" // expected-error{{initial value is not allowed here}} expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{28-28= { get <#set#> \}}}
 
   associatedtype mytype
   associatedtype mybadtype = Int
@@ -454,7 +454,7 @@ protocol ShouldntCrash {
   let fullName: String { get }  // expected-error {{'let' declarations cannot be computed properties}} {{3-6=var}}
   
   // <rdar://problem/17200672> Let in protocol causes unclear errors and crashes
-  let fullName2: String  // expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
+  let fullName2: String  // expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}} {{24-24= { get \}}}
 
   // <rdar://problem/16789886> Assert on protocol property requirement without a type
   var propertyWithoutType { get } // expected-error {{type annotation missing in pattern}}
@@ -502,6 +502,7 @@ protocol LetThereBeCrash {
   let x: Int
   // expected-error@-1 {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
   // expected-note@-2 {{declared here}}
+  // {{13-13= { get \}}}
 }
 
 extension LetThereBeCrash {

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -346,7 +346,7 @@ class Foo {
 protocol r23952125 {
   associatedtype ItemType
   var count: Int { get }
-  subscript(index: Int) -> ItemType  // expected-error {{subscript in protocol must have explicit { get } or { get set } specifier}} {{36-36= { get set \}}}
+  subscript(index: Int) -> ItemType  // expected-error {{subscript in protocol must have explicit { get } or { get set } specifier}} {{36-36= { get <#set#> \}}}
   
   var c : Int // expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
 }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -347,8 +347,8 @@ protocol r23952125 {
   associatedtype ItemType
   var count: Int { get }
   subscript(index: Int) -> ItemType  // expected-error {{subscript in protocol must have explicit { get } or { get set } specifier}} {{36-36= { get <#set#> \}}}
-  
-  var c : Int // expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
+
+  var c : Int // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-14= { get <#set#> \}}}
 }
 
 // <rdar://problem/16812341> QoI: Poor error message when providing a default value for a subscript parameter

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -12,6 +12,7 @@ protocol SomeProtocol {
   lazy var x : Int  // expected-error {{'lazy' isn't allowed on a protocol requirement}} {{3-8=}}
   // expected-error@-1 {{property in protocol must have explicit { get } or { get set } specifier}}
   // expected-error@-2 {{lazy properties must have an initializer}}
+  // {{18-18= { get set \}}}
   lazy var y : Int { get } // expected-error {{'lazy' isn't allowed on a protocol requirement}} {{3-8=}}
   // expected-error@-1 {{'lazy' must not be used on a computed property}}
   // expected-error@-2 {{lazy properties must have an initializer}}

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -10,9 +10,8 @@ struct S {
 
 protocol SomeProtocol {
   lazy var x : Int  // expected-error {{'lazy' isn't allowed on a protocol requirement}} {{3-8=}}
-  // expected-error@-1 {{property in protocol must have explicit { get } or { get set } specifier}}
+  // expected-error@-1 {{property in protocol must have explicit { get } or { get set } specifier}} {{19-19= { get <#set#> \}}}
   // expected-error@-2 {{lazy properties must have an initializer}}
-  // {{18-18= { get set \}}}
   lazy var y : Int { get } // expected-error {{'lazy' isn't allowed on a protocol requirement}} {{3-8=}}
   // expected-error@-1 {{'lazy' must not be used on a computed property}}
   // expected-error@-2 {{lazy properties must have an initializer}}

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -850,7 +850,7 @@ struct WillSetDidSetDisambiguate3 {
 }
 
 protocol ProtocolGetSet1 {
-  var a: Int // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} //{{13-13= { get <#set#> \}}}
+  var a: Int // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{13-13= { get <#set#> \}}}
 }
 protocol ProtocolGetSet2 {
   var a: Int {} // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-16={ get <#set#> \}}}

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -881,6 +881,9 @@ protocol ProtocolWillSetDidSet3 {
 protocol ProtocolWillSetDidSet4 {
   var a: Int { didSet willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-32={ get <#set#> \}}} expected-error 2 {{expected get or set in a protocol property}}
 }
+protocol ProtocolWillSetDidSet5 {
+  let a: Int { didSet willSet }  // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-32={ get <#set#> \}}} {{none}} expected-error 2 {{expected get or set in a protocol property}} expected-error {{'let' declarations cannot be computed properties}} {{3-6=var}}
+}
 
 var globalDidsetWillSet: Int {  // expected-error {{non-member observing properties require an initializer}}
   didSet {}

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -850,10 +850,10 @@ struct WillSetDidSetDisambiguate3 {
 }
 
 protocol ProtocolGetSet1 {
-  var a: Int // expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
+  var a: Int // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} //{{13-13= { get <#set#> \}}}
 }
 protocol ProtocolGetSet2 {
-  var a: Int {} // expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
+  var a: Int {} // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-16={ get <#set#> \}}}
 }
 protocol ProtocolGetSet3 {
   var a: Int { get }
@@ -869,16 +869,17 @@ protocol ProtocolGetSet6 {
 }
 
 protocol ProtocolWillSetDidSet1 {
-  var a: Int { willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error {{expected get or set in a protocol property}}
+  var a: Int { willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-25={ get <#set#> \}}} expected-error {{expected get or set in a protocol property}}
 }
 protocol ProtocolWillSetDidSet2 {
-  var a: Int { didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error {{expected get or set in a protocol property}}
+  var a: Int { didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-24={ get <#set#> \}}} expected-error {{expected get or set in a protocol property}}
 }
 protocol ProtocolWillSetDidSet3 {
-  var a: Int { willSet didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error 2 {{expected get or set in a protocol property}}
+  var a: Int { willSet didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-32={ get <#set#> \}}} expected-error 2 {{expected get or set in a protocol property}}
+
 }
 protocol ProtocolWillSetDidSet4 {
-  var a: Int { didSet willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error 2 {{expected get or set in a protocol property}}
+  var a: Int { didSet willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-32={ get <#set#> \}}} expected-error 2 {{expected get or set in a protocol property}}
 }
 
 var globalDidsetWillSet: Int {  // expected-error {{non-member observing properties require an initializer}}


### PR DESCRIPTION
Improve fix-it for following code to resolves [SR-8340](https://bugs.swift.org/browse/SR-8340).

```swift
protocol P {
  subscript() -> Bool 
  // before: insert "{ get set }"
  // after: insert "{ get <#set#> }"

  var v : Bool
  // before: No fixit (error message only)
  // after: insert "{ get <#set#> } "

  let n : Bool
  // before: No fixit (error message only)
  // after: replace with "var" and insert "{ get } "
}
```