### PR TITLE
(constexpr) fix: getSingleWriterAddressValue sets some incorrect TupleElementAddrInst values

### DIFF
--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -81,6 +81,18 @@ func test_loops() {
   #assert(loops2(a: 20000) > 42)
 }
 
+func test_tupleElementAddrInitialization() {
+  func identity<T>(_ t: T) -> T {
+    return t
+  }
+
+  // SIL initializes a buffer of type (Int, Int), stores "1" and "2" to the
+  // tuple_element_addr's, and then passes the address of the buffer to
+  // `identity`. Therefore, this test tests that we can evaluate top-level
+  // buffers initialized via tuple_element_addr's.
+  #assert(identity((1, 2)) == (1, 2))
+}
+
 //===----------------------------------------------------------------------===//
 // Reduced testcase propagating substitutions around.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Fixes the following bug:

`getSingleWriterAddressValue` calls itself (on L1250) to test whether a TupleElementAddrInst is a "single writer address value".

If the TupleElementAddrInst is indeed a "single writer address value", then everything works fine and we point the TupleElementAddrInst at memory containing the correct value.

However, if the TupleElementAddrInst is for reading the tuple value, then we point the TupleElementAddrInst at uninitialized memory. When later code comes along and tries to calculate the address for reading, it gives up because it sees that the TupleElementAddrInst is already pointing at uninitialized memory.