### PR TITLE
[stdlib] Force-inline Dictionary.subscript(_:, default:)._modify

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -933,6 +933,7 @@ extension Dictionary {
     get {
       return _variant.lookup(key) ?? defaultValue()
     }
+    @inline(__always)
     _modify {
       let (bucket, found) = _variant.mutatingFind(key)
       let native = _variant.asNative


### PR DESCRIPTION
Otherwise the autoclosure argument gets allocated on the heap, which leads to a 2x slowdown.

rdar://problem/44936389