### PR TITLE
[stdlib] Speed up _Bitset in size-optimized builds

### DIFF
--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -38,7 +38,10 @@ extension _UnsafeBitset {
   @inline(__always)
   internal static func word(for element: Int) -> Int {
     _sanityCheck(element >= 0)
-    return element &>> Word.shift
+    // Note: We perform on UInts to get faster unsigned math (shifts).
+    let element = UInt(bitPattern: element)
+    let capacity = UInt(bitPattern: Word.capacity)
+    return Int(bitPattern: element / capacity)
   }
 
   @inlinable
@@ -48,7 +51,7 @@ extension _UnsafeBitset {
     // Note: We perform on UInts to get faster unsigned math (masking).
     let element = UInt(bitPattern: element)
     let capacity = UInt(bitPattern: Word.capacity)
-    return Int(bitPattern: element & (capacity &- 1))
+    return Int(bitPattern: element % capacity)
   }
 
   @inlinable
@@ -61,7 +64,7 @@ extension _UnsafeBitset {
   @inline(__always)
   internal static func join(word: Int, bit: Int) -> Int {
     _sanityCheck(bit >= 0 && bit < Word.capacity)
-    return (word &<< Word.shift) + bit
+    return word * Word.capacity + bit
   }
 }
 
@@ -69,14 +72,14 @@ extension _UnsafeBitset {
   @inlinable
   @inline(__always)
   internal static func wordCount(forCapacity capacity: Int) -> Int {
-    return (capacity + Word.capacity - 1) &>> Word.shift
+    return word(for: capacity + Word.capacity - 1)
   }
 
   @inlinable
   internal var capacity: Int {
     @inline(__always)
     get {
-      return wordCount &<< Word.shift
+      return wordCount * Word.capacity
     }
   }
 
@@ -198,14 +201,6 @@ extension _UnsafeBitset.Word {
     @inline(__always)
     get {
       return UInt.bitWidth
-    }
-  }
-
-  @inlinable
-  internal static var shift: Int {
-    @inline(__always)
-    get {
-      return UInt.bitWidth.trailingZeroBitCount
     }
   }
 

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -64,7 +64,7 @@ extension _UnsafeBitset {
   @inline(__always)
   internal static func join(word: Int, bit: Int) -> Int {
     _sanityCheck(bit >= 0 && bit < Word.capacity)
-    return word * Word.capacity + bit
+    return word &* Word.capacity + bit
   }
 }
 
@@ -79,7 +79,7 @@ extension _UnsafeBitset {
   internal var capacity: Int {
     @inline(__always)
     get {
-      return wordCount * Word.capacity
+      return wordCount &* Word.capacity
     }
   }
 

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -38,7 +38,7 @@ extension _UnsafeBitset {
   @inline(__always)
   internal static func word(for element: Int) -> Int {
     _sanityCheck(element >= 0)
-    return element / Word.capacity
+    return element &>> Word.shift
   }
 
   @inlinable
@@ -48,7 +48,7 @@ extension _UnsafeBitset {
     // Note: We perform on UInts to get faster unsigned math (masking).
     let element = UInt(bitPattern: element)
     let capacity = UInt(bitPattern: Word.capacity)
-    return Int(bitPattern: element % capacity)
+    return Int(bitPattern: element & (capacity &- 1))
   }
 
   @inlinable
@@ -61,7 +61,7 @@ extension _UnsafeBitset {
   @inline(__always)
   internal static func join(word: Int, bit: Int) -> Int {
     _sanityCheck(bit >= 0 && bit < Word.capacity)
-    return word * Word.capacity + bit
+    return (word &<< Word.shift) + bit
   }
 }
 
@@ -69,14 +69,14 @@ extension _UnsafeBitset {
   @inlinable
   @inline(__always)
   internal static func wordCount(forCapacity capacity: Int) -> Int {
-    return (capacity + Word.capacity - 1) / Word.capacity
+    return (capacity + Word.capacity - 1) &>> Word.shift
   }
 
   @inlinable
   internal var capacity: Int {
     @inline(__always)
     get {
-      return wordCount * Word.capacity
+      return wordCount &<< Word.shift
     }
   }
 
@@ -198,6 +198,14 @@ extension _UnsafeBitset.Word {
     @inline(__always)
     get {
       return UInt.bitWidth
+    }
+  }
+
+  @inlinable
+  internal static var shift: Int {
+    @inline(__always)
+    get {
+      return UInt.bitWidth.trailingZeroBitCount
     }
   }
 


### PR DESCRIPTION
Due to a possible low-level optimizer issue, a division-by-constant-power-of-two expression gets compiled into an actual division instruction with `-Osize`. Explicitly changing to unsigned arithmetic ensures they get emitted as right shifts.

There is a similar issue with multiplications, although that one boils down to unnecessary overflow checking. Switching to `&*` makes sure those get compiled into corresponding left shifts.