### PR TITLE
[SDK] Rename _NSKeyValueObservation to NSKeyValueObservation in source code.

### DIFF
--- a/stdlib/public/SDK/Foundation/NSObject.swift
+++ b/stdlib/public/SDK/Foundation/NSObject.swift
@@ -131,20 +131,21 @@ func _bridgeStringToKeyPath(_ keyPath:String) -> AnyKeyPath? {
     return __KVOKeyPathBridgeMachinery._bridgeKeyPath(keyPath)
 }
 
-// NOTE: older overlays called this NSKeyValueObservation. The two must
-// coexist, so it was renamed. The old name must not be used in the new
-// runtime.
-public class _NSKeyValueObservation : NSObject {
+// NOTE: older overlays called this NSKeyValueObservation. We now use
+// that name in the source code, but add an underscore to the runtime
+// name to avoid conflicts when both are loaded into the same process.
+@objc(_NSKeyValueObservation)
+public class NSKeyValueObservation : NSObject {
     
     @nonobjc weak var object : NSObject?
     @nonobjc let callback : (NSObject, NSKeyValueObservedChange<Any>) -> Void
     @nonobjc let path : String
     
     //workaround for <rdar://problem/31640524> Erroneous (?) error when using bridging in the Foundation overlay
-    @nonobjc static var swizzler : _NSKeyValueObservation? = {
-        let bridgeClass: AnyClass = _NSKeyValueObservation.self
+    @nonobjc static var swizzler : NSKeyValueObservation? = {
+        let bridgeClass: AnyClass = NSKeyValueObservation.self
         let observeSel = #selector(NSObject.observeValue(forKeyPath:of:change:context:))
-        let swapSel = #selector(_NSKeyValueObservation._swizzle_me_observeValue(forKeyPath:of:change:context:))
+        let swapSel = #selector(NSKeyValueObservation._swizzle_me_observeValue(forKeyPath:of:change:context:))
         let rootObserveImpl = class_getInstanceMethod(bridgeClass, observeSel)
         let swapObserveImpl = class_getInstanceMethod(bridgeClass, swapSel)
         method_exchangeImplementations(rootObserveImpl, swapObserveImpl)
@@ -153,7 +154,7 @@ public class _NSKeyValueObservation : NSObject {
     
     fileprivate init(object: NSObject, keyPath: AnyKeyPath, callback: @escaping (NSObject, NSKeyValueObservedChange<Any>) -> Void) {
         path = _bridgeKeyPathToString(keyPath)
-        let _ = _NSKeyValueObservation.swizzler
+        let _ = NSKeyValueObservation.swizzler
         self.object = object
         self.callback = callback
     }
@@ -162,7 +163,7 @@ public class _NSKeyValueObservation : NSObject {
         object?.addObserver(self, forKeyPath: path, options: options, context: nil)
     }
     
-    ///invalidate() will be called automatically when an _NSKeyValueObservation is deinited
+    ///invalidate() will be called automatically when an NSKeyValueObservation is deinited
     @objc public func invalidate() {
         object?.removeObserver(self, forKeyPath: path, context: nil)
         object = nil
@@ -187,13 +188,13 @@ public class _NSKeyValueObservation : NSObject {
 
 extension _KeyValueCodingAndObserving {
     
-    ///when the returned _NSKeyValueObservation is deinited or invalidated, it will stop observing
+    ///when the returned NSKeyValueObservation is deinited or invalidated, it will stop observing
     public func observe<Value>(
             _ keyPath: KeyPath<Self, Value>,
             options: NSKeyValueObservingOptions = [],
             changeHandler: @escaping (Self, NSKeyValueObservedChange<Value>) -> Void)
-        -> _NSKeyValueObservation {
-        let result = _NSKeyValueObservation(object: self as! NSObject, keyPath: keyPath) { (obj, change) in
+        -> NSKeyValueObservation {
+        let result = NSKeyValueObservation(object: self as! NSObject, keyPath: keyPath) { (obj, change) in
             let notification = NSKeyValueObservedChange(kind: change.kind,
                                                         newValue: change.newValue as? Value,
                                                         oldValue: change.oldValue as? Value,

--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -66,7 +66,7 @@ class Target : NSObject, NSKeyValueObservingCustomization {
 
 class ObserverKVO : NSObject {
     var target: Target?
-    var observation: _NSKeyValueObservation? = nil
+    var observation: NSKeyValueObservation? = nil
     
     override init() { target = nil; super.init() }
     


### PR DESCRIPTION
Keep _NSKeyValueObservation as the runtime name, since we need to avoid colliding with the name used in the pre-ABI-stable libraries.

rdar://problem/44914709