### PR TITLE
[stdlib] Mark _NativeDictionary._delete(at:) non-releasing

### DIFF
--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -540,6 +540,7 @@ extension _NativeDictionary: _HashTableDelegate {
 
 extension _NativeDictionary { // Deletion
   @inlinable
+  @_effects(releasenone)
   internal func _delete(at bucket: Bucket) {
     hashTable.delete(at: bucket, with: self)
     _storage._count -= 1

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -442,6 +442,7 @@ extension _NativeSet: _HashTableDelegate {
 
 extension _NativeSet { // Deletion
   @inlinable
+  @_effects(releasenone)
   internal mutating func _delete(at bucket: Bucket) {
     hashTable.delete(at: bucket, with: self)
     _storage._count -= 1


### PR DESCRIPTION
This eliminates a retain/release pair around calls to it when it doesn’t get inlined.

`_delete` is responsible for restoring hash table invariants after a removal. It moves elements around in complicated patterns, but it doesn’t release them.
