### PR TITLE
[AST] static_assert that Decls, Stmts, and Exprs don't need cleanup

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -67,6 +67,12 @@ STATISTIC(NumLazyGenericEnvironments,
 STATISTIC(NumLazyGenericEnvironmentsLoaded,
           "# of lazily-deserialized generic environments loaded");
 
+#define DECL(Id, _) \
+  static_assert((DeclKind::Id == DeclKind::Module) ^ \
+                IsTriviallyDestructible<Id##Decl>::value, \
+                "Decls are BumpPtrAllocated; the destructor is never called");
+#include "swift/AST/DeclNodes.def"
+
 const clang::MacroInfo *ClangNode::getAsMacro() const {
   if (auto MM = getAsModuleMacro())
     return MM->getMacroInfo();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -32,6 +32,11 @@
 #include "llvm/ADT/Twine.h"
 using namespace swift;
 
+#define EXPR(Id, _) \
+  static_assert(IsTriviallyDestructible<Id##Expr>::value, \
+                "Exprs are BumpPtrAllocated; the destructor is never called");
+#include "swift/AST/ExprNodes.def"
+
 StringRef swift::getFunctionRefKindStr(FunctionRefKind refKind) {
   switch (refKind) {
   case FunctionRefKind::Unapplied:

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -24,6 +24,11 @@
 
 using namespace swift;
 
+#define STMT(Id, _) \
+  static_assert(IsTriviallyDestructible<Id##Stmt>::value, \
+                "Stmts are BumpPtrAllocated; the destructor is never called");
+#include "swift/AST/StmtNodes.def"
+
 //===----------------------------------------------------------------------===//
 // Stmt methods.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
These types are all allocated on the ASTContext's BumpPtrAllocator, and by default their destructors are never called. (ModuleDecl is the exception; it registers its destructor with the ASTContext on construction.)

No functionality change.