### PR TITLE
SourceKit: explicitly link against BlocksRuntime as well

### DIFF
--- a/tools/SourceKit/lib/Support/CMakeLists.txt
+++ b/tools/SourceKit/lib/Support/CMakeLists.txt
@@ -8,12 +8,11 @@ set(SourceKitSupport_sources
   UIDRegistry.cpp
 )
 
-set(SOURCEKIT_SUPPORT_DEPEND swiftBasic swiftSyntax clangBasic clangRewrite)
-if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-  list(APPEND SOURCEKIT_SUPPORT_DEPEND dispatch BlocksRuntime)
-endif()
-
 add_sourcekit_library(SourceKitSupport
   ${SourceKitSupport_sources}
-  LINK_LIBS ${SOURCEKIT_SUPPORT_DEPEND}
+  LINK_LIBS swiftBasic swiftSyntax clangBasic clangRewrite
 )
+if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
+  target_link_libraries(SourceKitSupport INTERFACE dispatch BlocksRuntime)
+endif()
+

--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
@@ -4,15 +4,14 @@ else()
   set(SOURCEKITD_TEST_LINK_LIBS sourcekitd)
 endif()
 
-if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-  set(SOURCEKITD_TEST_LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS} dispatch)
-endif()
-
 add_sourcekit_executable(complete-test
   complete-test.cpp
   LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS}
   LLVM_COMPONENT_DEPENDS support option coverage lto
 )
+if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
+  target_link_libraries(complete-test PRIVATE dispatch BlocksRuntime)
+endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set_target_properties(complete-test

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -8,15 +8,14 @@ if(HAVE_UNICODE_LIBEDIT)
     set(SOURCEKITD_REPL_LINK_LIBS sourcekitd)
   endif()
 
-  if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-    set(SOURCEKITD_REPL_LINK_LIBS ${SOURCEKITD_REPL_LINK_LIBS} dispatch)
-  endif()
-
   add_sourcekit_executable(sourcekitd-repl
     sourcekitd-repl.cpp
     LINK_LIBS ${SOURCEKITD_REPL_LINK_LIBS} edit
     LLVM_COMPONENT_DEPENDS support coverage lto
   )
+  if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
+    target_link_libraries(sourcekitd-repl PRIVATE dispatch BlocksRuntime)
+  endif()
 
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(sourcekitd-repl

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -8,10 +8,6 @@ else()
   set(SOURCEKITD_TEST_LINK_LIBS sourcekitd)
 endif()
 
-if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
-  set(SOURCEKITD_TEST_LINK_LIBS ${SOURCEKITD_TEST_LINK_LIBS} dispatch)
-endif()
-
 add_sourcekit_executable(sourcekitd-test
   sourcekitd-test.cpp
   TestOptions.cpp
@@ -19,6 +15,9 @@ add_sourcekit_executable(sourcekitd-test
     clangRewrite clangLex clangBasic
   LLVM_COMPONENT_DEPENDS core support option coverage lto
 )
+if(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH)
+  target_link_libraries(sourcekitd-test PRIVATE dispatch BlocksRuntime)
+endif()
 
 add_dependencies(sourcekitd-test sourcekitdTestOptionsTableGen)
 


### PR DESCRIPTION
On Darwin platforms, libdispatch and libBlocksRuntime are re-exported from
libSystem (via LC_REEXPORT_DYLIB).  Other platforms do not have libdispatch and
libBlocksRuntime in their C runtime, so we need to explicitly link against them.
Now that we are building BlocksRuntime with hidden visibility, we do not
accidentally get the symbols from libdispatch.