### PR TITLE
[AST] More static_asserts for non-destroyed bump-allocated AST types

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -28,6 +28,15 @@
 #include "llvm/ADT/StringSwitch.h"
 using namespace swift;
 
+#define DECL_ATTR(_, Id, ...) \
+  static_assert(IsTriviallyDestructible<Id##Attr>::value, \
+                "Attrs are BumpPtrAllocated; the destructor is never called");
+#include "swift/AST/Attr.def"
+static_assert(IsTriviallyDestructible<DeclAttributes>::value,
+              "DeclAttributes are BumpPtrAllocated; the d'tor is never called");
+static_assert(IsTriviallyDestructible<TypeAttributes>::value,
+              "TypeAttributes are BumpPtrAllocated; the d'tor is never called");
+
 
 // Only allow allocation of attributes using the allocator in ASTContext.
 void *AttributeBase::operator new(size_t Bytes, ASTContext &C,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -72,6 +72,10 @@ STATISTIC(NumLazyGenericEnvironmentsLoaded,
                 IsTriviallyDestructible<Id##Decl>::value, \
                 "Decls are BumpPtrAllocated; the destructor is never called");
 #include "swift/AST/DeclNodes.def"
+static_assert(IsTriviallyDestructible<ParameterList>::value,
+              "ParameterLists are BumpPtrAllocated; the d'tor is never called");
+static_assert(IsTriviallyDestructible<GenericParamList>::value,
+              "GenericParamLists are BumpPtrAllocated; the d'tor isn't called");
 
 const clang::MacroInfo *ClangNode::getAsMacro() const {
   if (auto MM = getAsModuleMacro())

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -25,6 +25,11 @@
 #include "llvm/Support/raw_ostream.h"
 using namespace swift;
 
+#define PATTERN(Id, _) \
+  static_assert(IsTriviallyDestructible<Id##Pattern>::value, \
+                "Patterns are BumpPtrAllocated; the d'tor is never called");
+#include "swift/AST/PatternNodes.def"
+
 /// Diagnostic printing of PatternKinds.
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS, PatternKind kind) {
   switch (kind) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -42,6 +42,11 @@
 #include <iterator>
 using namespace swift;
 
+#define TYPE(Id, _) \
+  static_assert(IsTriviallyDestructible<Id##Type>::value, \
+                "Types are BumpPtrAllocated; the destructor is never called");
+#include "swift/AST/TypeNodes.def"
+
 Type QueryTypeSubstitutionMap::operator()(SubstitutableType *type) const {
   auto key = type->getCanonicalType()->castTo<SubstitutableType>();
   auto known = substitutions.find(key);

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -28,6 +28,11 @@
 #include "llvm/Support/raw_ostream.h"
 using namespace swift;
 
+#define TYPEREPR(Id, _) \
+  static_assert(IsTriviallyDestructible<Id##TypeRepr>::value, \
+                "TypeReprs are BumpPtrAllocated; the d'tor is never called");
+#include "swift/AST/TypeReprNodes.def"
+
 SourceLoc TypeRepr::getLoc() const {
   switch (getKind()) {
 #define TYPEREPR(CLASS, PARENT) \


### PR DESCRIPTION
Attributes, ParameterLists, GenericParamLists, Patterns, Types, and TypeReprs. Follow-up to #19667; thanks, @rintaro!