### PR TITLE
[TypeJoin] Implement Type::join for protocols and protocol compositions.

### DIFF
--- a/test/Sema/type_join.swift
+++ b/test/Sema/type_join.swift
@@ -75,9 +75,9 @@ expectEqualType(Builtin.type_join(FakeEquatable.self, FakeEquatable.self), FakeE
 expectEqualType(Builtin.type_join(FakeHashable.self, FakeEquatable.self), FakeEquatable.self)
 expectEqualType(Builtin.type_join(FakeEquatable.self, FakeHashable.self), FakeEquatable.self)
 expectEqualType(Builtin.type_join(FakeNumeric.self, FakeHashable.self), FakeEquatable.self)
-expectEqualType(Builtin.type_join((FakeHashable & Strideable).self, (FakeHashable & FakeNumeric).self),
+expectEqualType(Builtin.type_join((FakeHashable & FakeStrideable).self, (FakeHashable & FakeNumeric).self),
                                   FakeHashable.self)
-expectEqualType(Builtin.type_join((FakeNumeric & Strideable).self,
+expectEqualType(Builtin.type_join((FakeNumeric & FakeStrideable).self,
                                   (FakeHashable & FakeNumeric).self), FakeNumeric.self)
 expectEqualType(Builtin.type_join(FakeBinaryInteger.self, FakeFloatingPoint.self),
                                   (FakeHashable & FakeNumeric & FakeStrideable).self)

--- a/test/Sema/type_join.swift
+++ b/test/Sema/type_join.swift
@@ -5,6 +5,31 @@ import Swift
 class C {}
 class D : C {}
 
+protocol L {}
+protocol M : L {}
+protocol N : L {}
+protocol P : M {}
+protocol Q : M {}
+protocol R : L {}
+protocol Y {}
+
+protocol FakeEquatable {}
+protocol FakeHashable : FakeEquatable {}
+protocol FakeExpressibleByIntegerLiteral {}
+protocol FakeNumeric : FakeEquatable, FakeExpressibleByIntegerLiteral {}
+protocol FakeSignedNumeric : FakeNumeric {}
+protocol FakeComparable : FakeEquatable {}
+protocol FakeStrideable : FakeComparable {}
+protocol FakeCustomStringConvertible {}
+protocol FakeBinaryInteger : FakeHashable, FakeNumeric, FakeCustomStringConvertible, FakeStrideable {}
+protocol FakeLosslessStringConvertible {}
+protocol FakeFixedWidthInteger : FakeBinaryInteger, FakeLosslessStringConvertible {}
+protocol FakeUnsignedInteger : FakeBinaryInteger {}
+protocol FakeSignedInteger : FakeBinaryInteger, FakeSignedNumeric {}
+protocol FakeFloatingPoint : FakeSignedNumeric, FakeStrideable, FakeHashable {}
+protocol FakeExpressibleByFloatLiteral {}
+protocol FakeBinaryFloatingPoint : FakeFloatingPoint, FakeExpressibleByFloatLiteral {}
+
 func expectEqualType<T>(_: T.Type, _: T.Type) {}
 func commonSupertype<T>(_: T, _: T) -> T {}
 
@@ -37,6 +62,27 @@ expectEqualType(Builtin.type_join(Any.self, Any?.self), Any?.self)
 expectEqualType(Builtin.type_join(Builtin.Int1.self, Builtin.Int1.self), Builtin.Int1.self)
 expectEqualType(Builtin.type_join(Builtin.Int32.self, Builtin.Int1.self), Any.self)
 expectEqualType(Builtin.type_join(Builtin.Int1.self, Builtin.Int32.self), Any.self)
+
+expectEqualType(Builtin.type_join(L.self, L.self), L.self)
+expectEqualType(Builtin.type_join(L.self, M.self), L.self)
+expectEqualType(Builtin.type_join(L.self, P.self), L.self)
+expectEqualType(Builtin.type_join(L.self, Y.self), Any.self)
+expectEqualType(Builtin.type_join(N.self, P.self), L.self)
+expectEqualType(Builtin.type_join(Q.self, P.self), M.self)
+expectEqualType(Builtin.type_join((N & P).self, (Q & R).self), M.self)
+expectEqualType(Builtin.type_join((Q & P).self, (Y & R).self), L.self)
+expectEqualType(Builtin.type_join(FakeEquatable.self, FakeEquatable.self), FakeEquatable.self)
+expectEqualType(Builtin.type_join(FakeHashable.self, FakeEquatable.self), FakeEquatable.self)
+expectEqualType(Builtin.type_join(FakeEquatable.self, FakeHashable.self), FakeEquatable.self)
+expectEqualType(Builtin.type_join(FakeNumeric.self, FakeHashable.self), FakeEquatable.self)
+expectEqualType(Builtin.type_join((FakeHashable & Strideable).self, (FakeHashable & FakeNumeric).self),
+                                  FakeHashable.self)
+expectEqualType(Builtin.type_join((FakeNumeric & Strideable).self,
+                                  (FakeHashable & FakeNumeric).self), FakeNumeric.self)
+expectEqualType(Builtin.type_join(FakeBinaryInteger.self, FakeFloatingPoint.self),
+                                  (FakeHashable & FakeNumeric & FakeStrideable).self)
+expectEqualType(Builtin.type_join(FakeFloatingPoint.self, FakeBinaryInteger.self),
+                                  (FakeHashable & FakeNumeric & FakeStrideable).self)
 
 func joinFunctions(
   _ escaping: @escaping () -> (),


### PR DESCRIPTION
This is mostly complete, but we still need to add support for joins
between these two types and other types.
