### PR TITLE
[stdlib] Underscore @usableFromInline symbols

### DIFF
--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -14,9 +14,8 @@
 /// `_ArrayBufferProtocol`.  This buffer does not provide value semantics.
 @usableFromInline
 internal protocol _ArrayBufferProtocol
-  : MutableCollection, RandomAccessCollection {
-
-  associatedtype Indices = Range<Int>
+  : MutableCollection, RandomAccessCollection 
+where Indices == Range<Int> {
 
   /// Create an empty buffer.
   init()
@@ -35,9 +34,9 @@ internal protocol _ArrayBufferProtocol
     initializing target: UnsafeMutablePointer<Element>
   ) -> UnsafeMutablePointer<Element>
 
-  /// Get or set the index'th element.
-  subscript(index: Int) -> Element { get nonmutating set }
-
+  // /// Get or set the index'th element.
+  // subscript(index: Int) -> Element { get nonmutating set }
+  //
   /// If this buffer is backed by a uniquely-referenced mutable
   /// `_ContiguousArrayBuffer` that can be grown in-place to allow the `self`
   /// buffer store `minimumCapacity` elements, returns that buffer.
@@ -121,9 +120,6 @@ internal protocol _ArrayBufferProtocol
   /// buffers address the same elements when they have the same
   /// identity and count.
   var identity: UnsafeRawPointer { get }
-
-  var startIndex: Int { get }
-  var endIndex: Int { get }
 }
 
 extension _ArrayBufferProtocol where Indices == Range<Int>{

--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -52,10 +52,10 @@ public func _arrayForceCast<SourceElement, TargetElement>(
   return source.map { $0 as! TargetElement }
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout
+@usableFromInline
 internal struct _UnwrappingFailed : Error {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   internal init() {}
 }
 

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -11,19 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 @usableFromInline
-internal protocol ArrayProtocol
-  : RangeReplaceableCollection,
-    ExpressibleByArrayLiteral
-{
-  //===--- public interface -----------------------------------------------===//
-  /// The number of elements the Array stores.
-  override var count: Int { get }
-
+internal protocol _ArrayProtocol
+  : RangeReplaceableCollection, ExpressibleByArrayLiteral
+where Index == Int {
   /// The number of elements the Array can store without reallocation.
   var capacity: Int { get }
-
-  /// `true` if and only if the Array is empty.
-  override var isEmpty: Bool { get }
 
   /// An object that guarantees the lifetime of this array's elements.
   var _owner: AnyObject? { get }
@@ -32,47 +24,145 @@ internal protocol ArrayProtocol
   /// element. Otherwise, `nil`.
   var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? { get }
 
-  subscript(index: Int) -> Element { get set }
-
-  //===--- basic mutations ------------------------------------------------===//
-
-  /// Reserve enough space to store minimumCapacity elements.
-  ///
-  /// - Postcondition: `capacity >= minimumCapacity` and the array has
-  ///   mutable contiguous storage.
-  ///
-  /// - Complexity: O(`self.count`).
-  override mutating func reserveCapacity(_ minimumCapacity: Int)
-
-  /// Insert `newElement` at index `i`.
-  ///
-  /// Invalidates all indices with respect to `self`.
-  ///
-  /// - Complexity: O(`self.count`).
-  ///
-  /// - Precondition: `startIndex <= i`, `i <= endIndex`.
-  mutating func insert(_ newElement: __owned Element, at i: Int)
-
-  /// Remove and return the element at the given index.
-  ///
-  /// - returns: The removed element.
-  ///
-  /// - Complexity: Worst case O(*n*).
-  ///
-  /// - Precondition: `count > index`.
-  @discardableResult
-  mutating func remove(at index: Int) -> Element
-
   //===--- implementation detail  -----------------------------------------===//
 
-  associatedtype _Buffer : _ArrayBufferProtocol
+  associatedtype _Buffer: _ArrayBufferProtocol where _Buffer.Element == Element
   init(_ buffer: _Buffer)
 
   // For testing.
-  var _buffer: _Buffer { get }
+  var _buffer: _Buffer { get set }
 }
 
-extension ArrayProtocol {
+extension _ArrayProtocol {
+  /// An object that guarantees the lifetime of this array's elements.
+  @inlinable
+  public // @testable
+  var _owner: AnyObject? {
+    @inline(__always)
+    get {
+      return _buffer.owner      
+    }
+  }
+
+  /// If the elements are stored contiguously, a pointer to the first
+  /// element. Otherwise, `nil`.
+  @inlinable
+  public var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? {
+    @inline(__always) // FIXME(TODO: JIRA): Hack around test failure
+    get { return _buffer.firstElementAddressIfContiguous }
+  }
+
+  @inlinable
+  internal var _baseAddress: UnsafeMutablePointer<Element> {
+    return _buffer.firstElementAddress
+  }
+  
+  @inlinable
+  @_semantics("array.get_count")
+  internal func _getCount() -> Int {
+    return _buffer.count
+  }
+
+  @inlinable
+  @_semantics("array.get_capacity")
+  internal func _getCapacity() -> Int {
+    return _buffer.capacity
+  }
+  
+  @inlinable
+  @_semantics("array.make_mutable")
+  internal mutating func _makeMutableAndUnique() {
+    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
+      _buffer = _Buffer(copying: _buffer)
+    }
+  }
+
+  @inlinable
+  @_semantics("array.reserve_capacity_for_append")
+  internal mutating func reserveCapacityForAppend(newElementsCount: Int) {
+    let oldCount = self.count
+    let oldCapacity = self.capacity
+    let newCount = oldCount + newElementsCount
+
+    // Ensure uniqueness, mutability, and sufficient storage.  Note that
+    // for consistency, we need unique self even if newElements is empty.
+    self.reserveCapacity(
+      newCount > oldCapacity ?
+      Swift.max(newCount, _growArrayCapacity(oldCapacity))
+      : newCount)
+  }
+
+  @inlinable
+  @_semantics("array.mutate_unknown")
+  internal mutating func _appendElementAssumeUniqueAndCapacity(
+    _ oldCount: Int,
+    newElement: __owned Element
+  ) {
+    _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
+    _sanityCheck(_buffer.capacity >= _buffer.count + 1)
+
+    _buffer.count = oldCount + 1
+    (_buffer.firstElementAddress + oldCount).initialize(to: newElement)
+  }
+
+  @inline(never)
+  @usableFromInline
+  internal static func _allocateBufferUninitialized(
+    minimumCapacity: Int
+  ) -> _Buffer {
+    let newBuffer = _ContiguousArrayBuffer<Element>(
+      _uninitializedCount: 0, minimumCapacity: minimumCapacity)
+    return _Buffer(_buffer: newBuffer, shiftedToStartIndex: 0)
+  }
+
+  /// Copy the contents of the current buffer to a new unique mutable buffer.
+  /// The count of the new buffer is set to `oldCount`, the capacity of the
+  /// new buffer is big enough to hold 'oldCount' + 1 elements.
+  @inline(never)
+  @inlinable // @specializable
+  internal mutating func _copyToNewBuffer(oldCount: Int) {
+    let newCount = oldCount + 1
+    var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
+      countForNewBuffer: oldCount, minNewCapacity: newCount)
+    _buffer._arrayOutOfPlaceUpdate(&newBuffer, oldCount, 0)
+  }
+
+  @inlinable
+  @_semantics("array.make_mutable")
+  internal mutating func _makeUniqueAndReserveCapacityIfNotUnique() {
+    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
+      _copyToNewBuffer(oldCount: _buffer.count)
+    }
+  }
+
+  @inlinable
+  @_semantics("array.mutate_unknown")
+  internal mutating func _reserveCapacityAssumingUniqueBuffer(oldCount: Int) {
+    // This is a performance optimization. This code used to be in an ||
+    // statement in the _sanityCheck below.
+    //
+    //   _sanityCheck(_buffer.capacity == 0 ||
+    //                _buffer.isMutableAndUniquelyReferenced())
+    //
+    // SR-6437
+    let capacity = _buffer.capacity == 0
+
+    // Due to make_mutable hoisting the situation can arise where we hoist
+    // _makeMutableAndUnique out of loop and use it to replace
+    // _makeUniqueAndReserveCapacityIfNotUnique that preceeds this call. If the
+    // array was empty _makeMutableAndUnique does not replace the empty array
+    // buffer by a unique buffer (it just replaces it by the empty array
+    // singleton).
+    // This specific case is okay because we will make the buffer unique in this
+    // function because we request a capacity > 0 and therefore _copyToNewBuffer
+    // will be called creating a new buffer.
+    _sanityCheck(capacity || _buffer.isMutableAndUniquelyReferenced())
+
+    if _slowPath(oldCount + 1 > _buffer.capacity) {
+      _copyToNewBuffer(oldCount: oldCount)
+    }
+  }
+  
   // Since RangeReplaceableCollection now has a version of filter that is less
   // efficient, we should make the default implementation coming from Sequence
   // preferred.

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -59,8 +59,7 @@ func _isStdlibInternalChecksEnabled() -> Bool {
 }
 
 @usableFromInline @_transparent
-internal
-func _fatalErrorFlags() -> UInt32 {
+internal func _fatalErrorFlags() -> UInt32 {
   // The current flags are:
   // (1 << 0): Report backtrace on fatal error
 #if os(iOS) || os(tvOS) || os(watchOS)

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -217,19 +217,19 @@ extension UInt {
 @_fixed_layout
 public struct CVaListPointer {
   @usableFromInline // unsafe-performance
-  internal var value: UnsafeMutableRawPointer
+  internal var _value: UnsafeMutableRawPointer
 
   @inlinable // unsafe-performance
   public // @testable
   init(_fromUnsafeMutablePointer from: UnsafeMutableRawPointer) {
-    value = from
+    _value = from
   }
 }
 
 extension CVaListPointer : CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
   public var debugDescription: String {
-    return value.debugDescription
+    return _value.debugDescription
   }
 }
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -672,7 +672,6 @@ extension _ClosureBasedSequence: Sequence {
 /// An instance of `AnySequence` forwards its operations to an underlying base
 /// sequence having the same `Element` type, hiding the specifics of the
 /// underlying sequence.
-//@usableFromInline
 @_fixed_layout
 public struct AnySequence<Element> {
   @usableFromInline
@@ -834,9 +833,7 @@ internal protocol _AnyIndexBox : class {
 
 @_fixed_layout
 @usableFromInline
-internal final class _IndexBox<
-  BaseIndex : Comparable
-> : _AnyIndexBox {
+internal final class _IndexBox<BaseIndex: Comparable>: _AnyIndexBox {
   @usableFromInline
   internal var _base: BaseIndex
 

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -50,14 +50,14 @@ extension JoinedSequence {
     
     @_frozen // lazy-performance
     @usableFromInline // lazy-performance
-    internal enum JoinIteratorState {
+    internal enum _JoinIteratorState {
       case start
       case generatingElements
       case generatingSeparator
       case end
     }
     @usableFromInline // lazy-performance
-    internal var _state: JoinIteratorState = .start
+    internal var _state: _JoinIteratorState = .start
 
     /// Creates a sequence that presents the elements of `base` sequences
     /// concatenated using `separator`.

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -226,7 +226,7 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   }
   
   @usableFromInline
-  internal final func projectReadOnly(from root: Root) -> Value {
+  internal final func _projectReadOnly(from root: Root) -> Value {
     // TODO: For perf, we could use a local growable buffer instead of Any
     var curBase: Any = root
     return withBuffer {
@@ -241,7 +241,7 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
         
         func project<CurValue>(_ base: CurValue) -> Value? {
           func project2<NewValue>(_: NewValue.Type) -> Value? {
-            switch rawComponent.projectReadOnly(base,
+            switch rawComponent._projectReadOnly(base,
               to: NewValue.self, endingWith: Value.self) {
             case .continue(let newBase):
               if isLast {
@@ -281,7 +281,7 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
   // `base` is assumed to be undergoing a formal access for the duration of the
   // call, so must not be mutated by an alias
   @usableFromInline
-  internal func projectMutableAddress(from base: UnsafePointer<Root>)
+  internal func _projectMutableAddress(from base: UnsafePointer<Root>)
       -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
     var p = UnsafeRawPointer(base)
     var type: Any.Type = Root.self
@@ -306,7 +306,7 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
         
         func project<CurValue>(_: CurValue.Type) {
           func project2<NewValue>(_: NewValue.Type) {
-            p = rawComponent.projectMutableAddress(p,
+            p = rawComponent._projectMutableAddress(p,
                                            from: CurValue.self,
                                            to: NewValue.self,
                                            isRoot: p == UnsafeRawPointer(base),
@@ -338,16 +338,16 @@ public class ReferenceWritableKeyPath<
 
   internal final override class var kind: Kind { return .reference }
   
-  internal final override func projectMutableAddress(
+  internal final override func _projectMutableAddress(
     from base: UnsafePointer<Root>
   ) -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
     // Since we're a ReferenceWritableKeyPath, we know we don't mutate the base
     // in practice.
-    return projectMutableAddress(from: base.pointee)
+    return _projectMutableAddress(from: base.pointee)
   }
   
   @usableFromInline
-  internal final func projectMutableAddress(from origBase: Root)
+  internal final func _projectMutableAddress(from origBase: Root)
       -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
     var keepAlive: AnyObject?
     var address: UnsafeMutablePointer<Value> = withBuffer {
@@ -362,7 +362,7 @@ public class ReferenceWritableKeyPath<
         
         func project<NewValue>(_: NewValue.Type) -> Any {
           func project2<CurValue>(_ base: CurValue) -> Any {
-            return rawComponent.projectReadOnly(
+            return rawComponent._projectReadOnly(
               base, to: NewValue.self, endingWith: Value.self)
               .assumingContinue
           }
@@ -384,7 +384,7 @@ public class ReferenceWritableKeyPath<
             let nextType = optNextType ?? Value.self
             func project<CurValue>(_: CurValue.Type) {
               func project2<NewValue>(_: NewValue.Type) {
-                p = rawComponent.projectMutableAddress(p,
+                p = rawComponent._projectMutableAddress(p,
                                              from: CurValue.self,
                                              to: NewValue.self,
                                              isRoot: p == baseBytes.baseAddress,
@@ -1305,7 +1305,7 @@ internal struct RawKeyPathComponent {
     }
   }
 
-  internal func projectReadOnly<CurValue, NewValue, LeafValue>(
+  internal func _projectReadOnly<CurValue, NewValue, LeafValue>(
     _ base: CurValue,
     to: NewValue.Type,
     endingWith: LeafValue.Type
@@ -1374,7 +1374,7 @@ internal struct RawKeyPathComponent {
     }
   }
 
-  internal func projectMutableAddress<CurValue, NewValue>(
+  internal func _projectMutableAddress<CurValue, NewValue>(
     _ base: UnsafeRawPointer,
     from _: CurValue.Type,
     to _: NewValue.Type,
@@ -1653,7 +1653,7 @@ func _projectKeyPathReadOnly<Root, Value>(
   root: Root,
   keyPath: KeyPath<Root, Value>
 ) -> Value {
-  return keyPath.projectReadOnly(from: root)
+  return keyPath._projectReadOnly(from: root)
 }
 
 @inlinable
@@ -1662,7 +1662,7 @@ func _projectKeyPathWritable<Root, Value>(
   root: UnsafeMutablePointer<Root>,
   keyPath: WritableKeyPath<Root, Value>
 ) -> (UnsafeMutablePointer<Value>, AnyObject?) {
-  return keyPath.projectMutableAddress(from: root)
+  return keyPath._projectMutableAddress(from: root)
 }
 
 @inlinable
@@ -1671,7 +1671,7 @@ func _projectKeyPathReferenceWritable<Root, Value>(
   root: Root,
   keyPath: ReferenceWritableKeyPath<Root, Value>
 ) -> (UnsafeMutablePointer<Value>, AnyObject?) {
-  return keyPath.projectMutableAddress(from: root)
+  return keyPath._projectMutableAddress(from: root)
 }
 
 // MARK: Appending type system

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -4,13 +4,19 @@
 /* RawRepresentable Changes */
 
 /* Removed Decls */
+Protocol ArrayProtocol has been removed
 
 /* Moved Decls */
 
 /* Renamed Decls */
+Var CVaListPointer.value has been renamed to Var CVaListPointer._value
 
 /* Type Changes */
+Var JoinedSequence.Iterator._state has declared type change from JoinedSequence<τ_0_0>.Iterator.JoinIteratorState to JoinedSequence<τ_0_0>.Iterator._JoinIteratorState
 
 /* Decl Attribute changes */
 
 /* Protocol Requirement Changes */
+Struct Array has removed conformance to ArrayProtocol
+Struct ArraySlice has removed conformance to ArrayProtocol
+Struct ContiguousArray has removed conformance to ArrayProtocol

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -4,6 +4,7 @@
 /* RawRepresentable Changes */
 
 /* Removed Decls */
+Protocol ArrayProtocol has been removed
 
 /* Moved Decls */
 
@@ -14,3 +15,6 @@
 /* Decl Attribute changes */
 
 /* Protocol Requirement Changes */
+Struct Array has removed conformance to ArrayProtocol
+Struct ArraySlice has removed conformance to ArrayProtocol
+Struct ContiguousArray has removed conformance to ArrayProtocol


### PR DESCRIPTION
Makes sure all internal methods that are `@usableFromInline` have an underscore, in case some day we want to create a public version with the same name.

Also factors a number of internal and public-but-underscored methods into `_ArrayProtocol` (they used to be gybbed per instance but they're identical).

Needs a couple of SILOptimizer tests fixed.