### PR TITLE
[Runtime] Make Swift errors bridged to NSError and cloned round-trippable

### DIFF
--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -555,6 +555,23 @@ ErrorBridgingTests.test("Customizing NSError via protocols") {
     nsError.userInfo[NSURLErrorKey as NSObject] as? URL)
 
   testCustomizedError(error: error, nsError: nsError)
+
+  // Clone the NSError.
+  let clonedNSError = NSError(domain: nsError.domain, code: nsError.code,
+    userInfo: nsError.userInfo)
+
+  // Cast the clone to the original.
+  let clonedError = clonedNSError as? MyCustomizedError
+  expectNotNil(clonedError)
+  expectEqual(12345, clonedError!.code)
+
+    // Cast the clone to Error and then localized error.
+  let clonedLocalizedTwoStep = clonedNSError as Error as? LocalizedError
+  expectNotNil(clonedLocalizedTwoStep)
+
+  // Cast the clone to a localized error.
+  let clonedLocalized = clonedNSError as? LocalizedError
+  expectNotNil(clonedLocalized)
 }
 
 ErrorBridgingTests.test("Customizing localization/recovery via protocols") {


### PR DESCRIPTION
When a Swift error is bridged to NSError, it maintains enough information
to round-trip back to Swift. However, if the NSError is then cloned—e.g.,
a new NSError is created with the same domain/code/user-info dictionary,
the identity of the Swift type is lost.

When we initially form the user-info dictionary for a Swift-defined
error that is not explicitly bridgeable back from an NSError instance,
add a new key to the user-info dictionary containing a wrapped copy of the
original error. When trying to bridge from NSError, look for that key in
the user-info dictionary and cast to its value.

Fixes rdar://problem/29882046.
