### PR TITLE
SILGen: Strip __owned from parameter types when emitting SE-0110 tuple splat

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -896,12 +896,18 @@ namespace {
         }
         auto outputOrigType = AbstractionPattern::getTuple(outputOrigTypes);
 
-        // Build the substituted output tuple type.
+        // Build the substituted output tuple type. Note that we deliberately
+        // don't use composeInput() because we want to drop ownership
+        // qualifiers.
+        SmallVector<TupleTypeElt, 8> elts;
+        for (auto param : outputSubstTypes) {
+          assert(!param.isVariadic());
+          assert(!param.isInOut());
+          elts.emplace_back(param.getParameterType());
+        }
         auto outputSubstType = cast<TupleType>(
-            AnyFunctionType::composeInput(SGF.getASTContext(),
-                                          outputSubstTypes,
-                                          /*canonicalVararg=*/true)
-              ->getCanonicalType());
+          TupleType::get(elts, SGF.getASTContext())
+            ->getCanonicalType());
 
         // Translate the input tuple value into the output tuple value. Note
         // that the output abstraction pattern is a tuple, and we explode tuples

--- a/test/Interpreter/FunctionConversion.swift
+++ b/test/Interpreter/FunctionConversion.swift
@@ -302,4 +302,25 @@ FunctionConversionTestSuite.test("CollectionUpCastsWithHashableInFuncParameters"
   expectEqual(rdar35702810_set_hashable(type: B.self, fn_set), 42)
 }
 
+func takesTwo(_ fn: ((AnyObject, AnyObject)) -> (),
+              _ a: AnyObject,
+              _ b: AnyObject) {
+  fn((a, b))
+}
+
+func takesTwoGeneric<T>(_ fn: (T) -> (), _ a: T) {
+  fn(a)
+}
+
+FunctionConversionTestSuite.test("SE0110") {
+  func callback1(_: AnyObject, _: AnyObject) {}
+  func callback2(_: __owned AnyObject, _: __owned AnyObject) {}
+
+  takesTwo(callback1, LifetimeTracked(0), LifetimeTracked(0))
+  takesTwo(callback2, LifetimeTracked(0), LifetimeTracked(0))
+
+  takesTwoGeneric(callback1, (LifetimeTracked(0), LifetimeTracked(0)))
+  takesTwoGeneric(callback2, (LifetimeTracked(0), LifetimeTracked(0)))
+}
+
 runAllTests()

--- a/test/SILGen/function_conversion_se0110.swift
+++ b/test/SILGen/function_conversion_se0110.swift
@@ -36,3 +36,24 @@ func givesNoneGeneric(_ fn: () -> ()) {
 
 // reabstraction thunk helper from @callee_guaranteed () -> () to @escaping @callee_guaranteed (@in_guaranteed ()) -> ()
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$sIg_ytIegn_TR : $@convention(thin) (@in_guaranteed (), @noescape @callee_guaranteed () -> ()) -> ()
+
+
+// "Tuple splat" still works if there are __owned parameters.
+// Make sure the memory management is correct also.
+
+// CHECK-LABEL: sil hidden @$s19function_conversion17takesTwoAnyObjectyyyyXl_yXlt_tXEF : $@convention(thin) (@noescape @callee_guaranteed (@guaranteed AnyObject, @guaranteed AnyObject) -> ()) -> ()
+func takesTwoAnyObject(_: ((AnyObject, AnyObject)) -> ()) {}
+
+// CHECK-LABEL: sil hidden @$s19function_conversion22givesTwoAnyObjectOwnedyyyyXln_yXlntXEF : $@convention(thin) (@noescape @callee_guaranteed (@owned AnyObject, @owned AnyObject) -> ()) -> ()
+func givesTwoAnyObjectOwned(_ fn: (__owned AnyObject, __owned AnyObject) -> ()) {
+  takesTwoAnyObject(fn)
+}
+
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$syXlyXlIgxx_yXlyXlIeggg_TR : $@convention(thin) (@guaranteed AnyObject, @guaranteed AnyObject, @noescape @callee_guaranteed (@owned AnyObject, @owned AnyObject) -> ()) -> () {
+// CHECK: bb0(%0 : @guaranteed $AnyObject, %1 : @guaranteed $AnyObject, %2 : @trivial $@noescape @callee_guaranteed (@owned AnyObject, @owned AnyObject) -> ()):
+// CHECK-NEXT: [[FIRST:%.*]] = copy_value %0
+// CHECK-NEXT: [[SECOND:%.*]] = copy_value %1
+// CHECK-NEXT: apply %2([[FIRST]], [[SECOND]]) : $@noescape @callee_guaranteed (@owned AnyObject, @owned AnyObject) -> ()
+// CHECK-NEXT: [[RESULT:%.*]] = tuple ()
+// CHECK-NEXT: return [[RESULT]] : $()
+// CHECK-NEXT: }


### PR DESCRIPTION
Instead of using composeInput(), build a tuple type containing
the element types only, dropping ownership qualifiers and
asserting that there are no inout or vararg elements.

This is correct because we already promote +0 values to +1, or
clean up +1 values that are only used as +0 as needed.

Fixes <rdar://problem/44915136>.