### PR TITLE
[stdlib] Force-inline some Sequence/Collection customization points

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1267,6 +1267,7 @@ extension Collection {
   ///
   /// - Complexity: Hopefully less than O(`count`).
   @inlinable
+  @inline(__always)
   public // dispatching
   func _customIndexOfEquatableElement(_: Element) -> Index?? {
     return nil
@@ -1283,6 +1284,7 @@ extension Collection {
   ///
   /// - Complexity: Hopefully less than O(`count`).
   @inlinable
+  @inline(__always)
   public // dispatching
   func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
     return nil
@@ -1802,6 +1804,7 @@ extension Collection where SubSequence == Self {
 
 extension Collection {
   @inlinable
+  @inline(__always)
   public func _preprocessingPass<R>(
     _ preprocess: () throws -> R
   ) rethrows -> R? {

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1383,16 +1383,19 @@ extension Dictionary {
     }
 
     @inlinable
+    @inline(__always)
     public func _customContainsEquatableElement(_ element: Element) -> Bool? {
       return _variant.contains(element)
     }
 
     @inlinable
+    @inline(__always)
     public func _customIndexOfEquatableElement(_ element: Element) -> Index?? {
       return Optional(_variant.index(forKey: element))
     }
 
     @inlinable
+    @inline(__always)
     public func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
       // The first and last elements are the same because each element is unique.
       return _customIndexOfEquatableElement(element)

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -905,6 +905,7 @@ extension Sequence {
   }
 
   @inlinable
+  @inline(__always)
   public func _preprocessingPass<R>(
     _ preprocess: () throws -> R
   ) rethrows -> R? {
@@ -912,6 +913,7 @@ extension Sequence {
   }
 
   @inlinable
+  @inline(__always)
   public func _customContainsEquatableElement(
     _ element: Iterator.Element
   ) -> Bool? {

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -266,6 +266,7 @@ extension Set: Sequence {
   }
 
   @inlinable
+  @inline(__always)
   public func _customContainsEquatableElement(_ member: Element) -> Bool? {
     return contains(member)
   }
@@ -361,6 +362,7 @@ extension Set: Collection {
   }
 
   @inlinable
+  @inline(__always)
   public func _customIndexOfEquatableElement(
      _ member: Element
     ) -> Index?? {
@@ -368,6 +370,7 @@ extension Set: Collection {
   }
 
   @inlinable
+  @inline(__always)
   public func _customLastIndexOfEquatableElement(
      _ member: Element
     ) -> Index?? {


### PR DESCRIPTION
This should be a code size win for specialized code at least, but I suspect there may be some performance improvements, too.