### PR TITLE
[stdlib] Set, Dictionary: force-inline native iterators

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1541,11 +1541,13 @@ extension Dictionary.Keys {
     internal var _base: Dictionary<Key, Value>.Iterator
 
     @inlinable
+    @inline(__always)
     internal init(_ base: Dictionary<Key, Value>.Iterator) {
       self._base = base
     }
 
     @inlinable
+    @inline(__always)
     public mutating func next() -> Key? {
 #if _runtime(_ObjC)
       if case .cocoa(let cocoa) = _base._variant {
@@ -1559,6 +1561,7 @@ extension Dictionary.Keys {
   }
 
   @inlinable
+  @inline(__always)
   public func makeIterator() -> Iterator {
     return Iterator(_variant.makeIterator())
   }
@@ -1571,11 +1574,13 @@ extension Dictionary.Values {
     internal var _base: Dictionary<Key, Value>.Iterator
 
     @inlinable
+    @inline(__always)
     internal init(_ base: Dictionary<Key, Value>.Iterator) {
       self._base = base
     }
 
     @inlinable
+    @inline(__always)
     public mutating func next() -> Value? {
 #if _runtime(_ObjC)
       if case .cocoa(let cocoa) = _base._variant {
@@ -1589,6 +1594,7 @@ extension Dictionary.Values {
   }
 
   @inlinable
+  @inline(__always)
   public func makeIterator() -> Iterator {
     return Iterator(_variant.makeIterator())
   }

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -233,6 +233,7 @@ extension _HashTable: Sequence {
     var word: Word
 
     @inlinable
+    @inline(__always)
     init(_ hashTable: _HashTable) {
       self.hashTable = hashTable
       self.wordIndex = 0
@@ -260,6 +261,7 @@ extension _HashTable: Sequence {
   }
 
   @inlinable
+  @inline(__always)
   internal func makeIterator() -> Iterator {
     return Iterator(self)
   }

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -656,6 +656,7 @@ extension _NativeDictionary: Sequence {
     internal var iterator: _HashTable.Iterator
 
     @inlinable
+    @inline(__always)
     init(_ base: __owned _NativeDictionary) {
       self.base = base
       self.iterator = base.hashTable.makeIterator()
@@ -673,18 +674,21 @@ extension _NativeDictionary.Iterator: IteratorProtocol {
   internal typealias Element = (key: Key, value: Value)
 
   @inlinable
+  @inline(__always)
   internal mutating func nextKey() -> Key? {
     guard let index = iterator.next() else { return nil }
     return base.uncheckedKey(at: index)
   }
 
   @inlinable
+  @inline(__always)
   internal mutating func nextValue() -> Value? {
     guard let index = iterator.next() else { return nil }
     return base.uncheckedValue(at: index)
   }
 
   @inlinable
+  @inline(__always)
   internal mutating func next() -> Element? {
     guard let index = iterator.next() else { return nil }
     let key = base.uncheckedKey(at: index)

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -494,6 +494,7 @@ extension _NativeSet: Sequence {
     internal var iterator: _HashTable.Iterator
 
     @inlinable
+    @inline(__always)
     init(_ base: __owned _NativeSet) {
       self.base = base
       self.iterator = base.hashTable.makeIterator()
@@ -501,6 +502,7 @@ extension _NativeSet: Sequence {
   }
 
   @inlinable
+  @inline(__always)
   internal __consuming func makeIterator() -> Iterator {
     return Iterator(self)
   }
@@ -508,6 +510,7 @@ extension _NativeSet: Sequence {
 
 extension _NativeSet.Iterator: IteratorProtocol {
   @inlinable
+  @inline(__always)
   internal mutating func next() -> Element? {
     guard let index = iterator.next() else { return nil }
     return base.uncheckedElement(at: index)


### PR DESCRIPTION
This is an experimental change. While looking at generated code, I noticed some inefficiencies that would be fixed by inlining the native `next()`.

This PR currently also inlines the top-level iterator entry points; however, that may have an adverse effect on code size, so I may need to remove that.