### PR TITLE
[stdlib] Underscore usable-from-inline types

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -315,7 +315,144 @@ public struct Array<Element>: _DestructorSafeContainer {
   internal init(_buffer: _Buffer) {
     self._buffer = _buffer
   }
+}
 
+//===--- private helpers---------------------------------------------------===//
+extension Array {
+  /// Returns `true` if the array is native and does not need a deferred
+  /// type check.  May be hoisted by the optimizer, which means its
+  /// results may be stale by the time they are used if there is an
+  /// inout violation in user code.
+  @inlinable
+  @_semantics("array.props.isNativeTypeChecked")
+  public // @testable
+  func _hoistableIsNativeTypeChecked() -> Bool {
+   return _buffer.arrayPropertyIsNativeTypeChecked
+  }
+
+  @inlinable
+  @_semantics("array.get_count")
+  internal func _getCount() -> Int {
+    return _buffer.count
+  }
+
+  @inlinable
+  @_semantics("array.get_capacity")
+  internal func _getCapacity() -> Int {
+    return _buffer.capacity
+  }
+
+  @inlinable
+  @_semantics("array.make_mutable")
+  internal mutating func _makeMutableAndUnique() {
+    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
+      _buffer = _Buffer(copying: _buffer)
+    }
+  }
+
+  /// Check that the given `index` is valid for subscripting, i.e.
+  /// `0 ≤ index < count`.
+  @inlinable
+  @inline(__always)
+  internal func _checkSubscript_native(_ index: Int) {
+    _ = _checkSubscript(index, wasNativeTypeChecked: true)
+  }
+
+  /// Check that the given `index` is valid for subscripting, i.e.
+  /// `0 ≤ index < count`.
+  @inlinable
+  @_semantics("array.check_subscript")
+  public // @testable
+  func _checkSubscript(
+    _ index: Int, wasNativeTypeChecked: Bool
+  ) -> _DependenceToken {
+#if _runtime(_ObjC)
+    _buffer._checkInoutAndNativeTypeCheckedBounds(
+      index, wasNativeTypeChecked: wasNativeTypeChecked)
+#else
+    _buffer._checkValidSubscript(index)
+#endif
+    return _DependenceToken()
+  }
+
+  /// Check that the specified `index` is valid, i.e. `0 ≤ index ≤ count`.
+  @inlinable
+  @_semantics("array.check_index")
+  internal func _checkIndex(_ index: Int) {
+    _precondition(index <= endIndex, "Array index is out of range")
+    _precondition(index >= startIndex, "Negative Array index is out of range")
+  }
+
+  @_semantics("array.get_element")
+  @inline(__always)
+  public // @testable
+  func _getElement(
+    _ index: Int,
+    wasNativeTypeChecked: Bool,
+    matchingSubscriptCheck: _DependenceToken
+  ) -> Element {
+#if _runtime(_ObjC)
+    return _buffer.getElement(index, wasNativeTypeChecked: wasNativeTypeChecked)
+#else
+    return _buffer.getElement(index)
+#endif
+  }
+
+  @inlinable
+  @_semantics("array.get_element_address")
+  internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
+    return _buffer.subscriptBaseAddress + index
+  }
+}
+
+extension Array: _ArrayProtocol {
+  /// The total number of elements that the array can contain without
+  /// allocating new storage.
+  ///
+  /// Every array reserves a specific amount of memory to hold its contents.
+  /// When you add elements to an array and that array begins to exceed its
+  /// reserved capacity, the array allocates a larger region of memory and
+  /// copies its elements into the new storage. The new storage is a multiple
+  /// of the old storage's size. This exponential growth strategy means that
+  /// appending an element happens in constant time, averaging the performance
+  /// of many append operations. Append operations that trigger reallocation
+  /// have a performance cost, but they occur less and less often as the array
+  /// grows larger.
+  ///
+  /// The following example creates an array of integers from an array literal,
+  /// then appends the elements of another collection. Before appending, the
+  /// array allocates new storage that is large enough store the resulting
+  /// elements.
+  ///
+  ///     var numbers = [10, 20, 30, 40, 50]
+  ///     // numbers.count == 5
+  ///     // numbers.capacity == 5
+  ///
+  ///     numbers.append(contentsOf: stride(from: 60, through: 100, by: 10))
+  ///     // numbers.count == 10
+  ///     // numbers.capacity == 12
+  @inlinable
+  public var capacity: Int {
+    return _getCapacity()
+  }
+
+  /// An object that guarantees the lifetime of this array's elements.
+  @inlinable
+  public // @testable
+  var _owner: AnyObject? {
+    @inline(__always)
+    get {
+      return _buffer.owner      
+    }
+  }
+
+  /// If the elements are stored contiguously, a pointer to the first
+  /// element. Otherwise, `nil`.
+  @inlinable
+  public var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? {
+    @inline(__always) // FIXME(TODO: JIRA): Hack around test failure
+    get { return _buffer.firstElementAddressIfContiguous }
+  }
 }
 
 extension Array: RandomAccessCollection, MutableCollection {
@@ -620,93 +757,11 @@ extension Array: RandomAccessCollection, MutableCollection {
       }
     }
   }
-}
-
-//===--- private helpers---------------------------------------------------===//
-extension Array {
-  /// Returns `true` if the array is native and does not need a deferred
-  /// type check.  May be hoisted by the optimizer, which means its
-  /// results may be stale by the time they are used if there is an
-  /// inout violation in user code.
+  
+  /// The number of elements in the array.
   @inlinable
-  @_semantics("array.props.isNativeTypeChecked")
-  public // @testable
-  func _hoistableIsNativeTypeChecked() -> Bool {
-   return _buffer.arrayPropertyIsNativeTypeChecked
-  }
-
-  @inlinable
-  @_semantics("array.get_count")
-  internal func _getCount() -> Int {
-    return _buffer.count
-  }
-
-  @inlinable
-  @_semantics("array.get_capacity")
-  internal func _getCapacity() -> Int {
-    return _buffer.capacity
-  }
-
-  @inlinable
-  @_semantics("array.make_mutable")
-  internal mutating func _makeMutableAndUnique() {
-    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
-      _buffer = _Buffer(copying: _buffer)
-    }
-  }
-
-  /// Check that the given `index` is valid for subscripting, i.e.
-  /// `0 ≤ index < count`.
-  @inlinable
-  @inline(__always)
-  internal func _checkSubscript_native(_ index: Int) {
-    _ = _checkSubscript(index, wasNativeTypeChecked: true)
-  }
-
-  /// Check that the given `index` is valid for subscripting, i.e.
-  /// `0 ≤ index < count`.
-  @inlinable
-  @_semantics("array.check_subscript")
-  public // @testable
-  func _checkSubscript(
-    _ index: Int, wasNativeTypeChecked: Bool
-  ) -> _DependenceToken {
-#if _runtime(_ObjC)
-    _buffer._checkInoutAndNativeTypeCheckedBounds(
-      index, wasNativeTypeChecked: wasNativeTypeChecked)
-#else
-    _buffer._checkValidSubscript(index)
-#endif
-    return _DependenceToken()
-  }
-
-  /// Check that the specified `index` is valid, i.e. `0 ≤ index ≤ count`.
-  @inlinable
-  @_semantics("array.check_index")
-  internal func _checkIndex(_ index: Int) {
-    _precondition(index <= endIndex, "Array index is out of range")
-    _precondition(index >= startIndex, "Negative Array index is out of range")
-  }
-
-  @_semantics("array.get_element")
-  @inline(__always)
-  public // @testable
-  func _getElement(
-    _ index: Int,
-    wasNativeTypeChecked: Bool,
-    matchingSubscriptCheck: _DependenceToken
-  ) -> Element {
-#if _runtime(_ObjC)
-    return _buffer.getElement(index, wasNativeTypeChecked: wasNativeTypeChecked)
-#else
-    return _buffer.getElement(index)
-#endif
-  }
-
-  @inlinable
-  @_semantics("array.get_element_address")
-  internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
-    return _buffer.subscriptBaseAddress + index
+  public var count: Int {
+    return _getCount()
   }
 }
 
@@ -731,7 +786,7 @@ extension Array: ExpressibleByArrayLiteral {
   }
 }
 
-extension Array: RangeReplaceableCollection, ArrayProtocol {
+extension Array: RangeReplaceableCollection {
   /// Creates a new, empty array.
   ///
   /// This is equivalent to initializing with an empty array literal.
@@ -785,9 +840,7 @@ extension Array: RangeReplaceableCollection, ArrayProtocol {
   ///
   /// - Parameter s: The sequence of elements to turn into an array.
   @inlinable
-  public init<S: Sequence>(_ s: S)
-    where S.Element == Element {
-
+  public init<S: Sequence>(_ s: S) where S.Element == Element {
     self = Array(
       _buffer: _Buffer(
         _buffer: s._copyToContiguousArray()._buffer,
@@ -887,60 +940,6 @@ extension Array: RangeReplaceableCollection, ArrayProtocol {
     // Set the count to zero and just release as normal.
     // Somewhat of a hack.
     _buffer.count = 0
-  }
-
-  /// The number of elements in the array.
-  @inlinable
-  public var count: Int {
-    return _getCount()
-  }
-
-  /// The total number of elements that the array can contain without
-  /// allocating new storage.
-  ///
-  /// Every array reserves a specific amount of memory to hold its contents.
-  /// When you add elements to an array and that array begins to exceed its
-  /// reserved capacity, the array allocates a larger region of memory and
-  /// copies its elements into the new storage. The new storage is a multiple
-  /// of the old storage's size. This exponential growth strategy means that
-  /// appending an element happens in constant time, averaging the performance
-  /// of many append operations. Append operations that trigger reallocation
-  /// have a performance cost, but they occur less and less often as the array
-  /// grows larger.
-  ///
-  /// The following example creates an array of integers from an array literal,
-  /// then appends the elements of another collection. Before appending, the
-  /// array allocates new storage that is large enough store the resulting
-  /// elements.
-  ///
-  ///     var numbers = [10, 20, 30, 40, 50]
-  ///     // numbers.count == 5
-  ///     // numbers.capacity == 5
-  ///
-  ///     numbers.append(contentsOf: stride(from: 60, through: 100, by: 10))
-  ///     // numbers.count == 10
-  ///     // numbers.capacity == 12
-  @inlinable
-  public var capacity: Int {
-    return _getCapacity()
-  }
-
-  /// An object that guarantees the lifetime of this array's elements.
-  @inlinable
-  public // @testable
-  var _owner: AnyObject? {
-    @inline(__always)
-    get {
-      return _buffer.owner      
-    }
-  }
-
-  /// If the elements are stored contiguously, a pointer to the first
-  /// element. Otherwise, `nil`.
-  @inlinable
-  public var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? {
-    @inline(__always) // FIXME(TODO: JIRA): Hack around test failure
-    get { return _buffer.firstElementAddressIfContiguous }
   }
 
   //===--- basic mutations ------------------------------------------------===//

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -14,9 +14,8 @@
 /// `_ArrayBufferProtocol`.  This buffer does not provide value semantics.
 @usableFromInline
 internal protocol _ArrayBufferProtocol
-  : MutableCollection, RandomAccessCollection {
-
-  associatedtype Indices = Range<Int>
+  : MutableCollection, RandomAccessCollection 
+where Indices == Range<Int> {
 
   /// Create an empty buffer.
   init()
@@ -34,9 +33,6 @@ internal protocol _ArrayBufferProtocol
     subRange bounds: Range<Int>,
     initializing target: UnsafeMutablePointer<Element>
   ) -> UnsafeMutablePointer<Element>
-
-  /// Get or set the index'th element.
-  subscript(index: Int) -> Element { get nonmutating set }
 
   /// If this buffer is backed by a uniquely-referenced mutable
   /// `_ContiguousArrayBuffer` that can be grown in-place to allow the `self`
@@ -121,9 +117,6 @@ internal protocol _ArrayBufferProtocol
   /// buffers address the same elements when they have the same
   /// identity and count.
   var identity: UnsafeRawPointer { get }
-
-  var startIndex: Int { get }
-  var endIndex: Int { get }
 }
 
 extension _ArrayBufferProtocol where Indices == Range<Int>{

--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -52,10 +52,10 @@ public func _arrayForceCast<SourceElement, TargetElement>(
   return source.map { $0 as! TargetElement }
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout
+@usableFromInline
 internal struct _UnwrappingFailed : Error {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   internal init() {}
 }
 

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -113,7 +113,6 @@
 /// - Note: To safely reference the starting and ending indices of a slice,
 ///   always use the `startIndex` and `endIndex` properties instead of
 ///   specific values.
-
 @_fixed_layout
 public struct ArraySlice<Element>: _DestructorSafeContainer {
   @usableFromInline
@@ -134,6 +133,170 @@ public struct ArraySlice<Element>: _DestructorSafeContainer {
   @inlinable
   internal init(_buffer buffer: _ContiguousArrayBuffer<Element>) {
     self.init(_buffer: _Buffer(_buffer: buffer, shiftedToStartIndex: 0))
+  }
+}
+
+//===--- private helpers---------------------------------------------------===//
+extension ArraySlice {
+  /// Returns `true` if the array is native and does not need a deferred
+  /// type check.  May be hoisted by the optimizer, which means its
+  /// results may be stale by the time they are used if there is an
+  /// inout violation in user code.
+  @inlinable
+  @_semantics("array.props.isNativeTypeChecked")
+  public // @testable
+  func _hoistableIsNativeTypeChecked() -> Bool {
+   return _buffer.arrayPropertyIsNativeTypeChecked
+  }
+
+  @inlinable
+  @_semantics("array.get_count")
+  internal func _getCount() -> Int {
+    return _buffer.count
+  }
+
+  @inlinable
+  @_semantics("array.get_capacity")
+  internal func _getCapacity() -> Int {
+    return _buffer.capacity
+  }
+
+  /// - Precondition: The array has a native buffer.
+  @inlinable
+  @_semantics("array.owner")
+  internal func _getOwnerWithSemanticLabel_native() -> Builtin.NativeObject {
+    return Builtin.unsafeCastToNativeObject(_buffer.nativeOwner)
+  }
+
+  /// - Precondition: The array has a native buffer.
+  @inlinable
+  @inline(__always)
+  internal func _getOwner_native() -> Builtin.NativeObject {
+#if _runtime(_ObjC)
+    if _isClassOrObjCExistential(Element.self) {
+      // We are hiding the access to '_buffer.owner' behind
+      // _getOwner() to help the compiler hoist uniqueness checks in
+      // the case of class or Objective-C existential typed array
+      // elements.
+      return _getOwnerWithSemanticLabel_native()
+    }
+#endif
+    // In the value typed case the extra call to
+    // _getOwnerWithSemanticLabel_native hinders optimization.
+    return Builtin.unsafeCastToNativeObject(_buffer.owner)
+  }
+
+  @inlinable
+  @_semantics("array.make_mutable")
+  internal mutating func _makeMutableAndUnique() {
+    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
+      _buffer = _Buffer(copying: _buffer)
+    }
+  }
+
+  /// Check that the given `index` is valid for subscripting, i.e.
+  /// `0 ≤ index < count`.
+  @inlinable
+  @inline(__always)
+  internal func _checkSubscript_native(_ index: Int) {
+    _buffer._checkValidSubscript(index)
+  }
+
+  /// Check that the given `index` is valid for subscripting, i.e.
+  /// `0 ≤ index < count`.
+  @inlinable
+  @_semantics("array.check_subscript")
+  public // @testable
+  func _checkSubscript(
+    _ index: Int, wasNativeTypeChecked: Bool
+  ) -> _DependenceToken {
+#if _runtime(_ObjC)
+    _buffer._checkValidSubscript(index)
+#else
+    _buffer._checkValidSubscript(index)
+#endif
+    return _DependenceToken()
+  }
+
+  /// Check that the specified `index` is valid, i.e. `0 ≤ index ≤ count`.
+  @inlinable
+  @_semantics("array.check_index")
+  internal func _checkIndex(_ index: Int) {
+    _precondition(index <= endIndex, "ArraySlice index is out of range")
+    _precondition(index >= startIndex, "ArraySlice index is out of range (before startIndex)")
+  }
+
+  @_semantics("array.get_element")
+  @inline(__always)
+  public // @testable
+  func _getElement(
+    _ index: Int,
+    wasNativeTypeChecked: Bool,
+    matchingSubscriptCheck: _DependenceToken
+  ) -> Element {
+#if false
+    return _buffer.getElement(index, wasNativeTypeChecked: wasNativeTypeChecked)
+#else
+    return _buffer.getElement(index)
+#endif
+  }
+
+  @inlinable
+  @_semantics("array.get_element_address")
+  internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
+    return _buffer.subscriptBaseAddress + index
+  }
+}
+
+extension ArraySlice: _ArrayProtocol {
+  /// The total number of elements that the array can contain without
+  /// allocating new storage.
+  ///
+  /// Every array reserves a specific amount of memory to hold its contents.
+  /// When you add elements to an array and that array begins to exceed its
+  /// reserved capacity, the array allocates a larger region of memory and
+  /// copies its elements into the new storage. The new storage is a multiple
+  /// of the old storage's size. This exponential growth strategy means that
+  /// appending an element happens in constant time, averaging the performance
+  /// of many append operations. Append operations that trigger reallocation
+  /// have a performance cost, but they occur less and less often as the array
+  /// grows larger.
+  ///
+  /// The following example creates an array of integers from an array literal,
+  /// then appends the elements of another collection. Before appending, the
+  /// array allocates new storage that is large enough store the resulting
+  /// elements.
+  ///
+  ///     var numbers = [10, 20, 30, 40, 50]
+  ///     // numbers.count == 5
+  ///     // numbers.capacity == 5
+  ///
+  ///     numbers.append(contentsOf: stride(from: 60, through: 100, by: 10))
+  ///     // numbers.count == 10
+  ///     // numbers.capacity == 12
+  @inlinable
+  public var capacity: Int {
+    return _getCapacity()
+  }
+
+  /// An object that guarantees the lifetime of this array's elements.
+  @inlinable
+  public // @testable
+  var _owner: AnyObject? {
+    return _buffer.owner
+  }
+
+  /// If the elements are stored contiguously, a pointer to the first
+  /// element. Otherwise, `nil`.
+  @inlinable
+  public var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? {
+    @inline(__always) // FIXME(TODO: JIRA): Hack around test failure
+    get { return _buffer.firstElementAddressIfContiguous }
+  }
+
+  @inlinable
+  internal var _baseAddress: UnsafeMutablePointer<Element> {
+    return _buffer.firstElementAddress
   }
 }
 
@@ -442,117 +605,11 @@ extension ArraySlice: RandomAccessCollection, MutableCollection {
       }
     }
   }
-}
 
-//===--- private helpers---------------------------------------------------===//
-extension ArraySlice {
-  /// Returns `true` if the array is native and does not need a deferred
-  /// type check.  May be hoisted by the optimizer, which means its
-  /// results may be stale by the time they are used if there is an
-  /// inout violation in user code.
+  /// The number of elements in the array.
   @inlinable
-  @_semantics("array.props.isNativeTypeChecked")
-  public // @testable
-  func _hoistableIsNativeTypeChecked() -> Bool {
-   return _buffer.arrayPropertyIsNativeTypeChecked
-  }
-
-  @inlinable
-  @_semantics("array.get_count")
-  internal func _getCount() -> Int {
-    return _buffer.count
-  }
-
-  @inlinable
-  @_semantics("array.get_capacity")
-  internal func _getCapacity() -> Int {
-    return _buffer.capacity
-  }
-
-  /// - Precondition: The array has a native buffer.
-  @inlinable
-  @_semantics("array.owner")
-  internal func _getOwnerWithSemanticLabel_native() -> Builtin.NativeObject {
-    return Builtin.unsafeCastToNativeObject(_buffer.nativeOwner)
-  }
-
-  /// - Precondition: The array has a native buffer.
-  @inlinable
-  @inline(__always)
-  internal func _getOwner_native() -> Builtin.NativeObject {
-#if _runtime(_ObjC)
-    if _isClassOrObjCExistential(Element.self) {
-      // We are hiding the access to '_buffer.owner' behind
-      // _getOwner() to help the compiler hoist uniqueness checks in
-      // the case of class or Objective-C existential typed array
-      // elements.
-      return _getOwnerWithSemanticLabel_native()
-    }
-#endif
-    // In the value typed case the extra call to
-    // _getOwnerWithSemanticLabel_native hinders optimization.
-    return Builtin.unsafeCastToNativeObject(_buffer.owner)
-  }
-
-  @inlinable
-  @_semantics("array.make_mutable")
-  internal mutating func _makeMutableAndUnique() {
-    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
-      _buffer = _Buffer(copying: _buffer)
-    }
-  }
-
-  /// Check that the given `index` is valid for subscripting, i.e.
-  /// `0 ≤ index < count`.
-  @inlinable
-  @inline(__always)
-  internal func _checkSubscript_native(_ index: Int) {
-    _buffer._checkValidSubscript(index)
-  }
-
-  /// Check that the given `index` is valid for subscripting, i.e.
-  /// `0 ≤ index < count`.
-  @inlinable
-  @_semantics("array.check_subscript")
-  public // @testable
-  func _checkSubscript(
-    _ index: Int, wasNativeTypeChecked: Bool
-  ) -> _DependenceToken {
-#if _runtime(_ObjC)
-    _buffer._checkValidSubscript(index)
-#else
-    _buffer._checkValidSubscript(index)
-#endif
-    return _DependenceToken()
-  }
-
-  /// Check that the specified `index` is valid, i.e. `0 ≤ index ≤ count`.
-  @inlinable
-  @_semantics("array.check_index")
-  internal func _checkIndex(_ index: Int) {
-    _precondition(index <= endIndex, "ArraySlice index is out of range")
-    _precondition(index >= startIndex, "ArraySlice index is out of range (before startIndex)")
-  }
-
-  @_semantics("array.get_element")
-  @inline(__always)
-  public // @testable
-  func _getElement(
-    _ index: Int,
-    wasNativeTypeChecked: Bool,
-    matchingSubscriptCheck: _DependenceToken
-  ) -> Element {
-#if false
-    return _buffer.getElement(index, wasNativeTypeChecked: wasNativeTypeChecked)
-#else
-    return _buffer.getElement(index)
-#endif
-  }
-
-  @inlinable
-  @_semantics("array.get_element_address")
-  internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
-    return _buffer.subscriptBaseAddress + index
+  public var count: Int {
+    return _getCount()
   }
 }
 
@@ -577,8 +634,7 @@ extension ArraySlice: ExpressibleByArrayLiteral {
   }
 }
 
-
-extension ArraySlice: RangeReplaceableCollection, ArrayProtocol {
+extension ArraySlice: RangeReplaceableCollection {
   /// Creates a new, empty array.
   ///
   /// This is equivalent to initializing with an empty array literal.
@@ -705,64 +761,7 @@ extension ArraySlice: RangeReplaceableCollection, ArrayProtocol {
     return (result, result._buffer.firstElementAddress)
   }
 
-
-  /// The number of elements in the array.
-  @inlinable
-  public var count: Int {
-    return _getCount()
-  }
-
-  /// The total number of elements that the array can contain without
-  /// allocating new storage.
-  ///
-  /// Every array reserves a specific amount of memory to hold its contents.
-  /// When you add elements to an array and that array begins to exceed its
-  /// reserved capacity, the array allocates a larger region of memory and
-  /// copies its elements into the new storage. The new storage is a multiple
-  /// of the old storage's size. This exponential growth strategy means that
-  /// appending an element happens in constant time, averaging the performance
-  /// of many append operations. Append operations that trigger reallocation
-  /// have a performance cost, but they occur less and less often as the array
-  /// grows larger.
-  ///
-  /// The following example creates an array of integers from an array literal,
-  /// then appends the elements of another collection. Before appending, the
-  /// array allocates new storage that is large enough store the resulting
-  /// elements.
-  ///
-  ///     var numbers = [10, 20, 30, 40, 50]
-  ///     // numbers.count == 5
-  ///     // numbers.capacity == 5
-  ///
-  ///     numbers.append(contentsOf: stride(from: 60, through: 100, by: 10))
-  ///     // numbers.count == 10
-  ///     // numbers.capacity == 12
-  @inlinable
-  public var capacity: Int {
-    return _getCapacity()
-  }
-
-  /// An object that guarantees the lifetime of this array's elements.
-  @inlinable
-  public // @testable
-  var _owner: AnyObject? {
-    return _buffer.owner
-  }
-
-  /// If the elements are stored contiguously, a pointer to the first
-  /// element. Otherwise, `nil`.
-  @inlinable
-  public var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? {
-    @inline(__always) // FIXME(TODO: JIRA): Hack around test failure
-    get { return _buffer.firstElementAddressIfContiguous }
-  }
-
-  @inlinable
-  internal var _baseAddress: UnsafeMutablePointer<Element> {
-    return _buffer.firstElementAddress
-  }
   //===--- basic mutations ------------------------------------------------===//
-
 
   /// Reserves enough space to store the specified number of elements.
   ///

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -11,19 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 @usableFromInline
-internal protocol ArrayProtocol
-  : RangeReplaceableCollection,
-    ExpressibleByArrayLiteral
-{
-  //===--- public interface -----------------------------------------------===//
-  /// The number of elements the Array stores.
-  override var count: Int { get }
-
+internal protocol _ArrayProtocol
+  : RangeReplaceableCollection, ExpressibleByArrayLiteral
+where Indices == Range<Int> {
   /// The number of elements the Array can store without reallocation.
   var capacity: Int { get }
-
-  /// `true` if and only if the Array is empty.
-  override var isEmpty: Bool { get }
 
   /// An object that guarantees the lifetime of this array's elements.
   var _owner: AnyObject? { get }
@@ -31,8 +23,6 @@ internal protocol ArrayProtocol
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
   var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? { get }
-
-  subscript(index: Int) -> Element { get set }
 
   //===--- basic mutations ------------------------------------------------===//
 
@@ -51,7 +41,7 @@ internal protocol ArrayProtocol
   /// - Complexity: O(`self.count`).
   ///
   /// - Precondition: `startIndex <= i`, `i <= endIndex`.
-  mutating func insert(_ newElement: __owned Element, at i: Int)
+  override mutating func insert(_ newElement: __owned Element, at i: Int)
 
   /// Remove and return the element at the given index.
   ///
@@ -61,18 +51,18 @@ internal protocol ArrayProtocol
   ///
   /// - Precondition: `count > index`.
   @discardableResult
-  mutating func remove(at index: Int) -> Element
+  override mutating func remove(at index: Int) -> Element
 
   //===--- implementation detail  -----------------------------------------===//
 
-  associatedtype _Buffer : _ArrayBufferProtocol
+  associatedtype _Buffer: _ArrayBufferProtocol where _Buffer.Element == Element
   init(_ buffer: _Buffer)
 
   // For testing.
   var _buffer: _Buffer { get }
 }
 
-extension ArrayProtocol {
+extension _ArrayProtocol {
   // Since RangeReplaceableCollection now has a version of filter that is less
   // efficient, we should make the default implementation coming from Sequence
   // preferred.

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -59,8 +59,7 @@ func _isStdlibInternalChecksEnabled() -> Bool {
 }
 
 @usableFromInline @_transparent
-internal
-func _fatalErrorFlags() -> UInt32 {
+internal func _fatalErrorFlags() -> UInt32 {
   // The current flags are:
   // (1 << 0): Report backtrace on fatal error
 #if os(iOS) || os(tvOS) || os(watchOS)

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -217,19 +217,19 @@ extension UInt {
 @_fixed_layout
 public struct CVaListPointer {
   @usableFromInline // unsafe-performance
-  internal var value: UnsafeMutableRawPointer
+  internal var _value: UnsafeMutableRawPointer
 
   @inlinable // unsafe-performance
   public // @testable
   init(_fromUnsafeMutablePointer from: UnsafeMutableRawPointer) {
-    value = from
+    _value = from
   }
 }
 
 extension CVaListPointer : CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
   public var debugDescription: String {
-    return value.debugDescription
+    return _value.debugDescription
   }
 }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -47,7 +47,103 @@ public struct ContiguousArray<Element>: _DestructorSafeContainer {
   internal init(_buffer: _Buffer) {
     self._buffer = _buffer
   }
+}
 
+//===--- private helpers---------------------------------------------------===//
+extension ContiguousArray {
+  @inlinable
+  @_semantics("array.get_count")
+  internal func _getCount() -> Int {
+    return _buffer.count
+  }
+
+  @inlinable
+  @_semantics("array.get_capacity")
+  internal func _getCapacity() -> Int {
+    return _buffer.capacity
+  }
+
+  @inlinable
+  @_semantics("array.make_mutable")
+  internal mutating func _makeMutableAndUnique() {
+    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
+      _buffer = _Buffer(copying: _buffer)
+    }
+  }
+
+  /// Check that the given `index` is valid for subscripting, i.e.
+  /// `0 ≤ index < count`.
+  @inlinable
+  @inline(__always)
+  internal func _checkSubscript_native(_ index: Int) {
+    _buffer._checkValidSubscript(index)
+  }
+
+  /// Check that the specified `index` is valid, i.e. `0 ≤ index ≤ count`.
+  @inlinable
+  @_semantics("array.check_index")
+  internal func _checkIndex(_ index: Int) {
+    _precondition(index <= endIndex, "ContiguousArray index is out of range")
+    _precondition(index >= startIndex, "Negative ContiguousArray index is out of range")
+  }
+
+  @inlinable
+  @_semantics("array.get_element_address")
+  internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
+    return _buffer.subscriptBaseAddress + index
+  }
+}
+
+extension ContiguousArray: _ArrayProtocol {
+  /// The total number of elements that the array can contain without
+  /// allocating new storage.
+  ///
+  /// Every array reserves a specific amount of memory to hold its contents.
+  /// When you add elements to an array and that array begins to exceed its
+  /// reserved capacity, the array allocates a larger region of memory and
+  /// copies its elements into the new storage. The new storage is a multiple
+  /// of the old storage's size. This exponential growth strategy means that
+  /// appending an element happens in constant time, averaging the performance
+  /// of many append operations. Append operations that trigger reallocation
+  /// have a performance cost, but they occur less and less often as the array
+  /// grows larger.
+  ///
+  /// The following example creates an array of integers from an array literal,
+  /// then appends the elements of another collection. Before appending, the
+  /// array allocates new storage that is large enough store the resulting
+  /// elements.
+  ///
+  ///     var numbers = [10, 20, 30, 40, 50]
+  ///     // numbers.count == 5
+  ///     // numbers.capacity == 5
+  ///
+  ///     numbers.append(contentsOf: stride(from: 60, through: 100, by: 10))
+  ///     // numbers.count == 10
+  ///     // numbers.capacity == 12
+  @inlinable
+  public var capacity: Int {
+    return _getCapacity()
+  }
+
+  /// An object that guarantees the lifetime of this array's elements.
+  @inlinable
+  public // @testable
+  var _owner: AnyObject? {
+    return _buffer.owner
+  }
+
+  /// If the elements are stored contiguously, a pointer to the first
+  /// element. Otherwise, `nil`.
+  @inlinable
+  public var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? {
+    @inline(__always) // FIXME(TODO: JIRA): Hack around test failure
+    get { return _buffer.firstElementAddressIfContiguous }
+  }
+
+  @inlinable
+  internal var _baseAddress: UnsafeMutablePointer<Element> {
+    return _buffer.firstElementAddress
+  }
 }
 
 extension ContiguousArray: RandomAccessCollection, MutableCollection {
@@ -339,50 +435,11 @@ extension ContiguousArray: RandomAccessCollection, MutableCollection {
       }
     }
   }
-}
 
-//===--- private helpers---------------------------------------------------===//
-extension ContiguousArray {
+  /// The number of elements in the array.
   @inlinable
-  @_semantics("array.get_count")
-  internal func _getCount() -> Int {
-    return _buffer.count
-  }
-
-  @inlinable
-  @_semantics("array.get_capacity")
-  internal func _getCapacity() -> Int {
-    return _buffer.capacity
-  }
-
-  @inlinable
-  @_semantics("array.make_mutable")
-  internal mutating func _makeMutableAndUnique() {
-    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
-      _buffer = _Buffer(copying: _buffer)
-    }
-  }
-
-  /// Check that the given `index` is valid for subscripting, i.e.
-  /// `0 ≤ index < count`.
-  @inlinable
-  @inline(__always)
-  internal func _checkSubscript_native(_ index: Int) {
-    _buffer._checkValidSubscript(index)
-  }
-
-  /// Check that the specified `index` is valid, i.e. `0 ≤ index ≤ count`.
-  @inlinable
-  @_semantics("array.check_index")
-  internal func _checkIndex(_ index: Int) {
-    _precondition(index <= endIndex, "ContiguousArray index is out of range")
-    _precondition(index >= startIndex, "Negative ContiguousArray index is out of range")
-  }
-
-  @inlinable
-  @_semantics("array.get_element_address")
-  internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
-    return _buffer.subscriptBaseAddress + index
+  public var count: Int {
+    return _getCount()
   }
 }
 
@@ -408,7 +465,7 @@ extension ContiguousArray: ExpressibleByArrayLiteral {
 }
 
 
-extension ContiguousArray: RangeReplaceableCollection, ArrayProtocol {
+extension ContiguousArray: RangeReplaceableCollection {
   /// Creates a new, empty array.
   ///
   /// This is equivalent to initializing with an empty array literal.
@@ -462,9 +519,7 @@ extension ContiguousArray: RangeReplaceableCollection, ArrayProtocol {
   ///
   /// - Parameter s: The sequence of elements to turn into an array.
   @inlinable
-  public init<S: Sequence>(_ s: S)
-    where S.Element == Element {
-
+  public init<S: Sequence>(_ s: S) where S.Element == Element {
     self = ContiguousArray(
       _buffer: _Buffer(
         _buffer: s._copyToContiguousArray()._buffer,
@@ -535,64 +590,7 @@ extension ContiguousArray: RangeReplaceableCollection, ArrayProtocol {
     return (result, result._buffer.firstElementAddress)
   }
 
-
-  /// The number of elements in the array.
-  @inlinable
-  public var count: Int {
-    return _getCount()
-  }
-
-  /// The total number of elements that the array can contain without
-  /// allocating new storage.
-  ///
-  /// Every array reserves a specific amount of memory to hold its contents.
-  /// When you add elements to an array and that array begins to exceed its
-  /// reserved capacity, the array allocates a larger region of memory and
-  /// copies its elements into the new storage. The new storage is a multiple
-  /// of the old storage's size. This exponential growth strategy means that
-  /// appending an element happens in constant time, averaging the performance
-  /// of many append operations. Append operations that trigger reallocation
-  /// have a performance cost, but they occur less and less often as the array
-  /// grows larger.
-  ///
-  /// The following example creates an array of integers from an array literal,
-  /// then appends the elements of another collection. Before appending, the
-  /// array allocates new storage that is large enough store the resulting
-  /// elements.
-  ///
-  ///     var numbers = [10, 20, 30, 40, 50]
-  ///     // numbers.count == 5
-  ///     // numbers.capacity == 5
-  ///
-  ///     numbers.append(contentsOf: stride(from: 60, through: 100, by: 10))
-  ///     // numbers.count == 10
-  ///     // numbers.capacity == 12
-  @inlinable
-  public var capacity: Int {
-    return _getCapacity()
-  }
-
-  /// An object that guarantees the lifetime of this array's elements.
-  @inlinable
-  public // @testable
-  var _owner: AnyObject? {
-    return _buffer.owner
-  }
-
-  /// If the elements are stored contiguously, a pointer to the first
-  /// element. Otherwise, `nil`.
-  @inlinable
-  public var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? {
-    @inline(__always) // FIXME(TODO: JIRA): Hack around test failure
-    get { return _buffer.firstElementAddressIfContiguous }
-  }
-
-  @inlinable
-  internal var _baseAddress: UnsafeMutablePointer<Element> {
-    return _buffer.firstElementAddress
-  }
   //===--- basic mutations ------------------------------------------------===//
-
 
   /// Reserves enough space to store the specified number of elements.
   ///

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -672,7 +672,6 @@ extension _ClosureBasedSequence: Sequence {
 /// An instance of `AnySequence` forwards its operations to an underlying base
 /// sequence having the same `Element` type, hiding the specifics of the
 /// underlying sequence.
-//@usableFromInline
 @_fixed_layout
 public struct AnySequence<Element> {
   @usableFromInline
@@ -834,9 +833,7 @@ internal protocol _AnyIndexBox : class {
 
 @_fixed_layout
 @usableFromInline
-internal final class _IndexBox<
-  BaseIndex : Comparable
-> : _AnyIndexBox {
+internal final class _IndexBox<BaseIndex: Comparable>: _AnyIndexBox {
   @usableFromInline
   internal var _base: BaseIndex
 

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -50,14 +50,14 @@ extension JoinedSequence {
     
     @_frozen // lazy-performance
     @usableFromInline // lazy-performance
-    internal enum JoinIteratorState {
+    internal enum _JoinIteratorState {
       case start
       case generatingElements
       case generatingSeparator
       case end
     }
     @usableFromInline // lazy-performance
-    internal var _state: JoinIteratorState = .start
+    internal var _state: _JoinIteratorState = .start
 
     /// Creates a sequence that presents the elements of `base` sequences
     /// concatenated using `separator`.

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -226,7 +226,7 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   }
   
   @usableFromInline
-  internal final func projectReadOnly(from root: Root) -> Value {
+  internal final func _projectReadOnly(from root: Root) -> Value {
     // TODO: For perf, we could use a local growable buffer instead of Any
     var curBase: Any = root
     return withBuffer {
@@ -241,7 +241,7 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
         
         func project<CurValue>(_ base: CurValue) -> Value? {
           func project2<NewValue>(_: NewValue.Type) -> Value? {
-            switch rawComponent.projectReadOnly(base,
+            switch rawComponent._projectReadOnly(base,
               to: NewValue.self, endingWith: Value.self) {
             case .continue(let newBase):
               if isLast {
@@ -281,7 +281,7 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
   // `base` is assumed to be undergoing a formal access for the duration of the
   // call, so must not be mutated by an alias
   @usableFromInline
-  internal func projectMutableAddress(from base: UnsafePointer<Root>)
+  internal func _projectMutableAddress(from base: UnsafePointer<Root>)
       -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
     var p = UnsafeRawPointer(base)
     var type: Any.Type = Root.self
@@ -306,7 +306,7 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
         
         func project<CurValue>(_: CurValue.Type) {
           func project2<NewValue>(_: NewValue.Type) {
-            p = rawComponent.projectMutableAddress(p,
+            p = rawComponent._projectMutableAddress(p,
                                            from: CurValue.self,
                                            to: NewValue.self,
                                            isRoot: p == UnsafeRawPointer(base),
@@ -338,16 +338,16 @@ public class ReferenceWritableKeyPath<
 
   internal final override class var kind: Kind { return .reference }
   
-  internal final override func projectMutableAddress(
+  internal final override func _projectMutableAddress(
     from base: UnsafePointer<Root>
   ) -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
     // Since we're a ReferenceWritableKeyPath, we know we don't mutate the base
     // in practice.
-    return projectMutableAddress(from: base.pointee)
+    return _projectMutableAddress(from: base.pointee)
   }
   
   @usableFromInline
-  internal final func projectMutableAddress(from origBase: Root)
+  internal final func _projectMutableAddress(from origBase: Root)
       -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
     var keepAlive: AnyObject?
     var address: UnsafeMutablePointer<Value> = withBuffer {
@@ -362,7 +362,7 @@ public class ReferenceWritableKeyPath<
         
         func project<NewValue>(_: NewValue.Type) -> Any {
           func project2<CurValue>(_ base: CurValue) -> Any {
-            return rawComponent.projectReadOnly(
+            return rawComponent._projectReadOnly(
               base, to: NewValue.self, endingWith: Value.self)
               .assumingContinue
           }
@@ -384,7 +384,7 @@ public class ReferenceWritableKeyPath<
             let nextType = optNextType ?? Value.self
             func project<CurValue>(_: CurValue.Type) {
               func project2<NewValue>(_: NewValue.Type) {
-                p = rawComponent.projectMutableAddress(p,
+                p = rawComponent._projectMutableAddress(p,
                                              from: CurValue.self,
                                              to: NewValue.self,
                                              isRoot: p == baseBytes.baseAddress,
@@ -1305,7 +1305,7 @@ internal struct RawKeyPathComponent {
     }
   }
 
-  internal func projectReadOnly<CurValue, NewValue, LeafValue>(
+  internal func _projectReadOnly<CurValue, NewValue, LeafValue>(
     _ base: CurValue,
     to: NewValue.Type,
     endingWith: LeafValue.Type
@@ -1374,7 +1374,7 @@ internal struct RawKeyPathComponent {
     }
   }
 
-  internal func projectMutableAddress<CurValue, NewValue>(
+  internal func _projectMutableAddress<CurValue, NewValue>(
     _ base: UnsafeRawPointer,
     from _: CurValue.Type,
     to _: NewValue.Type,
@@ -1653,7 +1653,7 @@ func _projectKeyPathReadOnly<Root, Value>(
   root: Root,
   keyPath: KeyPath<Root, Value>
 ) -> Value {
-  return keyPath.projectReadOnly(from: root)
+  return keyPath._projectReadOnly(from: root)
 }
 
 @inlinable
@@ -1662,7 +1662,7 @@ func _projectKeyPathWritable<Root, Value>(
   root: UnsafeMutablePointer<Root>,
   keyPath: WritableKeyPath<Root, Value>
 ) -> (UnsafeMutablePointer<Value>, AnyObject?) {
-  return keyPath.projectMutableAddress(from: root)
+  return keyPath._projectMutableAddress(from: root)
 }
 
 @inlinable
@@ -1671,7 +1671,7 @@ func _projectKeyPathReferenceWritable<Root, Value>(
   root: Root,
   keyPath: ReferenceWritableKeyPath<Root, Value>
 ) -> (UnsafeMutablePointer<Value>, AnyObject?) {
-  return keyPath.projectMutableAddress(from: root)
+  return keyPath._projectMutableAddress(from: root)
 }
 
 // MARK: Appending type system

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -4,13 +4,19 @@
 /* RawRepresentable Changes */
 
 /* Removed Decls */
+Protocol ArrayProtocol has been removed
 
 /* Moved Decls */
 
 /* Renamed Decls */
+Var CVaListPointer.value has been renamed to Var CVaListPointer._value
 
 /* Type Changes */
+Var JoinedSequence.Iterator._state has declared type change from JoinedSequence<τ_0_0>.Iterator.JoinIteratorState to JoinedSequence<τ_0_0>.Iterator._JoinIteratorState
 
 /* Decl Attribute changes */
 
 /* Protocol Requirement Changes */
+Struct Array has removed conformance to ArrayProtocol
+Struct ArraySlice has removed conformance to ArrayProtocol
+Struct ContiguousArray has removed conformance to ArrayProtocol

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -4,6 +4,7 @@
 /* RawRepresentable Changes */
 
 /* Removed Decls */
+Protocol ArrayProtocol has been removed
 
 /* Moved Decls */
 
@@ -14,3 +15,6 @@
 /* Decl Attribute changes */
 
 /* Protocol Requirement Changes */
+Struct Array has removed conformance to ArrayProtocol
+Struct ArraySlice has removed conformance to ArrayProtocol
+Struct ContiguousArray has removed conformance to ArrayProtocol


### PR DESCRIPTION
Makes sure all internal methods that are @usableFromInline have an underscore, in case some day we want to create a public version with the same name.

Also adds some constraints that appeared to be missing from `_ArrayProtocol`, and separates out the conformances to it to match std lib style.