### PR TITLE
[stdlib] Factor shared code out of Array types

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -424,16 +424,6 @@ extension Array: _ArrayProtocol {
     return _getCapacity()
   }
 
-  /// An object that guarantees the lifetime of this array's elements.
-  @inlinable
-  public // @testable
-  var _owner: AnyObject? {
-    @inline(__always)
-    get {
-      return _buffer.owner      
-    }
-  }
-
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
   @inlinable

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -330,14 +330,6 @@ extension Array {
    return _buffer.arrayPropertyIsNativeTypeChecked
   }
 
-  @inlinable
-  @_semantics("array.make_mutable")
-  internal mutating func _makeMutableAndUnique() {
-    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
-      _buffer = _Buffer(copying: _buffer)
-    }
-  }
-
   /// Check that the given `index` is valid for subscripting, i.e.
   /// `0 ≤ index < count`.
   @inlinable

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -968,68 +968,6 @@ extension Array: RangeReplaceableCollection {
     _sanityCheck(capacity >= minimumCapacity)
   }
 
-  /// Copy the contents of the current buffer to a new unique mutable buffer.
-  /// The count of the new buffer is set to `oldCount`, the capacity of the
-  /// new buffer is big enough to hold 'oldCount' + 1 elements.
-  @inline(never)
-  @inlinable // @specializable
-  internal mutating func _copyToNewBuffer(oldCount: Int) {
-    let newCount = oldCount + 1
-    var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
-      countForNewBuffer: oldCount, minNewCapacity: newCount)
-    _buffer._arrayOutOfPlaceUpdate(&newBuffer, oldCount, 0)
-  }
-
-  @inlinable
-  @_semantics("array.make_mutable")
-  internal mutating func _makeUniqueAndReserveCapacityIfNotUnique() {
-    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
-      _copyToNewBuffer(oldCount: _buffer.count)
-    }
-  }
-
-  @inlinable
-  @_semantics("array.mutate_unknown")
-  internal mutating func _reserveCapacityAssumingUniqueBuffer(oldCount: Int) {
-    // This is a performance optimization. This code used to be in an ||
-    // statement in the _sanityCheck below.
-    //
-    //   _sanityCheck(_buffer.capacity == 0 ||
-    //                _buffer.isMutableAndUniquelyReferenced())
-    //
-    // SR-6437
-    let capacity = _buffer.capacity == 0
-
-    // Due to make_mutable hoisting the situation can arise where we hoist
-    // _makeMutableAndUnique out of loop and use it to replace
-    // _makeUniqueAndReserveCapacityIfNotUnique that preceeds this call. If the
-    // array was empty _makeMutableAndUnique does not replace the empty array
-    // buffer by a unique buffer (it just replaces it by the empty array
-    // singleton).
-    // This specific case is okay because we will make the buffer unique in this
-    // function because we request a capacity > 0 and therefore _copyToNewBuffer
-    // will be called creating a new buffer.
-    _sanityCheck(capacity ||
-                 _buffer.isMutableAndUniquelyReferenced())
-
-    if _slowPath(oldCount + 1 > _buffer.capacity) {
-      _copyToNewBuffer(oldCount: oldCount)
-    }
-  }
-
-  @inlinable
-  @_semantics("array.mutate_unknown")
-  internal mutating func _appendElementAssumeUniqueAndCapacity(
-    _ oldCount: Int,
-    newElement: __owned Element
-  ) {
-    _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
-    _sanityCheck(_buffer.capacity >= _buffer.count + 1)
-
-    _buffer.count = oldCount + 1
-    (_buffer.firstElementAddress + oldCount).initialize(to: newElement)
-  }
-
   /// Adds a new element at the end of the array.
   ///
   /// Use this method to append a single element to the end of a mutable array.
@@ -1105,21 +1043,6 @@ extension Array: RangeReplaceableCollection {
       // append them in slow sequence-only mode
       _buffer._arrayAppendSequence(IteratorSequence(remainder))
     }
-  }
-
-  @inlinable
-  @_semantics("array.reserve_capacity_for_append")
-  internal mutating func reserveCapacityForAppend(newElementsCount: Int) {
-    let oldCount = self.count
-    let oldCapacity = self.capacity
-    let newCount = oldCount + newElementsCount
-
-    // Ensure uniqueness, mutability, and sufficient storage.  Note that
-    // for consistency, we need unique self even if newElements is empty.
-    self.reserveCapacity(
-      newCount > oldCapacity ?
-      Swift.max(newCount, _growArrayCapacity(oldCapacity))
-      : newCount)
   }
 
   @inlinable

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -850,46 +850,6 @@ extension Array: RangeReplaceableCollection {
     }
   }
 
-  @inline(never)
-  @usableFromInline
-  internal static func _allocateBufferUninitialized(
-    minimumCapacity: Int
-  ) -> _Buffer {
-    let newBuffer = _ContiguousArrayBuffer<Element>(
-      _uninitializedCount: 0, minimumCapacity: minimumCapacity)
-    return _Buffer(_buffer: newBuffer, shiftedToStartIndex: 0)
-  }
-
-  /// Construct a Array of `count` uninitialized elements.
-  @inlinable
-  internal init(_uninitializedCount count: Int) {
-    _precondition(count >= 0, "Can't construct Array with count < 0")
-    // Note: Sinking this constructor into an else branch below causes an extra
-    // Retain/Release.
-    _buffer = _Buffer()
-    if count > 0 {
-      // Creating a buffer instead of calling reserveCapacity saves doing an
-      // unnecessary uniqueness check. We disable inlining here to curb code
-      // growth.
-      _buffer = Array._allocateBufferUninitialized(minimumCapacity: count)
-      _buffer.count = count
-    }
-    // Can't store count here because the buffer might be pointing to the
-    // shared empty array.
-  }
-
-  /// Entry point for `Array` literal construction; builds and returns
-  /// a Array of `count` uninitialized elements.
-  @inlinable
-  @_semantics("array.uninitialized")
-  internal static func _allocateUninitialized(
-    _ count: Int
-  ) -> (Array, UnsafeMutablePointer<Element>) {
-    let result = Array(_uninitializedCount: count)
-    return (result, result._buffer.firstElementAddress)
-  }
-
-
   /// Returns an Array of `count` uninitialized elements using the
   /// given `storage`, and a pointer to uninitialized memory for the
   /// first element.

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -331,18 +331,6 @@ extension Array {
   }
 
   @inlinable
-  @_semantics("array.get_count")
-  internal func _getCount() -> Int {
-    return _buffer.count
-  }
-
-  @inlinable
-  @_semantics("array.get_capacity")
-  internal func _getCapacity() -> Int {
-    return _buffer.capacity
-  }
-
-  @inlinable
   @_semantics("array.make_mutable")
   internal mutating func _makeMutableAndUnique() {
     if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -790,69 +790,6 @@ extension ArraySlice: RangeReplaceableCollection {
     _sanityCheck(capacity >= minimumCapacity)
   }
 
-  /// Copy the contents of the current buffer to a new unique mutable buffer.
-  /// The count of the new buffer is set to `oldCount`, the capacity of the
-  /// new buffer is big enough to hold 'oldCount' + 1 elements.
-  @inline(never)
-  @inlinable // @specializable
-  internal mutating func _copyToNewBuffer(oldCount: Int) {
-    let newCount = oldCount + 1
-    var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
-      countForNewBuffer: oldCount, minNewCapacity: newCount)
-    _buffer._arrayOutOfPlaceUpdate(
-      &newBuffer, oldCount, 0)
-  }
-
-  @inlinable
-  @_semantics("array.make_mutable")
-  internal mutating func _makeUniqueAndReserveCapacityIfNotUnique() {
-    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
-      _copyToNewBuffer(oldCount: _buffer.count)
-    }
-  }
-
-  @inlinable
-  @_semantics("array.mutate_unknown")
-  internal mutating func _reserveCapacityAssumingUniqueBuffer(oldCount: Int) {
-    // This is a performance optimization. This code used to be in an ||
-    // statement in the _sanityCheck below.
-    //
-    //   _sanityCheck(_buffer.capacity == 0 ||
-    //                _buffer.isMutableAndUniquelyReferenced())
-    //
-    // SR-6437
-    let capacity = _buffer.capacity == 0
-
-    // Due to make_mutable hoisting the situation can arise where we hoist
-    // _makeMutableAndUnique out of loop and use it to replace
-    // _makeUniqueAndReserveCapacityIfNotUnique that preceeds this call. If the
-    // array was empty _makeMutableAndUnique does not replace the empty array
-    // buffer by a unique buffer (it just replaces it by the empty array
-    // singleton).
-    // This specific case is okay because we will make the buffer unique in this
-    // function because we request a capacity > 0 and therefore _copyToNewBuffer
-    // will be called creating a new buffer.
-    _sanityCheck(capacity ||
-                 _buffer.isMutableAndUniquelyReferenced())
-
-    if _slowPath(oldCount + 1 > _buffer.capacity) {
-      _copyToNewBuffer(oldCount: oldCount)
-    }
-  }
-
-  @inlinable
-  @_semantics("array.mutate_unknown")
-  internal mutating func _appendElementAssumeUniqueAndCapacity(
-    _ oldCount: Int,
-    newElement: __owned Element
-  ) {
-    _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
-    _sanityCheck(_buffer.capacity >= _buffer.count + 1)
-
-    _buffer.count = oldCount + 1
-    (_buffer.firstElementAddress + oldCount).initialize(to: newElement)
-  }
-
   /// Adds a new element at the end of the array.
   ///
   /// Use this method to append a single element to the end of a mutable array.
@@ -928,21 +865,6 @@ extension ArraySlice: RangeReplaceableCollection {
       // append them in slow sequence-only mode
       _buffer._arrayAppendSequence(IteratorSequence(remainder))
     }
-  }
-
-  @inlinable
-  @_semantics("array.reserve_capacity_for_append")
-  internal mutating func reserveCapacityForAppend(newElementsCount: Int) {
-    let oldCount = self.count
-    let oldCapacity = self.capacity
-    let newCount = oldCount + newElementsCount
-
-    // Ensure uniqueness, mutability, and sufficient storage.  Note that
-    // for consistency, we need unique self even if newElements is empty.
-    self.reserveCapacity(
-      newCount > oldCapacity ?
-      Swift.max(newCount, _growArrayCapacity(oldCapacity))
-      : newCount)
   }
 
   @inlinable

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -703,45 +703,6 @@ extension ArraySlice: RangeReplaceableCollection {
     }
   }
 
-  @inline(never)
-  @usableFromInline
-  internal static func _allocateBufferUninitialized(
-    minimumCapacity: Int
-  ) -> _Buffer {
-    let newBuffer = _ContiguousArrayBuffer<Element>(
-      _uninitializedCount: 0, minimumCapacity: minimumCapacity)
-    return _Buffer(_buffer: newBuffer, shiftedToStartIndex: 0)
-  }
-
-  /// Construct a ArraySlice of `count` uninitialized elements.
-  @inlinable
-  internal init(_uninitializedCount count: Int) {
-    _precondition(count >= 0, "Can't construct ArraySlice with count < 0")
-    // Note: Sinking this constructor into an else branch below causes an extra
-    // Retain/Release.
-    _buffer = _Buffer()
-    if count > 0 {
-      // Creating a buffer instead of calling reserveCapacity saves doing an
-      // unnecessary uniqueness check. We disable inlining here to curb code
-      // growth.
-      _buffer = ArraySlice._allocateBufferUninitialized(minimumCapacity: count)
-      _buffer.count = count
-    }
-    // Can't store count here because the buffer might be pointing to the
-    // shared empty array.
-  }
-
-  /// Entry point for `Array` literal construction; builds and returns
-  /// a ArraySlice of `count` uninitialized elements.
-  @inlinable
-  @_semantics("array.uninitialized")
-  internal static func _allocateUninitialized(
-    _ count: Int
-  ) -> (ArraySlice, UnsafeMutablePointer<Element>) {
-    let result = ArraySlice(_uninitializedCount: count)
-    return (result, result._buffer.firstElementAddress)
-  }
-
   //===--- basic mutations ------------------------------------------------===//
 
   /// Reserves enough space to store the specified number of elements.

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -149,18 +149,6 @@ extension ArraySlice {
    return _buffer.arrayPropertyIsNativeTypeChecked
   }
 
-  @inlinable
-  @_semantics("array.get_count")
-  internal func _getCount() -> Int {
-    return _buffer.count
-  }
-
-  @inlinable
-  @_semantics("array.get_capacity")
-  internal func _getCapacity() -> Int {
-    return _buffer.capacity
-  }
-
   /// - Precondition: The array has a native buffer.
   @inlinable
   @_semantics("array.owner")

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -174,14 +174,6 @@ extension ArraySlice {
     return Builtin.unsafeCastToNativeObject(_buffer.owner)
   }
 
-  @inlinable
-  @_semantics("array.make_mutable")
-  internal mutating func _makeMutableAndUnique() {
-    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
-      _buffer = _Buffer(copying: _buffer)
-    }
-  }
-
   /// Check that the given `index` is valid for subscripting, i.e.
   /// `0 ≤ index < count`.
   @inlinable

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -267,13 +267,6 @@ extension ArraySlice: _ArrayProtocol {
     return _getCapacity()
   }
 
-  /// An object that guarantees the lifetime of this array's elements.
-  @inlinable
-  public // @testable
-  var _owner: AnyObject? {
-    return _buffer.owner
-  }
-
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
   @inlinable

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -44,6 +44,16 @@ extension _ArrayProtocol {
     return _buffer.capacity
   }
 
+  /// An object that guarantees the lifetime of this array's elements.
+  @inlinable
+  public // @testable
+  var _owner: AnyObject? {
+    @inline(__always)
+    get {
+      return _buffer.owner      
+    }
+  }
+
   // Since RangeReplaceableCollection now has a version of filter that is less
   // efficient, we should make the default implementation coming from Sequence
   // preferred.

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -24,37 +24,6 @@ where Indices == Range<Int> {
   /// element. Otherwise, `nil`.
   var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? { get }
 
-  //===--- basic mutations ------------------------------------------------===//
-
-  /// Reserve enough space to store minimumCapacity elements.
-  ///
-  /// - Postcondition: `capacity >= minimumCapacity` and the array has
-  ///   mutable contiguous storage.
-  ///
-  /// - Complexity: O(`self.count`).
-  override mutating func reserveCapacity(_ minimumCapacity: Int)
-
-  /// Insert `newElement` at index `i`.
-  ///
-  /// Invalidates all indices with respect to `self`.
-  ///
-  /// - Complexity: O(`self.count`).
-  ///
-  /// - Precondition: `startIndex <= i`, `i <= endIndex`.
-  override mutating func insert(_ newElement: __owned Element, at i: Int)
-
-  /// Remove and return the element at the given index.
-  ///
-  /// - returns: The removed element.
-  ///
-  /// - Complexity: Worst case O(*n*).
-  ///
-  /// - Precondition: `count > index`.
-  @discardableResult
-  override mutating func remove(at index: Int) -> Element
-
-  //===--- implementation detail  -----------------------------------------===//
-
   associatedtype _Buffer: _ArrayBufferProtocol where _Buffer.Element == Element
   init(_ buffer: _Buffer)
 
@@ -63,6 +32,18 @@ where Indices == Range<Int> {
 }
 
 extension _ArrayProtocol {
+  @inlinable @inline(__always)
+  @_semantics("array.get_count")
+  internal func _getCount() -> Int {
+    return _buffer.count
+  }
+
+  @inlinable @inline(__always)
+  @_semantics("array.get_capacity")
+  internal func _getCapacity() -> Int {
+    return _buffer.capacity
+  }
+
   // Since RangeReplaceableCollection now has a version of filter that is less
   // efficient, we should make the default implementation coming from Sequence
   // preferred.

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -44,6 +44,14 @@ extension _ArrayProtocol {
     return _buffer.capacity
   }
 
+  @inlinable
+  @_semantics("array.make_mutable")
+  internal mutating func _makeMutableAndUnique() {
+    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
+      _buffer = _Buffer(copying: _buffer)
+    }
+  }
+
   /// An object that guarantees the lifetime of this array's elements.
   @inlinable
   public // @testable

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -532,45 +532,6 @@ extension ContiguousArray: RangeReplaceableCollection {
     }
   }
 
-  @inline(never)
-  @usableFromInline
-  internal static func _allocateBufferUninitialized(
-    minimumCapacity: Int
-  ) -> _Buffer {
-    let newBuffer = _ContiguousArrayBuffer<Element>(
-      _uninitializedCount: 0, minimumCapacity: minimumCapacity)
-    return _Buffer(_buffer: newBuffer, shiftedToStartIndex: 0)
-  }
-
-  /// Construct a ContiguousArray of `count` uninitialized elements.
-  @inlinable
-  internal init(_uninitializedCount count: Int) {
-    _precondition(count >= 0, "Can't construct ContiguousArray with count < 0")
-    // Note: Sinking this constructor into an else branch below causes an extra
-    // Retain/Release.
-    _buffer = _Buffer()
-    if count > 0 {
-      // Creating a buffer instead of calling reserveCapacity saves doing an
-      // unnecessary uniqueness check. We disable inlining here to curb code
-      // growth.
-      _buffer = ContiguousArray._allocateBufferUninitialized(minimumCapacity: count)
-      _buffer.count = count
-    }
-    // Can't store count here because the buffer might be pointing to the
-    // shared empty array.
-  }
-
-  /// Entry point for `Array` literal construction; builds and returns
-  /// a ContiguousArray of `count` uninitialized elements.
-  @inlinable
-  @_semantics("array.uninitialized")
-  internal static func _allocateUninitialized(
-    _ count: Int
-  ) -> (ContiguousArray, UnsafeMutablePointer<Element>) {
-    let result = ContiguousArray(_uninitializedCount: count)
-    return (result, result._buffer.firstElementAddress)
-  }
-
   //===--- basic mutations ------------------------------------------------===//
 
   /// Reserves enough space to store the specified number of elements.

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -51,14 +51,6 @@ public struct ContiguousArray<Element>: _DestructorSafeContainer {
 
 //===--- private helpers---------------------------------------------------===//
 extension ContiguousArray {
-  @inlinable
-  @_semantics("array.make_mutable")
-  internal mutating func _makeMutableAndUnique() {
-    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
-      _buffer = _Buffer(copying: _buffer)
-    }
-  }
-
   /// Check that the given `index` is valid for subscripting, i.e.
   /// `0 ≤ index < count`.
   @inlinable

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -615,69 +615,6 @@ extension ContiguousArray: RangeReplaceableCollection {
     _sanityCheck(capacity >= minimumCapacity)
   }
 
-  /// Copy the contents of the current buffer to a new unique mutable buffer.
-  /// The count of the new buffer is set to `oldCount`, the capacity of the
-  /// new buffer is big enough to hold 'oldCount' + 1 elements.
-  @inline(never)
-  @inlinable // @specializable
-  internal mutating func _copyToNewBuffer(oldCount: Int) {
-    let newCount = oldCount + 1
-    var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
-      countForNewBuffer: oldCount, minNewCapacity: newCount)
-    _buffer._arrayOutOfPlaceUpdate(
-      &newBuffer, oldCount, 0)
-  }
-
-  @inlinable
-  @_semantics("array.make_mutable")
-  internal mutating func _makeUniqueAndReserveCapacityIfNotUnique() {
-    if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {
-      _copyToNewBuffer(oldCount: _buffer.count)
-    }
-  }
-
-  @inlinable
-  @_semantics("array.mutate_unknown")
-  internal mutating func _reserveCapacityAssumingUniqueBuffer(oldCount: Int) {
-    // This is a performance optimization. This code used to be in an ||
-    // statement in the _sanityCheck below.
-    //
-    //   _sanityCheck(_buffer.capacity == 0 ||
-    //                _buffer.isMutableAndUniquelyReferenced())
-    //
-    // SR-6437
-    let capacity = _buffer.capacity == 0
-
-    // Due to make_mutable hoisting the situation can arise where we hoist
-    // _makeMutableAndUnique out of loop and use it to replace
-    // _makeUniqueAndReserveCapacityIfNotUnique that preceeds this call. If the
-    // array was empty _makeMutableAndUnique does not replace the empty array
-    // buffer by a unique buffer (it just replaces it by the empty array
-    // singleton).
-    // This specific case is okay because we will make the buffer unique in this
-    // function because we request a capacity > 0 and therefore _copyToNewBuffer
-    // will be called creating a new buffer.
-    _sanityCheck(capacity ||
-                 _buffer.isMutableAndUniquelyReferenced())
-
-    if _slowPath(oldCount + 1 > _buffer.capacity) {
-      _copyToNewBuffer(oldCount: oldCount)
-    }
-  }
-
-  @inlinable
-  @_semantics("array.mutate_unknown")
-  internal mutating func _appendElementAssumeUniqueAndCapacity(
-    _ oldCount: Int,
-    newElement: __owned Element
-  ) {
-    _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
-    _sanityCheck(_buffer.capacity >= _buffer.count + 1)
-
-    _buffer.count = oldCount + 1
-    (_buffer.firstElementAddress + oldCount).initialize(to: newElement)
-  }
-
   /// Adds a new element at the end of the array.
   ///
   /// Use this method to append a single element to the end of a mutable array.
@@ -753,21 +690,6 @@ extension ContiguousArray: RangeReplaceableCollection {
       // append them in slow sequence-only mode
       _buffer._arrayAppendSequence(IteratorSequence(remainder))
     }
-  }
-
-  @inlinable
-  @_semantics("array.reserve_capacity_for_append")
-  internal mutating func reserveCapacityForAppend(newElementsCount: Int) {
-    let oldCount = self.count
-    let oldCapacity = self.capacity
-    let newCount = oldCount + newElementsCount
-
-    // Ensure uniqueness, mutability, and sufficient storage.  Note that
-    // for consistency, we need unique self even if newElements is empty.
-    self.reserveCapacity(
-      newCount > oldCapacity ?
-      Swift.max(newCount, _growArrayCapacity(oldCapacity))
-      : newCount)
   }
 
   @inlinable

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -113,13 +113,6 @@ extension ContiguousArray: _ArrayProtocol {
     return _getCapacity()
   }
 
-  /// An object that guarantees the lifetime of this array's elements.
-  @inlinable
-  public // @testable
-  var _owner: AnyObject? {
-    return _buffer.owner
-  }
-
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
   @inlinable

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -52,18 +52,6 @@ public struct ContiguousArray<Element>: _DestructorSafeContainer {
 //===--- private helpers---------------------------------------------------===//
 extension ContiguousArray {
   @inlinable
-  @_semantics("array.get_count")
-  internal func _getCount() -> Int {
-    return _buffer.count
-  }
-
-  @inlinable
-  @_semantics("array.get_capacity")
-  internal func _getCapacity() -> Int {
-    return _buffer.capacity
-  }
-
-  @inlinable
   @_semantics("array.make_mutable")
   internal mutating func _makeMutableAndUnique() {
     if _slowPath(!_buffer.isMutableAndUniquelyReferenced()) {


### PR DESCRIPTION
There's a lot of duplication across `Array`, `ContiguousArray` and `ArraySlice` that could be factored into the existing `_ArrayProtocol`.