### PR TITLE
[SourceKit] Make each Variant keep a strong reference to its SourceKitdResponse context

### DIFF
--- a/test/SourceKit/SwiftLang/basic.swift
+++ b/test/SourceKit/SwiftLang/basic.swift
@@ -1,0 +1,28 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import SwiftLang
+
+func getSyntaxMap() -> SourceKitdResponse.Array {
+  let service = SourceKitdService()
+  let request = SourceKitdRequest(uid: .request_EditorOpen)
+
+  request.addParameter(.key_Name, value: "foo")
+  request.addParameter(.key_SourceText, value: "print(\"Hello, world!\")")
+  request.addParameter(.key_EnableSyntaxMap, value: 1)
+  request.addParameter(.key_SyntacticOnly, value: 1)
+
+  return service.sendSyn(request: request).value.getArray(.key_SyntaxMap)
+}
+
+var swiftLangVariantTests = TestSuite("SwiftLangVariantTests")
+
+swiftLangVariantTests.test("VariantLifetime") {
+  let syntaxMap = getSyntaxMap()
+  expectEqual(2, syntaxMap.count)
+}
+
+runAllTests()


### PR DESCRIPTION
`sourcekitd_variant_t` is only safe to use while the `sourcekitd_response_t` it was retrieved from is still alive, so keep a strong reference to `SourceKitdResponse` (the Swift wrapper of `sourcekitd_response_t`) in each `Array`, `Dictionary` and `Variant` (Swift wrappers of `sourcekitd_variant_t`).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
