### PR TITLE
[SDK] Get the preferred @encode string for MapKit types dynamically

### DIFF
--- a/stdlib/public/SDK/CoreLocation/NSValue.swift.gyb
+++ b/stdlib/public/SDK/CoreLocation/NSValue.swift.gyb
@@ -2,7 +2,37 @@
 import Foundation
 
 %{
-from gyb_foundation_support import ObjectiveCBridgeableImplementationForNSValue
+from gyb_foundation_support import \
+  ObjectiveCBridgeableImplementationForNSValueWithCategoryMethods
 }%
 
-${ ObjectiveCBridgeableImplementationForNSValue("CLLocationCoordinate2D") }
+// Get the ObjC type used by -[NSValue valueWithMKCoordinate:]
+// to instantiate the resulting NSValue objects, in case these get changed
+// in the future. This is extra tricky because MapKit *might not be loaded*,
+// in which case we need to fall back to the static @encode string.
+private let CLLocationCoordinate2DInNSValueObjCType: UnsafePointer<CChar> = {
+  let factorySel = Selector(("valueWithMKCoordinate:"))
+  guard let opaqueFactoryMethod = NSValue.method(for: factorySel) else {
+    return _getObjCTypeEncoding(CLLocationCoordinate2D.self)
+  }
+  typealias FactoryMethodType =
+      @convention(c) (AnyClass, Selector, CLLocationCoordinate2D) -> NSValue
+  let factoryMethod =
+      unsafeBitCast(opaqueFactoryMethod, to: FactoryMethodType.self)
+  return factoryMethod(NSValue.self, factorySel, .init()).objCType
+}()
+
+${ ObjectiveCBridgeableImplementationForNSValueWithCategoryMethods(
+  Type="CLLocationCoordinate2D",
+  initializer="""{
+    var addressableValue = $0
+    return NSValue(bytes: &addressableValue,
+                   objCType: CLLocationCoordinate2DInNSValueObjCType)
+  }""",
+  getter="""{
+    var result = CLLocationCoordinate2D()
+    $0.getValue(&result)
+    return result
+  }""",
+  objCType="{ _ in CLLocationCoordinate2DInNSValueObjCType }",
+) }

--- a/stdlib/public/SDK/MapKit/NSValue.swift.gyb
+++ b/stdlib/public/SDK/MapKit/NSValue.swift.gyb
@@ -2,7 +2,35 @@
 import Foundation
 
 %{
-from gyb_foundation_support import ObjectiveCBridgeableImplementationForNSValue
+from gyb_foundation_support import \
+  ObjectiveCBridgeableImplementationForNSValueWithCategoryMethods
 }%
 
-${ ObjectiveCBridgeableImplementationForNSValue("MKCoordinateSpan") }
+// Get the ObjC type used by -[NSValue valueWithMKCoordinateSpan:]
+// to instantiate the resulting NSValue objects, in case these get changed
+// in the future.
+@available(tvOS 9.2, *)
+private let MKCoordinateSpanInNSValueObjCType =
+  NSValue(mkCoordinateSpan: .init()).objCType
+
+${ ObjectiveCBridgeableImplementationForNSValueWithCategoryMethods(
+  Type="MKCoordinateSpan",
+  initializer="""{
+    guard #available(tvOS 9.2, *) else {
+      fatalError("MKCoordinateSpan is not supported on tvOS before tvOS 9.2")
+    }
+    return NSValue(mkCoordinateSpan: $0)
+  }""",
+  getter="""{
+    guard #available(tvOS 9.2, *) else {
+      fatalError("MKCoordinateSpan is not supported on tvOS before tvOS 9.2")
+    }
+    return $0.mkCoordinateSpanValue
+  }""",
+  objCType="""{ _ in
+    guard #available(tvOS 9.2, *) else {
+      fatalError("MKCoordinateSpan is not supported on tvOS before tvOS 9.2")
+    }
+    return MKCoordinateSpanInNSValueObjCType
+  }""",
+) }

--- a/test/stdlib/MapKit.swift
+++ b/test/stdlib/MapKit.swift
@@ -20,14 +20,14 @@ func spansEqual(_ x: MKCoordinateSpan, _ y: MKCoordinateSpan)
 }
 
 if #available(tvOS 9.2, *) {
-  mapKit.test("NSValue bridging")
-      .xfail(.iOSMinor(9, 3, reason: "<rdar://problem/41440036>"))
-      .xfail(.osxMinorRange(10, 9...10, reason: "<rdar://problem/44866579>"))
-      .code {
+  mapKit.test("CLLocationCoordinate2D bridging") {
     expectBridgeToNSValue(CLLocationCoordinate2D(latitude: 17, longitude: 38),
                           nsValueInitializer: { NSValue(mkCoordinate: $0) },
                           nsValueGetter: { $0.mkCoordinateValue },
                           equal: coordinatesEqual)
+  }
+
+  mapKit.test("MKCoordinateSpan bridging") {
     expectBridgeToNSValue(MKCoordinateSpan(latitudeDelta: 6,
                                            longitudeDelta: 79),
                           nsValueInitializer: { NSValue(mkCoordinateSpan: $0) },


### PR DESCRIPTION
On older OSs, CLLocationCoordinate2D was an anonymous struct with a typedef, which meant its [Objective-C type encoding string](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html) was `"{?=dd}"` instead of `"{CLLocationCoordinate2D=dd}"`. This incompatibility led to us rejecting casts from NSValues created with CLLocationCoordinate2Ds in Objective-C on older OSs because they didn't match the type encoding provided. Instead, we can try to create an NSValue the way the frameworks do, and see what *its* type encoding is. This is what SceneKit already does.

There's an extra wrinkle here because the convenience methods for encoding CLLocationCoordinate2Ds are actually added in MapKit rather than CoreLocation. That means that if someone's app just uses CoreLocation, we can't rely on those convenience methods to get the correct type encoding. In this case, the best thing we can do is just give up and use the static encoding.

This whole thing is indicative of a bigger problem, namely that NSValue normally doesn't try to validate types at all. However, Swift bridge casting really does want to distinguish, say, a CLLocationCoordinate2D from a CGPoint, and checking the NSValue encode string was a way to do that. But this shows that it's still not safe to assume that's consistent against everything in a process even if they're all using `@encode` on the real struct (or the Swift equivalent), because the different parts of the process may have been compiled against different SDKs.

This change does not attempt to solve that problem.

Finishes rdar://problem/44866579. Follow-up to #19634.