### PR TITLE
[stdlib] Allow native dictionaries to advance Cocoa indices

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1854,6 +1854,19 @@ extension Dictionary.Index {
 #endif
 
   @usableFromInline @_transparent
+  internal var _isNative: Bool {
+    switch _variant {
+    case .native:
+      return true
+#if _runtime(_ObjC)
+    case .cocoa:
+      _cocoaPath()
+      return false
+#endif
+    }
+  }
+
+  @usableFromInline @_transparent
   internal var _asNative: _HashTable.Index {
     switch _variant {
     case .native(let nativeIndex):

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -642,6 +642,14 @@ extension _CocoaDictionary.Index {
   }
 
   @usableFromInline
+  internal var dictionary: _CocoaDictionary {
+    @_effects(releasenone)
+    get {
+      return storage.base
+    }
+  }
+
+  @usableFromInline
   internal func copy() -> _CocoaDictionary.Index {
     let storage = self.storage
     return _CocoaDictionary.Index(Storage(

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -316,7 +316,13 @@ extension _NativeDictionary: _DictionaryBuffer {
 
   @inlinable
   internal func index(after index: Index) -> Index {
-    // Note that _asNative forces this not to work on Cocoa indices.
+#if _runtime(_ObjC)
+    guard _fastPath(index._isNative) else {
+      let _ = validatedBucket(for: index)
+      let i = index._asCocoa
+      return Index(_cocoa: i.dictionary.index(after: i))
+    }
+#endif
     let bucket = validatedBucket(for: index._asNative)
     let next = hashTable.occupiedBucket(after: bucket)
     return Index(_native: _HashTable.Index(bucket: next, age: age))

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -4778,6 +4778,40 @@ DictionaryTestSuite.test("Hashable") {
   checkHashable(variants, equalityOracle: { _, _ in true })
 }
 
+#if _runtime(_ObjC)
+DictionaryTestSuite.test("Values.MutationDoesNotInvalidateIndices") {
+  let objects: [NSNumber] = [1, 2, 3, 4]
+  let keys: [NSString] = ["Blanche", "Rose", "Dorothy", "Sophia"]
+  let ns = NSDictionary(objects: objects, forKeys: keys)
+  var d = ns as! Dictionary<NSString, NSNumber>
+
+  let i = d.index(forKey: "Rose")!
+  expectEqual(d[i].key, "Rose")
+  expectEqual(d[i].value, 2 as NSNumber)
+
+  // Mutating a value through the Values view will convert the bridged
+  // NSDictionary instance to native Dictionary storage. However, Values is a
+  // MutableCollection, so doing so must not invalidate existing indices.
+  d.values[i] = 20 as NSNumber
+
+  // The old Cocoa-based index must still work with the new dictionary.
+  expectEqual(d.values[i], 20 as NSNumber)
+
+  let i2 = d.index(forKey: "Rose")
+
+  // You should also be able to advance Cocoa indices.
+  let j = d.index(after: i)
+
+  // Unfortunately, Cocoa and Native indices aren't comparable, so the
+  // Collection conformance is not quite perfect.
+  expectCrash(withMessage: "Comparing indexes from different dictionaries") {
+    print(i == i2)
+  }
+}
+#endif
+
+
+
 DictionaryTestSuite.setUp {
 #if _runtime(_ObjC)
   // Exercise ARC's autoreleased return value optimization in Foundation.


### PR DESCRIPTION
This gets us a step closer to `Dictionary.Values` actually becoming a `MutableCollection`.

https://bugs.swift.org/browse/SR-7145
rdar://problem/38394644