### PR TITLE
In eager mode, added support to running a Tensor<Float>(x) statement.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2014,7 +2014,10 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
       auto tensorHandleValue =
           getLoweredSingletonExplosion(tensorHandleSilValue);
       auto *extractHandleFn = IGM.getTFC_GetCTensorHandleFromSwiftFn();
-      auto cHandle = Builder.CreateCall(extractHandleFn, {tensorHandleValue});
+      // Cast to a void*
+      auto tensorHandleValueUntyped =
+          Builder.CreateBitCast(tensorHandleValue, IGM.Int8PtrTy);
+      auto cHandle = Builder.CreateCall(extractHandleFn, {tensorHandleValueUntyped});
 
       // Add an op input as in:
       //   TFE_OpAddInput(op, cHandle);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2014,7 +2014,7 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
       auto tensorHandleValue =
           getLoweredSingletonExplosion(tensorHandleSilValue);
       auto *extractHandleFn = IGM.getTFC_GetCTensorHandleFromSwiftFn();
-      // Cast to a void*
+      // Cast to a void*, as required by TFC_GetCTensorHandleFromSwift().
       auto tensorHandleValueUntyped =
           Builder.CreateBitCast(tensorHandleValue, IGM.Int8PtrTy);
       auto cHandle = Builder.CreateCall(extractHandleFn, {tensorHandleValueUntyped});

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -112,6 +112,8 @@ public:
         numInstEvaluated(numInstEvaluated) {}
 
   void setValue(SILValue value, SymbolicValue symVal) {
+    LLVM_DEBUG(llvm::dbgs() << "For sil value " << value << ", setting it to: ";
+               symVal.dump());
     calculatedValues.insert({value, symVal});
   }
 
@@ -122,6 +124,10 @@ public:
     auto type = simplifyType(addr->getType().getASTType());
     auto *memObject = SymbolicValueMemoryObject::create(
         type, initialValue, evaluator.getAllocator());
+    LLVM_DEBUG(llvm::dbgs()
+                   << "For sil addr " << addr << ", creating memory obj: "
+                   << memObject << ", with init value " << initialValue
+                   << ", mem obj value: " << memObject->getValue(););
     auto result = SymbolicValue::getAddress(memObject);
     setValue(addr, result);
     return result;
@@ -1113,6 +1119,11 @@ static bool updateIndexedElement(SymbolicValue &aggregate,
 ///  pointer_to_address, if the address is to be written to, caller should call
 ///  this method (e.g. a[3] = 17). If the address is to be read (e.g. let v =
 ///  a[3]), call getConstAddrAndLoadResult().
+///
+/// Invariant: When this function returns, if it fails the const-evaluate, the
+/// memory object associated with `addr` is set to uninit memory or Unknown.
+// TODO: consider always setting it to Unknown, which would be a better error
+// code.
 SymbolicValue
 ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
   // Check to see if we already have an answer.
@@ -1125,7 +1136,12 @@ ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
   if (!addrInst)
     return evaluator.getUnknown(addr, UnknownReason::Default);
 
-  // Keep track of the value found for the first constant store.
+  // Keep track of the value found for the first constant store.  Tentatively
+  // point/link `addr` to the memory object, whose content will be set when we
+  // find a qualified writer (some writer such as ApplyInst depends on the
+  // existence of such a memory object). But when we find a violation
+  // (e.g. unsupported inst types or multiple writers, set the memory object
+  // content back to uninit memory.)
   auto memoryAddress =
       createMemoryObject(addr, SymbolicValue::getUninitMemory());
   auto *memoryObject = memoryAddress.getAddressValueMemoryObject();
@@ -1157,8 +1173,10 @@ ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
           return evaluator.getUnknown(addr, UnknownReason::Default);
 
         auto result = getConstantValue(si->getOperand(0));
-        if (!result.isConstant())
+        if (!result.isConstant()) {
+          memoryObject->setValue(SymbolicValue::getUninitMemory());
           return evaluator.getUnknown(addr, UnknownReason::Default);
+        }
         memoryObject->setValue(result);
         continue;
       }
@@ -1174,12 +1192,16 @@ ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
 
       // If we have already found a value for this stack slot then we're done:
       // we don't support multiple assignment.
-      if (memoryObject->getValue().getKind() != SymbolicValue::UninitMemory)
+      if (memoryObject->getValue().getKind() != SymbolicValue::UninitMemory) {
+        memoryObject->setValue(SymbolicValue::getUninitMemory());
         return evaluator.getUnknown(addr, UnknownReason::Default);
+      }
 
       auto result = getConstAddrAndLoadResult(cai->getOperand(0));
-      if (!result.isConstant())
+      if (!result.isConstant()) {
+        memoryObject->setValue(SymbolicValue::getUninitMemory());
         return evaluator.getUnknown(addr, UnknownReason::Default);
+      }
       memoryObject->setValue(result);
       continue;
     }
@@ -1199,8 +1221,10 @@ ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
 
       // Otherwise this is a write.  If we have already found a value for this
       // stack slot then we're done: we don't support multiple assignment.
-      if (memoryObject->getValue().getKind() != SymbolicValue::UninitMemory)
+      if (memoryObject->getValue().getKind() != SymbolicValue::UninitMemory) {
+        memoryObject->setValue(SymbolicValue::getUninitMemory());
         return evaluator.getUnknown(addr, UnknownReason::Default);
+      }
 
       // The callee needs to be a direct call to a constant expression.
       auto callResult = computeCallResult(apply);
@@ -1208,6 +1232,8 @@ ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
       // If the call failed, we're done.
       if (callResult.hasValue()) {
         assert(!callResult.getValue().isConstant());
+        LLVM_DEBUG(llvm::dbgs() << "  The failed call result returned "
+                                << callResult.getValue() << "\n");
         memoryObject->setValue(callResult.getValue());
         return memoryAddress;
       }
@@ -1226,6 +1252,7 @@ ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
         if (ili->getValue().getLimitedValue() != 0)
           continue;
       }
+      memoryObject->setValue(SymbolicValue::getUninitMemory());
       return evaluator.getUnknown(addr, UnknownReason::Default);
     }
 
@@ -1266,8 +1293,10 @@ ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
       bool failed = updateIndexedElement(
           objectVal, /*accessPath*/ {index}, tupleEltValue, objectType,
           /*writeOnlyOnce*/ true, evaluator.getAllocator());
-      if (failed)
+      if (failed) {
+        memoryObject->setValue(SymbolicValue::getUninitMemory());
         return evaluator.getUnknown(addr, UnknownReason::Default);
+      }
       memoryObject->setValue(objectVal);
 #ifndef NDEBUG
       // If all aggregate elements are const, we have successfully
@@ -1285,6 +1314,7 @@ ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
 
     // If this is some other user that we don't know about, then we should
     // treat it conservatively, because it could store into the address.
+    memoryObject->setValue(SymbolicValue::getUninitMemory());
     return evaluator.getUnknown(addr, UnknownReason::Default);
   }
 

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -1169,8 +1169,10 @@ ConstExprFunctionState::getSingleWriterAddressValue(SILValue addr) {
 
         // If we have already found a value for this stack slot then we're done:
         // we don't support multiple assignment.
-        if (memoryObject->getValue().getKind() != SymbolicValue::UninitMemory)
+        if (memoryObject->getValue().getKind() != SymbolicValue::UninitMemory) {
+          memoryObject->setValue(SymbolicValue::getUninitMemory());
           return evaluator.getUnknown(addr, UnknownReason::Default);
+        }
 
         auto result = getConstantValue(si->getOperand(0));
         if (!result.isConstant()) {

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1850,10 +1850,9 @@ transformTensorFromScalar(ApplyInst *apply,
     auto *decl = scalarTy.getStructOrBoundGenericStruct();
     assert(decl);
     for (auto *field : decl->getStoredProperties()) {
-        // Check the struct only has 1 field.
+      // Check the struct only has 1 field.
       assert(!loadScalarBuiltin);
-      loadScalarBuiltin =
-          B.createStructExtract(loc, loadScalar, field);
+      loadScalarBuiltin = B.createStructExtract(loc, loadScalar, field);
     }
     assert(loadScalarBuiltin);
   }

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1855,7 +1855,7 @@ transformTensorFromScalar(ApplyInst *apply,
       loadScalarBuiltin =
           B.createStructExtract(loc, loadScalar, field);
     }
-    assert(!loadScalarBuiltin);
+    assert(loadScalarBuiltin);
   }
   GraphOperationBuilder opBuilder("tfc.scalarToTensor");
   opBuilder.addArgument(loadScalarBuiltin);

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -105,7 +105,7 @@ extension Bool : AccelerableByTensorFlow {
   }
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: Bool) -> TensorHandle<Bool> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_Bool") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<Bool>)
@@ -128,7 +128,7 @@ extension Int8 : AccelerableByTensorFlow {
   }
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: Int8) -> TensorHandle<Int8> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_Int8") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<Int8>)
@@ -151,7 +151,7 @@ extension UInt8 : AccelerableByTensorFlow {
   }
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: UInt8) -> TensorHandle<UInt8> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_UInt8") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<UInt8>)
@@ -174,7 +174,7 @@ extension Int16 : AccelerableByTensorFlow {
   }
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: Int16) -> TensorHandle<Int16> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_Int16") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<Int16>)
@@ -198,7 +198,7 @@ extension UInt16 : AccelerableByTensorFlow {
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: UInt16)
   -> TensorHandle<UInt16> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_UInt16") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<UInt16>)
@@ -221,7 +221,7 @@ extension Int32 : AccelerableByTensorFlow {
   }
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: Int32) -> TensorHandle<Int32> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_Int32") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<Int32>)
@@ -245,7 +245,7 @@ extension UInt32 : AccelerableByTensorFlow {
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: UInt32)
     -> TensorHandle<UInt32> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_UInt32") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<UInt32>)
@@ -268,7 +268,7 @@ extension Int64 : AccelerableByTensorFlow {
   }
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: Int64) -> TensorHandle<Int64> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_Int64") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<Int64>)
@@ -292,7 +292,7 @@ extension UInt64 : AccelerableByTensorFlow {
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: UInt64)
     -> TensorHandle<UInt64> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_UInt64") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<UInt64>)
@@ -325,7 +325,7 @@ extension BFloat16 : AccelerableByTensorFlow {
   public static func _makeScalarTensor(
     _ scalar: BFloat16
   ) -> TensorHandle<BFloat16> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_BFloat16") @_optimize(none) @inline(never)
   public static func _hoistableClosure(
@@ -349,7 +349,7 @@ extension Float : AccelerableByTensorFlow {
   }
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: Float) -> TensorHandle<Float> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_Float") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<Float>)
@@ -373,7 +373,7 @@ extension Double : AccelerableByTensorFlow {
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: Double)
     -> TensorHandle<Double> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_Double") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<Double>)
@@ -397,7 +397,7 @@ extension String : AccelerableByTensorFlow {
   @inlinable @inline(__always)
   public static func _makeScalarTensor(_ scalar: String)
     -> TensorHandle<String> {
-    return #tfop("tfc.scalarToTensor", scalar)
+    return _TFTensorFromScalar(scalar)
   }
   @_silgen_name("__tf_hoistable_String") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<String>)

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -20,6 +20,16 @@ DynamicCompilationTests.testCPUOrGPU("Const") {
   expectNearlyEqualWithScalarTensor(1.0, Tensor<Float>(handle: x))
 }
 
+DynamicCompilationTests.testCPUOrGPU("ScalarNonConst") {
+  _RuntimeConfig.printsDebugLog = true
+  func scalarInitializer_CreateHostTensor(_ x: Float) {
+    let y = Tensor<Float>(x)
+    _hostOp(y)
+    expectNearlyEqualWithScalarTensor(x, y)
+  }
+  scalarInitializer_CreateHostTensor(1.2)
+}
+
 DynamicCompilationTests.testCPUOrGPU("AddFloat") {
   _RuntimeConfig.printsDebugLog = true
   let x = Tensor<Float>(1.0)


### PR DESCRIPTION
In eager mode, added support to running a Tensor<Float>(x) statement.

This involves refactoring the scalar promotion code, and also fixing a bug in
const eval over an alloc_stack inst. The details are as follows.

# Scalar promotion

Previously, `Tensor<Float>(x)` compiles to a tfc.scalarToTensor graph_op. It is a
pseudo graph op in that it is not backed by any TF ops. Instead, the partition
pass (SILCloner) lowers tfc.scalarToTensor to scalar-promoted graph nodes. As
such, in eager mode, this graph_op has no runtime implementation that IRGen can
dispatch to.

In this patch, we changed the above Tensor initializer on scalar to generate a
call to a new function __tf_tensor_from_scalar(scalar), which has a runtime impl. In
the deabstraction pass, it is either transformed to a "Const" graph node, if `x`
is a compile-time constant, or otherwise a `tfc.scalarToTensor` graph_op, so
that the existing scalar promotion infra in the partition pass continues to work.

## Design rationale

The following example shows the importance of representing this scalar-to-tensor
transformation as a graph_op (as opposed to, say an apply inst of some function)
in the current scalar promotion infrastructure.

```swift
let x_scalar = x_tensor.mean()
let y_scalar = y_tensor.mean()
let z_scalar = x_scalar + y_scalar
let z_tensor = Tensor(z_scalar)
```

The scalar promotion code starts at the tfc.scalarToTensor graph_op inst
associated with `Tensor(z_scalar)`, and transitively promotes the operands and
their producer insts to the graph. In this case, the scalar add is promoted to
graph, and the host-side scalars `x_scalar` and `y_scalar` are eliminated, since
they are produced by _getScalarOrDie() calls. As such, the
tfc.scalarToTensor graph_op and the _getScalarOrDie() call that feeds the
graph_op "cancel out" on each other, such that all intermediate computation is
promoted into the graph.

While it is possible to refactor the scalar promotion code to work on an apply
inst over __tf_tensor_from_scalar() instead of a tfc.scalarToTensor graph_op,
doing so would be inconvenient (and thus add code base complexity). In
particular, __tf_tensor_from_scalar() is generic over the Scalar data
type (any type that conforms to AccelerableByTensorFlow), and therefore will be
taking the input `scalar` indirectly. See the `@in_guaranteed` param in the
example SIL below:

```
  %702 = function_ref @__tf_tensor_from_scalar : $@convention(thin) <�_0_0 where �_0_0 : AccelerableByTensorFlow> (@in_guaranteed �_0_0) -> @owned TensorHandle<�_0_0> // user: %703
  %703 = apply %702<Int32>(%700) : $@convention(thin) <�_0_0 where �_0_0 : AccelerableByTensorFlow> (@in_guaranteed �_0_0) -> @owned TensorHandle<�_0_0> // users: %710, %707, %738, %708, %706, %705
```

To make scalar promotion work on the __tf_tensor_from_scalar() call instead of
the tfc.scalarToTensor graph_op, the changes include:
1. Add apply insts over __tf_tensor_from_scalar() to tensor_ops
2. Find the producer of the (indirect) input scalar operand of
__tf_tensor_from_scalar(), and recursively promote the producer of that scalar.

Since the param is indirect, step `#2` involves some SIL code traversal
logic (similar to the const evaluator) to find the producer inst of the
scalar. In the SIL example below, we start at `%700` used by the
__tf_tensor_from_scalar() call above, and traverse back to `%58` (and possibly
further). This would add non-trivial complexity.

```
  %694 = begin_access [read] [static] %58 : $*Int32 // users: %695, %696
  %695 = load %694 : $*Int32                      // user: %698
  end_access %694 : $*Int32                       // id: %696
  %697 = alloc_stack $Int32                       // users: %711, %709, %699, %698
  store %695 to %697 : $*Int32                    // id: %698
  %699 = load %697 : $*Int32                      // user: %701
  %700 = alloc_stack $Int32                       // users: %704, %703, %701
  store %699 to %700 : $*Int32                    // id: %701
```

To summarize, we attempted to eliminate tfc.scalarToTensor, but concluded that
doing so would not reduce code complexity. The lifetime of tfc.scalarToTensor insts is well
constrained (and thus its associated code complexity is contained) -- it only
occurs in graph mode, where it's generated in deabstraction, and consumed in
partition. It does not appear in graph lowering.

## Other painpoints dealing with SIL code that calls __tf_tensor_from_scalar()
(This section is to document our compiler development experiences w.r.t. protocol conformance. The work/changed involved is no longer present in the current version of the patch, so feel free to skip this section.)

Earlier we also tried having `Tensor<Float>(x)` continue to generate
tfc.scalarToTensor, and transform it to a __tf_tensor_from_scalar() call in
deabstraction when needed. We find it significantly more challenging to
synthesize a call to __tf_tensor_from_scalar() than to synthesize a graph_op
inst.

The main complexity comes from protocol conformance
requirements. To create an apply inst, we need a SubstitutionMap (subMap). Since _tf_tensor_from_scalar() is generic over Scalar type, and
Scalar conforms to AccelerableByTensorFlow, we cannot create a subMap
via tf::getSingleSubstitutionMapForElementType() (as we did in
createHostReceive() and various other parts in the partition pass). Instead, we
have to write code like (thanks for pointers from rxwei@):

```
auto &ctx = B.getASTContext();
auto *tfModule = ctx.getLoadedModule(ctx.Id_TensorFlow);
auto proto =
    ctx.getProtocol(KnownProtocolKind::AccelerableByTensorFlow);
SmallVector<ProtocolConformance *, 1> conformances;
auto nominal = scalarValueTy->getAnyNominal();
auto lookup =
    nominal->lookupConformance(tfModule, proto, conformances);
if (!lookup) {
  llvm_unreachable("No conformance to AccelerableByTensorFlow found.");
}
assert(conformances.size() == 1 &&
       "Found multiple conformance candidates.");
auto *conf =
    ctx.getConformance(scalarValueTy, proto, nominal->getLoc(),
                       nominal, ProtocolConformanceState::Complete);
ProtocolConformanceRef confRef(conf);
// Get substitutions.
auto subMap = SubstitutionMap::getProtocolSubstitutions(
    proto, scalarValueTy, confRef);
```

Even with the above, we got linker errors on missing symbols like
`SSf10TensorFlow013AccelerableByaB0sWa`.

 swift-demangle tells us:
```
$ swift-demangle   SSf10TensorFlow013AccelerableByaB0sWa
$SSf10TensorFlow013AccelerableByaB0sWa ---> protocol witness table accessor for Swift.Float : TensorFlow.AccelerableByTensorFlow in Swift
```

A possible fix is to call additional code like the following, but we have not
tried that.
```c++
  auto Ret = lookUpWitnessTable(C);
```

Overall there is not much existing compiler code that generates/synthesizes calls
to functions with protocol conformance requirements for us to follow. The code in SILGen in that
regard seems tightly packaged such that we haven't been able to identify (and
refactor) the relevant parts for us to (re)use in other compiler phases/passes.

# Const eval over alloc_stack

This PR exposed an existing bug in const eval, which was written up at 
https://github.com/apple/swift/pull/19661. The last test in
"DatasetAPITests.testAllBackends("DoubleValueDatasetIteration")" would fail, and
in non-deterministic ways (release and debug versions of the compiler behave
differently).

A short summary of the bug: If a call to `ConstExprFunctionState::getSingleWriterAddressValue(addr)` fails to produce a const, the function should restore the memory object associated with `addr` to be "uninit memory" or unknown, instead of storing a const value written by a writer inst (e.g. StoreInst) to `addr` that happens to be processed by the getSingleWriterAddressValue() before it exits with failure.

We created a short-term fix in this patch, and it will be replaced by a more
thorough fix from marcrasi@ shortly.
