### PR TITLE
[TF] Suppress TensorFlow runtime logging unless specified by the user

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -264,6 +264,9 @@ public final class _ExecutionContext {
   init() {
     configureRuntimeFromEnvironment()
 
+    // Suppress TensorFlow logging, unless the user specified a log level.
+    setenv("TF_CPP_MIN_LOG_LEVEL", "3", /*override*/ 0)
+
     debugLog("Initializing global context.")
 
     // Initialize the TF runtime exactly once. Only affects local execution


### PR DESCRIPTION
TensorFlow logging has become noise to the user. We set environment variable "TF_CPP_MIN_LOG_LEVEL" to “3” to suppress such logging without overriding any user-given log level. We do this at TF (or _ExecutionContext) initialization time in the compiler runtime.

The following:
```console
2018-10-02 14:54:52.724042: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.2 AVX AVX2 AVX512F FMA
2018-10-02 14:54:52.739486: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.741925: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.767617: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.769572: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.771369: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.773258: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.775125: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.776862: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.778672: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.780525: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.782194: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.784092: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.785902: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.787656: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
2018-10-02 14:54:52.789460: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:344] Starting optimization for grappler item: tf_graph
[[1.07379355e+24, 1.5649758e+24], [2.3474636e+24, 3.421257e+24]]
```

... becomes 

```console
[[1.07379355e+24, 1.5649758e+24], [2.3474636e+24, 3.421257e+24]]
```