### PR TITLE
swift-module-digester: use getEffectiveAccess() to get accessibility when checking ABI stability.

### DIFF
--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -88,3 +88,6 @@ public extension P1 {
 }
 
 infix operator ..*..
+
+@usableFromInline
+class UsableFromInlineClass {}

--- a/test/api-digester/Inputs/cake1.swift
+++ b/test/api-digester/Inputs/cake1.swift
@@ -55,8 +55,9 @@ public struct fixedLayoutStruct {
   public var a = 1
 }
 
+@usableFromInline
 @_fixed_layout
-public struct fixedLayoutStruct2 {
+struct fixedLayoutStruct2 {
   public private(set) var NoLongerWithFixedBinaryOrder = 1
   public var BecomeFixedBinaryOrder: Int { return 1 }
 }

--- a/test/api-digester/Inputs/cake2.swift
+++ b/test/api-digester/Inputs/cake2.swift
@@ -59,8 +59,9 @@ public struct fixedLayoutStruct {
   private lazy var lazy_d = 4
 }
 
+@usableFromInline
 @_fixed_layout
-public struct fixedLayoutStruct2 {
+struct fixedLayoutStruct2 {
   public var NoLongerWithFixedBinaryOrder: Int { return 1 }
   public var BecomeFixedBinaryOrder = 1
 }

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -78,6 +78,3 @@ cake2: Var RequiementChanges.addedVar has been added as a protocol requirement
 cake1: Class C4 has changed its super class from OldType to NewType
 cake1: Class SubGenericClass has changed its super class from GenericClass<P1> to GenericClass<P2>
 cake1: Class SuperClassRemoval has removed its super class C3
-cake1: Func ClassWithOpenMember.bar() is no longer open for subclassing
-cake1: Func ClassWithOpenMember.foo() is no longer open for subclassing
-cake1: Var ClassWithOpenMember.property is no longer open for subclassing

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -9,7 +9,6 @@ cake1: Protocol P3 has generic signature change from <Self : P1, Self : P2> to <
 cake1: AssociatedType RequiementChanges.removedType has been removed
 cake1: Constructor Somestruct2.init(_:) has been removed
 cake1: Constructor fixedLayoutStruct.init(b:a:) has been removed
-cake1: Constructor fixedLayoutStruct2.init(NoLongerWithFixedBinaryOrder:) has been removed
 cake1: Func C4.foo() has been removed
 cake1: Func RequiementChanges.removedFunc() has been removed
 cake1: Subscript RemoveSetters.subscript(_:) has removed its setter

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -231,8 +231,7 @@
           "declKind": "Func",
           "usr": "s:4cake2C1C4foo1yyFZ",
           "moduleName": "cake",
-          "static": true,
-          "isOpen": true
+          "static": true
         },
         {
           "kind": "Var",
@@ -1198,6 +1197,37 @@
       "moduleName": "cake",
       "declAttributes": [
         "Infix"
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "UsableFromInlineClass",
+      "printedName": "UsableFromInlineClass",
+      "children": [
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UsableFromInlineClass",
+              "printedName": "UsableFromInlineClass",
+              "usr": "s:4cake21UsableFromInlineClassC"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:4cake21UsableFromInlineClassCACycfc",
+          "moduleName": "cake",
+          "implicit": true,
+          "isInternal": true
+        }
+      ],
+      "declKind": "Class",
+      "usr": "s:4cake21UsableFromInlineClassC",
+      "moduleName": "cake",
+      "declAttributes": [
+        "UsableFromInline"
       ]
     },
     {

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -4,19 +4,13 @@
 /* RawRepresentable Changes */
 
 /* Removed Decls */
-Protocol ArrayProtocol has been removed
 
 /* Moved Decls */
 
 /* Renamed Decls */
-Var CVaListPointer.value has been renamed to Var CVaListPointer._value
 
 /* Type Changes */
-Var JoinedSequence.Iterator._state has declared type change from JoinedSequence<τ_0_0>.Iterator.JoinIteratorState to JoinedSequence<τ_0_0>.Iterator._JoinIteratorState
 
 /* Decl Attribute changes */
 
 /* Protocol Requirement Changes */
-Struct Array has removed conformance to ArrayProtocol
-Struct ArraySlice has removed conformance to ArrayProtocol
-Struct ContiguousArray has removed conformance to ArrayProtocol

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1216,11 +1216,12 @@ SwiftDeclCollector::shouldIgnore(Decl *D, const Decl* Parent) {
       if (isa<TypeAliasDecl>(VD))
         return true;
     }
+  } else {
+    if (D->isPrivateStdlibDecl(false))
+      return true;
+    if (AvailableAttr::isUnavailable(D))
+      return true;
   }
-  if (D->isPrivateStdlibDecl(false))
-    return true;
-  if (AvailableAttr::isUnavailable(D))
-    return true;
   if (isa<ConstructorDecl>(D))
     return false;
   if (auto VD = dyn_cast<ValueDecl>(D)) {

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -188,6 +188,7 @@ public:
   }
   bool isEqual(const SDKNode &Left, const SDKNode &Right);
   bool checkingABI() const { return Opts.ABI; }
+  AccessLevel getAccessLevel(const ValueDecl *VD) const;
   const CheckerOptions &getOpts() const { return Opts; }
   ArrayRef<ABIAttributeInfo> getABIAttributeInfo() const { return ABIAttrs; }
 


### PR DESCRIPTION
This allows us to include internal decls with @usableFromInline attribute, whose stored property changes can affect ABI.

This PR also re-generates ABI baseline after incorporating this enhancement.