### PR TITLE
[ConstraintSystem] Form argument constraints instead of using `matchT…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -816,10 +816,6 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
                                       parameterBindings))
     return cs.getTypeMatchFailure(locator);
 
-  // Check the argument types for each of the parameters.
-  ConstraintSystem::TypeMatchOptions subflags =
-    ConstraintSystem::TMF_GenerateConstraints;
-
   // If this application is part of an operator, then we allow an implicit
   // lvalue to be compatible with inout arguments.  This is used by
   // assignment operators.
@@ -848,9 +844,7 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
                                             getApplyArgToParam(argIdx,
                                                                paramIdx));
       auto argTy = argsWithLabels[argIdx].getOldType();
-      auto result = cs.matchTypes(argTy, paramTy, subKind, subflags, loc);
-      if (result.isFailure())
-        return result;
+      cs.addConstraint(subKind, argTy, paramTy, loc, /*isFavored=*/false);
     }
   }
 

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -32,6 +32,7 @@ func takesNoEscapeClosure(_ fn : () -> Int) {
   // expected-note@-5{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
   // expected-note@-6{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
   // expected-note@-7{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
+  // expected-note@-8{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
   takesNoEscapeClosure { 4 }  // ok
 
   _ = fn()  // ok
@@ -56,7 +57,7 @@ func takesNoEscapeClosure(_ fn : () -> Int) {
   takesGenericClosure(4) { fn() }  // ok.
 
   _ = [fn] // expected-error {{converting non-escaping value to 'Element' may allow it to escape}}
-  _ = [doesEscape(fn)] // expected-error {{'(() -> Int) -> ()' is not convertible to '(@escaping () -> Int) -> ()'}}
+  _ = [doesEscape(fn)] // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
   _ = [1 : fn] // expected-error {{converting non-escaping value to 'Value' may allow it to escape}}
   _ = [1 : doesEscape(fn)] // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
   _ = "\(doesEscape(fn))" // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}


### PR DESCRIPTION
…ypes` directly

Forming constraints instead of using `matchTypes` while matching argument/parameter
types makes sure that `failedConstraint` points to failed argument conversion
instead of `applicable function` constraint, which is better for diagnostics.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
