### PR TITLE
build: Fix Android 64 bit architecture name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -770,7 +770,7 @@ if(swift_build_android AND NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
   endif()
 
   if("${SWIFT_SDK_ANDROID_ARCHITECTURES}" STREQUAL "")
-    set(SWIFT_SDK_ANDROID_ARCHITECTURES armv7;aarch)
+    set(SWIFT_SDK_ANDROID_ARCHITECTURES armv7;aarch64)
   endif()
   configure_sdk_unix(ANDROID "Android" "android" "android" "${SWIFT_SDK_ANDROID_ARCHITECTURES}" "" "")
 endif()


### PR DESCRIPTION
The Android ARM 64 bits was just `aarch` instead of `aarch64`.

/cc @compnerd 