### PR TITLE
[test] Tweak some tests so that they run consistently on OS X 10.9

### DIFF
--- a/test/Interpreter/SDK/class_getImageName.swift
+++ b/test/Interpreter/SDK/class_getImageName.swift
@@ -115,7 +115,7 @@ testSuite.test("KVO/ObjC") {
 }
 
 testSuite.test("dynamic") {
-  let newClass: AnyClass = objc_allocateClassPair(/*superclass*/nil,
+  let newClass: AnyClass = objc_allocateClassPair(/*superclass*/NSObject.self,
                                                   "CompletelyDynamic",
                                                   /*extraBytes*/0)!
   objc_registerClassPair(newClass)

--- a/test/Interpreter/SDK/objc_bridge_cast.swift
+++ b/test/Interpreter/SDK/objc_bridge_cast.swift
@@ -254,15 +254,16 @@ func testValueToObjectBridgingInSwitch() {
     }
   }
 
-#if arch(i386) || arch(arm)
-#else
-  // Small strings should be immortal
-  autoreleasepool {
-    let string = "hello"
-    let nsString = string as NSString
-    objc_setAssociatedObject(
-      nsString, &ImmortalCanaryAssocObjectHandle, ImmortalCanary(),
-      .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+#if !(arch(i386) || arch(arm))
+  // Small strings should be immortal on new enough 64-bit Apple platforms.
+  if #available(macOS 10.10, *) {
+    autoreleasepool {
+      let string = "hello"
+      let nsString = string as NSString
+      objc_setAssociatedObject(
+        nsString, &ImmortalCanaryAssocObjectHandle, ImmortalCanary(),
+        .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
   }
 #endif // 64-bit
   print("Done")

--- a/test/Interpreter/SDK/objc_swift_getObjectType.swift
+++ b/test/Interpreter/SDK/objc_swift_getObjectType.swift
@@ -31,14 +31,14 @@ extension P {
 class O: NSObject, P { }
 var o = O()
 let obase: NSObject = o
-print(String(cString: object_getClassName(o)))
+print(NSStringFromClass(object_getClass(o)!))
 _ = (o as P).anyP
 _ = (obase as! P).anyP
-// CHECK: main.O
+// CHECK: {{^}}main.O{{$}}
 
 // ... and KVO's artificial subclass thereof
 o.addObserver(NSObject(), forKeyPath: "xxx", options: [.new], context: nil)
-print(String(cString: object_getClassName(o)))
+print(NSStringFromClass(object_getClass(o)!))
 _ = (o as P).anyP
 _ = (obase as! P).anyP
 // CHECK-NEXT: NSKVONotifying_main.O
@@ -47,14 +47,14 @@ _ = (obase as! P).anyP
 extension NSLock: P { }
 var l = NSLock()
 let lbase: NSObject = l
-print(String(cString: object_getClassName(l)))
+print(NSStringFromClass(object_getClass(l)!))
 _ = (l as P).anyP
 _ = (lbase as! P).anyP
 // CHECK-NEXT: NSLock
 
 // ... and KVO's artificial subclass thereof
 l.addObserver(NSObject(), forKeyPath: "xxx", options: [.new], context: nil)
-print(String(cString: object_getClassName(l)))
+print(NSStringFromClass(object_getClass(l)!))
 _ = (l as P).anyP
 _ = (lbase as! P).anyP
 // CHECK-NEXT: NSKVONotifying_NSLock

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -442,6 +442,8 @@ class TestCodable : TestCodableSuper {
     lazy var indexSetValues: [Int : IndexSet] = [
         #line : IndexSet(),
         #line : IndexSet(integer: 42),
+    ]
+    lazy var indexSetMaxValues: [Int : IndexSet] = [
         #line : IndexSet(integersIn: 0 ..< Int.max)
     ]
 
@@ -449,10 +451,19 @@ class TestCodable : TestCodableSuper {
         for (testLine, indexSet) in indexSetValues {
             expectRoundTripEqualityThroughJSON(for: indexSet, lineNumber: testLine)
         }
+        if #available(macOS 10.10, iOS 8, *) {
+            // Mac OS X 10.9 and iOS 7 weren't able to round-trip Int.max in JSON.
+            for (testLine, indexSet) in indexSetMaxValues {
+                expectRoundTripEqualityThroughJSON(for: indexSet, lineNumber: testLine)
+            }
+        }
     }
 
     func test_IndexSet_Plist() {
         for (testLine, indexSet) in indexSetValues {
+            expectRoundTripEqualityThroughPlist(for: indexSet, lineNumber: testLine)
+        }
+        for (testLine, indexSet) in indexSetMaxValues {
             expectRoundTripEqualityThroughPlist(for: indexSet, lineNumber: testLine)
         }
     }
@@ -506,6 +517,9 @@ class TestCodable : TestCodableSuper {
     // MARK: - NSRange
     lazy var nsrangeValues: [Int : NSRange] = [
         #line : NSRange(),
+        #line : NSRange(location: 5, length: 20),
+    ]
+    lazy var nsrangeMaxValues: [Int : NSRange] = [
         #line : NSRange(location: 0, length: Int.max),
         #line : NSRange(location: NSNotFound, length: 0),
     ]
@@ -514,10 +528,19 @@ class TestCodable : TestCodableSuper {
         for (testLine, range) in nsrangeValues {
             expectRoundTripEqualityThroughJSON(for: range, lineNumber: testLine)
         }
+        if #available(macOS 10.10, iOS 8, *) {
+            // Mac OS X 10.9 and iOS 7 weren't able to round-trip Int.max in JSON.
+            for (testLine, range) in nsrangeMaxValues {
+                expectRoundTripEqualityThroughJSON(for: range, lineNumber: testLine)
+            }
+        }
     }
 
     func test_NSRange_Plist() {
         for (testLine, range) in nsrangeValues {
+            expectRoundTripEqualityThroughPlist(for: range, lineNumber: testLine)
+        }
+        for (testLine, range) in nsrangeMaxValues {
             expectRoundTripEqualityThroughPlist(for: range, lineNumber: testLine)
         }
     }

--- a/test/stdlib/NSSlowString.swift
+++ b/test/stdlib/NSSlowString.swift
@@ -57,7 +57,10 @@ tests.test("Iterator") {
   expectEqualSequence(opaque.utf8.reversed(), native.utf8.reversed())
 }
 
-tests.test("Unicode 9 grapheme breaking") {
+tests.test("Unicode 9 grapheme breaking")
+    .xfail(.osxMinor(10, 9, reason: "Mac OS X 10.9 has an old version of ICU"))
+    .xfail(.iOSMajor(7, reason: "iOS 7 has an old version of ICU"))
+    .code {
 
 	// Test string lengths that correspond to smaller than our fixed size code
 	// unit buffer, larger than it, and exactly it.
@@ -69,7 +72,11 @@ tests.test("Unicode 9 grapheme breaking") {
 	check(strJustRight as String, expectedCount: 5, expectedCodeUnitCount: 16)
 }
 
-tests.test("Zalgo") {
+tests.test("Zalgo")
+    .xfail(.osxMinor(10, 9, reason: "Mac OS X 10.9 has an old version of ICU"))
+    .xfail(.iOSMajor(7, reason: "iOS 7 has an old version of ICU"))
+    .code {
+
 	// Check that we handle absurdly long graphemes
 	var zalgo = "a👩‍👩‍👧‍👦c"
 	for combo in 0x300...0x36f {

--- a/test/stdlib/TestCalendar.swift
+++ b/test/stdlib/TestCalendar.swift
@@ -182,7 +182,10 @@ class TestCalendar : TestCalendarSuper {
             
             expectEqual(Date(timeIntervalSince1970: 1468652400.0), c.startOfDay(for: d))
             
-            expectEqual(.orderedSame, c.compare(d, to: d + 10, toGranularity: .minute))
+            if #available(iOS 8, macOS 10.10, *) {
+              // Mac OS X 10.9 and iOS 7 had a bug in NSCalendar for hour, minute, and second granularities.
+              expectEqual(.orderedSame, c.compare(d, to: d + 10, toGranularity: .minute))
+            }
             
             expectFalse(c.isDate(d, equalTo: d + 10, toGranularity: .second))
             expectTrue(c.isDate(d, equalTo: d + 10, toGranularity: .day))

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -29,7 +29,6 @@ SubstringTests.test("Equality") {
   expectEqual("fg" as String, s.suffix(2))
   
 #if _runtime(_ObjC)
-  let emoji: String = s + "😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈" + "😡🇧🇪🇨🇦🇮🇳"
   expectTrue(s == s[...])
   expectTrue(s[...] == s)
   expectTrue(s.dropFirst(2) != s)
@@ -43,6 +42,20 @@ SubstringTests.test("Equality") {
   expectNotEqual(s.dropLast(2), s.dropLast(1))
   expectEqual(s.dropFirst(1), s.dropFirst(1))
   expectTrue(s != s[...].dropFirst(1))
+#endif
+
+	// equatable conformance
+	expectTrue("one,two,three".split(separator: ",").contains("two"))
+	expectTrue("one,two,three".split(separator: ",") == ["one","two","three"])
+}
+
+#if _runtime(_ObjC)
+SubstringTests.test("Equality/Emoji")
+    .xfail(.osxMinor(10, 9, reason: "Mac OS X 10.9 has an old ICU"))
+    .xfail(.iOSMajor(7, reason: "iOS 7 has an old ICU"))
+    .code {
+  let s = "abcdefg"
+  let emoji: String = s + "😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈" + "😡🇧🇪🇨🇦🇮🇳"
   let i = emoji.firstIndex(of: "😄")!
   expectEqual("😄👍🏽" as String, emoji[i...].prefix(2))
   expectTrue("😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String == emoji[i...].dropLast(2))
@@ -50,11 +63,8 @@ SubstringTests.test("Equality") {
   expectTrue(s as String != emoji[i...].dropLast(2).dropFirst(2))
   expectEqualSequence("😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String, emoji[i...].dropLast(2))
   expectEqualSequence("🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String, emoji[i...].dropLast(2).dropFirst(2))
-#endif
-	// equatable conformance
-	expectTrue("one,two,three".split(separator: ",").contains("two"))
-	expectTrue("one,two,three".split(separator: ",") == ["one","two","three"])
 }
+#endif
 
 SubstringTests.test("Comparison") {
   var s = "abc"


### PR DESCRIPTION
The tests aren't all passing yet on Mac OS X 10.9, but this takes care of a bunch of the easy ones. The remaining ones are:

```
Swift(macosx-x86_64) :: Interpreter/class_resilience.swift
Swift(macosx-x86_64) :: Interpreter/generic_class.swift
Swift(macosx-x86_64) :: Interpreter/objc_extensions.swift
Swift(macosx-x86_64) :: Interpreter/subclass_existentials.swift
Swift(macosx-x86_64) :: stdlib/FloatingPoint.swift.gyb
Swift(macosx-x86_64) :: stdlib/SetTrapsObjC.swift
```
(validation)
```
Swift(macosx-x86_64) :: stdlib/AnyHashable.swift.gyb
Swift(macosx-x86_64) :: stdlib/Dictionary.swift
Swift(macosx-x86_64) :: stdlib/DictionaryTrapsObjC.swift
Swift(macosx-x86_64) :: stdlib/Set.swift
