### PR TITLE
build: be a bit more resilient

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -50,7 +50,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     execute_process(COMMAND sw_vers -productVersion
                     OUTPUT_VARIABLE SOURCEKIT_DEPLOYMENT_TARGET
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(REGEX MATCH "[0-9]+\\.[0-9]+" SOURCEKIT_DEPLOYMENT_TARGET ${SOURCEKIT_DEPLOYMENT_TARGET})
+    string(REGEX MATCH "[0-9]+\\.[0-9]+" SOURCEKIT_DEPLOYMENT_TARGET "${SOURCEKIT_DEPLOYMENT_TARGET}")
   endif()
 
   # Sadly there are two OS naming conventions.


### PR DESCRIPTION
In the case that a system update temporarily breaks the command, the output may
be empty, and this can cause CMake to fail in a weird manner.  Quote the
variable to be more resilient to the transient failure.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
