### PR TITLE
improve ConstExprFunctionState::getSingleWriterAddressValue

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -429,6 +429,24 @@ struct SymbolicValueMemoryObject {
   static SymbolicValueMemoryObject *create(Type type, SymbolicValue value,
                                            llvm::BumpPtrAllocator &allocator);
 
+  /// Given that this memory object contains an aggregate value like
+  /// {{1, 2}, 3}, and given an access path like [0,1], return the indexed
+  /// element, e.g. "2" in this case.
+  ///
+  /// Returns uninit memory if the access path points at or into uninit memory.
+  ///
+  /// Precondition: The access path must be valid for this memory object's type.
+  SymbolicValue getIndexedElement(ArrayRef<unsigned> accessPath);
+
+  /// Given that this memory object contains an aggregate value like
+  /// {{1, 2}, 3}, given an access path like [0,1], and given a scalar like "4",
+  /// set the indexed element to the specified scalar, producing {{1, 4}, 3} in
+  /// this case.
+  ///
+  /// Precondition: The access path must be valid for this memory object's type.
+  void setIndexedElement(ArrayRef<unsigned> accessPath, SymbolicValue scalar,
+                         llvm::BumpPtrAllocator &allocator);
+
 private:
   const Type type;
   SymbolicValue value;

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -1181,14 +1181,13 @@ ConstExprFunctionState::initializeSingleWriterAddress(
       // `initializeSingleWriterAddress` below detects and forbids multiple
       // assignment, so we don't need to do it here.
 
-      // Set `teai`'s value to satisfy the `initializeSingleWriterAddress`
-      // precondition.
       SmallVector<unsigned, 4> teaiAccessPath(accessPath.begin(),
                                               accessPath.end());
       teaiAccessPath.push_back(teai->getFieldNo());
-
+        
       auto initializationResult = initializeSingleWriterAddress(
           teai, memoryObject, teaiAccessPath);
+        
       if (initializationResult.failure)
         return initializationResult;
 

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -1020,8 +1020,8 @@ SymbolicValue ConstExprFunctionState::getConstantValue(SILValue value) {
 ///   * `addr` points at uninitialized memory;
 ///   * there are store(s) to `addr` that, taken together, set the memory
 ///     exactly once (e.g. a single "store" to `addr` OR multiple "store"s to
-///     different "tuple_element_addr"s of `addr`);
-///   * the stores' value(s) can be const-evaluated; and
+///     different "tuple_element_addr"s of `addr`); and
+///   * the stores' value(s) can be const-evaluated;
 /// Then: initializes the memory at `addr` and returns {true, None}.
 ///
 /// Otherwise, sets the memory at `addr` to an unspecified value and returns

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -81,6 +81,18 @@ func test_loops() {
   #assert(loops2(a: 20000) > 42)
 }
 
+func test_tupleElementAddrInitialization() {
+  func identity<T>(_ t: T) -> T {
+    return t
+  }
+
+  // SIL initializes a buffer of type (Int, Int), stores "1" and "2" to the
+  // tuple_element_addr's, and then passes the address of the buffer to
+  // `identity`. Therefore, this test tests that we can evaluate top-level
+  // buffers initialized via tuple_element_addr's.
+  #assert(identity((1, 2)) == (1, 2))
+}
+
 //===----------------------------------------------------------------------===//
 // Reduced testcase propagating substitutions around.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
We discovered two problems with `ConstExprFunctionState::getSingleWriterAddressValue`:
1. In certain situations involving recursion, it'll allocate uninitialized memory, point `tuple_element_addr`s at that memory, and then never initialize it -- even if the underlying tuple gets fully const-evaluated.
2. When it discovers partway though execution that some memory is non-constant, it'll bail out and leave that memory in an intermediate state -- sometimes even as a constant value.

See the description and discussion on https://github.com/apple/swift/pull/19661 for a more detailed description of these problems.

Also, it's overall kind of unclear what side effects `getSingleWriterAddressValue` should have, which probably contributed to the bugs.

This PR splits `getSingleWriterAddressValue` into:
* A wrapper function responsible for allocating the initial uninitialized memory, for invoking an inner function that tries to initialize the memory, and for setting the memory to "unknown" if the inner function fails.
* An inner function that tries to initialize the memory in-place.

The wrapper function solves problem 2, because it guarantees that the memory gets set to "unknown" in all failure cases. The fact that the inner function doesn't allocate memory solves problem 1, because the recursive call to itself doesn't allocate extra memory that can get accidentally forgotten.

Test case for problem 1 is included.