### PR TITLE
Separate build directory for libdispatch_static

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1172,6 +1172,7 @@ SWIFTSYNTAX_SOURCE_DIR="${WORKSPACE}/swift-syntax"
 XCTEST_SOURCE_DIR="${WORKSPACE}/swift-corelibs-xctest"
 FOUNDATION_SOURCE_DIR="${WORKSPACE}/swift-corelibs-foundation"
 LIBDISPATCH_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
+LIBDISPATCH_STATIC_SOURCE_DIR="${LIBDISPATCH_SOURCE_DIR}"
 LIBICU_SOURCE_DIR="${WORKSPACE}/icu"
 PLAYGROUNDSUPPORT_SOURCE_DIR="${WORKSPACE}/swift-xcode-playground-support"
 
@@ -1213,6 +1214,9 @@ fi
 # added to the list of build products first.
 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" libdispatch)
+     if [[ "${BUILD_SWIFT_STATIC_STDLIB}" ]]; then
+         PRODUCTS=("${PRODUCTS[@]}" libdispatch_static)
+     fi
 fi
 if [[ ! "${SKIP_BUILD_FOUNDATION}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" foundation)
@@ -1552,7 +1556,7 @@ function build_directory_bin() {
             foundation)
                 echo "${root}/${FOUNDATION_BUILD_TYPE}/bin"
                 ;;
-            libdispatch)
+            libdispatch|libdispatch_static)
                 echo "${root}/${LIBDISPATCH_BUILD_TYPE}/bin"
                 ;;
             libicu)
@@ -1691,7 +1695,7 @@ function cmake_config_opt() {
             foundation)
                 echo "--config ${FOUNDATION_BUILD_TYPE}"
                 ;;
-            libdispatch)
+            libdispatch|libdispatch_static)
                 echo "--config ${LIBDISPATCH_BUILD_TYPE}"
                 ;;
             libicu)
@@ -2214,7 +2218,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_PATH_TO_CMARK_SOURCE:PATH="${CMARK_SOURCE_DIR}"
                     -DSWIFT_PATH_TO_CMARK_BUILD:PATH="$(build_directory ${host} cmark)"
                     -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE:PATH="${LIBDISPATCH_SOURCE_DIR}"
-                    -DSWIFT_PATH_TO_LIBDISPATCH_BUILD:PATH="$(build_directory ${host} libdispatch)"
                 )
 
                 if [[ ! "${SKIP_BUILD_LIBICU}" ]] ; then
@@ -2567,8 +2570,9 @@ for host in "${ALL_HOSTS[@]}"; do
                 # Foundation builds itself and doesn't use cmake
                 continue
                 ;;
-            libdispatch)
-                LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
+            libdispatch|libdispatch_static)
+                LIBDISPATCH_BUILD_DIR=$(build_directory ${host} libdispatch)
+                LIBDISPATCH_STATIC_BUILD_DIR=$(build_directory ${host} libdispatch_static)
                 SWIFT_BUILD_PATH="$(build_directory ${host} swift)"
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
@@ -2613,11 +2617,6 @@ for host in "${ALL_HOSTS[@]}"; do
                   continue
                 ;;
                 *)
-                  # FIXME: Always re-build libdispatch on non-darwin platforms.
-                  # Remove this when products build in the CMake system.
-                  echo "Cleaning the libdispatch build directory"
-                  call rm -rf "${LIBDISPATCH_BUILD_DIR}"
-
                   cmake_options=(
                     ${cmake_options[@]}
                     -DCMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
@@ -2628,10 +2627,32 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_INSTALL_LIBDIR:PATH="lib"
 
                     -DENABLE_SWIFT=YES
-                    -DSWIFT_RUNTIME_LIBDIR:PATH="${SWIFT_BUILD_PATH}/lib/swift/${SWIFT_HOST_VARIANT}/${SWIFT_HOST_VARIANT_ARCH}"
 
                     -DENABLE_TESTING=YES
                   )
+
+                  case ${product} in
+                    libdispatch)
+                      cmake_options=(
+                        ${cmake_options[@]}
+                        -DSWIFT_RUNTIME_LIBDIR:PATH="${SWIFT_BUILD_PATH}/lib/swift/${SWIFT_HOST_VARIANT}/${SWIFT_HOST_VARIANT_ARCH}"
+                        -DBUILD_SHARED_LIBS=YES
+                      )
+                    ;;
+                    libdispatch_static)
+                      cmake_options=(
+                        ${cmake_options[@]}
+                        -DBUILD_SHARED_LIBS=NO
+                        -DSWIFT_RUNTIME_LIBDIR:PATH="${SWIFT_BUILD_PATH}/lib/swift_static/${SWIFT_HOST_VARIANT}/${SWIFT_HOST_VARIANT_ARCH}"
+                        -DINSTALL_TARGET_DIR:PATH=lib/swift_static/${target}
+                      )
+                    ;;
+                    *)
+                      echo "Error: unknown product ${product}" >&2
+                      exit 1
+                    ;;
+                  esac
+
                 ;;
                 esac
 
@@ -3094,6 +3115,10 @@ for host in "${ALL_HOSTS[@]}"; do
                 echo "--- Finished tests for ${product} ---"
                 continue
                 ;;
+            libdispatch_static)
+                # FIXME: Merge with libdispatch once the unit tests work with libdispatch_static
+                continue
+                ;;
             libdispatch)
                 if [[ "${SKIP_TEST_LIBDISPATCH}" ]]; then
                     continue
@@ -3361,7 +3386,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 # As foundation installation is self-contained, we break early here.
                 continue
                 ;;
-            libdispatch)
+            libdispatch|libdispatch_static)
                 if [[ -z "${INSTALL_LIBDISPATCH}" ]] ; then
                     continue
                 fi


### PR DESCRIPTION
This change adds a separate build directory for libdispatch_static, which mirrors the configuration of libdispatch with BUILD_SHARED_LIBS=NO. It also creates a separate build directory sourcekit-libdispatch which is used by the swift build.

Resolves [SR-8854](https://bugs.swift.org/browse/SR-8854).