### PR TITLE
COWArrayOpts: make the optimization work again for two-dimensional arrays.

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -57,10 +57,6 @@ SILValue stripAddressAccess(SILValue V);
 /// instructions.
 SILValue stripAddressProjections(SILValue V);
 
-/// Return the underlying SILValue after stripping off all address projection
-/// instructions which have a single operand.
-SILValue stripUnaryAddressProjections(SILValue V);
-
 /// Return the underlying SILValue after stripping off all aggregate projection
 /// instructions.
 ///

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -600,13 +600,6 @@ SILType getExactDynamicType(SILValue S, SILModule &M,
 SILType getExactDynamicTypeOfUnderlyingObject(SILValue S, SILModule &M,
                                               ClassHierarchyAnalysis *CHA);
 
-/// Hoist the address projection rooted in \p Op to \p InsertBefore.
-/// Requires the projected value to dominate the insertion point.
-///
-/// Will look through single basic block predecessor arguments.
-void hoistAddressProjections(Operand &Op, SILInstruction *InsertBefore,
-                             DominanceInfo *DomTree);
-
 /// Utility class for cloning init values into the static initializer of a
 /// SILGlobalVariable.
 class StaticInitCloner : public SILCloner<StaticInitCloner> {

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -203,18 +203,6 @@ SILValue swift::stripAddressProjections(SILValue V) {
   }
 }
 
-SILValue swift::stripUnaryAddressProjections(SILValue V) {
-  while (true) {
-    V = stripSinglePredecessorArgs(V);
-    if (!Projection::isAddressProjection(V))
-      return V;
-    auto *Inst = cast<SingleValueInstruction>(V);
-    if (Inst->getNumOperands() > 1)
-      return V;
-    V = Inst->getOperand(0);
-  }
-}
-
 SILValue swift::stripValueProjections(SILValue V) {
   while (true) {
     V = stripSinglePredecessorArgs(V);

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -46,8 +46,13 @@ using namespace swift;
 /// either refer to the next element (indexed) or a subelement.
 static SILValue getAccessPath(SILValue V, SmallVectorImpl<unsigned>& Path) {
   V = stripCasts(V);
+  if (auto *IA = dyn_cast<IndexAddrInst>(V)) {
+    // Don't include index_addr projections in the access path. We could if
+    // the index is constant. For simplicity we just ignore them.
+    V = stripCasts(IA->getBase());
+  }
   ProjectionIndex PI(V);
-  if (!PI.isValid() || isa<IndexAddrInst>(V))
+  if (!PI.isValid())
     return V;
 
   SILValue UnderlyingObject = getAccessPath(PI.Aggregate, Path);
@@ -131,6 +136,17 @@ public:
     }
   }
 
+  /// Returns true if there is a single address user of the value.
+  bool hasSingleAddressUse(SILInstruction *SingleAddressUser) {
+    if (!AggregateAddressUsers.empty())
+      return false;
+    if (!ElementAddressUsers.empty())
+      return false;
+    if (StructAddressUsers.size() != 1)
+      return false;
+    return StructAddressUsers[0] == SingleAddressUser;
+  }
+
 protected:
 
   static bool definesSingleObjectType(ValueBase *V) {
@@ -152,6 +168,10 @@ protected:
       }
 
       SILInstruction *UseInst = UI->getUser();
+
+      if (UseInst->isDebugInstruction())
+        continue;
+
       if (StructVal) {
         // Found a use of an element.
         assert(AccessPathSuffix.empty() && "should have accessed struct");
@@ -166,6 +186,13 @@ protected:
         }
 
         ElementAddressUsers.push_back(std::make_pair(UseInst,StructVal));
+        continue;
+      }
+
+      if (isa<UncheckedRefCastInst>(UseInst) || isa<IndexAddrInst>(UseInst)) {
+        // Skip over unchecked_ref_cast and index_addr.
+        collectAddressUses(cast<SingleValueInstruction>(UseInst),
+                           AccessPathSuffix, nullptr);
         continue;
       }
 
@@ -194,7 +221,7 @@ protected:
       // Check for uses of projections.
 
       // These are all single-value instructions.
-      auto ProjInst = dyn_cast<SingleValueInstruction>(UseInst);
+      auto *ProjInst = dyn_cast<SingleValueInstruction>(UseInst);
       if (!ProjInst) {
         AggregateAddressUsers.push_back(UseInst);
         continue;
@@ -202,7 +229,7 @@ protected:
       ProjectionIndex PI(ProjInst);
       // Do not form a path from an IndexAddrInst without otherwise
       // distinguishing it from subelement addressing.
-      if (!PI.isValid() || isa<IndexAddrInst>(V)) {
+      if (!PI.isValid()) {
         // Found a use of an aggregate containing the given element.
         AggregateAddressUsers.push_back(UseInst);
         continue;
@@ -352,11 +379,6 @@ class COWArrayOpt {
   // Set of all blocks that may reach the loop, not including loop blocks.
   llvm::SmallPtrSet<SILBasicBlock*,32> ReachingBlocks;
 
-  // Map an array to a hoisted make_mutable call for the current loop. An array
-  // is only mapped to a call once the analysis has determined that no
-  // make_mutable calls are required within the loop body for that array.
-  llvm::SmallDenseMap<SILValue, ApplyInst*> ArrayMakeMutableMap;
-
   /// \brief Transient per-Array user set.
   ///
   /// Track all known array users with the exception of struct_extract users
@@ -366,6 +388,11 @@ class COWArrayOpt {
   /// the array. If the array escaped through an unknown use, the analysis must
   /// abort earlier.
   SmallPtrSet<SILInstruction*, 8> ArrayUserSet;
+
+  /// Array loads which can be hoisted because a make_mutable of that array
+  /// was hoisted previously.
+  /// This is important to handle the two dimensional array case.
+  SmallPtrSet<LoadInst *, 4> HoistableLoads;
 
   // When matching retains to releases we must not match the same release twice.
   //
@@ -401,12 +428,9 @@ protected:
   bool checkSafeArrayElementUse(SILInstruction *UseInst, SILValue ArrayVal);
   bool checkSafeElementValueUses(UserOperList &ElementValueUsers);
   bool hoistMakeMutable(ArraySemanticsCall MakeMutable);
-  void hoistMakeMutableAndSelfProjection(ArraySemanticsCall MakeMutable,
-                                         bool HoistProjection);
+  void hoistAddressProjections(Operand &ArrayOp);
   bool hasLoopOnlyDestructorSafeArrayOperations();
-  bool isArrayValueReleasedBeforeMutate(
-      SILValue V, llvm::SmallSet<SILInstruction *, 16> &Releases);
-  bool hoistInLoopWithOnlyNonArrayValueMutatingOperations();
+  SILValue getArrayAddressBase(SILValue V);
 };
 } // end anonymous namespace
 
@@ -441,6 +465,17 @@ bool COWArrayOpt::checkUniqueArrayContainer(SILValue ArrayContainer) {
   }
   else if (isa<AllocStackInst>(ArrayContainer))
     return true;
+
+  if (auto *LI = dyn_cast<LoadInst>(ArrayContainer)) {
+    // A load of another array, which follows a make_mutable, also guarantees
+    // a unique container. This is the case if the current array is an element
+    // of the outer array in nested arrays.
+    if (HoistableLoads.count(LI) != 0)
+      return true;
+  }
+
+  // TODO: we should also take advantage of access markers to identify
+  // unique arrays.
 
   LLVM_DEBUG(llvm::dbgs()
              << "    Skipping Array: Not an argument or local variable!\n");
@@ -573,9 +608,6 @@ bool COWArrayOpt::isRetainReleasedBeforeMutate(SILInstruction *RetainInst,
 bool COWArrayOpt::checkSafeArrayAddressUses(UserList &AddressUsers) {
 
   for (auto *UseInst : AddressUsers) {
-
-    if (UseInst->isDebugInstruction())
-      continue;
 
     if (auto *AI = dyn_cast<ApplyInst>(UseInst)) {
       if (ArraySemanticsCall(AI))
@@ -740,6 +772,10 @@ bool COWArrayOpt::checkSafeArrayElementUse(SILInstruction *UseInst,
     // buffer that is loaded from a local array struct.
     return true;
 
+  if (isa<RefTailAddrInst>(UseInst)) {
+    return true;
+  }
+
   // Look for a safe mark_dependence instruction use.
   //
   // This use looks something like:
@@ -791,546 +827,6 @@ bool COWArrayOpt::checkSafeElementValueUses(UserOperList &ElementValueUsers) {
       return false;
   }
   return true;
-}
-
-/// Check whether the array semantic operation could change an array value to
-/// not be uniquely referenced.
-///
-/// Array.append for example can capture another array value.
-static bool mayChangeArrayValueToNonUniqueState(ArraySemanticsCall &Call) {
-  switch (Call.getKind()) {
-  case ArrayCallKind::kArrayPropsIsNativeTypeChecked:
-  case ArrayCallKind::kCheckSubscript:
-  case ArrayCallKind::kCheckIndex:
-  case ArrayCallKind::kGetCount:
-  case ArrayCallKind::kGetCapacity:
-  case ArrayCallKind::kGetElement:
-  case ArrayCallKind::kGetArrayOwner:
-  case ArrayCallKind::kGetElementAddress:
-  case ArrayCallKind::kMakeMutable:
-    return false;
-
-  case ArrayCallKind::kNone:
-  case ArrayCallKind::kMutateUnknown:
-  case ArrayCallKind::kReserveCapacityForAppend:
-  case ArrayCallKind::kWithUnsafeMutableBufferPointer:
-  case ArrayCallKind::kArrayInit:
-  case ArrayCallKind::kArrayUninitialized:
-  case ArrayCallKind::kAppendContentsOf:
-  case ArrayCallKind::kAppendElement:
-    return true;
-  }
-
-  llvm_unreachable("Unhandled ArrayCallKind in switch.");
-}
-
-/// Check that the array value stored in \p ArrayStruct is released by \Inst.
-static bool isReleaseOfArrayValueAt(AllocStackInst *ArrayStruct,
-                                    SILInstruction *Inst,
-                                    RCIdentityFunctionInfo *RCIA) {
-  auto *SRI = dyn_cast<StrongReleaseInst>(Inst);
-  if (!SRI)
-   return false;
-  auto Root = RCIA->getRCIdentityRoot(SRI->getOperand());
-  auto *ArrayLoad = dyn_cast<LoadInst>(Root);
-  if (!ArrayLoad)
-    return false;
-
-  if (ArrayLoad->getOperand() == ArrayStruct)
-    return true;
-
-  return false;
-}
-
-static bool isReleaseOfArrayValue(SILValue Array, SILInstruction *Inst,
-                                  RCIdentityFunctionInfo *RCIA) {
-  if (!isa<StrongReleaseInst>(Inst) && !isa<ReleaseValueInst>(Inst))
-    return false;
-  SILValue Root = RCIA->getRCIdentityRoot(Inst->getOperand(0));
-  return Root == Array;
-}
-
-/// Check that the array value is released before a mutating operation happens.
-bool COWArrayOpt::isArrayValueReleasedBeforeMutate(
-    SILValue V, llvm::SmallSet<SILInstruction *, 16> &Releases) {
-  AllocStackInst *ASI = nullptr;
-  SILInstruction *StartInst = nullptr;
-  if (V->getType().isAddress()) {
-    ASI = dyn_cast<AllocStackInst>(V);
-    if (!ASI)
-      return false;
-    StartInst = ASI;
-  } else {
-    // True because of the caller.
-    StartInst = V->getDefiningInstruction();
-  }
-  for (auto II = std::next(SILBasicBlock::iterator(StartInst)),
-            IE = StartInst->getParent()->end();
-       II != IE; ++II) {
-    auto *Inst = &*II;
-    // Ignore matched releases.
-    if (auto SRI = dyn_cast<StrongReleaseInst>(Inst))
-      if (MatchedReleases.count(&SRI->getOperandRef()))
-        continue;
-    if (auto RVI = dyn_cast<ReleaseValueInst>(Inst))
-      if (MatchedReleases.count(&RVI->getOperandRef()))
-        continue;
-
-    if (ASI) {
-      if (isReleaseOfArrayValueAt(ASI, &*II, RCIA)) {
-        Releases.erase(&*II);
-        return true;
-      }
-    } else {
-      if (isReleaseOfArrayValue(V, &*II, RCIA)) {
-        Releases.erase(&*II);
-        return true;
-      }
-    }
-
-    if (isa<RetainValueInst>(II) || isa<StrongRetainInst>(II))
-      continue;
-
-    // A side effect free instruction cannot mutate the array.
-    if (!II->mayHaveSideEffects())
-      continue;
-
-    // Non mutating array calls are safe.
-    if (isNonMutatingArraySemanticCall(&*II))
-      continue;
-
-    return false;
-  }
-  return true;
-}
-
-static SILInstruction *getInstBefore(SILInstruction *I) {
-  auto It = ++I->getIterator().getReverse();
-  if (I->getParent()->rend() == It)
-    return nullptr;
-  return &*It;
-}
-
-static SILInstruction *getInstAfter(SILInstruction *I) {
-  auto It = SILBasicBlock::iterator(I);
-  It = std::next(It);
-  if (I->getParent()->end() == It)
-    return nullptr;
-  return &*It;
-}
-
-/// Strips and stores the struct_extract projections leading to the array
-/// storage reference.
-static SILValue
-stripValueProjections(SILValue V,
-                      SmallVectorImpl<SILInstruction *> &ValuePrjs) {
-  while (auto SEI = dyn_cast<StructExtractInst>(V)) {
-    ValuePrjs.push_back(SEI);
-    V = SEI->getOperand();
-  }
-  return V;
-}
-
-/// Finds the preceding check_subscript, make_mutable call or returns nil.
-///
-/// If we found a make_mutable call this means that check_subscript was removed
-/// by the array bounds check elimination pass.
-static SILInstruction *
-findPrecedingCheckSubscriptOrMakeMutable(ApplyInst *GetElementAddr) {
-  for (auto ReverseIt = ++GetElementAddr->getIterator().getReverse(),
-            End = GetElementAddr->getParent()->rend();
-       ReverseIt != End; ++ReverseIt) {
-    auto Apply = dyn_cast<ApplyInst>(&*ReverseIt);
-    if (!Apply)
-      continue;
-    ArraySemanticsCall CheckSubscript(Apply);
-    if (!CheckSubscript ||
-        (CheckSubscript.getKind() != ArrayCallKind::kCheckSubscript &&
-         CheckSubscript.getKind() != ArrayCallKind::kMakeMutable))
-      return nullptr;
-    return CheckSubscript;
-  }
-  return nullptr;
-}
-
-/// Matches the self parameter arguments, verifies that \p Self is called and
-/// stores the instructions in \p DepInsts in order.
-static bool
-matchSelfParameterSetup(ArraySemanticsCall Call, LoadInst *Self,
-                        SmallVectorImpl<SILInstruction *> &DepInsts) {
-  bool MayHaveBridgedObjectElementType = Call.mayHaveBridgedObjectElementType();
-  // We only need the retain/release for the guaranteed parameter if the call
-  // could release self. This can only happen if the array is backed by an
-  // Objective-C array. If this is not the case we can safely hoist the call
-  // without the retain/releases.
-  auto *RetainArray = dyn_cast_or_null<StrongRetainInst>(getInstBefore(Call));
-  if (!RetainArray && MayHaveBridgedObjectElementType)
-    return false;
-  auto *ReleaseArray = dyn_cast_or_null<StrongReleaseInst>(getInstAfter(Call));
-  if (!ReleaseArray && MayHaveBridgedObjectElementType)
-    return false;
-  if (ReleaseArray && RetainArray &&
-      ReleaseArray->getOperand() != RetainArray->getOperand())
-    return false;
-
-  if (ReleaseArray)
-    DepInsts.push_back(ReleaseArray);
-  DepInsts.push_back(Call);
-  if (RetainArray)
-    DepInsts.push_back(RetainArray);
-
-  if (RetainArray) {
-    auto ArrayLoad = stripValueProjections(RetainArray->getOperand(), DepInsts);
-    if (ArrayLoad != Self)
-      return false;
-  }
-
-  DepInsts.push_back(Self);
-  return true;
-}
-
-/// Match a hoistable make_mutable call.
-///
-/// Precondition: The client must make sure that it is valid to actually hoist
-/// the call. It must make sure that no write and no increment to the array
-/// reference has happened such that hoisting is not valid.
-///
-/// This helper only checks that the operands computing the array reference
-/// are also hoistable.
-struct HoistableMakeMutable {
-  SILLoop *Loop;
-  bool IsHoistable;
-  ApplyInst *MakeMutable;
-  SmallVector<SILInstruction *, 24> DepInsts;
-
-  HoistableMakeMutable(ArraySemanticsCall M, SILLoop *L) {
-    IsHoistable = false;
-    Loop = L;
-    MakeMutable = M;
-
-    // The function_ref needs to be invariant.
-    if (Loop->contains(MakeMutable->getCallee()->getParentBlock()))
-      return;
-
-    // The array reference is invariant.
-    if (!L->contains(M.getSelf()->getParentBlock())) {
-      IsHoistable = true;
-      return;
-    }
-
-    // Check whether we can hoist the dependent instructions resulting in the
-    // array reference.
-    if (canHoistDependentInstructions(M))
-      IsHoistable = true;
-  }
-
-  /// Is this a hoistable make_mutable call.
-  bool isHoistable() {
-    return IsHoistable;
-  }
-
-  /// Hoist this make_mutable call and depend instructions to the preheader.
-  void hoist() {
-    auto *Term = Loop->getLoopPreheader()->getTerminator();
-    for (auto *It : swift::reversed(DepInsts)) {
-      if (It->getParent() != Term->getParent())
-        It->moveBefore(Term);
-    }
-    MakeMutable->moveBefore(Term);
-  }
-
-private:
-
-  /// Check whether we can hoist the dependent instructions resulting in the
-  /// array reference passed to the make_mutable call.
-  /// We pattern match the first dimension's array access here.
-  bool canHoistDependentInstructions(ArraySemanticsCall &M) {
-    // Match get_element_addr call.
-    // %124 = load %3
-    // %125 = struct_extract %124
-    // %126 = struct_extract %125
-    // %127 = struct_extract %126
-    // strong_retain %127
-    // %129 = apply %70(%30, %124)
-    // strong_release %127
-    //
-    // %131 = load %73
-    // %132 = unchecked_ref_cast %131
-    // %133 = enum $Optional<NativeObject>, #Optional.Some!enumelt.1, %132
-    // %134 = struct_extract %129
-    // %135 = pointer_to_address %134 to strict $*Array<Int>
-    // %136 = mark_dependence %135 on %133
-
-    auto *MarkDependence = dyn_cast<MarkDependenceInst>(M.getSelf());
-    if (!MarkDependence)
-      return false;
-    DepInsts.push_back(MarkDependence);
-
-    auto *PtrToAddrArrayAddr =
-        dyn_cast<PointerToAddressInst>(MarkDependence->getValue());
-    if (!PtrToAddrArrayAddr)
-      return false;
-    DepInsts.push_back(PtrToAddrArrayAddr);
-
-    auto *StructExtractArrayAddr =
-        dyn_cast<StructExtractInst>(PtrToAddrArrayAddr->getOperand());
-    if (!StructExtractArrayAddr)
-      return false;
-    DepInsts.push_back(StructExtractArrayAddr);
-
-    // Check the base the array element address is dependent on.
-    SILValue base = MarkDependence->getBase();
-
-    // We can optionally have an enum instruction here.
-    if (auto *EnumArrayAddr = dyn_cast<EnumInst>(base)) {
-      DepInsts.push_back(EnumArrayAddr);
-      base = EnumArrayAddr->getOperand();
-    }
-
-    // We can optionally have an unchecked cast.
-    if (auto *UncheckedRefCast = dyn_cast<UncheckedRefCastInst>(base)) {
-      DepInsts.push_back(UncheckedRefCast);
-      base = UncheckedRefCast->getOperand();
-    }
-
-    SILValue ArrayBuffer = stripValueProjections(base, DepInsts);
-    auto *BaseLoad = dyn_cast<LoadInst>(ArrayBuffer);
-    if (!BaseLoad ||  Loop->contains(BaseLoad->getOperand()->getParentBlock()))
-      return false;
-    DepInsts.push_back(BaseLoad);
-
-    // Check the get_element_addr call.
-    ArraySemanticsCall GetElementAddrCall(
-        StructExtractArrayAddr->getOperand());
-    if (!GetElementAddrCall ||
-        GetElementAddrCall.getKind() != ArrayCallKind::kGetElementAddress)
-      return false;
-    if (Loop->contains(
-            ((ApplyInst *)GetElementAddrCall)->getCallee()->getParentBlock()))
-      return false;
-    if (Loop->contains(GetElementAddrCall.getIndex()->getParentBlock()))
-      return false;
-
-    auto *GetElementAddrArrayLoad =
-        dyn_cast<LoadInst>(GetElementAddrCall.getSelf());
-    if (!GetElementAddrArrayLoad ||
-        Loop->contains(GetElementAddrArrayLoad->getOperand()->getParentBlock()))
-      return false;
-
-    // Check the retain/release around the get_element_addr call.
-    if (!matchSelfParameterSetup(GetElementAddrCall, GetElementAddrArrayLoad,
-                                 DepInsts))
-      return false;
-
-    // Check check_subscript.
-    // %116 = load %3
-    // %118 = struct_extract %116
-    // %119 = struct_extract %118
-    // %120 = struct_extract %119
-    // strong_retain %120
-    // %122 = apply %23(%30, %69, %116)
-    // strong_release %120
-    //
-    // Find the check_subscript call.
-    auto *Check = findPrecedingCheckSubscriptOrMakeMutable(GetElementAddrCall);
-    if (!Check)
-      return false;
-
-    ArraySemanticsCall CheckSubscript(Check);
-    // The check_subscript call was removed.
-    if (CheckSubscript.getKind() == ArrayCallKind::kMakeMutable)
-      return true;
-
-    if (Loop->contains(CheckSubscript.getIndex()->getParentBlock()) ||
-        Loop->contains(CheckSubscript.getArrayPropertyIsNativeTypeChecked()
-                           ->getParentBlock()))
-      return false;
-
-    auto *CheckSubscriptArrayLoad =
-        dyn_cast<LoadInst>(CheckSubscript.getSelf());
-    if (!CheckSubscript ||
-        Loop->contains(CheckSubscriptArrayLoad->getOperand()->getParentBlock()))
-      return false;
-  if (Loop->contains(
-            ((ApplyInst *)CheckSubscript)->getCallee()->getParentBlock()))
-      return false;
-
-    // The array must match get_element_addr's array.
-    if (CheckSubscriptArrayLoad->getOperand() !=
-        GetElementAddrArrayLoad->getOperand())
-      return false;
-
-    // Check the retain/release around the check_subscript call.
-    if (!matchSelfParameterSetup(CheckSubscript, CheckSubscriptArrayLoad,
-                                 DepInsts))
-      return false;
-
-    return true;
-  }
-};
-
-/// Prove that there are not array value mutating or capturing operations in the
-/// loop and hoist make_mutable.
-bool COWArrayOpt::hoistInLoopWithOnlyNonArrayValueMutatingOperations() {
-  // Only handle innermost loops.
-  assert(Loop->getSubLoops().empty() && "Only works in innermost loops");
-
-  LLVM_DEBUG(llvm::dbgs() << "    Checking whether loop only has only "
-                             "non array value mutating operations ...\n");
-
-  // There is no current array addr value.
-  CurrentArrayAddr = SILValue();
-
-  // We need to cleanup the MatchedRelease on return.
-  auto ReturnWithCleanup = [&] (bool LoopHasSafeOperations) {
-    MatchedReleases.clear();
-    return LoopHasSafeOperations;
-  };
-
-  llvm::SmallSet<SILValue, 16> ArrayValues;
-  llvm::SmallSetVector<SILValue, 16> CreatedNonTrivialValues;
-  llvm::SmallSet<SILInstruction *, 16> Releases;
-  llvm::SmallVector<ArraySemanticsCall, 8> MakeMutableCalls;
-
-
-  /// Make sure that no writes to an array value happens in the loop and that
-  /// no array values are retained without being released before hitting a
-  /// make_unique:
-  ///
-  /// * array semantic functions that don't change the uniqueness state to
-  ///   non-unique are safe.
-  /// * retains must be matched by a release before hitting a mutating operation
-  /// * stores must not store an array value (only trivial stores are safe).
-  ///
-  auto &Module = Function->getModule();
-  for (auto *BB : Loop->getBlocks()) {
-    for (auto &InstIt : *BB) {
-      auto *Inst = &InstIt;
-      ArraySemanticsCall Sem(Inst);
-      if (Sem) {
-        // Give up if the array semantic function might change the uniqueness
-        // state of an array value in the loop. An example of such an operation
-        // would be append. We also give up for array initializations.
-        if (mayChangeArrayValueToNonUniqueState(Sem))
-          return ReturnWithCleanup(false);
-
-        // Collect both the value and the pointer.
-        ArrayValues.insert(Sem.getSelf());
-        if (auto *LI = dyn_cast<LoadInst>(Sem.getSelf()))
-          ArrayValues.insert(LI->getOperand());
-
-        // Collect non-trivial generated values. This could be an array value.
-        // We must make sure that any non-trivial generated values (== +1)
-        // are release before we hit a make_unique instruction.
-        ApplyInst *SemCall = Sem;
-        if (Sem.getKind() == ArrayCallKind::kGetElement) {
-          SILValue Elem = (Sem.hasGetElementDirectResult()
-                            ? Sem.getCallResult()
-                            : SemCall->getArgument(0));
-          if (!Elem->getType().isTrivial(Module))
-            CreatedNonTrivialValues.insert(Elem);
-        } else if (Sem.getKind() == ArrayCallKind::kMakeMutable) {
-          MakeMutableCalls.push_back(Sem);
-        }
-
-        continue;
-      }
-
-      // Instructions without side effects are safe.
-      if (!Inst->mayHaveSideEffects())
-        continue;
-      if (isa<CondFailInst>(Inst))
-        continue;
-      if (isa<AllocationInst>(Inst) || isa<DeallocStackInst>(Inst))
-        continue;
-
-      // A retain must be released before make_unique.
-      if (isa<RetainValueInst>(Inst) ||
-          isa<StrongRetainInst>(Inst)) {
-        if (!isRetainReleasedBeforeMutate(Inst, false)) {
-          LLVM_DEBUG(llvm::dbgs()
-                     << "    (NO) retain not released before mutate "
-                     << *Inst);
-          return ReturnWithCleanup(false);
-        }
-        continue;
-      }
-      // A store is only safe if it is to an array element and the element type
-      // is trivial.
-      if (auto *SI = dyn_cast<StoreInst>(Inst)) {
-        if (!isAddressOfArrayElement(SI->getDest()) ||
-            !SI->getSrc()->getType().isTrivial(Module)) {
-          LLVM_DEBUG(llvm::dbgs()
-                     <<"     (NO) non trivial store could store an array value "
-                     << *Inst);
-          return ReturnWithCleanup(false);
-        }
-        continue;
-      }
-      // Releases must be matched by a retain otherwise a destructor could run.
-      if (auto SRI = dyn_cast<StrongReleaseInst>(Inst)) {
-        if (!MatchedReleases.count(&SRI->getOperandRef()))
-          Releases.insert(Inst);
-        continue;
-      }
-      if (auto RVI = dyn_cast<ReleaseValueInst>(Inst)) {
-        if (!MatchedReleases.count(&RVI->getOperandRef()))
-          Releases.insert(Inst);
-        continue;
-      }
-
-      LLVM_DEBUG(llvm::dbgs()
-                 << "    (NO) instruction prevents make_unique hoisting "
-                 << *Inst);
-      return ReturnWithCleanup(false);
-    }
-  }
-
-  // Nothing to do.
-  if (MakeMutableCalls.empty())
-    return ReturnWithCleanup(false);
-
-  // Verify that all created non trivial values are array values and that they
-  // are released before mutation.
-  for (auto &NonTrivial : CreatedNonTrivialValues) {
-    if (!ArrayValues.count(NonTrivial)) {
-      LLVM_DEBUG(llvm::dbgs() << "    (NO) non-trivial non-array value: "
-                 << NonTrivial);
-      return ReturnWithCleanup(false);
-    }
-
-    if (!isArrayValueReleasedBeforeMutate(NonTrivial, Releases)) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "    (NO) array value not released before mutation "
-                 << NonTrivial);
-      return ReturnWithCleanup(false);
-    }
-  }
-
-  if (!Releases.empty()) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "    (NO) remaining releases not matched by retain\n");
-    return ReturnWithCleanup(false);
-  }
-
-  // Collect all recursively hoistable calls.
-  SmallVector<std::unique_ptr<HoistableMakeMutable>, 16> CallsToHoist;
-  for (auto M : MakeMutableCalls) {
-    auto Call = llvm::make_unique<HoistableMakeMutable>(M, Loop);
-    if (!Call->isHoistable()) {
-      LLVM_DEBUG(llvm::dbgs() << "    (NO) make_mutable not hoistable"
-                              << *Call->MakeMutable);
-      return ReturnWithCleanup(false);
-    }
-    CallsToHoist.push_back(std::move(Call));
-  }
-
-  for (auto &Call: CallsToHoist)
-    Call->hoist();
-
-  LLVM_DEBUG(llvm::dbgs() << "    Hoisting make_mutable in "
-                          << Function->getName() << "\n");
-  return ReturnWithCleanup(true);
 }
 
 /// Check if a loop has only 'safe' array operations such that we can hoist the
@@ -1440,21 +936,104 @@ bool COWArrayOpt::hasLoopOnlyDestructorSafeArrayOperations() {
   return ReturnWithCleanup(true);
 }
 
-/// Hoist the make_mutable call and optionally the projection chain that feeds
-/// the array self argument.
-void COWArrayOpt::hoistMakeMutableAndSelfProjection(
-    ArraySemanticsCall MakeMutable, bool HoistProjection) {
-  // Hoist projections.
-  if (HoistProjection)
-    hoistAddressProjections(MakeMutable.getSelfOperand(),
-      Preheader->getTerminator(), DomTree);
+/// Return the underlying Array address after stripping off all address
+/// projections. Returns an invalid SILValue if the array base does not dominate
+/// the loop.
+SILValue COWArrayOpt::getArrayAddressBase(SILValue V) {
+  while (true) {
+    V = stripSinglePredecessorArgs(V);
+    if (auto *RefCast = dyn_cast<UncheckedRefCastInst>(V)) {
+      V = RefCast->getOperand();
+      continue;
+    }
+    if (auto *SE = dyn_cast<StructExtractInst>(V)) {
+      V = SE->getOperand();
+      continue;
+    }
+    if (auto *IA = dyn_cast<IndexAddrInst>(V)) {
+      // index_addr is the only projection which has a second operand: the index.
+      // Check if the index is loop invariant.
+      SILBasicBlock *IndexBlock = IA->getIndex()->getParentBlock();
+      if (IndexBlock && !DomTree->dominates(IndexBlock, Preheader))
+        return SILValue();
+      V = IA->getBase();
+      continue;
+    }
+    if (!Projection::isAddressProjection(V))
+      break;
+    auto *Inst = cast<SingleValueInstruction>(V);
+    if (Inst->getNumOperands() > 1)
+      break;
+    V = Inst->getOperand(0);
+  }
+  if (auto *LI = dyn_cast<LoadInst>(V)) {
+    if (HoistableLoads.count(LI) != 0)
+      return V;
+  }
+  SILBasicBlock *ArrayAddrBaseBB = V->getParentBlock();
+  if (ArrayAddrBaseBB && !DomTree->dominates(ArrayAddrBaseBB, Preheader))
+    return SILValue();
 
-  assert(MakeMutable.canHoist(Preheader->getTerminator(), DomTree) &&
-         "Should be able to hoist make_mutable");
+  return V;
+}
 
-  // Hoist this call to make_mutable.
-  LLVM_DEBUG(llvm::dbgs() << "    Hoisting make_mutable: " << *MakeMutable);
-  MakeMutable.hoist(Preheader->getTerminator(), DomTree);
+/// Hoist the address projection rooted in \p Op to \p InsertBefore.
+/// Requires the projected value to dominate the insertion point.
+///
+/// Will look through single basic block predecessor arguments.
+void COWArrayOpt::hoistAddressProjections(Operand &ArrayOp) {
+  SILValue V = ArrayOp.get();
+  SILInstruction *Prev = nullptr;
+  SILInstruction *InsertPt = Preheader->getTerminator();
+  while (true) {
+    SILValue Incoming = stripSinglePredecessorArgs(V);
+
+    // Forward the incoming arg from a single predecessor.
+    if (V != Incoming) {
+      if (V == ArrayOp.get()) {
+        // If we are the operand itself set the operand to the incoming
+        // argument.
+        ArrayOp.set(Incoming);
+        V = Incoming;
+      } else {
+        // Otherwise, set the previous projections operand to the incoming
+        // argument.
+        assert(Prev && "Must have seen a projection");
+        Prev->setOperand(0, Incoming);
+        V = Incoming;
+      }
+    }
+
+    switch (V->getKind()) {
+      case ValueKind::LoadInst:
+      case ValueKind::StructElementAddrInst:
+      case ValueKind::TupleElementAddrInst:
+      case ValueKind::RefElementAddrInst:
+      case ValueKind::RefTailAddrInst:
+      case ValueKind::UncheckedRefCastInst:
+      case ValueKind::StructExtractInst:
+      case ValueKind::IndexAddrInst:
+      case ValueKind::UncheckedTakeEnumDataAddrInst: {
+        auto *Inst = cast<SingleValueInstruction>(V);
+        // We are done once the current projection dominates the insert point.
+        if (DomTree->dominates(Inst->getParent(), Preheader))
+          return;
+
+        assert(!isa<LoadInst>(V) || HoistableLoads.count(cast<LoadInst>(V)) != 0);
+
+        // Move the current projection and memorize it for the next iteration.
+        Prev = Inst;
+        Inst->moveBefore(InsertPt);
+        InsertPt = Inst;
+        V = Inst->getOperand(0);
+        continue;
+      }
+      default:
+        assert(DomTree->dominates(V->getParentBlock(), Preheader) &&
+               "The projected value must dominate the insertion point");
+        return;
+    }
+  }
 }
 
 /// Check if this call to "make_mutable" is hoistable, and move it, or delete it
@@ -1464,49 +1043,67 @@ bool COWArrayOpt::hoistMakeMutable(ArraySemanticsCall MakeMutable) {
 
   // We can hoist address projections (even if they are only conditionally
   // executed).
-  auto ArrayAddrBase = stripUnaryAddressProjections(CurrentArrayAddr);
-  SILBasicBlock *ArrayAddrBaseBB = ArrayAddrBase->getParentBlock();
-
-  if (ArrayAddrBaseBB && !DomTree->dominates(ArrayAddrBaseBB, Preheader)) {
+  SILValue ArrayAddrBase = getArrayAddressBase(CurrentArrayAddr);
+  if (!ArrayAddrBase) {
     LLVM_DEBUG(llvm::dbgs() << "    Skipping Array: does not dominate loop!\n");
     return false;
   }
 
   SmallVector<unsigned, 4> AccessPath;
   SILValue ArrayContainer = getAccessPath(CurrentArrayAddr, AccessPath);
+  bool arrayContainerIsUnique = checkUniqueArrayContainer(ArrayContainer);
+
+  StructUseCollector StructUses;
 
   // Check whether we can hoist make_mutable based on the operations that are
   // in the loop.
   if (hasLoopOnlyDestructorSafeArrayOperations()) {
-    hoistMakeMutableAndSelfProjection(MakeMutable,
-                                      CurrentArrayAddr != ArrayAddrBase);
-    LLVM_DEBUG(llvm::dbgs()
-               << "    Can Hoist: loop only has 'safe' array operations!\n");
-    return true;
+    // Done. We can hoist the make_mutable.
+    // We still need the array uses later to check if we can add loads to
+    // HoistableLoads.
+    StructUses.collectUses(ArrayContainer, AccessPath);
+  } else {
+    // There are some unsafe operations in the loop. If the array is uniquely
+    // identifyable and not escaping, then we are good if all the array uses
+    // are safe.
+    if (!arrayContainerIsUnique) {
+      LLVM_DEBUG(llvm::dbgs() << "    Skipping Array: is not unique!\n");
+      return false;
+    }
+
+    // Check that the Array is not retained with this loop and it's address does
+    // not escape within this function.
+    StructUses.collectUses(ArrayContainer, AccessPath);
+    for (auto *Oper : StructUses.Visited)
+      ArrayUserSet.insert(Oper->getUser());
+
+    if (!checkSafeArrayAddressUses(StructUses.AggregateAddressUsers) ||
+        !checkSafeArrayAddressUses(StructUses.StructAddressUsers) ||
+        !checkSafeArrayValueUses(StructUses.StructValueUsers) ||
+        !checkSafeElementValueUses(StructUses.ElementValueUsers) ||
+        !StructUses.ElementAddressUsers.empty())
+      return false;
   }
 
-  // Check that the array is a member of an inout argument or return value.
-  if (!checkUniqueArrayContainer(ArrayContainer)) {
-    LLVM_DEBUG(llvm::dbgs() << "    Skipping Array: is not unique!\n");
-    return false;
+  // Hoist the make_mutable.
+  LLVM_DEBUG(llvm::dbgs() << "    Hoisting make_mutable: " << *MakeMutable);
+
+  hoistAddressProjections(MakeMutable.getSelfOperand());
+
+  assert(MakeMutable.canHoist(Preheader->getTerminator(), DomTree) &&
+         "Should be able to hoist make_mutable");
+
+  MakeMutable.hoist(Preheader->getTerminator(), DomTree);
+
+  // Register array loads. This is needed for hoisting make_mutable calls of
+  // inner arrays in the two-dimensional case.
+  if (arrayContainerIsUnique &&
+      StructUses.hasSingleAddressUse((ApplyInst *)MakeMutable)) {
+    for (auto use : MakeMutable.getSelf()->getUses()) {
+      if (auto *LI = dyn_cast<LoadInst>(use->getUser()))
+        HoistableLoads.insert(LI);
+    }
   }
-
-  // Check that the Array is not retained with this loop and it's address does
-  // not escape within this function.
-  StructUseCollector StructUses;
-  StructUses.collectUses(ArrayContainer, AccessPath);
-  for (auto *Oper : StructUses.Visited)
-    ArrayUserSet.insert(Oper->getUser());
-
-  if (!checkSafeArrayAddressUses(StructUses.AggregateAddressUsers) ||
-      !checkSafeArrayAddressUses(StructUses.StructAddressUsers) ||
-      !checkSafeArrayValueUses(StructUses.StructValueUsers) ||
-      !checkSafeElementValueUses(StructUses.ElementValueUsers) ||
-      !StructUses.ElementAddressUsers.empty())
-    return false;
-
-  hoistMakeMutableAndSelfProjection(MakeMutable,
-                                    CurrentArrayAddr != ArrayAddrBase);
   return true;
 }
 
@@ -1519,12 +1116,10 @@ bool COWArrayOpt::run() {
     return false;
   }
 
-  // Hoist make_mutable in two dimensional arrays if there are no array value
-  // mutating operations in the loop.
-  if (Loop->getSubLoops().empty() &&
-      hoistInLoopWithOnlyNonArrayValueMutatingOperations()) {
-    return true;
-  }
+  // Map an array to a hoisted make_mutable call for the current loop. An array
+  // is only mapped to a call once the analysis has determined that no
+  // make_mutable calls are required within the loop body for that array.
+  llvm::SmallDenseMap<SILValue, ApplyInst*> ArrayMakeMutableMap;
 
   for (auto *BB : Loop->getBlocks()) {
     if (ColdBlocks.isCold(BB))

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -38,12 +38,6 @@
 #include "llvm/Support/Debug.h"
 using namespace swift;
 
-#ifndef NDEBUG
-llvm::cl::opt<std::string>
-COWViewCFGFunction("view-cfg-before-cow-for", llvm::cl::init(""),
-                   llvm::cl::desc("Only print out the sil for this function"));
-#endif
-
 /// \return a sequence of integers representing the access path of this element
 /// within a Struct/Ref/Tuple.
 ///
@@ -1584,13 +1578,6 @@ class COWArrayOptPass : public SILFunctionTransform {
       LLVM_DEBUG(llvm::dbgs() << "  Skipping Function: No loops.\n");
       return;
     }
-
-#ifndef NDEBUG
-    if (!COWViewCFGFunction.empty() && getFunction()->getName() == COWViewCFGFunction) {
-      getFunction()->dump();
-      getFunction()->viewCFG();
-    }
-#endif
 
     // Create a flat list of loops in loop-tree postorder (bottom-up).
     llvm::SmallVector<SILLoop *, 16> Loops;

--- a/test/SILOptimizer/array_mutable_assertonly.swift
+++ b/test/SILOptimizer/array_mutable_assertonly.swift
@@ -13,8 +13,6 @@
 // RUN: %target-swift-frontend -O -emit-sil -Xllvm -debug-only=cowarray-opts -primary-file %s 2>&1 | %FileCheck %s --check-prefix=TEST13
 // REQUIRES: asserts,swift_stdlib_no_asserts,optimized_stdlib
 
-// XFAIL: *
-
 // TEST1-LABEL: COW Array Opts in Func {{.*}}inoutarr{{.*}}
 // TEST1: Hoisting make_mutable
 // TEST1: COW Array Opts

--- a/test/SILOptimizer/cowarray_opt.sil
+++ b/test/SILOptimizer/cowarray_opt.sil
@@ -38,6 +38,13 @@ struct ContainerContainer {
   var container: Container
 }
 
+class MyArrayStorage {
+  @sil_stored var header: Int
+
+  init()
+  deinit
+}
+
 sil [_semantics "array.make_mutable"] @array_make_mutable : $@convention(method) (@inout MyArray<MyStruct>) -> ()
 sil [_semantics "array.get_count"] @guaranteed_array_get_count : $@convention(method) (@guaranteed MyArray<MyStruct>) -> Int
 sil [_semantics "array.get_capacity"] @guaranteed_array_get_capacity : $@convention(method) (@guaranteed MyArray<MyStruct>) -> Int
@@ -475,555 +482,6 @@ struct MyInt {
   init(_ value: Int16)
 }
 
-sil [_semantics "array.check_subscript"] @checkSubscript : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-sil [_semantics "array.check_subscript"] @checkSubscript2 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-sil [_semantics "array.make_mutable"] @makeMutable : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-sil [_semantics "array.get_element_address"] @getElementAddress : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-sil [_semantics "array.make_mutable"] @makeMutable2 : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-sil [_semantics "array.get_element_address"] @getElementAddress2 : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-
-// Check hoisting of uniqueness checks in a 2D array loop.
-
-// CHECK-LABEL: sil @hoist2DArray
-// CHECK: bb0
-// CHECK:   cond_br undef, bb2, bb1
-// CHECK: bb1
-// CHECK:   [[CS:%.*]] = function_ref @checkSubscript
-// CHECK:   [[MM:%.*]] = function_ref @makeMutable
-// CHECK:   apply [[MM]]
-// CHECK:   br bb3
-// CHECK: bb2
-// CHECK:   return
-// CHECK: bb3:
-// CHECK:   cond_br undef, bb5, bb4
-// CHECK: bb4:
-// CHECK:  [[CS2:%.*]] = function_ref @checkSubscript2
-// CHECK:  [[GEA:%.*]] = function_ref @getElementAddress
-// CHECK:  [[MM2:%.*]] = function_ref @makeMutable2
-// CHECK:  [[GEA2:%.*]] = function_ref @getElementAddress2
-// CHECK:  strong_retain
-// CHECK:  apply [[CS]]
-// CHECK:  strong_release
-// CHECK:  strong_retain
-// CHECK:  [[ADDR:%.*]] = apply [[GEA]]
-// CHECK:  strong_release
-// CHECK:  [[SE:%.*]] = struct_extract [[ADDR]]
-// CHECK:  [[PTA:%.*]] = pointer_to_address [[SE]]
-// CHECK:  [[MD:%.*]] = mark_dependence [[PTA]]
-// CHECK:  apply [[MM2]]([[MD]]
-// CHECK:  br bb6
-// CHECK:  bb5:
-// CHECK:  cond_br undef, bb2, bb3
-// CHECK:  bb6
-// CHECK:  strong_retain
-// CHECK:  apply [[CS2]]
-// CHECK:  strong_release
-// CHECK:  strong_retain
-// CHECK:  apply [[GEA2]]
-// CHECK:  strong_release
-// CHECK-NOT: apply
-// CHECK:  cond_br
-
-sil @hoist2DArray : $@convention(thin) (@inout My2dArray<My2dArray<MyInt>>) -> () {
-bb0(%0 : $*My2dArray<My2dArray<MyInt>>):
-  %1 = integer_literal $Builtin.Int64, 0
-  %2 = struct $MyInt (%1 : $Builtin.Int64)
-  %3 = integer_literal $Builtin.Int1, -1
-  cond_br undef, bb2, bb1
-
-bb1:
-  %5 = integer_literal $Builtin.Int64, 1
-  %6 = integer_literal $Builtin.Int1, 0
-  %7 = function_ref @checkSubscript : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  br bb3
-
-bb2:
-  %9 = tuple ()
-  return %9 : $()
-
-bb3:
-  cond_br undef, bb5, bb4
-
-bb4:
-  %12 = function_ref @checkSubscript2 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  %13 = function_ref @makeMutable : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %14 = struct $Bool (%3 : $Builtin.Int1)
-  %15 = function_ref @getElementAddress : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  %16 = struct_element_addr %0 : $*My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %17 = struct_element_addr %16 : $*_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %18 = struct_element_addr %17 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %19 = function_ref @makeMutable2 : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %20 = function_ref @getElementAddress2 : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  br bb6(%1 : $Builtin.Int64)
-
-bb5:
-  cond_br undef, bb2, bb3
-
-bb6(%23 : $Builtin.Int64):
-  %24 = struct $MyInt (%23 : $Builtin.Int64)
-  %25 = builtin "sadd_with_overflow_Int64"(%23 : $Builtin.Int64, %5 : $Builtin.Int64, %6 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %26 = tuple_extract %25 : $(Builtin.Int64, Builtin.Int1), 0
-  %27 = apply %13(%0) : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %28 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %29 = struct_extract %28 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %30 = struct_extract %29 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %31 = struct_extract %30 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %31 : $Builtin.BridgeObject
-  %33 = apply %7(%2, %14, %28) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  strong_release %31 : $Builtin.BridgeObject
-  %35 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %36 = struct_extract %35 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %37 = struct_extract %36 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %38 = struct_extract %37 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %38 : $Builtin.BridgeObject
-  %40 = apply %15(%2, %35) : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  strong_release %38 : $Builtin.BridgeObject
-  %42 = load %18 : $*Builtin.BridgeObject
-  %43 = unchecked_ref_cast %42 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %44 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %43 : $Builtin.NativeObject
-  %45 = struct_extract %40 : $UnsafeMutablePointer<My2dArray<MyInt>>, #UnsafeMutablePointer._rawValue
-  %46 = pointer_to_address %45 : $Builtin.RawPointer to [strict] $*My2dArray<MyInt>
-  %47 = mark_dependence %46 : $*My2dArray<MyInt> on %44 : $Optional<Builtin.NativeObject>
-  %48 = apply %19(%47) : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %49 = load %47 : $*My2dArray<MyInt>
-  %50 = struct_extract %49 : $My2dArray<MyInt>, #My2dArray._buffer
-  %51 = struct_extract %50 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %52 = struct_extract %51 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %52 : $Builtin.BridgeObject
-  %54 = apply %12(%24, %14, %49) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  strong_release %52 : $Builtin.BridgeObject
-  %56 = load %47 : $*My2dArray<MyInt>
-  %57 = struct_extract %56 : $My2dArray<MyInt>, #My2dArray._buffer
-  %58 = struct_extract %57 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %59 = struct_extract %58 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %59 : $Builtin.BridgeObject
-  %61 = apply %20(%24, %56) : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  strong_release %59 : $Builtin.BridgeObject
-  %63 = struct_element_addr %47 : $*My2dArray<MyInt>, #My2dArray._buffer
-  %64 = struct_element_addr %63 : $*_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %65 = struct_element_addr %64 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %66 = load %65 : $*Builtin.BridgeObject
-  %67 = unchecked_ref_cast %66 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %68 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %67 : $Builtin.NativeObject
-  %69 = struct_extract %61 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
-  %70 = pointer_to_address %69 : $Builtin.RawPointer to [strict] $*MyInt
-  %71 = mark_dependence %70 : $*MyInt on %68 : $Optional<Builtin.NativeObject>
-  store %24 to %71 : $*MyInt
-  cond_br undef, bb5, bb6(%26 : $Builtin.Int64)
-}
-
-// CHECK-LABEL: sil @dont_hoist_because_release_2DArray
-// CHECK: bb0
-// CHECK:   cond_br undef, bb2, bb1
-// CHECK: bb1
-// CHECK:   br bb3
-// CHECK: bb2
-// CHECK:   return
-// CHECK: bb3:
-// CHECK:   cond_br undef, bb5, bb4
-// CHECK: bb4:
-// CHECK-NOT:  apply
-// CHECK:  br bb6
-
-sil @dont_hoist_because_release_2DArray : $@convention(thin) (@inout My2dArray<My2dArray<MyInt>>) -> () {
-bb0(%0 : $*My2dArray<My2dArray<MyInt>>):
-  %1 = integer_literal $Builtin.Int64, 0
-  %2 = struct $MyInt (%1 : $Builtin.Int64)
-  %3 = integer_literal $Builtin.Int1, -1
-  cond_br undef, bb2, bb1
-
-bb1:
-  %5 = integer_literal $Builtin.Int64, 1
-  %6 = integer_literal $Builtin.Int1, 0
-  %7 = function_ref @checkSubscript : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  br bb3
-
-bb2:
-  %9 = tuple ()
-  return %9 : $()
-
-bb3:
-  cond_br undef, bb5, bb4
-
-bb4:
-  %12 = function_ref @checkSubscript2 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  %13 = function_ref @makeMutable : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %14 = struct $Bool (%3 : $Builtin.Int1)
-  %15 = function_ref @getElementAddress : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  %16 = struct_element_addr %0 : $*My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %17 = struct_element_addr %16 : $*_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %18 = struct_element_addr %17 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %19 = function_ref @makeMutable2 : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %20 = function_ref @getElementAddress2 : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  br bb6(%1 : $Builtin.Int64)
-
-bb5:
-  cond_br undef, bb2, bb3
-
-bb6(%23 : $Builtin.Int64):
-  %24 = struct $MyInt (%23 : $Builtin.Int64)
-  %25 = builtin "sadd_with_overflow_Int64"(%23 : $Builtin.Int64, %5 : $Builtin.Int64, %6 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %26 = tuple_extract %25 : $(Builtin.Int64, Builtin.Int1), 0
-  %27 = apply %13(%0) : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %28 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %29 = struct_extract %28 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %30 = struct_extract %29 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %31 = struct_extract %30 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %31 : $Builtin.BridgeObject
-  %33 = apply %7(%2, %14, %28) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  strong_release %31 : $Builtin.BridgeObject
-  %35 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %36 = struct_extract %35 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %37 = struct_extract %36 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %38 = struct_extract %37 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %38 : $Builtin.BridgeObject
-  %40 = apply %15(%2, %35) : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  strong_release %38 : $Builtin.BridgeObject
-  %42 = load %18 : $*Builtin.BridgeObject
-  %43 = unchecked_ref_cast %42 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %44 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %43 : $Builtin.NativeObject
-  %45 = struct_extract %40 : $UnsafeMutablePointer<My2dArray<MyInt>>, #UnsafeMutablePointer._rawValue
-  %46 = pointer_to_address %45 : $Builtin.RawPointer to [strict] $*My2dArray<MyInt>
-  %47 = mark_dependence %46 : $*My2dArray<MyInt> on %44 : $Optional<Builtin.NativeObject>
-  %48 = apply %19(%47) : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %49 = load %47 : $*My2dArray<MyInt>
-  %50 = struct_extract %49 : $My2dArray<MyInt>, #My2dArray._buffer
-  %51 = struct_extract %50 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %52 = struct_extract %51 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %52 : $Builtin.BridgeObject
-  %54 = apply %12(%24, %14, %49) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  strong_release %52 : $Builtin.BridgeObject
-  %56 = load %47 : $*My2dArray<MyInt>
-  %57 = struct_extract %56 : $My2dArray<MyInt>, #My2dArray._buffer
-  %58 = struct_extract %57 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %59 = struct_extract %58 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %59 : $Builtin.BridgeObject
-  %61 = apply %20(%24, %56) : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  strong_release %59 : $Builtin.BridgeObject
-  %63 = struct_element_addr %47 : $*My2dArray<MyInt>, #My2dArray._buffer
-  %64 = struct_element_addr %63 : $*_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %65 = struct_element_addr %64 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %66 = load %65 : $*Builtin.BridgeObject
-  %67 = unchecked_ref_cast %66 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %68 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %67 : $Builtin.NativeObject
-  %69 = struct_extract %61 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
-  %70 = pointer_to_address %69 : $Builtin.RawPointer to [strict] $*MyInt
-  %71 = mark_dependence %70 : $*MyInt on %68 : $Optional<Builtin.NativeObject>
-  store %24 to %71 : $*MyInt
-  release_value %28 : $My2dArray<My2dArray<MyInt>>
-  cond_br undef, bb5, bb6(%26 : $Builtin.Int64)
-}
-
-// CHECK-LABEL: sil @dont_hoist_because_retain_2DArray
-// CHECK: bb0
-// CHECK:   cond_br undef, bb2, bb1
-// CHECK: bb1
-// CHECK:   br bb3
-// CHECK: bb2
-// CHECK:   return
-// CHECK: bb3:
-// CHECK:   cond_br undef, bb5, bb4
-// CHECK: bb4:
-// CHECK-NOT:  apply
-// CHECK:  br bb6
-
-sil @dont_hoist_because_retain_2DArray : $@convention(thin) (@inout My2dArray<My2dArray<MyInt>>) -> () {
-bb0(%0 : $*My2dArray<My2dArray<MyInt>>):
-  %1 = integer_literal $Builtin.Int64, 0
-  %2 = struct $MyInt (%1 : $Builtin.Int64)
-  %3 = integer_literal $Builtin.Int1, -1
-  cond_br undef, bb2, bb1
-
-bb1:
-  %5 = integer_literal $Builtin.Int64, 1
-  %6 = integer_literal $Builtin.Int1, 0
-  %7 = function_ref @checkSubscript : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  br bb3
-
-bb2:
-  %9 = tuple ()
-  return %9 : $()
-
-bb3:
-  cond_br undef, bb5, bb4
-
-bb4:
-  %12 = function_ref @checkSubscript2 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  %13 = function_ref @makeMutable : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %14 = struct $Bool (%3 : $Builtin.Int1)
-  %15 = function_ref @getElementAddress : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  %16 = struct_element_addr %0 : $*My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %17 = struct_element_addr %16 : $*_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %18 = struct_element_addr %17 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %19 = function_ref @makeMutable2 : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %20 = function_ref @getElementAddress2 : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  br bb6(%1 : $Builtin.Int64)
-
-bb5:
-  cond_br undef, bb2, bb3
-
-bb6(%23 : $Builtin.Int64):
-  %24 = struct $MyInt (%23 : $Builtin.Int64)
-  %25 = builtin "sadd_with_overflow_Int64"(%23 : $Builtin.Int64, %5 : $Builtin.Int64, %6 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %26 = tuple_extract %25 : $(Builtin.Int64, Builtin.Int1), 0
-  %27 = apply %13(%0) : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %28 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %29 = struct_extract %28 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %30 = struct_extract %29 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %31 = struct_extract %30 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %31 : $Builtin.BridgeObject
-  %33 = apply %7(%2, %14, %28) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  strong_release %31 : $Builtin.BridgeObject
-  %35 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %36 = struct_extract %35 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %37 = struct_extract %36 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %38 = struct_extract %37 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %38 : $Builtin.BridgeObject
-  %40 = apply %15(%2, %35) : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  strong_release %38 : $Builtin.BridgeObject
-  %42 = load %18 : $*Builtin.BridgeObject
-  %43 = unchecked_ref_cast %42 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %44 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %43 : $Builtin.NativeObject
-  %45 = struct_extract %40 : $UnsafeMutablePointer<My2dArray<MyInt>>, #UnsafeMutablePointer._rawValue
-  %46 = pointer_to_address %45 : $Builtin.RawPointer to [strict] $*My2dArray<MyInt>
-  %47 = mark_dependence %46 : $*My2dArray<MyInt> on %44 : $Optional<Builtin.NativeObject>
-  %48 = apply %19(%47) : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %49 = load %47 : $*My2dArray<MyInt>
-  %50 = struct_extract %49 : $My2dArray<MyInt>, #My2dArray._buffer
-  %51 = struct_extract %50 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %52 = struct_extract %51 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %52 : $Builtin.BridgeObject
-  %54 = apply %12(%24, %14, %49) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  strong_release %52 : $Builtin.BridgeObject
-  %56 = load %47 : $*My2dArray<MyInt>
-  %57 = struct_extract %56 : $My2dArray<MyInt>, #My2dArray._buffer
-  %58 = struct_extract %57 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %59 = struct_extract %58 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %59 : $Builtin.BridgeObject
-  %61 = apply %20(%24, %56) : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  strong_release %59 : $Builtin.BridgeObject
-  %63 = struct_element_addr %47 : $*My2dArray<MyInt>, #My2dArray._buffer
-  %64 = struct_element_addr %63 : $*_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %65 = struct_element_addr %64 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %66 = load %65 : $*Builtin.BridgeObject
-  %67 = unchecked_ref_cast %66 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %68 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %67 : $Builtin.NativeObject
-  %69 = struct_extract %61 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
-  %70 = pointer_to_address %69 : $Builtin.RawPointer to [strict] $*MyInt
-  %71 = mark_dependence %70 : $*MyInt on %68 : $Optional<Builtin.NativeObject>
-  store %24 to %71 : $*MyInt
-  retain_value %28 : $My2dArray<My2dArray<MyInt>>
-  cond_br undef, bb5, bb6(%26 : $Builtin.Int64)
-}
-
-
-// CHECK-LABEL: sil @dont_hoist_because_store_2DArray
-// CHECK: bb0
-// CHECK:   cond_br undef, bb2, bb1
-// CHECK: bb1
-// CHECK:   br bb3
-// CHECK: bb2
-// CHECK:   return
-// CHECK: bb3:
-// CHECK:   cond_br undef, bb5, bb4
-// CHECK: bb4:
-// CHECK-NOT:  apply
-// CHECK:  br bb6
-
-sil @dont_hoist_because_store_2DArray : $@convention(thin) (@inout My2dArray<My2dArray<MyInt>>, @inout My2dArray<My2dArray<MyInt>>) -> () {
-bb0(%0 : $*My2dArray<My2dArray<MyInt>>, %100: $*My2dArray<My2dArray<MyInt>>):
-  %1 = integer_literal $Builtin.Int64, 0
-  %2 = struct $MyInt (%1 : $Builtin.Int64)
-  %3 = integer_literal $Builtin.Int1, -1
-  cond_br undef, bb2, bb1
-
-bb1:
-  %5 = integer_literal $Builtin.Int64, 1
-  %6 = integer_literal $Builtin.Int1, 0
-  %7 = function_ref @checkSubscript : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  br bb3
-
-bb2:
-  %9 = tuple ()
-  return %9 : $()
-
-bb3:
-  cond_br undef, bb5, bb4
-
-bb4:
-  %12 = function_ref @checkSubscript2 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  %13 = function_ref @makeMutable : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %14 = struct $Bool (%3 : $Builtin.Int1)
-  %15 = function_ref @getElementAddress : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  %16 = struct_element_addr %0 : $*My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %17 = struct_element_addr %16 : $*_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %18 = struct_element_addr %17 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %19 = function_ref @makeMutable2 : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %20 = function_ref @getElementAddress2 : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  br bb6(%1 : $Builtin.Int64)
-
-bb5:
-  cond_br undef, bb2, bb3
-
-bb6(%23 : $Builtin.Int64):
-  %24 = struct $MyInt (%23 : $Builtin.Int64)
-  %25 = builtin "sadd_with_overflow_Int64"(%23 : $Builtin.Int64, %5 : $Builtin.Int64, %6 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %26 = tuple_extract %25 : $(Builtin.Int64, Builtin.Int1), 0
-  %27 = apply %13(%0) : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %28 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %29 = struct_extract %28 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %30 = struct_extract %29 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %31 = struct_extract %30 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %31 : $Builtin.BridgeObject
-  %33 = apply %7(%2, %14, %28) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  strong_release %31 : $Builtin.BridgeObject
-  %35 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %36 = struct_extract %35 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %37 = struct_extract %36 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %38 = struct_extract %37 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %38 : $Builtin.BridgeObject
-  %40 = apply %15(%2, %35) : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  strong_release %38 : $Builtin.BridgeObject
-  %42 = load %18 : $*Builtin.BridgeObject
-  %43 = unchecked_ref_cast %42 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %44 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %43 : $Builtin.NativeObject
-  %45 = struct_extract %40 : $UnsafeMutablePointer<My2dArray<MyInt>>, #UnsafeMutablePointer._rawValue
-  %46 = pointer_to_address %45 : $Builtin.RawPointer to [strict] $*My2dArray<MyInt>
-  %47 = mark_dependence %46 : $*My2dArray<MyInt> on %44 : $Optional<Builtin.NativeObject>
-  %48 = apply %19(%47) : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %49 = load %47 : $*My2dArray<MyInt>
-  %50 = struct_extract %49 : $My2dArray<MyInt>, #My2dArray._buffer
-  %51 = struct_extract %50 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %52 = struct_extract %51 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %52 : $Builtin.BridgeObject
-  %54 = apply %12(%24, %14, %49) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  strong_release %52 : $Builtin.BridgeObject
-  %56 = load %47 : $*My2dArray<MyInt>
-  %57 = struct_extract %56 : $My2dArray<MyInt>, #My2dArray._buffer
-  %58 = struct_extract %57 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %59 = struct_extract %58 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %59 : $Builtin.BridgeObject
-  %61 = apply %20(%24, %56) : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  strong_release %59 : $Builtin.BridgeObject
-  %63 = struct_element_addr %47 : $*My2dArray<MyInt>, #My2dArray._buffer
-  %64 = struct_element_addr %63 : $*_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %65 = struct_element_addr %64 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %66 = load %65 : $*Builtin.BridgeObject
-  %67 = unchecked_ref_cast %66 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %68 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %67 : $Builtin.NativeObject
-  %69 = struct_extract %61 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
-  %70 = pointer_to_address %69 : $Builtin.RawPointer to [strict] $*MyInt
-  %71 = mark_dependence %70 : $*MyInt on %68 : $Optional<Builtin.NativeObject>
-  store %24 to %71 : $*MyInt
-  %72 = load %100: $*My2dArray<My2dArray<MyInt>>
-  store %72 to %0: $*My2dArray<My2dArray<MyInt>>
-  cond_br undef, bb5, bb6(%26 : $Builtin.Int64)
-}
-
-
-// CHECK-LABEL: sil @dont_hoist_because_apply_2DArray
-// CHECK: bb0
-// CHECK:   cond_br undef, bb2, bb1
-// CHECK: bb1
-// CHECK:   br bb3
-// CHECK: bb2
-// CHECK:   return
-// CHECK: bb3:
-// CHECK:   cond_br undef, bb5, bb4
-// CHECK: bb4:
-// CHECK-NOT:  apply
-// CHECK:  br bb6
-
-sil @dont_hoist_because_apply_2DArray : $@convention(thin) (@inout My2dArray<My2dArray<MyInt>>, @inout My2dArray<My2dArray<MyInt>>) -> () {
-bb0(%0 : $*My2dArray<My2dArray<MyInt>>, %100: $*My2dArray<My2dArray<MyInt>>):
-  %1 = integer_literal $Builtin.Int64, 0
-  %2 = struct $MyInt (%1 : $Builtin.Int64)
-  %3 = integer_literal $Builtin.Int1, -1
-  cond_br undef, bb2, bb1
-
-bb1:
-  %5 = integer_literal $Builtin.Int64, 1
-  %6 = integer_literal $Builtin.Int1, 0
-  %7 = function_ref @checkSubscript : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  br bb3
-
-bb2:
-  %9 = tuple ()
-  return %9 : $()
-
-bb3:
-  cond_br undef, bb5, bb4
-
-bb4:
-  %12 = function_ref @checkSubscript2 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  %13 = function_ref @makeMutable : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %14 = struct $Bool (%3 : $Builtin.Int1)
-  %15 = function_ref @getElementAddress : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  %16 = struct_element_addr %0 : $*My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %17 = struct_element_addr %16 : $*_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %18 = struct_element_addr %17 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %19 = function_ref @makeMutable2 : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %20 = function_ref @getElementAddress2 : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  br bb6(%1 : $Builtin.Int64)
-
-bb5:
-  cond_br undef, bb2, bb3
-
-bb6(%23 : $Builtin.Int64):
-  %24 = struct $MyInt (%23 : $Builtin.Int64)
-  %25 = builtin "sadd_with_overflow_Int64"(%23 : $Builtin.Int64, %5 : $Builtin.Int64, %6 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %26 = tuple_extract %25 : $(Builtin.Int64, Builtin.Int1), 0
-  %27 = apply %13(%0) : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %28 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %29 = struct_extract %28 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %30 = struct_extract %29 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %31 = struct_extract %30 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %31 : $Builtin.BridgeObject
-  %33 = apply %7(%2, %14, %28) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> ()
-  strong_release %31 : $Builtin.BridgeObject
-  %35 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %36 = struct_extract %35 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %37 = struct_extract %36 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %38 = struct_extract %37 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %38 : $Builtin.BridgeObject
-  %40 = apply %15(%2, %35) : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  strong_release %38 : $Builtin.BridgeObject
-  %42 = load %18 : $*Builtin.BridgeObject
-  %43 = unchecked_ref_cast %42 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %44 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %43 : $Builtin.NativeObject
-  %45 = struct_extract %40 : $UnsafeMutablePointer<My2dArray<MyInt>>, #UnsafeMutablePointer._rawValue
-  %46 = pointer_to_address %45 : $Builtin.RawPointer to [strict] $*My2dArray<MyInt>
-  %47 = mark_dependence %46 : $*My2dArray<MyInt> on %44 : $Optional<Builtin.NativeObject>
-  %48 = apply %19(%47) : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %49 = load %47 : $*My2dArray<MyInt>
-  %50 = struct_extract %49 : $My2dArray<MyInt>, #My2dArray._buffer
-  %51 = struct_extract %50 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %52 = struct_extract %51 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %52 : $Builtin.BridgeObject
-  %54 = apply %12(%24, %14, %49) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> ()
-  strong_release %52 : $Builtin.BridgeObject
-  %56 = load %47 : $*My2dArray<MyInt>
-  %57 = struct_extract %56 : $My2dArray<MyInt>, #My2dArray._buffer
-  %58 = struct_extract %57 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %59 = struct_extract %58 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_retain %59 : $Builtin.BridgeObject
-  %61 = apply %20(%24, %56) : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  strong_release %59 : $Builtin.BridgeObject
-  %63 = struct_element_addr %47 : $*My2dArray<MyInt>, #My2dArray._buffer
-  %64 = struct_element_addr %63 : $*_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %65 = struct_element_addr %64 : $*_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %66 = load %65 : $*Builtin.BridgeObject
-  %67 = unchecked_ref_cast %66 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %68 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %67 : $Builtin.NativeObject
-  %69 = struct_extract %61 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
-  %70 = pointer_to_address %69 : $Builtin.RawPointer to [strict] $*MyInt
-  %71 = mark_dependence %70 : $*MyInt on %68 : $Optional<Builtin.NativeObject>
-  store %24 to %71 : $*MyInt
-  %72 = function_ref @unknown : $@convention(thin) () -> ()
-  %73 = apply %72() : $@convention(thin) () -> ()
-  cond_br undef, bb5, bb6(%26 : $Builtin.Int64)
-}
-
 // CHECK-LABEL: sil @hoist_projections
 // CHECK: bb0([[CONTAINER:%[0-9]+]]
 // CHECK: [[CONTAINER2:%.*]] = struct_element_addr [[CONTAINER]] : $*ContainerContainer
@@ -1052,14 +510,15 @@ bb2:
   return %7 : $()
 }
 
-// We don't support hoisting non-unary projections yet.
-
-// CHECK-LABEL: sil @dont_hoist_non_unary_projections
-// CHECK-NOT: index_addr
-// CHECK: bb2({{.*}}):
+// CHECK-LABEL: sil @hoist_non_unary_projections
 // CHECK: index_addr
-sil @dont_hoist_non_unary_projections : $@convention(thin) (@inout ContainerContainer, @inout Builtin.Int1) -> () {
+// CHECK: struct_element_addr
+// CHECK: bb1:
+// CHECK-NOT: index_addr
+// CHECK-NOT: struct_element_addr
+sil @hoist_non_unary_projections : $@convention(thin) (@inout ContainerContainer, @inout Builtin.Int1) -> () {
 bb0(%0 : $*ContainerContainer, %1 : $*Builtin.Int1):
+  %i = integer_literal $Builtin.Int32, 0
   br bb1
 
 bb1:
@@ -1067,7 +526,6 @@ bb1:
   br bb2(%2 : $*Container)
 
 bb2(%3: $*Container):
-  %i = integer_literal $Builtin.Int32, 0
   %3i = index_addr %3 : $*Container, %i : $Builtin.Int32
   %4 = struct_element_addr %3i : $*Container, #Container.array
   %5 = function_ref @array_make_mutable : $@convention(method) (@inout MyArray<MyStruct>) -> ()
@@ -1132,193 +590,104 @@ bb2:
   return %7 : $()
 }
 
-
-sil [_semantics "array.props.isNativeTypeChecked"] @hoistableIsNativeTypeChecked : $@convention(method) (@guaranteed My2dArray<My2dArray<MyInt>>) -> Bool
-sil [_semantics "array.check_subscript"] @checkSubscript3 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> _DependenceToken
-sil [_semantics "array.get_element"] @getElement3 : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<My2dArray<MyInt>>) -> @out My2dArray<MyInt>
-sil [_semantics "array.props.isNativeTypeChecked"] @hoistableIsNativeTypeChecked2 : $@convention(method) (@guaranteed My2dArray<MyInt>) -> Bool
-sil [_semantics "array.check_subscript"] @checkSubscript4 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> _DependenceToken
-sil [_semantics "array.get_element"] @getElement4 : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<MyInt>) -> @out MyInt
-sil [_semantics "array.make_mutable"] @makeMutable3 : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-sil [_semantics "array.get_element_address"] @getElementAddress3 : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-sil [_semantics "array.make_mutable"] @makeMutable4 : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-sil [_semantics "array.get_element_address"] @getElementAddress4 : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-
-// CHECK-LABEL: sil @hoist2DArray_2
-// CHECK: bb0
-// CHECK:  apply {{.*}} : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-// CHECK:  apply {{.*}} : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-// CHECK: br bb2
-// CHECK: bb1
-// CHECK:  return
-// CHECK: bb2
-// CHECK-NOT:  apply {{.*}} : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-// CHECK-NOT:  apply {{.*}} : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-// CHECK: cond_br
-
-sil @hoist2DArray_2 : $@convention(thin) (@inout My2dArray<My2dArray<MyInt>>, MyInt) -> () {
-bb0(%0 : $*My2dArray<My2dArray<MyInt>>, %1 : $MyInt):
-  %4 = integer_literal $Builtin.Int64, 0
-  %5 = integer_literal $Builtin.Int64, 1024
-  %6 = integer_literal $Builtin.Int64, 1
-  %7 = integer_literal $Builtin.Int1, 0
-  %9 = function_ref @hoistableIsNativeTypeChecked : $@convention(method) (@guaranteed My2dArray<My2dArray<MyInt>>) -> Bool
-  %10 = function_ref @checkSubscript3 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> _DependenceToken
-  %11 = function_ref @getElement3 : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<My2dArray<MyInt>>) -> @out My2dArray<MyInt>
-  %12 = function_ref @hoistableIsNativeTypeChecked2 : $@convention(method) (@guaranteed My2dArray<MyInt>) -> Bool
-  %13 = function_ref @checkSubscript4 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> _DependenceToken
-  %14 = function_ref @getElement4 : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<MyInt>) -> @out MyInt
-  %15 = integer_literal $Builtin.Int1, -1
-  %18 = function_ref @makeMutable3 : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %20 = struct $Bool (%15 : $Builtin.Int1)
-  %21 = function_ref @getElementAddress3 : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  %22 = function_ref @makeMutable4 : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %23 = function_ref @getElementAddress4 : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  br bb2(%4 : $Builtin.Int64)
+// CHECK-LABEL: sil @hoist_array2d
+// CHECK:      bb0({{.*}}):
+// CHECK:        apply
+// CHECK-NEXT:   load
+// CHECK-NEXT:   struct_extract
+// CHECK-NEXT:   struct_extract
+// CHECK-NEXT:   unchecked_ref_cast
+// CHECK-NEXT:   ref_tail_addr
+// CHECK-NEXT:   index_addr
+// CHECK-NEXT:   apply
+// CHECK-NEXT:   br bb1
+// CHECK:      bb1:
+// CHECK-NOT:    apply
+sil @hoist_array2d : $@convention(thin) (@inout MyArray<MyStruct>) -> () {
+bb0(%0 : $*MyArray<MyStruct>):
+  %2 = load %0 : $*MyArray<MyStruct>
+  %3 = integer_literal $Builtin.Word, 1
+  br bb1
 
 bb1:
-  %25 = tuple ()
-  return %25 : $()
+  %5 = function_ref @array_make_mutable : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  %6 = apply %5(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  %7 = load %0 : $*MyArray<MyStruct>
+  %8 = struct_extract  %7 : $MyArray<MyStruct>, #MyArray.buffer
+  %9 = struct_extract  %8 : $ArrayIntBuffer, #ArrayIntBuffer.storage
+  %10 = unchecked_ref_cast %9 : $Builtin.NativeObject to $MyArrayStorage
+  %11 = ref_tail_addr %10 : $MyArrayStorage, $MyArray<MyStruct>
+  %12 = index_addr %11 : $*MyArray<MyStruct>, %3 : $Builtin.Word
+  %13 = apply %5(%12) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  cond_br undef, bb1, bb2
 
-bb2(%27 : $Builtin.Int64):
-  %28 = struct $MyInt (%27 : $Builtin.Int64)
-  %29 = builtin "sadd_with_overflow_Int64"(%27 : $Builtin.Int64, %6 : $Builtin.Int64, %7 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %30 = tuple_extract %29 : $(Builtin.Int64, Builtin.Int1), 0
-  %32 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %33 = alloc_stack $My2dArray<MyInt>
-  %35 = apply %9(%32) : $@convention(method) (@guaranteed My2dArray<My2dArray<MyInt>>) -> Bool
-  %37 = apply %10(%1, %35, %32) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> _DependenceToken
-  %39 = apply %11(%33, %1, %35, %37, %32) : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<My2dArray<MyInt>>) -> @out My2dArray<MyInt>
-  %40 = load %33 : $*My2dArray<MyInt>
-  %41 = alloc_stack $MyInt
-  %44 = apply %12(%40) : $@convention(method) (@guaranteed My2dArray<MyInt>) -> Bool
-  %46 = apply %13(%28, %44, %40) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> _DependenceToken
-  %48 = apply %14(%41, %28, %44, %46, %40) : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<MyInt>) -> @out MyInt
-  %49 = struct_extract %40 : $My2dArray<MyInt>, #My2dArray._buffer
-  %50 = struct_extract %49 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %51 = struct_extract %50 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_release %51 : $Builtin.BridgeObject
-  %53 = struct_element_addr %41 : $*MyInt, #MyInt._value
-  %54 = load %53 : $*Builtin.Int64
-  %55 = builtin "sadd_with_overflow_Int64"(%54 : $Builtin.Int64, %6 : $Builtin.Int64, %15 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %56 = tuple_extract %55 : $(Builtin.Int64, Builtin.Int1), 0
-  %57 = tuple_extract %55 : $(Builtin.Int64, Builtin.Int1), 1
-  cond_fail %57 : $Builtin.Int1
-  %59 = struct $MyInt (%56 : $Builtin.Int64)
-  %60 = apply %18(%0) : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %61 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %63 = apply %21(%1, %61) : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  %65 = struct_extract %61 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %66 = struct_extract %65 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %67 = struct_extract %66 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %72 = unchecked_ref_cast %67 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %73 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %72 : $Builtin.NativeObject
-  %74 = struct_extract %63 : $UnsafeMutablePointer<My2dArray<MyInt>>, #UnsafeMutablePointer._rawValue
-  %75 = pointer_to_address %74 : $Builtin.RawPointer to [strict] $*My2dArray<MyInt>
-  %76 = mark_dependence %75 : $*My2dArray<MyInt> on %73 : $Optional<Builtin.NativeObject>
-  %79 = apply %22(%76) : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %80 = load %76 : $*My2dArray<MyInt>
-  %83 = apply %13(%28, %20, %80) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> _DependenceToken
-  %84 = apply %23(%28, %80) : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  %86 = struct_extract %80 : $My2dArray<MyInt>, #My2dArray._buffer
-  %87 = struct_extract %86 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %88 = struct_extract %87 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %93 = unchecked_ref_cast %88 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %94 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %93 : $Builtin.NativeObject
-  %95 = struct_extract %84 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
-  %96 = pointer_to_address %95 : $Builtin.RawPointer to [strict] $*MyInt
-  %97 = mark_dependence %96 : $*MyInt on %94 : $Optional<Builtin.NativeObject>
-  store %59 to %97 : $*MyInt
-  dealloc_stack %41 : $*MyInt
-  dealloc_stack %33 : $*My2dArray<MyInt>
-  %101 = builtin "cmp_eq_Int64"(%30 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %101, bb1, bb2(%30 : $Builtin.Int64)
+bb2:
+  %r = tuple()
+  return %r : $()
 }
 
-sil [_semantics "array.get_element"] @getElement5 : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<My2dArray<MyInt>>) -> @owned My2dArray<MyInt>
-sil [_semantics "array.get_element"] @getElement6 : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<MyInt>) -> MyInt
-
-// CHECK-LABEL: sil @hoist2DArray_with_get_element_returning_direct_result
-// CHECK: bb0
-// CHECK:  apply {{.*}} : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-// CHECK:  apply {{.*}} : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-// CHECK: br bb2
-// CHECK: bb1
-// CHECK:  return
-// CHECK: bb2
-// CHECK-NOT:  apply {{.*}} : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-// CHECK-NOT:  apply {{.*}} : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-// CHECK: cond_br
-
-sil @hoist2DArray_with_get_element_returning_direct_result : $@convention(thin) (@inout My2dArray<My2dArray<MyInt>>, MyInt) -> () {
-bb0(%0 : $*My2dArray<My2dArray<MyInt>>, %1 : $MyInt):
-  %4 = integer_literal $Builtin.Int64, 0
-  %5 = integer_literal $Builtin.Int64, 1024
-  %6 = integer_literal $Builtin.Int64, 1
-  %7 = integer_literal $Builtin.Int1, 0
-  %9 = function_ref @hoistableIsNativeTypeChecked : $@convention(method) (@guaranteed My2dArray<My2dArray<MyInt>>) -> Bool
-  %10 = function_ref @checkSubscript3 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> _DependenceToken
-  %11 = function_ref @getElement5 : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<My2dArray<MyInt>>) -> @owned My2dArray<MyInt>
-  %12 = function_ref @hoistableIsNativeTypeChecked2 : $@convention(method) (@guaranteed My2dArray<MyInt>) -> Bool
-  %13 = function_ref @checkSubscript4 : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> _DependenceToken
-  %14 = function_ref @getElement6 : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<MyInt>) -> MyInt
-  %15 = integer_literal $Builtin.Int1, -1
-  %18 = function_ref @makeMutable3 : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %20 = struct $Bool (%15 : $Builtin.Int1)
-  %21 = function_ref @getElementAddress3 : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  %22 = function_ref @makeMutable4 : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %23 = function_ref @getElementAddress4 : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  br bb2(%4 : $Builtin.Int64)
+// CHECK-LABEL: sil @dont_hoist_inner_mutating_outer
+// CHECK:     bb0({{.*}}):
+// CHECK:       apply
+// CHECK-NOT:   apply
+// CHECK:     bb1:
+// CHECK:       apply
+// CHECK:       apply
+// CHECK-NOT:   apply
+// CHECK:       return
+sil @dont_hoist_inner_mutating_outer : $@convention(thin) (@inout MyArray<MyStruct>) -> () {
+bb0(%0 : $*MyArray<MyStruct>):
+  %2 = load %0 : $*MyArray<MyStruct>
+  %3 = integer_literal $Builtin.Word, 1
+  %4 = function_ref @array_unknown_mutate : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  br bb1
 
 bb1:
-  %25 = tuple ()
-  return %25 : $()
+  %5 = function_ref @array_make_mutable : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  %6 = apply %5(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  %7 = load %0 : $*MyArray<MyStruct>
+  %8 = struct_extract  %7 : $MyArray<MyStruct>, #MyArray.buffer
+  %9 = struct_extract  %8 : $ArrayIntBuffer, #ArrayIntBuffer.storage
+  %10 = unchecked_ref_cast %9 : $Builtin.NativeObject to $MyArrayStorage
+  %11 = ref_tail_addr %10 : $MyArrayStorage, $MyArray<MyStruct>
+  %12 = index_addr %11 : $*MyArray<MyStruct>, %3 : $Builtin.Word
+  %13 = apply %5(%12) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  apply %4(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  cond_br undef, bb1, bb2
 
-bb2(%27 : $Builtin.Int64):
-  %28 = struct $MyInt (%27 : $Builtin.Int64)
-  %29 = builtin "sadd_with_overflow_Int64"(%27 : $Builtin.Int64, %6 : $Builtin.Int64, %7 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %30 = tuple_extract %29 : $(Builtin.Int64, Builtin.Int1), 0
-  %32 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %35 = apply %9(%32) : $@convention(method) (@guaranteed My2dArray<My2dArray<MyInt>>) -> Bool
-  %37 = apply %10(%1, %35, %32) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<My2dArray<MyInt>>) -> _DependenceToken
-  %40 = apply %11(%1, %35, %37, %32) : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<My2dArray<MyInt>>) -> @owned My2dArray<MyInt>
-  %44 = apply %12(%40) : $@convention(method) (@guaranteed My2dArray<MyInt>) -> Bool
-  %46 = apply %13(%28, %44, %40) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> _DependenceToken
-  %48 = apply %14(%28, %44, %46, %40) : $@convention(method) (MyInt, Bool, _DependenceToken, @guaranteed My2dArray<MyInt>) -> MyInt
-  %49 = struct_extract %40 : $My2dArray<MyInt>, #My2dArray._buffer
-  %50 = struct_extract %49 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %51 = struct_extract %50 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  strong_release %51 : $Builtin.BridgeObject
-  %54 = struct_extract %48 : $MyInt, #MyInt._value
-  %55 = builtin "sadd_with_overflow_Int64"(%54 : $Builtin.Int64, %6 : $Builtin.Int64, %15 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %56 = tuple_extract %55 : $(Builtin.Int64, Builtin.Int1), 0
-  %57 = tuple_extract %55 : $(Builtin.Int64, Builtin.Int1), 1
-  cond_fail %57 : $Builtin.Int1
-  %59 = struct $MyInt (%56 : $Builtin.Int64)
-  %60 = apply %18(%0) : $@convention(method) (@inout My2dArray<My2dArray<MyInt>>) -> ()
-  %61 = load %0 : $*My2dArray<My2dArray<MyInt>>
-  %63 = apply %21(%1, %61) : $@convention(method) (MyInt, @guaranteed My2dArray<My2dArray<MyInt>>) -> UnsafeMutablePointer<My2dArray<MyInt>>
-  %65 = struct_extract %61 : $My2dArray<My2dArray<MyInt>>, #My2dArray._buffer
-  %66 = struct_extract %65 : $_My2dArrayBuffer<My2dArray<MyInt>>, #_My2dArrayBuffer._storage
-  %67 = struct_extract %66 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %72 = unchecked_ref_cast %67 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %73 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %72 : $Builtin.NativeObject
-  %74 = struct_extract %63 : $UnsafeMutablePointer<My2dArray<MyInt>>, #UnsafeMutablePointer._rawValue
-  %75 = pointer_to_address %74 : $Builtin.RawPointer to [strict] $*My2dArray<MyInt>
-  %76 = mark_dependence %75 : $*My2dArray<MyInt> on %73 : $Optional<Builtin.NativeObject>
-  %79 = apply %22(%76) : $@convention(method) (@inout My2dArray<MyInt>) -> ()
-  %80 = load %76 : $*My2dArray<MyInt>
-  %83 = apply %13(%28, %20, %80) : $@convention(method) (MyInt, Bool, @guaranteed My2dArray<MyInt>) -> _DependenceToken
-  %84 = apply %23(%28, %80) : $@convention(method) (MyInt, @guaranteed My2dArray<MyInt>) -> UnsafeMutablePointer<MyInt>
-  %86 = struct_extract %80 : $My2dArray<MyInt>, #My2dArray._buffer
-  %87 = struct_extract %86 : $_My2dArrayBuffer<MyInt>, #_My2dArrayBuffer._storage
-  %88 = struct_extract %87 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
-  %93 = unchecked_ref_cast %88 : $Builtin.BridgeObject to $Builtin.NativeObject
-  %94 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %93 : $Builtin.NativeObject
-  %95 = struct_extract %84 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
-  %96 = pointer_to_address %95 : $Builtin.RawPointer to [strict] $*MyInt
-  %97 = mark_dependence %96 : $*MyInt on %94 : $Optional<Builtin.NativeObject>
-  store %59 to %97 : $*MyInt
-  %101 = builtin "cmp_eq_Int64"(%30 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %101, bb1, bb2(%30 : $Builtin.Int64)
+bb2:
+  %r = tuple()
+  return %r : $()
 }
+
+// CHECK-LABEL: sil @dont_hoist_inner_variant_index
+// CHECK:     bb0({{.*}}):
+// CHECK:       apply
+// CHECK-NOT:   apply
+// CHECK:     bb1:
+// CHECK:       apply
+// CHECK-NOT:   apply
+// CHECK:       return
+sil @dont_hoist_inner_variant_index : $@convention(thin) (@inout MyArray<MyStruct>, @inout Builtin.Word) -> () {
+bb0(%0 : $*MyArray<MyStruct>, %1 : $*Builtin.Word):
+  %2 = load %0 : $*MyArray<MyStruct>
+  br bb1
+
+bb1:
+  %4 = load %1 : $*Builtin.Word
+  %5 = function_ref @array_make_mutable : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  %6 = apply %5(%0) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  %7 = load %0 : $*MyArray<MyStruct>
+  %8 = struct_extract  %7 : $MyArray<MyStruct>, #MyArray.buffer
+  %9 = struct_extract  %8 : $ArrayIntBuffer, #ArrayIntBuffer.storage
+  %10 = unchecked_ref_cast %9 : $Builtin.NativeObject to $MyArrayStorage
+  %11 = ref_tail_addr %10 : $MyArrayStorage, $MyArray<MyStruct>
+  %12 = index_addr %11 : $*MyArray<MyStruct>, %4 : $Builtin.Word
+  %13 = apply %5(%12) : $@convention(method) (@inout MyArray<MyStruct>) -> ()
+  cond_br undef, bb1, bb2
+
+bb2:
+  %r = tuple()
+  return %r : $()
+}
+


### PR DESCRIPTION
With removing of pinning and with addressors, the pattern matching did not work anymore.
The good thing is that the SIL is now much simpler and we can handle the 2D case without pattern matching at all.
This removes a lot of code from COWArrayOpts.

rdar://problem/43863081