### PR TITLE
swift-demangle: Also accept $s symbols without the $ prefix.

### DIFF
--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
   } else {
     swift::Demangle::Context DCtx;
     for (llvm::StringRef name : InputNames) {
-      if (name.startswith("S")) {
+      if (name.startswith("S") || name.startswith("s") ) {
         std::string correctedName = std::string("$") + name.str();
         demangle(llvm::outs(), correctedName, DCtx, options);
       } else {


### PR DESCRIPTION
This makes it easier to copy-paste $s symbols with a double-click.
We already had this for $S, now it also works for the new mangling prefix $s.
