### PR TITLE
SourceKit: enable builds for Windows

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -35,7 +35,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND NOT CMAKE_CROSSCOMPILING)
 endif()
 
 # If we were don't have XPC, just build inproc.
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND NOT HAVE_XPC_H)
+if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" OR NOT HAVE_XPC_H)
   set(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY TRUE)
 endif()
 
@@ -95,12 +95,11 @@ include_directories(BEFORE
   ${SOURCEKIT_BINARY_DIR}/tools/SourceKit/include
 )
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-  set(SOURCEKIT_DEFAULT_TARGET_SDK "LINUX")
+if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+  string(TOUPPER "${CMAKE_SYSTEM_NAME}" SOURCEKIT_DEFAULT_TARGET_SDK)
   set(SOURCEKIT_NEED_EXPLICIT_LIBDISPATCH TRUE)
 
   if(SWIFT_BUILD_SOURCEKIT)
-
     include(ExternalProject)
     ExternalProject_Add(libdispatch
                         SOURCE_DIR

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -69,7 +69,13 @@ function(add_sourcekit_default_compiler_flags target)
   # TODO(compnerd) this should really use target_compile_options but the use
   # of keyword and non-keyword flags prevents this
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    list(APPEND c_compile_flags "-fblocks")
+    list(APPEND c_compile_flags -fblocks)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if(SWIFT_COMPILER_IS_MSVC_LIKE)
+      list(APPEND c_compile_flags -Xclang;-fblocks)
+    else()
+      list(APPEND c_compile_flags -fblocks)
+    endif()
   endif()
 
   # Convert variables to space-separated strings.


### PR DESCRIPTION
SourceKit's build is now ammenable to building for Windows.  Generalize the path
to enable building it for Windows as well as Linux.  The libdispatch build for
the compiler is needed for all non-Darwin targets currently.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
