### PR TITLE
 Debug Info: Normalize paths when creating DIFile objects.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -361,6 +361,7 @@ private:
     StringRef File = llvm::sys::path::filename(Filename);
     llvm::SmallString<512> Path(Filename);
     llvm::sys::path::remove_filename(Path);
+    llvm::sys::path::remove_dots(Path);
     llvm::DIFile *F = DBuilder.createFile(DebugPrefixMap.remapPath(File),
                                           DebugPrefixMap.remapPath(Path));
 

--- a/test/DebugInfo/ClangPathDots.swift
+++ b/test/DebugInfo/ClangPathDots.swift
@@ -1,0 +1,21 @@
+// REQUIRES: objc_interop
+// RUN: rm -rf %t.cache
+// RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs -o - \
+// RUN:   -module-cache-path %t.cache | %FileCheck %s --check-prefix=FIRST
+// RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs -o - \
+// RUN:   -module-cache-path %t.cache | %FileCheck %s --check-prefix=CACHED
+
+// FIRST: !DIFile(filename: "NSObject.h", directory: {{.*}}/include/objc")
+// CACHED: !DIFile(filename: "NSObject.h", directory: {{.*}}/include/objc")
+
+import ObjectiveC
+
+extension NSObject : CVarArg {
+  /// Transform `self` into a series of machine words that can be
+  /// appropriately interpreted by C varargs
+  public var _cVarArgEncoding: [Int] {
+    _autorelease(self)
+    return _encodeBitsAsWords(self)
+  }
+}
+


### PR DESCRIPTION
For a yet-to-be-determined reason the Clang SourceManager returns
source file paths with a ./ component before the filename if the
module cache is cold.

<rdar://problem/43439465>
