### PR TITLE
[Driver] Expose -emit-parseable-module-interface[-path]

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -501,7 +501,7 @@ function(_compile_swift_files
         COMMAND
           "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}"
-          "-experimental-emit-interface" ${swift_flags} "@${file_path}"
+          "-emit-parseable-module-interface" ${swift_flags} "@${file_path}"
         ${command_touch_module_outputs}
         OUTPUT ${module_outputs}
         DEPENDS

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -84,6 +84,9 @@ ERROR(error_unknown_target,none,
 
 ERROR(error_framework_bridging_header,none,
       "using bridging headers with framework targets is unsupported", ())
+ERROR(error_bridging_header_parseable_interface,none,
+      "using bridging headers with parseable module interfaces is unsupported",
+      ())
 
 ERROR(error_i_mode,none,
       "the flag '-i' is no longer required and has been removed; "

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -63,9 +63,10 @@ def emit_fixits_path
   : Separate<["-"], "emit-fixits-path">, MetaVarName<"<path>">,
     HelpText<"Output compiler fixits as source edits to <path>">;
 
+// For transition purposes.
 def emit_interface_path
-  : Separate<["-"], "emit-interface-path">, MetaVarName<"<path>">,
-    HelpText<"Output parseable interface file to <path>">;
+  : Separate<["-"], "emit-interface-path">,
+    Alias<emit_parseable_module_interface_path>;
 
 def tbd_install_name
   : Separate<["-"], "tbd-install_name">, MetaVarName<"<path>">,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -300,9 +300,15 @@ def emit_module_path_EQ : Joined<["-"], "emit-module-path=">,
          ArgumentIsPath]>,
   Alias<emit_module_path>;
 
-def experimental_emit_interface : Flag<["-"], "experimental-emit-interface">,
-  Flags<[NoInteractiveOption, HelpHidden]>,
-  HelpText<"Test out the parseable interfaces feature">;
+def emit_parseable_module_interface :
+  Flag<["-"], "emit-parseable-module-interface">,
+  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Output parseable interface file">;
+def emit_parseable_module_interface_path :
+  Separate<["-"], "emit-parseable-module-interface-path">,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath]>,
+  MetaVarName<"<path>">, HelpText<"Output parseable interface file to <path>">;
 
 def emit_objc_header : Flag<["-"], "emit-objc-header">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -121,9 +121,15 @@ ArrayRef<const char *> Driver::getArgsWithoutProgramNameAndDriverMode(
 
 static void validateBridgingHeaderArgs(DiagnosticEngine &diags,
                                        const ArgList &args) {
-  if (args.hasArgNoClaim(options::OPT_import_underlying_module) &&
-      args.hasArgNoClaim(options::OPT_import_objc_header)) {
+  if (!args.hasArgNoClaim(options::OPT_import_objc_header))
+    return;
+
+  if (args.hasArgNoClaim(options::OPT_import_underlying_module))
     diags.diagnose({}, diag::error_framework_bridging_header);
+
+  if (args.hasArgNoClaim(options::OPT_emit_parseable_module_interface,
+                         options::OPT_emit_parseable_module_interface_path)) {
+    diags.diagnose({}, diag::error_bridging_header_parseable_interface);
   }
 }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1494,7 +1494,8 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
     OI.ShouldTreatModuleAsTopLevelOutput = false;
   } else if (Args.hasArg(options::OPT_emit_objc_header,
                          options::OPT_emit_objc_header_path,
-                         options::OPT_experimental_emit_interface) &&
+                         options::OPT_emit_parseable_module_interface,
+                         options::OPT_emit_parseable_module_interface_path) &&
              OI.CompilerMode != OutputInfo::Mode::SingleCompile) {
     // An option has been passed which requires whole-module knowledge, but we
     // don't have that. Generate a module, but treat it as an intermediate
@@ -2473,7 +2474,8 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
     chooseSwiftModuleDocOutputPath(C, OutputMap, workingDirectory,
                                    Output.get());
 
-  if (C.getArgs().hasArg(options::OPT_experimental_emit_interface))
+  if (C.getArgs().hasArg(options::OPT_emit_parseable_module_interface,
+                         options::OPT_emit_parseable_module_interface_path))
     chooseParseableInterfacePath(C, JA, workingDirectory, Buf, Output.get());
 
   if (C.getArgs().hasArg(options::OPT_update_code) && isa<CompileJobAction>(JA))
@@ -2773,9 +2775,9 @@ void Driver::chooseRemappingOutputPath(Compilation &C,
 }
 
 void Driver::chooseParseableInterfacePath(Compilation &C, const JobAction *JA,
-                                        StringRef workingDirectory,
-                                        llvm::SmallString<128> &buffer,
-                                        CommandOutput *output) const {
+                                          StringRef workingDirectory,
+                                          llvm::SmallString<128> &buffer,
+                                          CommandOutput *output) const {
   switch (C.getOutputInfo().CompilerMode) {
   case OutputInfo::Mode::StandardCompile:
   case OutputInfo::Mode::BatchModeCompile:
@@ -2792,9 +2794,10 @@ void Driver::chooseParseableInterfacePath(Compilation &C, const JobAction *JA,
   }
 
   StringRef outputPath = *getOutputFilenameFromPathArgOrAsTopLevel(
-        C.getOutputInfo(), C.getArgs(), llvm::opt::OptSpecifier(),
-        file_types::TY_SwiftModuleInterfaceFile,
-        /*TreatAsTopLevelOutput*/true, workingDirectory, buffer);
+      C.getOutputInfo(), C.getArgs(),
+      options::OPT_emit_parseable_module_interface_path,
+      file_types::TY_SwiftModuleInterfaceFile,
+      /*TreatAsTopLevelOutput*/true, workingDirectory, buffer);
   output->setAdditionalOutputForType(file_types::TY_SwiftModuleInterfaceFile,
                                      outputPath);
 }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -547,7 +547,7 @@ void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(
 
   addOutputsOfType(arguments, Output, Args,
                    file_types::ID::TY_SwiftModuleInterfaceFile,
-                   "-emit-interface-path");
+                   "-emit-parseable-module-interface-path");
 
   addOutputsOfType(arguments, Output, Args,
                    file_types::TY_SerializedDiagnostics,
@@ -804,7 +804,7 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
                    file_types::TY_SwiftModuleDocFile, "-emit-module-doc-path");
   addOutputsOfType(Arguments, context.Output, context.Args,
                    file_types::ID::TY_SwiftModuleInterfaceFile,
-                   "-emit-interface-path");
+                   "-emit-parseable-module-interface-path");
   addOutputsOfType(Arguments, context.Output, context.Args,
                    file_types::TY_SerializedDiagnostics,
                    "-serialize-diagnostics-path");

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -295,7 +295,7 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       options::OPT_emit_loaded_module_trace_path);
   auto TBD = getSupplementaryFilenamesFromArguments(options::OPT_emit_tbd_path);
   auto parseableInterfaceOutput = getSupplementaryFilenamesFromArguments(
-      options::OPT_emit_interface_path);
+      options::OPT_emit_parseable_module_interface_path);
 
   if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
       !dependenciesFile || !referenceDependenciesFile ||

--- a/test/Driver/emit-interface.swift
+++ b/test/Driver/emit-interface.swift
@@ -1,15 +1,21 @@
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -experimental-emit-interface -o %t/foo 2>&1 | %FileCheck %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-parseable-module-interface -o %t/foo 2>&1 | %FileCheck %s
 
 // CHECK: swift -frontend
 // CHECK-SAME: emit-interface.swift
 // CHECK: swift -frontend -merge-modules
-// CHECK-SAME: -emit-interface-path {{.+}}/foo.swiftinterface
+// CHECK-SAME: -emit-parseable-module-interface-path {{.+}}/foo.swiftinterface
 // CHECK: bin/ld
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -experimental-emit-interface -o %t/foo -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-WHOLE-MODULE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-parseable-module-interface -o %t/foo -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-WHOLE-MODULE %s
 
 // CHECK-WHOLE-MODULE: swift -frontend
 // CHECK-WHOLE-MODULE-SAME: emit-interface.swift
-// CHECK-WHOLE-MODULE-SAME: -emit-interface-path {{.+}}/foo.swiftinterface
+// CHECK-WHOLE-MODULE-SAME: -emit-parseable-module-interface-path {{.+}}/foo.swiftinterface
 // CHECK-WHOLE-MODULE-NOT: -merge-modules
 // CHECK-WHOLE-MODULE: bin/ld
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-parseable-module-interface-path %t/unrelated.swiftinterface -o %t/foo -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-EXPLICIT-PATH %s
+
+// CHECK-EXPLICIT-PATH: swift -frontend
+// CHECK-EXPLICIT-PATH-SAME: emit-interface.swift
+// CHECK-EXPLICIT-PATH-SAME: -emit-parseable-module-interface-path {{.+}}/unrelated.swiftinterface

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -25,6 +25,10 @@
 // RUN: not %swiftc_driver -import-objc-header fake.h -import-underlying-module -c %s 2>&1 | %FileCheck -check-prefix=FRAMEWORK_BRIDGING_HEADER %s
 // FRAMEWORK_BRIDGING_HEADER: error: using bridging headers with framework targets is unsupported
 
+// RUN: not %swiftc_driver -import-objc-header fake.h -emit-parseable-module-interface %s 2>&1 | %FileCheck -check-prefix=BRIDGING_HEADER_SWIFTINTERFACE %s
+// RUN: not %swiftc_driver -import-objc-header fake.h -emit-parseable-module-interface-path fake.swiftinterface %s 2>&1 | %FileCheck -check-prefix=BRIDGING_HEADER_SWIFTINTERFACE %s
+// BRIDGING_HEADER_SWIFTINTERFACE: error: using bridging headers with parseable module interfaces is unsupported
+
 // RUN: %swift_driver -### | %FileCheck -check-prefix=DEFAULT_REPL %s
 // DEFAULT_REPL: -repl
 // RUN: not %swiftc_driver 2>&1 | %FileCheck -check-prefix=DEFAULT_EXEC_ERR  %s

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -25,7 +25,7 @@
 // NO-PRIMARY-FILE: warning: ignoring -emit-reference-dependencies (requires -primary-file)
 
 
-// RUN: %target-swift-frontend -emit-dependencies-path - -emit-module %S/../Inputs/empty\ file.swift -o %t/empty\ file.swiftmodule -emit-module-doc-path %t/empty\ file.swiftdoc -emit-objc-header-path %t/empty\ file.h -emit-interface-path %t/empty\ file.swiftinterface | %FileCheck -check-prefix=CHECK-MULTIPLE-OUTPUTS %s
+// RUN: %target-swift-frontend -emit-dependencies-path - -emit-module %S/../Inputs/empty\ file.swift -o %t/empty\ file.swiftmodule -emit-module-doc-path %t/empty\ file.swiftdoc -emit-objc-header-path %t/empty\ file.h -emit-parseable-module-interface-path %t/empty\ file.swiftinterface | %FileCheck -check-prefix=CHECK-MULTIPLE-OUTPUTS %s
 
 // CHECK-MULTIPLE-OUTPUTS-LABEL: empty\ file.swiftmodule :
 // CHECK-MULTIPLE-OUTPUTS: Inputs/empty\ file.swift

--- a/test/Frontend/supplementary-output-support.swift
+++ b/test/Frontend/supplementary-output-support.swift
@@ -24,7 +24,7 @@
 // RUN: not %target-swift-frontend -resolve-imports -emit-objc-header %s 2>&1 | %FileCheck -check-prefix=RESOLVE_IMPORTS_NO_OBJC_HEADER %s
 // RESOLVE_IMPORTS_NO_OBJC_HEADER: error: this mode does not support emitting Objective-C headers{{$}}
 
-// RUN: not %target-swift-frontend -parse -emit-interface-path %t %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_INTERFACE %s
+// RUN: not %target-swift-frontend -parse -emit-parseable-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_INTERFACE %s
 // PARSE_NO_INTERFACE: error: this mode does not support emitting parseable interface files{{$}}
-// RUN: not %target-swift-frontend -emit-silgen -emit-interface-path %t %s 2>&1 | %FileCheck -check-prefix=SILGEN_NO_INTERFACE %s
+// RUN: not %target-swift-frontend -emit-silgen -emit-parseable-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=SILGEN_NO_INTERFACE %s
 // SILGEN_NO_INTERFACE: error: this mode does not support emitting parseable interface files{{$}}

--- a/test/ParseableInterface/access-filter.swift
+++ b/test/ParseableInterface/access-filter.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -emit-interface-path %t.swiftinterface %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
 

--- a/test/ParseableInterface/attrs.swift
+++ b/test/ParseableInterface/attrs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -emit-interface-path %t.swiftinterface -enable-resilience %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface -enable-resilience %s
 // RUN: %FileCheck %s < %t.swiftinterface
 
 // CHECK: @_transparent public func glass() -> Int { return 0 }{{$}}

--- a/test/ParseableInterface/conformances.swift
+++ b/test/ParseableInterface/conformances.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend-typecheck -emit-interface-path %t.swiftinterface %s
+// RUN: %target-swift-frontend-typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
 

--- a/test/ParseableInterface/dataflow-errors.swift
+++ b/test/ParseableInterface/dataflow-errors.swift
@@ -1,7 +1,7 @@
 // RUN: rm -f %t
-// RUN: not %target-swift-frontend -emit-interface-path %t -emit-module -o /dev/null %s
+// RUN: not %target-swift-frontend -emit-parseable-module-interface-path %t -emit-module -o /dev/null %s
 // RUN: test ! -f %t
-// RUN: %target-swift-frontend -emit-interface-path %t -typecheck %s
+// RUN: %target-swift-frontend -emit-parseable-module-interface-path %t -typecheck %s
 // RUN: test -f %t
 
 public struct BadInit {

--- a/test/ParseableInterface/if-configs.swift
+++ b/test/ParseableInterface/if-configs.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -merge-modules -emit-module -o %t/Test.swiftmodule %t/Test~partial.swiftmodule
 // RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t | %FileCheck %s
 
-// RUN: %target-swift-frontend -typecheck -emit-interface-path %t.swiftinterface -enable-resilience %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface -enable-resilience %s
 // RUN: %FileCheck %s < %t.swiftinterface
 
 // CHECK: func hasClosureDefaultArg(_ x: () -> Void = {

--- a/test/ParseableInterface/imports-submodule-order.swift
+++ b/test/ParseableInterface/imports-submodule-order.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -emit-interface-path - %s -I %S/Inputs/imports-submodule-order/ | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -emit-interface-path - %s -I %S/Inputs/imports-submodule-order/ -D XY | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s -I %S/Inputs/imports-submodule-order/ | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s -I %S/Inputs/imports-submodule-order/ -D XY | %FileCheck %s
 
 #if XY
 @_exported import X.Submodule

--- a/test/ParseableInterface/imports.swift
+++ b/test/ParseableInterface/imports.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/empty.swiftmodule %S/../Inputs/empty.swift
-// RUN: %target-swift-frontend -typecheck -emit-interface-path - %s %S/Inputs/imports-other.swift -I %S/Inputs/imports-clang-modules/ -I %t -verify | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s %S/Inputs/imports-other.swift -I %S/Inputs/imports-clang-modules/ -I %t -verify | %FileCheck %s
 
 
 @_exported import empty

--- a/test/ParseableInterface/inlinable-function.swift
+++ b/test/ParseableInterface/inlinable-function.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-interface-path %t/Test.swiftinterface -module-name Test %s
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-parseable-module-interface-path %t/Test.swiftinterface -module-name Test %s
 // RUN: %FileCheck %s < %t/Test.swiftinterface
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-interface-path - -module-name Test | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-parseable-module-interface-path - -module-name Test | %FileCheck %s
 
 // CHECK: public struct Foo : Hashable {
 public struct Foo: Hashable {

--- a/test/ParseableInterface/modifiers.swift
+++ b/test/ParseableInterface/modifiers.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-interface-path %t/Test.swiftinterface -module-name Test -disable-objc-attr-requires-foundation-module -enable-objc-interop %s
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-parseable-module-interface-path %t/Test.swiftinterface -module-name Test -disable-objc-attr-requires-foundation-module -enable-objc-interop %s
 // RUN: %FileCheck %s < %t/Test.swiftinterface
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-interface-path - -module-name Test -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-parseable-module-interface-path - -module-name Test -enable-objc-interop | %FileCheck %s
 
 // CHECK: final public class FinalClass {
 public final class FinalClass {

--- a/test/ParseableInterface/print-from-partial-modules.swift
+++ b/test/ParseableInterface/print-from-partial-modules.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/main~partial.swiftmodule -primary-file %s %S/Inputs/other.swift -module-name main
 // RUN: %target-swift-frontend -emit-module -o %t/other~partial.swiftmodule %s -primary-file %S/Inputs/other.swift -module-name main
-// RUN: %target-swift-frontend -merge-modules -emit-module -o /dev/null -emit-interface-path - %t/main~partial.swiftmodule -module-name main %t/other~partial.swiftmodule | %FileCheck %s
+// RUN: %target-swift-frontend -merge-modules -emit-module -o /dev/null -emit-parseable-module-interface-path - %t/main~partial.swiftmodule -module-name main %t/other~partial.swiftmodule | %FileCheck %s
 
 // CHECK: {{^}}public func verySimpleFunction(){{$}}
 public func verySimpleFunction() {}

--- a/test/ParseableInterface/private-stored-member-type-layout.swift
+++ b/test/ParseableInterface/private-stored-member-type-layout.swift
@@ -2,7 +2,7 @@
 
 // Check that importing this module creates the right types
 
-// RUN: %target-swift-frontend -emit-interface-path %t/private-stored-members.swiftinterface -module-name PrivateStoredMembers -emit-module -o %t/PrivateStoredMembers.swiftmodule %S/private-stored-members.swift
+// RUN: %target-swift-frontend -emit-parseable-module-interface-path %t/private-stored-members.swiftinterface -module-name PrivateStoredMembers -emit-module -o %t/PrivateStoredMembers.swiftmodule %S/private-stored-members.swift
 // RUN: %target-swift-frontend -emit-ir %s -I %t 2>&1 -DSHOULD_IMPORT | %FileCheck %s --check-prefix CHECK-EXEC --check-prefix CHECK
 
 // Check that the types are also correct when importing a module created from an interface

--- a/test/ParseableInterface/private-stored-members.swift
+++ b/test/ParseableInterface/private-stored-members.swift
@@ -1,16 +1,16 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -emit-interface-path %t.swiftinterface %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
 // RUN: %FileCheck %s < %t.swiftinterface --check-prefix CHECK --check-prefix COMMON
 
-// RUN: %target-swift-frontend -typecheck -emit-interface-path %t-resilient.swiftinterface -enable-resilience %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t-resilient.swiftinterface -enable-resilience %s
 // RUN: %FileCheck %s --check-prefix RESILIENT --check-prefix COMMON < %t-resilient.swiftinterface
 
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t.swiftinterface -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-interface-path - | %FileCheck %s --check-prefix CHECK --check-prefix COMMON
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix CHECK --check-prefix COMMON
 
 // RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-resilience %t.swiftinterface -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-resilience -emit-interface-path - | %FileCheck %s --check-prefix RESILIENT --check-prefix COMMON
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-resilience -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix RESILIENT --check-prefix COMMON
 
 
 // COMMON: struct MyStruct {{{$}}

--- a/test/ParseableInterface/smoke-test.swift
+++ b/test/ParseableInterface/smoke-test.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -emit-interface-path - %s | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -emit-interface-path - %s %S/Inputs/other.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MULTI-FILE %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s %S/Inputs/other.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MULTI-FILE %s
 
 // CHECK: public func verySimpleFunction(){{$}}
 public func verySimpleFunction() {}

--- a/test/ParseableInterface/stdlib.swift
+++ b/test/ParseableInterface/stdlib.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -emit-interface-path - -parse-stdlib %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-interface-path - -emit-module -o /dev/null -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-parseable-module-interface-path - -emit-module -o /dev/null -parse-stdlib %s | %FileCheck %s
 
 // CHECK-NOT: import Builtin
 

--- a/test/SILGen/dynamic_accessors.swift
+++ b/test/SILGen/dynamic_accessors.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o /dev/null -disable-objc-attr-requires-foundation-module -enable-objc-interop -emit-interface-path %t/dynamic_accessors.swiftinterface %s
+// RUN: %target-swift-frontend -emit-module -o /dev/null -disable-objc-attr-requires-foundation-module -enable-objc-interop -emit-parseable-module-interface-path %t/dynamic_accessors.swiftinterface %s
 // RUN: %target-swift-emit-silgen -disable-objc-attr-requires-foundation-module -enable-objc-interop %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen -disable-objc-attr-requires-foundation-module -enable-objc-interop %t/dynamic_accessors.swiftinterface | %FileCheck %s
 


### PR DESCRIPTION
Commit to a command line option spelling so that build systems can start testing it. I deliberately picked one of the longer names we were considering because we can always decide to add a shorter alias, but can't decide a shorter name was too generic. This follows the new name from #19713.

Like the other supplementary output flags, `-emit-parseable-module-interface-path` will emit a .swiftinterface file to a particular path, while `-emit-parseable-module-interface` will put it next to the main output (the one specified with `-o`).

rdar://problem/43776945
rdar://problem/44113493