### PR TITLE
Clean up ModuleDecl, in particular removing its need for a destructor

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -463,7 +463,8 @@ protected:
     HasStubImplementation : 1
   );
 
-  SWIFT_INLINE_BITFIELD_EMPTY(AbstractTypeParamDecl, ValueDecl);
+  SWIFT_INLINE_BITFIELD_EMPTY(TypeDecl, ValueDecl);
+  SWIFT_INLINE_BITFIELD_EMPTY(AbstractTypeParamDecl, TypeDecl);
 
   SWIFT_INLINE_BITFIELD_FULL(GenericTypeParamDecl, AbstractTypeParamDecl, 16+16,
     : NumPadBits,
@@ -472,7 +473,7 @@ protected:
     Index : 16
   );
 
-  SWIFT_INLINE_BITFIELD_EMPTY(GenericTypeDecl, ValueDecl);
+  SWIFT_INLINE_BITFIELD_EMPTY(GenericTypeDecl, TypeDecl);
 
   SWIFT_INLINE_BITFIELD(TypeAliasDecl, GenericTypeDecl, 1+1,
     /// Whether the typealias forwards perfectly to its underlying type.
@@ -570,6 +571,22 @@ protected:
     /// attribute.  A single bit because it's lazily computed along with the
     /// HasAssociatedValues bit.
     HasAnyUnavailableValues : 1
+  );
+
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1,
+    /// If the module was or is being compiled with `-enable-testing`.
+    TestingEnabled : 1,
+
+    /// If the module failed to load
+    FailedToLoad : 1,
+
+    /// Whether the module is resilient.
+    ///
+    /// \sa ResilienceStrategy
+    RawResilienceStrategy : 1,
+
+    /// Whether all imports have been resolved. Used to detect circular imports.
+    HasResolvedImports : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -241,13 +241,6 @@ private:
   /// \see EntryPointInfoTy
   EntryPointInfoTy EntryPointInfo;
 
-  struct {
-    unsigned TestingEnabled : 1;
-    unsigned FailedToLoad : 1;
-    unsigned ResilienceStrategy : 1;
-    unsigned HasResolvedImports : 1;
-  } Flags;
-
   ModuleDecl(Identifier name, ASTContext &ctx);
 
 public:
@@ -284,32 +277,32 @@ public:
 
   /// Returns true if this module was or is being compiled for testing.
   bool isTestingEnabled() const {
-    return Flags.TestingEnabled;
+    return Bits.ModuleDecl.TestingEnabled;
   }
   void setTestingEnabled(bool enabled = true) {
-    Flags.TestingEnabled = enabled;
+    Bits.ModuleDecl.TestingEnabled = enabled;
   }
 
   /// Returns true if there was an error trying to load this module.
   bool failedToLoad() const {
-    return Flags.FailedToLoad;
+    return Bits.ModuleDecl.FailedToLoad;
   }
   void setFailedToLoad(bool failed = true) {
-    Flags.FailedToLoad = failed;
+    Bits.ModuleDecl.FailedToLoad = failed;
   }
 
   bool hasResolvedImports() const {
-    return Flags.HasResolvedImports;
+    return Bits.ModuleDecl.HasResolvedImports;
   }
   void setHasResolvedImports() {
-    Flags.HasResolvedImports = true;
+    Bits.ModuleDecl.HasResolvedImports = true;
   }
 
   ResilienceStrategy getResilienceStrategy() const {
-    return ResilienceStrategy(Flags.ResilienceStrategy);
+    return ResilienceStrategy(Bits.ModuleDecl.RawResilienceStrategy);
   }
   void setResilienceStrategy(ResilienceStrategy strategy) {
-    Flags.ResilienceStrategy = unsigned(strategy);
+    Bits.ModuleDecl.RawResilienceStrategy = unsigned(strategy);
   }
 
   /// Look up a (possibly overloaded) value set at top-level scope

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -76,10 +76,12 @@ class CompilerInvocation {
   /// invocation
   SyntaxParsingCache *MainFileSyntaxParsingCache = nullptr;
 
-  llvm::MemoryBuffer *CodeCompletionBuffer = nullptr;
+  /// \see CodeCompletionOffset
+  std::string CodeCompletionBufferName;
 
-  /// \brief Code completion offset in bytes from the beginning of the main
-  /// source file.  Valid only if \c isCodeCompletion() == true.
+  /// Code completion offset in bytes from the beginning of the buffer
+  /// identified by #CodeCompletionBufferName. Valid only if
+  /// `isCodeCompletion() == true`.
   unsigned CodeCompletionOffset = ~0U;
 
   CodeCompletionCallbacksFactory *CodeCompletionFactory = nullptr;
@@ -266,17 +268,17 @@ public:
     return FrontendOpts.InputsAndOutputs.getSingleOutputFilename();
   }
 
-  void setCodeCompletionPoint(llvm::MemoryBuffer *Buf, unsigned Offset) {
-    assert(Buf);
-    CodeCompletionBuffer = Buf;
+  void setCodeCompletionPoint(StringRef BufferName, unsigned Offset) {
+    assert(!BufferName.empty());
+    CodeCompletionBufferName = BufferName;
     CodeCompletionOffset = Offset;
     // We don't need typo-correction for code-completion.
     // FIXME: This isn't really true, but is a performance issue.
     LangOpts.TypoCorrectionLimit = 0;
   }
 
-  std::pair<llvm::MemoryBuffer *, unsigned> getCodeCompletionPoint() const {
-    return std::make_pair(CodeCompletionBuffer, CodeCompletionOffset);
+  std::pair<std::string, unsigned> getCodeCompletionPoint() const {
+    return std::make_pair(CodeCompletionBufferName, CodeCompletionOffset);
   }
 
   /// \returns true if we are doing code completion.

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -169,6 +169,8 @@ public:
   void addPrimaryInputFile(StringRef file,
                            llvm::MemoryBuffer *buffer = nullptr);
 
+  void overrideBufferForInput(StringRef file, llvm::MemoryBuffer *buffer);
+
   // Outputs
 
 private:

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -66,6 +66,10 @@ public:
     return Filename;
   }
 
+  void overrideBuffer(llvm::MemoryBuffer *newBuffer) {
+    Buffer = newBuffer;
+  }
+
   /// Return Swift-standard file name from a buffer name set by
   /// llvm::MemoryBuffer::getFileOrSTDIN, which uses "<stdin>" instead of "-".
   static StringRef convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -68,8 +68,7 @@ STATISTIC(NumLazyGenericEnvironmentsLoaded,
           "# of lazily-deserialized generic environments loaded");
 
 #define DECL(Id, _) \
-  static_assert((DeclKind::Id == DeclKind::Module) ^ \
-                IsTriviallyDestructible<Id##Decl>::value, \
+  static_assert(IsTriviallyDestructible<Id##Decl>::value, \
                 "Decls are BumpPtrAllocated; the destructor is never called");
 #include "swift/AST/DeclNodes.def"
 static_assert(IsTriviallyDestructible<ParameterList>::value,
@@ -112,12 +111,6 @@ const clang::Module *ClangNode::getClangModule() const {
 // Only allow allocation of Decls using the allocator in ASTContext.
 void *Decl::operator new(size_t Bytes, const ASTContext &C,
                          unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
-// Only allow allocation of Modules using the allocator in ASTContext.
-void *ModuleDecl::operator new(size_t Bytes, const ASTContext &C,
-                           unsigned Alignment) {
   return C.Allocate(Bytes, Alignment);
 }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -353,8 +353,8 @@ void SourceLookupCache::invalidate() {
 
 ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx)
   : DeclContext(DeclContextKind::Module, nullptr),
-    TypeDecl(DeclKind::Module, &ctx, name, SourceLoc(), { }),
-    Flags() {
+    TypeDecl(DeclKind::Module, &ctx, name, SourceLoc(), { }) {
+
   ctx.addDestructorCleanup(*this);
   setImplicit();
   setInterfaceType(ModuleType::get(this));

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -269,6 +269,19 @@ void FrontendInputsAndOutputs::addPrimaryInputFile(StringRef file,
   addInput(InputFile(file, true, buffer));
 }
 
+void FrontendInputsAndOutputs::overrideBufferForInput(
+    StringRef file, llvm::MemoryBuffer *buffer) {
+  // FIXME: If we knew this was only interesting for primary inputs, we could
+  // use the PrimaryInputsByName map instead of a linear scan. But at the time
+  // this was added, the CompilerInvocation used for code completion does not
+  // guarantee that.
+  auto indexIter = llvm::find_if(AllInputs, [file](const InputFile &input) {
+    return input.file() == file;
+  });
+  assert(indexIter != AllInputs.end() && "input file not found");
+  indexIter->overrideBuffer(buffer);
+}
+
 // Outputs
 
 unsigned FrontendInputsAndOutputs::countOfInputsProducingMainOutputs() const {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1808,7 +1808,8 @@ public:
                                           Declaration,
                                           SemanticContextKind::OtherModule,
                                           ExpectedTypes);
-      auto MD = ModuleDecl::create(Ctx.getIdentifier(Pair.first), Ctx);
+      auto MD = ModuleDecl::create(Ctx.getIdentifier(Pair.first), Ctx,
+                                   /*MaxFiles*/0);
       Builder.setAssociatedDecl(MD);
       Builder.addTextChunk(MD->getNameStr());
       Builder.addTypeAnnotation("Module");
@@ -1866,7 +1867,8 @@ public:
     collectImportedModules(ImportedModules);
 
     for (auto ModuleName : ModuleNames) {
-      auto MD = ModuleDecl::create(Ctx.getIdentifier(ModuleName), Ctx);
+      auto MD = ModuleDecl::create(Ctx.getIdentifier(ModuleName), Ctx,
+                                   /*MaxFiles*/0);
       CodeCompletionResultBuilder Builder(
           Sink,
           CodeCompletionResult::ResultKind::Declaration,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1718,7 +1718,7 @@ IRGenModule::getAddrOfObjCModuleContextDescriptor() {
   if (!ObjCModule)
     ObjCModule = ModuleDecl::create(
       Context.getIdentifier(MANGLING_MODULE_OBJC),
-      Context);
+      Context, /*MaxFiles*/0);
   return getAddrOfModuleContextDescriptor(ObjCModule);
 }
 
@@ -1727,7 +1727,7 @@ IRGenModule::getAddrOfClangImporterModuleContextDescriptor() {
   if (!ClangImporterModule)
     ClangImporterModule = ModuleDecl::create(
       Context.getIdentifier(MANGLING_MODULE_CLANG_IMPORTER),
-      Context);
+      Context, /*MaxFiles*/0);
   return getAddrOfModuleContextDescriptor(ClangImporterModule);
 }
 

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -315,7 +315,7 @@ FileUnit *SerializedModuleLoader::loadAST(
       return fileUnit;
     }
 
-    M.removeFile(*fileUnit);
+    M.removeLastFile(*fileUnit);
   }
 
   // From here on is the failure path.

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -152,7 +152,9 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
   if (Failed) {
     return false;
   }
-  if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
+
+  auto &InputsAndOutputs = Invocation.getFrontendOptions().InputsAndOutputs;
+  if (!InputsAndOutputs.hasInputs()) {
     Error = "no input filenames specified";
     return false;
   }
@@ -167,7 +169,10 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
   *NewPos = '\0';
   std::copy(Position, InputFile->getBufferEnd(), NewPos+1);
 
-  Invocation.setCodeCompletionPoint(NewBuffer.get(), CodeCompletionOffset);
+  InputsAndOutputs.overrideBufferForInput(InputFile->getBufferIdentifier(),
+                                          NewBuffer.get());
+  Invocation.setCodeCompletionPoint(InputFile->getBufferIdentifier(),
+                                    CodeCompletionOffset);
 
   auto swiftCache = Lang.getCodeCompletionCache(); // Pin the cache.
   ide::CodeCompletionContext CompletionContext(swiftCache->getCache());

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -176,7 +176,8 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   ClangImporterOptions ClangImporterOpts;
   ASTCtx.addModuleLoader(ClangImporter::create(ASTCtx, ClangImporterOpts, ""),
                          true);
-  ModuleDecl *M = ModuleDecl::create(ASTCtx.getIdentifier("swiftmodule"), ASTCtx);
+  ModuleDecl *M = ModuleDecl::create(ASTCtx.getIdentifier("swiftmodule"),
+                                     ASTCtx, /*MaxFiles*/0);
   SILOptions SILOpts;
   std::unique_ptr<SILModule> SM = SILModule::createEmptyModule(M, SILOpts);
   createSwiftModuleObjectFile(*SM, (*ErrOrBuf)->getBuffer(),

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -709,9 +709,9 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
                << " at offset " << CodeCompletionOffset << "\n";
 
   CompilerInvocation Invocation(InitInvok);
-
-  Invocation.setCodeCompletionPoint(CleanFile.get(), CodeCompletionOffset);
-
+  Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
+      SourceFilename, CleanFile.get());
+  Invocation.setCodeCompletionPoint(SourceFilename, CodeCompletionOffset);
 
   std::unique_ptr<ide::OnDiskCodeCompletionCache> OnDiskCache;
   if (!options::CompletionCachePath.empty()) {


### PR DESCRIPTION
- [AST] Sink ModuleDecl's flags down into the shared Decl bitfields
- [AST] Tail-allocate space for the files in a ModuleDecl
- Require that the code completion buffer be a normal input buffer

This last is the one that needs the most actual review, even though it's a fairly small change. The first two were pretty straightforward, and you can read about them in the commit messages.