### PR TITLE
[test] Fix spurious failure in optimized tests

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -4801,10 +4801,11 @@ DictionaryTestSuite.test("Values.MutationDoesNotInvalidateIndices") {
 
   // You should also be able to advance Cocoa indices.
   let j = d.index(after: i)
+  expectLT(i, j)
 
   // Unfortunately, Cocoa and Native indices aren't comparable, so the
   // Collection conformance is not quite perfect.
-  expectCrash(withMessage: "Comparing indexes from different dictionaries") {
+  expectCrash() {
     print(i == i2)
   }
 }


### PR DESCRIPTION
We don’t emit the trap message in optimized builds, so don’t check for it.

rdar://problem/45022029