### PR TITLE
SR-8925: Require clang-3.9 on Ubuntu 14.04

### DIFF
--- a/docs/Ubuntu14.md
+++ b/docs/Ubuntu14.md
@@ -3,9 +3,11 @@
 ## Upgrade Clang
 You'll need to upgrade your clang compiler for C++14 support and create a symlink. The minimum required version of clang may change, and may not be available on Ubuntu 14.04 in the future.
 ```bash
-sudo apt-get install clang-3.6
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 100
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 100
+sudo apt-get install clang-3.9
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.9 100
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.9 100
+sudo update-alternatives --set clang /usr/bin/clang-3.9
+sudo update-alternatives --set clang++ /usr/bin/clang++-3.9
 ```
 
 ## Upgrade CMake


### PR DESCRIPTION
Since commit 3469797d changed to build libdispatch for SourceKit with the
host compiler, we now require a clang with builtin `__builtin_add_overflow`.
Since Ubuntu 14 repositories have a clang that supports this update our
build instructions to use it.

Resolves [SR-8925](https://bugs.swift.org/browse/SR-8925).