### PR TITLE
[Type checker] Ensure that synthesized accessors get generic parameter lists

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -164,6 +164,20 @@ buildIndexForwardingParamList(AbstractStorageDecl *storage,
   return ParameterList::create(context, elements);
 }
 
+/// Create the generic parameters needed for the given accessor, if any.
+static GenericParamList *createAccessorGenericParams(
+                                              AbstractStorageDecl *storage) {
+  // Accessors of generic subscripts get a copy of the subscript's
+  // generic parameter list, because they're not nested inside the
+  // subscript.
+  if (auto *subscript = dyn_cast<SubscriptDecl>(storage)) {
+    if (auto genericParams = subscript->getGenericParams())
+      return genericParams->clone(subscript->getDeclContext());
+  }
+
+  return nullptr;
+}
+
 static AccessorDecl *createGetterPrototype(TypeChecker &TC,
                                            AbstractStorageDecl *storage) {
   assert(!storage->getGetter());
@@ -193,6 +207,8 @@ static AccessorDecl *createGetterPrototype(TypeChecker &TC,
     }
   }
 
+  GenericParamList *genericParams = createAccessorGenericParams(storage);
+
   // Add an index-forwarding clause.
   auto *getterParams = buildIndexForwardingParamList(storage, {});
 
@@ -209,7 +225,7 @@ static AccessorDecl *createGetterPrototype(TypeChecker &TC,
       AccessorKind::Get, AddressorKind::NotAddressor, storage,
       staticLoc, StaticSpellingKind::None,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr,
+      genericParams,
       getterParams,
       TypeLoc::withoutLoc(storageInterfaceType),
       storage->getDeclContext());
@@ -255,7 +271,9 @@ static AccessorDecl *createSetterPrototype(TypeChecker &TC,
 
   bool isStatic = storage->isStatic();
   bool isMutating = storage->isSetterMutating();
-  
+
+  GenericParamList *genericParams = createAccessorGenericParams(storage);
+
   // Add a "(value : T, indices...)" argument list.
   auto storageInterfaceType = storage->getValueInterfaceType();
   auto valueDecl = buildArgument(storage->getLoc(), storage->getDeclContext(),
@@ -269,7 +287,7 @@ static AccessorDecl *createSetterPrototype(TypeChecker &TC,
       AccessorKind::Set, AddressorKind::NotAddressor, storage,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, params,
+      genericParams, params,
       TypeLoc::withoutLoc(setterRetTy),
       storage->getDeclContext());
   setter->setImplicit();
@@ -379,15 +397,7 @@ createCoroutineAccessorPrototype(TypeChecker &TC,
   // Coroutine accessors always return ().
   Type retTy = TupleType::getEmpty(ctx);
 
-  // Accessors of generic subscripts get a copy of the subscript's
-  // generic parameter list, because they're not nested inside the
-  // subscript.
-  GenericParamList *genericParams = nullptr;
-  if (auto *subscript = dyn_cast<SubscriptDecl>(storage)) {
-    genericParams = subscript->getGenericParams();
-    if (genericParams)
-      genericParams = genericParams->clone(dc);
-  }
+  GenericParamList *genericParams = createAccessorGenericParams(storage);
 
   auto *accessor = AccessorDecl::create(
       ctx, loc, /*AccessorKeywordLoc=*/SourceLoc(),

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -411,6 +411,29 @@ class Sub : Base {
   }
 }
 
+// rdar://problem/45046969
+struct Bar<T> { }
+
+protocol FooProtocol {
+  subscript<T>(index: Bar<T>) -> T { get set }
+}
+
+// Make sure we get the right generic signatures for the synthesized
+// getter/setter.
+
+// CHECK: sil hidden [transparent] @$s10addressors3FooVyqd__AA3BarVyqd__Gcluig : $@convention(method) <Base><T> (Bar<T>, Foo<Base>)
+// CHECK: sil hidden [transparent] @$s10addressors3FooVyqd__AA3BarVyqd__Gcluis : $@convention(method) <Base><T> (@in T, Bar<T>, @inout Foo<Base>) -> ()
+struct Foo<Base>: FooProtocol {
+  subscript<T>(index: Bar<T>) -> T {
+    unsafeAddress {
+      return UnsafePointer<T>(bitPattern: 0)!
+    }
+    unsafeMutableAddress {
+      return UnsafeMutablePointer<T>(bitPattern: 0)!
+    }
+  }
+}
+
 // Make sure addressors don't get vtable entries.
 // CHECK-LABEL: sil_vtable Base {
 // CHECK-NEXT: #Base.data!getter.1: (Base) -> () -> UnsafeMutablePointer<Int32> : @$s10addressors4BaseC4dataSpys5Int32VGvg


### PR DESCRIPTION
When we synthesize the declaration for getters and setters from (e.g.) an
addressor, ensure that we clone the generic parameter list when we have a
generic subscript. Fixes rdar://problem/45046969.
