### PR TITLE
[Sema] Synthesize default values for memberwise init

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4855,7 +4855,7 @@ class ParamDecl : public VarDecl {
   SourceLoc SpecifierLoc;
 
   struct StoredDefaultArgument {
-    Expr *DefaultArg = nullptr;
+    PointerUnion<Expr *, VarDecl *> DefaultArg;
     Initializer *InitContext = nullptr;
     StringRef StringRepresentation;
   };
@@ -4912,11 +4912,19 @@ public:
   
   Expr *getDefaultValue() const {
     if (auto stored = DefaultValueAndFlags.getPointer())
-      return stored->DefaultArg;
+      return stored->DefaultArg.dyn_cast<Expr *>();
+    return nullptr;
+  }
+
+  VarDecl *getStoredProperty() const {
+    if (auto stored = DefaultValueAndFlags.getPointer())
+      return stored->DefaultArg.dyn_cast<VarDecl *>();
     return nullptr;
   }
 
   void setDefaultValue(Expr *E);
+
+  void setStoredProperty(VarDecl *var);
 
   Initializer *getDefaultArgumentInitContext() const {
     if (auto stored = DefaultValueAndFlags.getPointer())

--- a/include/swift/AST/DefaultArgumentKind.h
+++ b/include/swift/AST/DefaultArgumentKind.h
@@ -52,6 +52,10 @@ enum class DefaultArgumentKind : uint8_t {
   EmptyArray,
   /// An empty dictionary literal.
   EmptyDictionary,
+  /// A reference to the stored property. This is a special default argument
+  /// kind for the synthesized memberwise constructor to emit a call to the
+  // property's initializer.
+  StoredProperty,
 };
 enum { NumDefaultArgumentKindBits = 4 };
 

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 477; // SILUndef serialized with ownership kind
+const uint16_t SWIFTMODULE_VERSION_MINOR = 478; // stored property default arg
 
 using DeclIDField = BCFixed<31>;
 

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -379,6 +379,7 @@ enum class DefaultArgumentKind : uint8_t {
   NilLiteral,
   EmptyArray,
   EmptyDictionary,
+  StoredProperty,
 };
 using DefaultArgumentField = BCFixed<4>;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -305,6 +305,7 @@ static StringRef getDefaultArgumentKindString(DefaultArgumentKind value) {
     case DefaultArgumentKind::EmptyArray: return "[]";
     case DefaultArgumentKind::EmptyDictionary: return "[:]";
     case DefaultArgumentKind::Normal: return "normal";
+    case DefaultArgumentKind::StoredProperty: return "stored property";
   }
 
   llvm_unreachable("Unhandled DefaultArgumentKind in switch.");

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5261,7 +5261,7 @@ void DefaultArgumentInitializer::changeFunction(
   }
 
   auto param = paramList->get(getIndex());
-  if (param->isDefaultArgument())
+  if (param->getDefaultValue() || param->getStoredProperty())
     param->setDefaultArgumentInitContext(this);
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2034,6 +2034,7 @@ public:
     for (auto param : *func->getParameters()) {
       switch (param->getDefaultArgumentKind()) {
       case DefaultArgumentKind::Normal:
+      case DefaultArgumentKind::StoredProperty:
       case DefaultArgumentKind::Inherited: // FIXME: include this?
         return true;
       default:
@@ -2061,6 +2062,7 @@ public:
         return false;
 
       case DefaultArgumentKind::Normal:
+      case DefaultArgumentKind::StoredProperty:
       case DefaultArgumentKind::Inherited:
       case DefaultArgumentKind::NilLiteral:
       case DefaultArgumentKind::EmptyArray:

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1082,6 +1082,7 @@ void SILGenModule::emitDefaultArgGenerator(SILDeclRef constant, Expr *arg,
   case DefaultArgumentKind::NilLiteral:
   case DefaultArgumentKind::EmptyArray:
   case DefaultArgumentKind::EmptyDictionary:
+  case DefaultArgumentKind::StoredProperty:
     return;
   }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3364,16 +3364,8 @@ void DelayedArgument::emitDefaultArgument(SILGenFunction &SGF,
           var->getDeclContext()->getGenericSignatureOfContext();
 
         if (genericEnv && typeGenericSig) {
-          subs = SubstitutionMap::get(
-            typeGenericSig,
-            [&](SubstitutableType *type) {
-              if (auto gp = type->getAs<GenericTypeParamType>()) {
-                return genericEnv->mapTypeIntoContext(gp);
-              }
-
-              return Type(type);
-            },
-            MakeAbstractConformanceForGenericType());
+          // Get the substitutions from the constructor's generic env.
+          subs = genericEnv->getForwardingSubstitutionMap();
         }
 
         value = SGF.emitApplyOfStoredPropertyInitializer(info.loc,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3366,7 +3366,7 @@ void DelayedArgument::emitDefaultArgument(SILGenFunction &SGF,
                                                          SGFContext());
       }
     }
-  }                      
+  }
 
   if (!isStoredPropertyDefaultArg) {
     value = SGF.emitApplyOfDefaultArgGenerator(info.loc,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3364,8 +3364,7 @@ void DelayedArgument::emitDefaultArgument(SILGenFunction &SGF,
           var->getDeclContext()->getGenericSignatureOfContext();
 
         if (genericEnv && typeGenericSig) {
-          // Get the substitutions from the constructor's generic env.
-          subs = genericEnv->getForwardingSubstitutionMap();
+          subs = info.defaultArgsOwner.getSubstitutions();
         }
 
         value = SGF.emitApplyOfStoredPropertyInitializer(info.loc,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3357,15 +3357,7 @@ void DelayedArgument::emitDefaultArgument(SILGenFunction &SGF,
 
         auto pbd = var->getParentPatternBinding();
         auto entry = pbd->getPatternEntryForVarDecl(var);
-
-        SubstitutionMap subs;
-        auto *genericEnv = ctor->getGenericEnvironmentOfContext();
-        auto typeGenericSig = 
-          var->getDeclContext()->getGenericSignatureOfContext();
-
-        if (genericEnv && typeGenericSig) {
-          subs = info.defaultArgsOwner.getSubstitutions();
-        }
+        auto subs = info.defaultArgsOwner.getSubstitutions();
 
         value = SGF.emitApplyOfStoredPropertyInitializer(info.loc,
                                                          entry, subs,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4896,6 +4896,7 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
   case DefaultArgumentKind::None:
     llvm_unreachable("No default argument here?");
 
+  case DefaultArgumentKind::StoredProperty:
   case DefaultArgumentKind::Normal:
     return {nullptr, param->getDefaultArgumentKind()};
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1706,9 +1706,10 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
       arg->setInterfaceType(varInterfaceType);
       arg->setImplicit();
       
-      // If this is a var that has a default value, lets assign a default value
+      // If this is a var that has a default value, and is only binding one var,
+      // i.e, var (a, b) = (3, 3) is not allowed, lets assign a default value
       // to the parameter with the same expression.
-      if (!var->isLet()) {
+      if (!var->isLet() && var->getParentPattern()->getSingleVar()) {
         if (auto init = var->getParentInitializer()) {
           // Give this some bogus context right now, we'll fix it after making
           // the constructor.

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1679,7 +1679,7 @@ static void maybeAddMemberwiseDefaultArg(ParamDecl *arg, VarDecl *var,
   // to nil literal. This is useful when we need to print the constructor.
   // Note, this will always be the sugared T? because we don't default init an
   // explicit Optional<T>.
-  if (isa<OptionalType>(var->getType().getPointer()) &&
+  if (isa<OptionalType>(var->getValueInterfaceType().getPointer()) &&
       !var->getParentInitializer())
     arg->setDefaultArgumentKind(DefaultArgumentKind::NilLiteral);
 }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -238,6 +238,8 @@ getActualDefaultArgKind(uint8_t raw) {
     return swift::DefaultArgumentKind::EmptyArray;
   case serialization::DefaultArgumentKind::EmptyDictionary:
     return swift::DefaultArgumentKind::EmptyDictionary;
+  case serialization::DefaultArgumentKind::StoredProperty:
+    return swift::DefaultArgumentKind::StoredProperty;
   }
   return None;
 }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1146,6 +1146,7 @@ static uint8_t getRawStableDefaultArgumentKind(swift::DefaultArgumentKind kind) 
   CASE(NilLiteral)
   CASE(EmptyArray)
   CASE(EmptyDictionary)
+  CASE(StoredProperty)
 #undef CASE
   }
 
@@ -3266,11 +3267,13 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(param->getDeclContext());
     Type interfaceType = param->getInterfaceType();
 
-    // Only save the text for normal default arguments, not any of the special
-    // ones.
+    // Only save the text for normal and stored property default arguments, not
+    // any of the special ones.
     StringRef defaultArgumentText;
     SmallString<128> scratch;
-    if (param->getDefaultArgumentKind() == swift::DefaultArgumentKind::Normal)
+    swift::DefaultArgumentKind argKind = param->getDefaultArgumentKind();
+    if (argKind == swift::DefaultArgumentKind::Normal ||
+        argKind == swift::DefaultArgumentKind::StoredProperty)
       defaultArgumentText =
         param->getDefaultValueStringRepresentation(scratch);
 
@@ -3283,7 +3286,7 @@ void Serializer::writeDecl(const Decl *D) {
         addTypeRef(interfaceType),
         param->isVariadic(),
         param->isAutoClosure(),
-        getRawStableDefaultArgumentKind(param->getDefaultArgumentKind()),
+        getRawStableDefaultArgumentKind(argKind),
         defaultArgumentText);
 
     if (interfaceType->hasError()) {

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -265,6 +265,7 @@ var topLevelVar2 = FooStruct#^TOP_LEVEL_VAR_INIT_2^#
 // TOP_LEVEL_VAR_INIT_2-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc({#(self): FooStruct#})[#(Int) -> Void#]{{; name=.+$}}
 // TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ({#instanceVar: Int#})[#FooStruct#]{{; name=.+$}}
 // TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ()[#FooStruct#]{{; name=.+$}}
+// TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ()[#FooStruct#]{{; name=.+$}}
 // TOP_LEVEL_VAR_INIT_2-NEXT: Keyword[self]/CurrNominal: .self[#FooStruct.Type#]; name=self
 // TOP_LEVEL_VAR_INIT_2-NEXT: Keyword/CurrNominal:       .Type[#FooStruct.Type#]; name=Type
 // TOP_LEVEL_VAR_INIT_2-NEXT: End completions

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -263,8 +263,8 @@ func resyncParser7() {}
 var topLevelVar2 = FooStruct#^TOP_LEVEL_VAR_INIT_2^#
 // TOP_LEVEL_VAR_INIT_2: Begin completions
 // TOP_LEVEL_VAR_INIT_2-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc({#(self): FooStruct#})[#(Int) -> Void#]{{; name=.+$}}
-// TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ({#instanceVar: Int#})[#FooStruct#]{{; name=.+$}}
 // TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ()[#FooStruct#]{{; name=.+$}}
+// TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ({#instanceVar: Int#})[#FooStruct#]{{; name=.+$}}
 // TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ()[#FooStruct#]{{; name=.+$}}
 // TOP_LEVEL_VAR_INIT_2-NEXT: Keyword[self]/CurrNominal: .self[#FooStruct.Type#]; name=self
 // TOP_LEVEL_VAR_INIT_2-NEXT: Keyword/CurrNominal:       .Type[#FooStruct.Type#]; name=Type

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -75,7 +75,8 @@ struct ImplicitConstructors2 {
 
 func testImplicitConstructors2() {
   ImplicitConstructors2#^IMPLICIT_CONSTRUCTORS_2^#
-// IMPLICIT_CONSTRUCTORS_2: Begin completions, 4 items
+// IMPLICIT_CONSTRUCTORS_2: Begin completions, 5 items
+// IMPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal: ()[#ImplicitConstructors2#]{{; name=.+$}}
 // IMPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal: ({#instanceVar: Int#})[#ImplicitConstructors2#]{{; name=.+$}}
 // IMPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal: ()[#ImplicitConstructors2#]{{; name=.+$}}
 // IMPLICIT_CONSTRUCTORS_2-DAG: Keyword[self]/CurrNominal:     .self[#ImplicitConstructors2.Type#]; name=self

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -440,6 +440,7 @@ var fooObject: FooStruct
 // FOO_STRUCT_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   overloadedStaticFunc1()[#Double#]{{; name=.+$}}
 // FOO_STRUCT_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   overloadedStaticFunc2({#(x): Int#})[#Int#]{{; name=.+$}}
 // FOO_STRUCT_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   overloadedStaticFunc2({#(x): Double#})[#Int#]{{; name=.+$}}
+// FOO_STRUCT_DOT-NEXT: Decl[Constructor]/CurrNominal:    init()[#FooStruct#]; name=init(){{$}}
 // FOO_STRUCT_DOT-NEXT: Decl[Constructor]/CurrNominal:    init({#lazyInstanceVar: Int?#}, {#instanceVar: Int#})[#FooStruct#]; name=init(lazyInstanceVar: Int?, instanceVar: Int){{$}}
 // FOO_STRUCT_DOT-NEXT: Decl[Constructor]/CurrNominal:    init()[#FooStruct#]; name=init(){{$}}
 // FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: extFunc0({#(self): &FooStruct#})[#() -> Void#]{{; name=.+$}}
@@ -488,6 +489,7 @@ var fooObject: FooStruct
 // FOO_STRUCT_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   .overloadedStaticFunc1()[#Double#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   .overloadedStaticFunc2({#(x): Int#})[#Int#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   .overloadedStaticFunc2({#(x): Double#})[#Int#]{{; name=.+$}}
+// FOO_STRUCT_NO_DOT-NEXT: Decl[Constructor]/CurrNominal:    ()[#FooStruct#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[Constructor]/CurrNominal:    ({#lazyInstanceVar: Int?#}, {#instanceVar: Int#})[#FooStruct#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[Constructor]/CurrNominal:    ()[#FooStruct#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .extFunc0({#(self): &FooStruct#})[#() -> Void#]{{; name=.+$}}

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -234,7 +234,7 @@ struct d0100_FooStruct {
   static func overloadedStaticFunc2(x: Double) -> Int { return 0 }
 // PASS_COMMON-NEXT: {{^}}  static func overloadedStaticFunc2(x: Double) -> Int{{$}}
 }
-// PASS_COMMON-NEXT: {{^}}  init(instanceVar1: Int){{$}}
+// PASS_COMMON-NEXT: {{^}}  init(instanceVar1: Int = 0){{$}}
 // PASS_COMMON-NEXT: {{^}}  init(){{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
@@ -626,7 +626,7 @@ struct d0200_EscapedIdentifiers {
   static func `static`(protocol: Int) {}
 // PASS_COMMON-NEXT: {{^}}  static func `static`(protocol: Int){{$}}
 
-// PASS_COMMON-NEXT: {{^}}  init(`var`: {{(d0200_EscapedIdentifiers.)?}}`struct`, tupleType: (`var`: Int, `let`: {{(d0200_EscapedIdentifiers.)?}}`struct`)){{$}}
+// PASS_COMMON-NEXT: {{^}}  init(`var`: {{(d0200_EscapedIdentifiers.)?}}`struct` = {{(d0200_EscapedIdentifiers.)?}}`struct`(), tupleType: (`var`: Int, `let`: {{(d0200_EscapedIdentifiers.)?}}`struct`)){{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 }
 

--- a/test/SILGen/stored_property_default_arg.swift
+++ b/test/SILGen/stored_property_default_arg.swift
@@ -38,3 +38,24 @@ struct F<T> {
 // CHECK-NEXT: {{.*}} = apply [[F1_REF]]<Int>({{.*}}, {{.*}}, [[H1]], {{.*}}) : $@convention(method) <τ_0_0> (@in τ_0_0, Int, @thin F<τ_0_0>.Type) -> @out F<τ_0_0>
 
 let i = F(g: 128)
+
+struct J {
+  lazy var k: Bool = false
+  lazy var l: Int = 0
+}
+
+// CHECK: {{.*}} = metatype $@thin Optional<Int>.Type
+// CHECK-NEXT: [[L1_REF:%.*]] = enum $Optional<Int>, #Optional.none!enumelt
+// CHECK-NEXT: function_ref J.init(k:l:)
+// CHECK-NEXT: [[J1_REF:%.*]] = function_ref @$s27stored_property_default_arg1JV1k1lACSbSg_SiSgtcfC : $@convention(method) (Optional<Bool>, Optional<Int>, @thin J.Type) -> J
+// CHECK-NEXT: {{.*}} = apply [[J1_REF]]({{.*}}, [[L1_REF]], {{.*}}) : $@convention(method) (Optional<Bool>, Optional<Int>, @thin J.Type) -> J
+
+let m = J(k: true)
+
+// CHECK: {{.*}} = metatype $@thin Optional<Bool>.Type
+// CHECK-NEXT: [[K1_REF:%.*]] = enum $Optional<Bool>, #Optional.none!enumelt
+// CHECK-NEXT: function_ref J.init(k:l:)
+// CHECK-NEXT: [[J2_REF:%.*]] = function_ref @$s27stored_property_default_arg1JV1k1lACSbSg_SiSgtcfC : $@convention(method) (Optional<Bool>, Optional<Int>, @thin J.Type) -> J
+// CHECK-NEXT: {{.*}} = apply [[J2_REF]]([[K1_REF]], {{.*}}, {{.*}}) : $@convention(method) (Optional<Bool>, Optional<Int>, @thin J.Type) -> J
+
+let n = J(l: 316)

--- a/test/SILGen/stored_property_default_arg.swift
+++ b/test/SILGen/stored_property_default_arg.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-emit-silgen -primary-file %s | %FileCheck %s
+
+// Currently, this only appears for memberwise initializers.
+
+struct A {
+  var b: Int = 0
+  var c: Bool = false
+}
+
+// CHECK: function_ref variable initialization expression of A.c
+// CHECK-NEXT: [[C1_REF:%.*]] = function_ref @$s27stored_property_default_arg1AV1cSbvpfi : $@convention(thin) () -> Bool
+// CHECK-NEXT: [[C1:%.*]] = apply [[C1_REF]]() : $@convention(thin) () -> Bool
+// CHECK-NEXT: function_ref A.init(b:c:)
+// CHECK-NEXT: [[A1_REF:%.*]] = function_ref @$s27stored_property_default_arg1AV1b1cACSi_SbtcfC : $@convention(method) (Int, Bool, @thin A.Type) -> A
+// CHECK-NEXT: {{.*}} = apply [[A1_REF]]({{.*}}, [[C1]], {{.*}}) : $@convention(method) (Int, Bool, @thin A.Type) -> A
+
+let d = A(b: 1)
+
+// CHECK: function_ref variable initialization expression of A.b
+// CHECK-NEXT: [[B1_REF:%.*]] = function_ref @$s27stored_property_default_arg1AV1bSivpfi : $@convention(thin) () -> Int
+// CHECK-NEXT: [[B1:%.*]] = apply [[B1_REF]]() : $@convention(thin) () -> Int
+// CHECK-NEXT: function_ref A.init(b:c:)
+// CHECK-NEXT: [[A2_REF:%.*]] = function_ref @$s27stored_property_default_arg1AV1b1cACSi_SbtcfC : $@convention(method) (Int, Bool, @thin A.Type) -> A
+// CHECK-NEXT: {{.*}} = apply [[A2_REF]]([[B1]], {{.*}}, {{.*}}) : $@convention(method) (Int, Bool, @thin A.Type) -> A
+
+let e = A(c: true)
+
+struct F<T> {
+  var g: T
+  var h: Int = 0
+}
+
+// CHECK: function_ref variable initialization expression of F.h
+// CHECK-NEXT: [[H1_REF:%.*]] = function_ref @$s27stored_property_default_arg1FV1hSivpfi : $@convention(thin) <τ_0_0> () -> Int
+// CHECK-NEXT: [[H1:%.*]] = apply [[H1_REF]]<Int>() : $@convention(thin) <τ_0_0> () -> Int
+// CHECK-NEXT: function_ref F.init(g:h:)
+// CHECK-NEXT: [[F1_REF:%.*]] = function_ref @$s27stored_property_default_arg1FV1g1hACyxGx_SitcfC : $@convention(method) <τ_0_0> (@in τ_0_0, Int, @thin F<τ_0_0>.Type) -> @out F<τ_0_0>
+// CHECK-NEXT: {{.*}} = apply [[F1_REF]]<Int>({{.*}}, {{.*}}, [[H1]], {{.*}}) : $@convention(method) <τ_0_0> (@in τ_0_0, Int, @thin F<τ_0_0>.Type) -> @out F<τ_0_0>
+
+let i = F(g: 128)

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -29,7 +29,7 @@ struct BA_DefaultStruct {
 private struct BB_PrivateStruct {
   // CHECK: internal var x
   var x = 0
-  // CHECK: internal init(x: Int)
+  // CHECK: internal init(x: Int = 0)
   // CHECK: internal init()
 } // CHECK: {{^[}]}}
 
@@ -44,7 +44,7 @@ internal struct BC_InternalStruct {
 public struct BD_PublicStruct {
   // CHECK: internal var x
   var x = 0
-  // CHECK: internal init(x: Int)
+  // CHECK: internal init(x: Int = 0)
   // CHECK: internal init()
 } // CHECK: {{^[}]}}
 
@@ -52,7 +52,7 @@ public struct BD_PublicStruct {
 public struct BE_PublicStructPrivateMembers {
   // CHECK: private{{(\*/)?}} var x
   private var x = 0
-  // CHECK: private init(x: Int)
+  // CHECK: private init(x: Int = 0)
   // CHECK: internal init()
 } // CHECK: {{^[}]}}
 
@@ -60,7 +60,7 @@ public struct BE_PublicStructPrivateMembers {
 fileprivate struct BF_FilePrivateStruct {
   // CHECK: {{^}} internal var x
   var x = 0
-  // CHECK: {{^}} internal init(x: Int)
+  // CHECK: {{^}} internal init(x: Int = 0)
   // CHECK: {{^}} internal init()
 } // CHECK: {{^[}]}}
 

--- a/test/decl/func/default-values.swift
+++ b/test/decl/func/default-values.swift
@@ -135,3 +135,36 @@ func inoutFuncWithDefaultArg4(x: inout Int = &aLiteral) {} // expected-error {{c
 func inoutFuncWithDefaultArg5(x: inout Int = &bLiteral) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
 func inoutFuncWithDefaultArg6(x: inout Int = #file) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
 func inoutFuncWithDefaultArg7(_: inout Int = 1) {} // expected-error {{cannot provide default value to inout parameter '_'}}
+
+// SE-0242 - Test that memberwise constructor generates default values
+
+struct Foo {
+  var a: Int
+  var b: Bool = false
+  let c: (Int, Bool) = (1, true)
+  let d: Int
+  var (e, f) = (0, false)
+  var g: Int?
+  let h: Bool?
+
+  // The generated memberwise should look like the following:
+  // init(a: Int, b: Bool = false, d: Int, e: Int, f: Bool, g: Int? = nil, h: Bool?)
+}
+
+// Here b = false and g = nil
+let fooThing1 = Foo(a: 0, d: 1, e: 2, f: false, h: nil) // ok
+// Here g = nil
+let fooThing2 = Foo(a: 0, b: true, d: 1, e: 2, f: false, h: nil) // ok
+// Here b = false
+let fooThing3 = Foo(a: 0, d: 1, e: 2, f: false, g: 10, h: nil) // ok
+// Use all the parameters
+let fooThing4 = Foo(a: 0, b: true, d: 1, e: 2, f: false, g: 10, h: nil) // ok
+
+// Ensure that tuple init is not allowed
+// Here b = false and g = nil, but we're checking that e and f don't get a default value
+let fooThing5 = Foo(a: 0, d: 1, h: nil) // expected-error {{missing argument for parameter 'e' in call}}
+                                        // expected-note@-25 {{'init(a:b:d:e:f:g:h:)' declared here}}
+
+// Here b = false and g = nil, but we're checking that f doesn't get a default value
+let fooThing6 = Foo(a: 0, d: 1, e: 2, h: nil) // expected-error {{missing argument for parameter 'f' in call}}
+                                              // expected-note@-29 {{'init(a:b:d:e:f:g:h:)' declared here}}


### PR DESCRIPTION
Previously we were synthesizing something like the following:
```swift
struct Dog {
  var age = 0
  var name = ""

  // compiler synthesized
  init(age: Int, name: String)

  // compiler synthesized
  init() {}
}
```

This patch is a QoL change to the way we synthesize the memberwise constructor for structures.

```swift
struct Dog {
  var age = 0
  var name = ""

  // compiler synthesized
  init(age: Int = 0, name: String = "")
}
```

Swift Evolution review: https://forums.swift.org/t/se-0242-synthesize-default-values-for-the-memberwise-initializer/20618

cc: @jrose-apple @harlanhaskins 