### PR TITLE
build: workaround cross-compilation for Windows

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -273,6 +273,13 @@ function(_add_variant_c_compile_flags)
     # RTTI as well.  This requires a newer SDK though and we do not have
     # guarantees on the SDK version currently.
     list(APPEND result "-D_HAS_STATIC_RTTI=0")
+
+    # NOTE(compnerd) workaround LLVM invoking `add_definitions(-D_DEBUG)` which
+    # causes failures for the runtime library when cross-compiling due to
+    # undefined symbols from the standard library.
+    if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
+      list(APPEND result "-U_DEBUG")
+    endif()
   endif()
 
   if(CFLAGS_ENABLE_ASSERTIONS)


### PR DESCRIPTION
When cross-compiling the Windows standard library in release mode, we
would get undefined symbols due to LLVM invoking
`add_definitions(-D_DEBUG)`.  This would change the behaviour of certain
functions from MSVCRT resulting in undefined symbols.  Scrub out the
unwanted `-D_DEBUG`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
