### PR TITLE
stdlib: use some clever C11 to define ssize_t

### DIFF
--- a/stdlib/public/SwiftShims/SwiftStddef.h
+++ b/stdlib/public/SwiftShims/SwiftStddef.h
@@ -28,20 +28,12 @@ typedef size_t __swift_size_t;
 typedef __SIZE_TYPE__ __swift_size_t;
 #endif
 
-// This declaration is not universally correct.  We verify its correctness for
-// the current platform in the runtime code.
-#if defined(__linux__) && (defined(__arm__) || defined(__i386__))
-typedef           int __swift_ssize_t;
-#elif defined(_WIN32)
-#if defined(_M_ARM) || defined(_M_IX86)
-typedef           int __swift_ssize_t;
-#elif defined(_M_X64) || defined(_M_ARM64)
-typedef long long int __swift_ssize_t;
-#else
-#error unsupported machine type
-#endif
-#else
-typedef      long int __swift_ssize_t;
-#endif
+// This selects the signed equivalent of the unsigned type chosen for size_t.
+typedef __typeof__(_Generic((__swift_size_t)0,                                 \
+                            unsigned long long int : (long long int)0,         \
+                            unsigned long int : (long int)0,                   \
+                            unsigned int : (int)0,                             \
+                            unsigned short : (short)0,                         \
+                            unsigned char : (signed char)0)) __swift_ssize_t;
 
 #endif // SWIFT_STDLIB_SHIMS_SWIFT_STDDEF_H

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -30,8 +30,6 @@
 
 using namespace swift;
 
-static_assert(std::is_same<ssize_t, __swift_ssize_t>::value,
-              "__swift_ssize_t must be defined as equivalent to ssize_t in LibcShims.h");
 #if !defined(_WIN32) || defined(__CYGWIN__)
 static_assert(std::is_same<mode_t, swift::__swift_mode_t>::value,
               "__swift_mode_t must be defined as equivalent to mode_t in LibcShims.h");


### PR DESCRIPTION
`ssize_t` is not universally available as it is not a standard type.
However, we require clang to build the runtime due to custom calling
convention support.  As a result, we know that the compiler will support
the `_Generic` keyword from the C11 standard.  Use this with an
expansion to map the type appropriately for all targets.  This avoids
having to have a sanity check in the runtime that the type definition
matches the underlying system.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
