### PR TITLE
[ConstraintSystem] Tweak -disable-constraint-solver-performance-hacks.

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -493,8 +493,6 @@ bool DisjunctionStep::shouldStopAt(const DisjunctionChoice &choice) const {
 bool DisjunctionStep::shortCircuitDisjunctionAt(
     Constraint *currentChoice, Constraint *lastSuccessfulChoice) const {
   auto &ctx = CS.getASTContext();
-  if (ctx.LangOpts.DisableConstraintSolverPerformanceHacks)
-    return false;
 
   // If the successfully applied constraint is favored, we'll consider that to
   // be the "best".
@@ -514,6 +512,9 @@ bool DisjunctionStep::shortCircuitDisjunctionAt(
   // Anything without a fix is better than anything with a fix.
   if (currentChoice->getFix() && !lastSuccessfulChoice->getFix())
     return true;
+
+  if (ctx.LangOpts.DisableConstraintSolverPerformanceHacks)
+    return false;
 
   if (auto restriction = currentChoice->getRestriction()) {
     // Non-optional conversions are better than optional-to-optional


### PR DESCRIPTION
Allow a couple of the tests in shortCircuitDisjunctionAt() to run even
when hacks are disabled.

The first of these tests is imperfect since it assumes that "favored"
disjunction choices all come before the others (which may be the case
now but is pretty brittle).

Similarly, the second of these tests assumes that choices that are
fixes always come after ones that are not.

What we really want to do is skip these choices rather than stopping
at these points.
