### PR TITLE
Allow AD to use primitive adjoints that provide a superset of indices

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -119,30 +119,30 @@ private:
   SILReverseAutoDiffIndices indices;
   /// The primal and adjoint function names.
   StringRef PrimalName, AdjointName;
-  /// Whether the adjoint is synthesized.
-  bool AdjointIsSynthesized;
+  /// Whether the adjoint is primitive.
+  bool AdjointIsPrimitive;
 
   SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
                                StringRef primalName,
                                StringRef adjointName,
-                               bool adjointIsSynthesized);
+                               bool adjointIsPrimitive);
 
 public:
   static SILReverseDifferentiableAttr *create(
       SILModule &M, const SILReverseAutoDiffIndices &indices,
       StringRef primalName = StringRef(), StringRef adjointName = StringRef(),
-      bool adjointIsSynthesized = false);
+      bool adjointIsPrimitive = false);
 
   bool hasPrimal() const { return !PrimalName.empty(); }
   StringRef getPrimalName() const { assert(hasPrimal()); return PrimalName; }
   void setPrimalName(StringRef name) { PrimalName = name; }
 
   bool hasAdjoint() const { return !AdjointName.empty(); }
-  bool isAdjointSynthesized() const { return AdjointIsSynthesized; }
+  bool isAdjointPrimitive() const { return AdjointIsPrimitive; }
   StringRef getAdjointName() const { assert(hasAdjoint()); return AdjointName; }
-  void setAdjointName(StringRef name, bool synthesized) {
+  void setAdjointName(StringRef name, bool primitive) {
     AdjointName = name;
-    AdjointIsSynthesized = synthesized;
+    AdjointIsPrimitive = primitive;
   }
 
   const SILReverseAutoDiffIndices &getIndices() const { return indices; }

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -119,30 +119,31 @@ private:
   SILReverseAutoDiffIndices indices;
   /// The primal and adjoint function names.
   StringRef PrimalName, AdjointName;
-  /// Whether the primal and adjoint are synthesized.
-  bool PrimalIsSynthesized, AdjointIsSynthesized;
+  /// Whether the adjoint is synthesized.
+  bool AdjointIsSynthesized;
 
   SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
                                StringRef primalName,
                                StringRef adjointName,
-                               bool primalIsSynthesized,
                                bool adjointIsSynthesized);
 
 public:
   static SILReverseDifferentiableAttr *create(
       SILModule &M, const SILReverseAutoDiffIndices &indices,
       StringRef primalName = StringRef(), StringRef adjointName = StringRef(),
-      bool primalIsSynthesized = false, bool adjointIsSynthesized = false);
+      bool adjointIsSynthesized = false);
 
   bool hasPrimal() const { return !PrimalName.empty(); }
-  bool isPrimalSynthesized() const { return PrimalIsSynthesized; }
   StringRef getPrimalName() const { assert(hasPrimal()); return PrimalName; }
-  void setPrimalName(StringRef name, bool synthesized) { PrimalName = name; }
+  void setPrimalName(StringRef name) { PrimalName = name; }
 
   bool hasAdjoint() const { return !AdjointName.empty(); }
   bool isAdjointSynthesized() const { return AdjointIsSynthesized; }
   StringRef getAdjointName() const { assert(hasAdjoint()); return AdjointName; }
-  void setAdjointName(StringRef name, bool synthesized) { AdjointName = name; }
+  void setAdjointName(StringRef name, bool synthesized) {
+    AdjointName = name;
+    AdjointIsSynthesized = synthesized;
+  }
 
   const SILReverseAutoDiffIndices &getIndices() const { return indices; }
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -119,23 +119,30 @@ private:
   SILReverseAutoDiffIndices indices;
   /// The primal and adjoint function names.
   StringRef PrimalName, AdjointName;
-  
+  /// Whether the primal and adjoint are synthesized.
+  bool PrimalIsSynthesized, AdjointIsSynthesized;
+
   SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
                                StringRef primalName,
-                               StringRef adjointName);
+                               StringRef adjointName,
+                               bool primalIsSynthesized,
+                               bool adjointIsSynthesized);
 
 public:
   static SILReverseDifferentiableAttr *create(
       SILModule &M, const SILReverseAutoDiffIndices &indices,
-      StringRef primalName = StringRef(), StringRef adjointName = StringRef());
-  
+      StringRef primalName = StringRef(), StringRef adjointName = StringRef(),
+      bool primalIsSynthesized = false, bool adjointIsSynthesized = false);
+
   bool hasPrimal() const { return !PrimalName.empty(); }
+  bool isPrimalSynthesized() const { return PrimalIsSynthesized; }
   StringRef getPrimalName() const { assert(hasPrimal()); return PrimalName; }
-  void setPrimalName(StringRef name) { PrimalName = name; }
+  void setPrimalName(StringRef name, bool synthesized) { PrimalName = name; }
 
   bool hasAdjoint() const { return !AdjointName.empty(); }
+  bool isAdjointSynthesized() const { return AdjointIsSynthesized; }
   StringRef getAdjointName() const { assert(hasAdjoint()); return AdjointName; }
-  void setAdjointName(StringRef name) { AdjointName = name; }
+  void setAdjointName(StringRef name, bool synthesized) { AdjointName = name; }
 
   const SILReverseAutoDiffIndices &getIndices() const { return indices; }
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1138,11 +1138,11 @@ static bool parseReverseDifferentiableAttr(
     P.consumeToken();
     if (parseFnName(AdjName)) return true;
   }
-  // Parse optional 'synthesized'.
-  bool adjointIsSynthesized = false;
-  if (P.Tok.is(tok::identifier) && P.Tok.getText() == "synthesized") {
+  // Parse optional 'primitive'.
+  bool adjointIsPrimitive = false;
+  if (P.Tok.is(tok::identifier) && P.Tok.getText() == "primitive") {
     P.consumeToken();
-    adjointIsSynthesized = true;
+    adjointIsPrimitive = true;
   }
   // Parse ']'.
   if (P.parseToken(tok::r_square,
@@ -1151,7 +1151,7 @@ static bool parseReverseDifferentiableAttr(
   // Create an AdjointAttr and we are done.
   auto *Attr = SILReverseDifferentiableAttr::create(
       SP.SILMod, {SourceIndex, ParamIndices}, PrimName.str(), AdjName.str(),
-      adjointIsSynthesized);
+      adjointIsPrimitive);
   DAs.push_back(Attr);
   return false;
 }

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1126,27 +1126,23 @@ static bool parseReverseDifferentiableAttr(
       P.parseIdentifier(id, LastLoc, diag::expected_sil_function_name);
   };
 
-  // Parse optional '(synthesized) primal'.
-  bool primalIsSynthesized = false;
-  if (P.Tok.is(tok::identifier) && P.Tok.getText() == "synthesized") {
-    P.consumeToken();
-    primalIsSynthesized = true;
-  }
+  // Parse optional 'primal'.
   Identifier PrimName;
   if (P.Tok.is(tok::identifier) && P.Tok.getText() == "primal") {
     P.consumeToken();
     if (parseFnName(PrimName)) return true;
   }
-  // Parse optional '(synthesized) adjoint'.
-  bool adjointIsSynthesized;
-  if (P.Tok.is(tok::identifier) && P.Tok.getText() == "synthesized") {
-    P.consumeToken();
-    adjointIsSynthesized = true;
-  }
+  // Parse optional 'adjoint'.
   Identifier AdjName;
   if (P.Tok.is(tok::identifier) && P.Tok.getText() == "adjoint") {
     P.consumeToken();
     if (parseFnName(AdjName)) return true;
+  }
+  // Parse optional 'synthesized'.
+  bool adjointIsSynthesized = false;
+  if (P.Tok.is(tok::identifier) && P.Tok.getText() == "synthesized") {
+    P.consumeToken();
+    adjointIsSynthesized = true;
   }
   // Parse ']'.
   if (P.parseToken(tok::r_square,
@@ -1155,7 +1151,7 @@ static bool parseReverseDifferentiableAttr(
   // Create an AdjointAttr and we are done.
   auto *Attr = SILReverseDifferentiableAttr::create(
       SP.SILMod, {SourceIndex, ParamIndices}, PrimName.str(), AdjName.str(),
-      primalIsSynthesized, adjointIsSynthesized);
+      adjointIsSynthesized);
   DAs.push_back(Attr);
   return false;
 }

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1126,13 +1126,23 @@ static bool parseReverseDifferentiableAttr(
       P.parseIdentifier(id, LastLoc, diag::expected_sil_function_name);
   };
 
-  // Parse optional 'primal'.
+  // Parse optional '(synthesized) primal'.
+  bool primalIsSynthesized = false;
+  if (P.Tok.is(tok::identifier) && P.Tok.getText() == "synthesized") {
+    P.consumeToken();
+    primalIsSynthesized = true;
+  }
   Identifier PrimName;
   if (P.Tok.is(tok::identifier) && P.Tok.getText() == "primal") {
     P.consumeToken();
     if (parseFnName(PrimName)) return true;
   }
-  // Parse optional 'adjoint'.
+  // Parse optional '(synthesized) adjoint'.
+  bool adjointIsSynthesized;
+  if (P.Tok.is(tok::identifier) && P.Tok.getText() == "synthesized") {
+    P.consumeToken();
+    adjointIsSynthesized = true;
+  }
   Identifier AdjName;
   if (P.Tok.is(tok::identifier) && P.Tok.getText() == "adjoint") {
     P.consumeToken();
@@ -1144,7 +1154,8 @@ static bool parseReverseDifferentiableAttr(
     return true;
   // Create an AdjointAttr and we are done.
   auto *Attr = SILReverseDifferentiableAttr::create(
-      SP.SILMod, {SourceIndex, ParamIndices}, PrimName.str(), AdjName.str());
+      SP.SILMod, {SourceIndex, ParamIndices}, PrimName.str(), AdjName.str(),
+      primalIsSynthesized, adjointIsSynthesized);
   DAs.push_back(Attr);
   return false;
 }

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -61,21 +61,21 @@ SILReverseDifferentiableAttr::
 SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
                              StringRef primalName,
                              StringRef adjointName,
-                             bool adjointIsSynthesized)
+                             bool adjointIsPrimitive)
   : indices(indices), PrimalName(primalName), AdjointName(adjointName),
-    AdjointIsSynthesized(adjointIsSynthesized) {}
+    AdjointIsPrimitive(adjointIsPrimitive) {}
 
 SILReverseDifferentiableAttr *
 SILReverseDifferentiableAttr::create(SILModule &M,
                                      const SILReverseAutoDiffIndices &indices,
                                      StringRef primalName,
                                      StringRef adjointName,
-                                     bool adjointIsSynthesized) {
+                                     bool adjointIsPrimitive) {
   void *mem = M.allocate(sizeof(SILReverseDifferentiableAttr),
                          alignof(SILReverseDifferentiableAttr));
   return ::new (mem)
       SILReverseDifferentiableAttr(indices, primalName, adjointName,
-                                   adjointIsSynthesized);
+                                   adjointIsPrimitive);
 }
 
 SILFunction *SILFunction::create(

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -61,10 +61,8 @@ SILReverseDifferentiableAttr::
 SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
                              StringRef primalName,
                              StringRef adjointName,
-                             bool primalIsSynthesized,
                              bool adjointIsSynthesized)
   : indices(indices), PrimalName(primalName), AdjointName(adjointName),
-    PrimalIsSynthesized(primalIsSynthesized),
     AdjointIsSynthesized(adjointIsSynthesized) {}
 
 SILReverseDifferentiableAttr *
@@ -72,13 +70,12 @@ SILReverseDifferentiableAttr::create(SILModule &M,
                                      const SILReverseAutoDiffIndices &indices,
                                      StringRef primalName,
                                      StringRef adjointName,
-                                     bool primalIsSynthesized,
                                      bool adjointIsSynthesized) {
   void *mem = M.allocate(sizeof(SILReverseDifferentiableAttr),
                          alignof(SILReverseDifferentiableAttr));
   return ::new (mem)
       SILReverseDifferentiableAttr(indices, primalName, adjointName,
-                                   primalIsSynthesized, adjointIsSynthesized);
+                                   adjointIsSynthesized);
 }
 
 SILFunction *SILFunction::create(

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -60,18 +60,25 @@ void SILFunction::addSpecializeAttr(SILSpecializeAttr *Attr) {
 SILReverseDifferentiableAttr::
 SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
                              StringRef primalName,
-                             StringRef adjointName)
-  : indices(indices), PrimalName(primalName), AdjointName(adjointName) {}
+                             StringRef adjointName,
+                             bool primalIsSynthesized,
+                             bool adjointIsSynthesized)
+  : indices(indices), PrimalName(primalName), AdjointName(adjointName),
+    PrimalIsSynthesized(primalIsSynthesized),
+    AdjointIsSynthesized(adjointIsSynthesized) {}
 
 SILReverseDifferentiableAttr *
 SILReverseDifferentiableAttr::create(SILModule &M,
                                      const SILReverseAutoDiffIndices &indices,
                                      StringRef primalName,
-                                     StringRef adjointName) {
+                                     StringRef adjointName,
+                                     bool primalIsSynthesized,
+                                     bool adjointIsSynthesized) {
   void *mem = M.allocate(sizeof(SILReverseDifferentiableAttr),
                          alignof(SILReverseDifferentiableAttr));
   return ::new (mem)
-      SILReverseDifferentiableAttr(indices, primalName, adjointName);
+      SILReverseDifferentiableAttr(indices, primalName, adjointName,
+                                   primalIsSynthesized, adjointIsSynthesized);
 }
 
 SILFunction *SILFunction::create(

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3153,7 +3153,7 @@ void SILReverseDifferentiableAttr::print(llvm::raw_ostream &OS) const {
   if (!AdjointName.empty()) {
     OS << " adjoint @" << AdjointName;
   }
-  if (AdjointIsSynthesized) OS << " synthesized";
+  if (AdjointIsPrimitive) OS << " primitive";
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3148,13 +3148,12 @@ void SILReverseDifferentiableAttr::print(llvm::raw_ostream &OS) const {
              [&](unsigned index) { OS << index; },
              [&] { OS << ", "; });
   if (!PrimalName.empty()) {
-    if (PrimalIsSynthesized) OS << " synthesized";
     OS << " primal @" << PrimalName;
   }
   if (!AdjointName.empty()) {
-    if (AdjointIsSynthesized) OS << " synthesized";
     OS << " adjoint @" << AdjointName;
   }
+  if (AdjointIsSynthesized) OS << " synthesized";
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3147,8 +3147,14 @@ void SILReverseDifferentiableAttr::print(llvm::raw_ostream &OS) const {
   interleave(indices.parameters.set_bits(),
              [&](unsigned index) { OS << index; },
              [&] { OS << ", "; });
-  if (!PrimalName.empty()) OS << " primal @" << PrimalName;
-  if (!AdjointName.empty()) OS << " adjoint @" << AdjointName;
+  if (!PrimalName.empty()) {
+    if (PrimalIsSynthesized) OS << " synthesized";
+    OS << " primal @" << PrimalName;
+  }
+  if (!AdjointName.empty()) {
+    if (AdjointIsSynthesized) OS << " synthesized";
+    OS << " adjoint @" << AdjointName;
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -811,6 +811,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
       // Either only adjoint is specified, or both primal and adjoint are
       // spcified.
       StringRef primName, adjName;
+      bool hasPrimitiveAdjoint = false;
       if (auto *primFn = diffAttr->getPrimalFunction())
         primName = getFunction(SILDeclRef(primFn), ForDefinition)->getName();
       if (auto *adjointFn = diffAttr->getAdjointFunction()) {
@@ -819,6 +820,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
         if (primName.empty())
           primName = silOriginalFn->getName();
         adjName = getFunction(SILDeclRef(adjointFn), ForDefinition)->getName();
+        hasPrimitiveAdjoint = true;
       }
       else {
         assert(primName.empty() &&
@@ -830,8 +832,9 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
                                              diffAttr);
       SILReverseAutoDiffIndices indices(/*source*/ 0, paramIndices);
       silOriginalFn->addReverseDifferentiableAttr(
-          SILReverseDifferentiableAttr::create(M, indices, primName, adjName,
-                                               /*synthesized*/ false));
+          SILReverseDifferentiableAttr::create(
+            M, indices, primName, adjName,
+            /*primitive*/ hasPrimitiveAdjoint));
       break;
     }
     }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -831,7 +831,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
       SILReverseAutoDiffIndices indices(/*source*/ 0, paramIndices);
       silOriginalFn->addReverseDifferentiableAttr(
           SILReverseDifferentiableAttr::create(M, indices, primName, adjName,
-                                               /*synthesized*/ false, false));
+                                               /*synthesized*/ false));
       break;
     }
     }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -830,7 +830,8 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
                                              diffAttr);
       SILReverseAutoDiffIndices indices(/*source*/ 0, paramIndices);
       silOriginalFn->addReverseDifferentiableAttr(
-          SILReverseDifferentiableAttr::create(M, indices, primName, adjName));
+          SILReverseDifferentiableAttr::create(M, indices, primName, adjName,
+                                               /*synthesized*/ false, false));
       break;
     }
     }

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -723,13 +723,13 @@ public:
   void setPrimal(SILFunction *fn) {
     assert(fn);
     primal = fn;
-    attr->setPrimalName(fn->getName());
+    attr->setPrimalName(fn->getName(), /*synthesized*/true);
   }
 
   void setAdjoint(SILFunction *fn) {
     assert(fn);
     adjoint = fn;
-    attr->setAdjointName(fn->getName());
+    attr->setAdjointName(fn->getName(), /*synthesized*/true);
   }
 
   DenseMap<ApplyInst *, DifferentiationTask *> &getAssociatedTasks() {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -628,12 +628,12 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
     uint64_t primalNameId;
     uint64_t adjointNameId;
-    bool adjointIsSynthesized;
+    bool adjointIsPrimitive;
     uint64_t source;
     ArrayRef<uint64_t> parameters;
     SILReverseDifferentiableAttrLayout::readRecord(scratch, primalNameId,
                                                    adjointNameId,
-                                                   adjointIsSynthesized,
+                                                   adjointIsPrimitive,
                                                    source, parameters);
 
     StringRef primalName = MF->getIdentifier(primalNameId).str();
@@ -645,7 +645,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
     auto *attr = SILReverseDifferentiableAttr::create(SILMod, indices,
                                                       primalName, adjointName,
-                                                      adjointIsSynthesized);
+                                                      adjointIsPrimitive);
     fn->addReverseDifferentiableAttr(attr);
   }
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -628,13 +628,11 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
     uint64_t primalNameId;
     uint64_t adjointNameId;
-    bool primalIsSynthesized;
     bool adjointIsSynthesized;
     uint64_t source;
     ArrayRef<uint64_t> parameters;
     SILReverseDifferentiableAttrLayout::readRecord(scratch, primalNameId,
                                                    adjointNameId,
-                                                   primalIsSynthesized,
                                                    adjointIsSynthesized,
                                                    source, parameters);
 
@@ -647,7 +645,6 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
     auto *attr = SILReverseDifferentiableAttr::create(SILMod, indices,
                                                       primalName, adjointName,
-                                                      primalIsSynthesized,
                                                       adjointIsSynthesized);
     fn->addReverseDifferentiableAttr(attr);
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -628,11 +628,15 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
     uint64_t primalNameId;
     uint64_t adjointNameId;
+    bool primalIsSynthesized;
+    bool adjointIsSynthesized;
     uint64_t source;
     ArrayRef<uint64_t> parameters;
     SILReverseDifferentiableAttrLayout::readRecord(scratch, primalNameId,
-                                                   adjointNameId, source,
-                                                   parameters);
+                                                   adjointNameId,
+                                                   primalIsSynthesized,
+                                                   adjointIsSynthesized,
+                                                   source, parameters);
 
     StringRef primalName = MF->getIdentifier(primalNameId).str();
     StringRef adjointName = MF->getIdentifier(adjointNameId).str();
@@ -642,7 +646,9 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     SILReverseAutoDiffIndices indices(source, parametersBitVector);
 
     auto *attr = SILReverseDifferentiableAttr::create(SILMod, indices,
-                                                      primalName, adjointName);
+                                                      primalName, adjointName,
+                                                      primalIsSynthesized,
+                                                      adjointIsSynthesized);
     fn->addReverseDifferentiableAttr(attr);
   }
 

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -315,7 +315,7 @@ namespace sil_block {
     SIL_REVERSE_DIFFERENTIABLE_ATTR,
     IdentifierIDField,  // Primal name.
     IdentifierIDField,  // Adjoint name.
-    BCFixed<1>,         // Adjoint is synthesized.
+    BCFixed<1>,         // Adjoint is primitive.
     BCFixed<32>,        // Indices' source.
     BCArray<BCFixed<1>> // Indices' parameters bitvector.
   >;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -315,6 +315,8 @@ namespace sil_block {
     SIL_REVERSE_DIFFERENTIABLE_ATTR,
     IdentifierIDField,  // Primal name.
     IdentifierIDField,  // Adjoint name.
+    BCFixed<1>,         // Primal is synthesized.
+    BCFixed<1>,         // Adjoint is synthesized.
     BCFixed<32>,        // Indices' source.
     BCArray<BCFixed<1>> // Indices' parameters bitvector.
   >;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -315,7 +315,6 @@ namespace sil_block {
     SIL_REVERSE_DIFFERENTIABLE_ATTR,
     IdentifierIDField,  // Primal name.
     IdentifierIDField,  // Adjoint name.
-    BCFixed<1>,         // Primal is synthesized.
     BCFixed<1>,         // Adjoint is synthesized.
     BCFixed<32>,        // Indices' source.
     BCArray<BCFixed<1>> // Indices' parameters bitvector.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -420,7 +420,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
         Out, ScratchRecord, differentiableAttrAbbrCode,
         S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getPrimalName())),
         S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getAdjointName())),
-        DA->isAdjointSynthesized(), indices.source, parameters);
+        DA->isAdjointPrimitive(), indices.source, parameters);
   }
 
   // Assign a unique ID to each basic block of the SILFunction.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -420,6 +420,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
         Out, ScratchRecord, differentiableAttrAbbrCode,
         S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getPrimalName())),
         S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getAdjointName())),
+        DA->isPrimalSynthesized(), DA->isAdjointSynthesized(),
         indices.source, parameters);
   }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -420,8 +420,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
         Out, ScratchRecord, differentiableAttrAbbrCode,
         S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getPrimalName())),
         S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getAdjointName())),
-        DA->isPrimalSynthesized(), DA->isAdjointSynthesized(),
-        indices.source, parameters);
+        DA->isAdjointSynthesized(), indices.source, parameters);
   }
 
   // Assign a unique ID to each basic block of the SILFunction.

--- a/test/AutoDiff/autodiff_basic.sil
+++ b/test/AutoDiff/autodiff_basic.sil
@@ -10,7 +10,7 @@ bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float):
   return %2 : $Float
 }
 
-sil hidden [reverse_differentiable source 0 wrt 0 primal @foo adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
+sil hidden [reverse_differentiable source 0 wrt 0 primal @foo adjoint @foo_adj primitive] @foo : $@convention(thin) (Float) -> Float {
 bb0(%0 : @trivial $Float):
   return %0 : $Float
 }

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -10,7 +10,7 @@ public func foo(_ x: Float, _ y: Float) -> Float {
   return 1
 }
 
-// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1 primal @foo adjoint @dfoo] @foo
+// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1 primal @foo adjoint @dfoo primitive] @foo
 
 @_silgen_name("dfoo")
 public func dfoo(_ x: Float, _ y: Float, partial: Float, seed: Float) -> (Float, Float) {
@@ -29,7 +29,7 @@ public func foo_indir_ret<T>(_ x: Float, _ y: T) -> T {
   return y
 }
 
-// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1 primal @foo_indir_ret adjoint @dfoo_indir_ret] @foo_indir_ret : $@convention(thin) <T> (Float, @in_guaranteed T) -> @out T {
+// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1 primal @foo_indir_ret adjoint @dfoo_indir_ret primitive] @foo_indir_ret : $@convention(thin) <T> (Float, @in_guaranteed T) -> @out T {
 // CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $Float, %2 : @trivial $*T):
 
 @_silgen_name("dfoo_indir_ret")
@@ -50,7 +50,7 @@ public func foo_tuple(_ x: ((Float, (Float, Float)), Float, ((Float))), _ y: Flo
   return 1
 }
 
-// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1, 2, 3, 4, 5 primal @foo_tuple adjoint @dfoo_tuple] @foo_tuple : $@convention(thin) (Float, Float, Float, Float, Float, Float) -> Float
+// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1, 2, 3, 4, 5 primal @foo_tuple adjoint @dfoo_tuple primitive] @foo_tuple : $@convention(thin) (Float, Float, Float, Float, Float, Float) -> Float
 
 @_silgen_name("dfoo_tuple")
 public func dfoo_tuple(_ x: ((Float, (Float, Float)), Float, ((Float))), _ y: Float, partial: Float, seed: Float) -> (((Float, (Float, Float)), Float, ((Float))), Float) {

--- a/test/AutoDiff/superset_adjoint.swift
+++ b/test/AutoDiff/superset_adjoint.swift
@@ -30,8 +30,29 @@ SupersetAdjointTests.test("SupersetNested") {
   expectEqual(2, #gradient(calls_mulxy, wrt: .1)(2, 3))
 }
 
-SupersetAdjointTests.test("CrossModule") {
+SupersetAdjointTests.test("CrossModuleClosure") {
   expectEqual(1, #gradient({ (x: Float, y: Float) in x + y }, wrt: .0)(1, 2))
 }
+
+// TODO: unbreak this test
+// SupersetAdjointTests.test("CrossModule") {
+//   expectEqual(1, #gradient((+) as (Float, Float) -> Float, wrt: .0)(1, 2))
+// }
+
+// TODO: unbreak this one too
+// @differentiable(reverse, wrt: (.0, .1), adjoint: dx_T)
+// func x_T<T>(_ x: Float, _ y: T) -> Float {
+//   if x > 1000 {
+//     return x
+//   }
+//   return x
+// }
+// func dx_T<T>(
+//     _ x: Float, _ y: T, primal: Float, seed: Float) -> (Float, T) {
+//   return (x, y)
+// }
+// SupersetAdjointTests.test("IndirectResults") {
+//   expectEqual(3, #gradient(x_T, wrt: .0)(2, Float(3)))
+// }
 
 runAllTests()

--- a/test/AutoDiff/superset_adjoint.swift
+++ b/test/AutoDiff/superset_adjoint.swift
@@ -1,0 +1,35 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var SupersetAdjointTests = TestSuite("SupersetAdjoint")
+
+@differentiable(reverse, wrt: (.0, .1), adjoint: dmulxy)
+func mulxy(_ x: Float, _ y: Float) -> Float {
+  // use control flow to prevent AD; NB fix when control flow is supported
+  if(x > 1000) {
+    return y
+  }
+  return x * y
+}
+func dmulxy(_ x: Float, _ y: Float, primal: Float, seed: Float)
+  -> (Float, Float) {
+  return (y * seed, x * seed)
+}
+
+func calls_mulxy(_ x: Float, _ y: Float) -> Float {
+  return mulxy(x, y)
+}
+
+SupersetAdjointTests.test("Superset") {
+  expectEqual((3, 2), #gradient(mulxy)(2, 3))
+  expectEqual(3, #gradient(mulxy, wrt: .0)(2, 3))
+}
+
+SupersetAdjointTests.test("SupersetNested") {
+  expectEqual((3, 2), #gradient(calls_mulxy)(2, 3))
+  expectEqual(3, #gradient(calls_mulxy, wrt: .0)(2, 3))
+}
+
+runAllTests()

--- a/test/AutoDiff/superset_adjoint.swift
+++ b/test/AutoDiff/superset_adjoint.swift
@@ -8,7 +8,7 @@ var SupersetAdjointTests = TestSuite("SupersetAdjoint")
 @differentiable(reverse, wrt: (.0, .1), adjoint: dmulxy)
 func mulxy(_ x: Float, _ y: Float) -> Float {
   // use control flow to prevent AD; NB fix when control flow is supported
-  if(x > 1000) {
+  if x > 1000 {
     return y
   }
   return x * y
@@ -23,13 +23,15 @@ func calls_mulxy(_ x: Float, _ y: Float) -> Float {
 }
 
 SupersetAdjointTests.test("Superset") {
-  expectEqual((3, 2), #gradient(mulxy)(2, 3))
   expectEqual(3, #gradient(mulxy, wrt: .0)(2, 3))
 }
 
 SupersetAdjointTests.test("SupersetNested") {
-  expectEqual((3, 2), #gradient(calls_mulxy)(2, 3))
-  expectEqual(3, #gradient(calls_mulxy, wrt: .0)(2, 3))
+  expectEqual(2, #gradient(calls_mulxy, wrt: .1)(2, 3))
+}
+
+SupersetAdjointTests.test("CrossModule") {
+  expectEqual(1, #gradient({ (x: Float, y: Float) in x + y }, wrt: .0)(1, 2))
 }
 
 runAllTests()


### PR DESCRIPTION
If a user provides a primitive adjoint for an `@differentiable` function, and AD or a `#gradient` instruction later requests the gradient of this function for a subset of the indices with respect to which the primitive adjoint provides derivatives, it would be surprising if the compiler then attempted autodiff of this function. It should instead generate gradient code that uses a subset of the indices of the primitive adjoint.

These changes:
- Add a field to the `[reverse_differentiable]` SIL attribute to mark whether the adjoint is primitive or synthetic.
- Allow synthesized gradient functions and nested adjoints to call adjoint functions that provide a superset of the required indices.
- Enable this behavior only for primitive adjoints.
- Per Richard, make `lookup` -> `lookUp` for consistency with upstream.