### PR TITLE
[AST] Ill-formed @objc protocols might have associated types.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3651,13 +3651,22 @@ ProtocolDecl::getInheritedProtocols() const {
 llvm::TinyPtrVector<AssociatedTypeDecl *>
 ProtocolDecl::getAssociatedTypeMembers() const {
   llvm::TinyPtrVector<AssociatedTypeDecl *> result;
-  if (!hasClangNode()) {
-    for (auto member : getMembers()) {
-      if (auto ATD = dyn_cast<AssociatedTypeDecl>(member)) {
-        result.push_back(ATD);
-      }
+
+  // Clang-imported protocols never have associated types.
+  if (hasClangNode())
+    return result;
+
+  // Deserialized @objc protocols never have associated types.
+  if (!getParentSourceFile() && isObjC())
+    return result;
+
+  // Find the associated type declarations.
+  for (auto member : getMembers()) {
+    if (auto ATD = dyn_cast<AssociatedTypeDecl>(member)) {
+      result.push_back(ATD);
     }
   }
+
   return result;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3651,7 +3651,7 @@ ProtocolDecl::getInheritedProtocols() const {
 llvm::TinyPtrVector<AssociatedTypeDecl *>
 ProtocolDecl::getAssociatedTypeMembers() const {
   llvm::TinyPtrVector<AssociatedTypeDecl *> result;
-  if (!isObjC()) {
+  if (!hasClangNode()) {
     for (auto member : getMembers()) {
       if (auto ATD = dyn_cast<AssociatedTypeDecl>(member)) {
         result.push_back(ATD);

--- a/validation-test/Runtime/sr8666.swift
+++ b/validation-test/Runtime/sr8666.swift
@@ -1,0 +1,57 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+private protocol AnyChangeTracker {
+    var myVariable: Any? { get }
+    var isModified: Bool { get }
+}
+
+protocol ChangeTrackerType {
+    associatedtype Value
+    var originalValue: Value { get }
+    var value: Value { get set }
+    var isModified: Bool { get }
+}
+
+extension ChangeTrackerType where Value: Equatable {
+    var isModified: Bool {
+	return value != originalValue
+    }
+}
+
+struct ChangeTracker<T: Equatable>: ChangeTrackerType {
+    let originalValue: T
+    var value: T
+
+    init(value: T) {
+	originalValue = value
+	self.value = value
+    }
+}
+
+extension ChangeTracker: AnyChangeTracker where Value: OptionalType, Value.Wrapped: Equatable {
+    var myVariable: Any? {
+	return value
+    }
+}
+
+protocol OptionalType {
+    associatedtype Wrapped
+    var value: Wrapped? { get }
+}
+
+extension Optional: OptionalType {
+    var value: Wrapped? {
+	return self
+    }
+}
+
+let s: Any = ChangeTracker<String?>(value: "Foo")
+
+guard let s = s as? AnyChangeTracker else {
+  fatalError("Does not comply to AnyChangeTracker")
+}
+
+let myVar = String(describing: s.myVariable ?? "nil")
+assert(myVar == "Optional(\"Foo\")")
+

--- a/validation-test/compiler_crashers_2_fixed/0176-sr-8094.swift
+++ b/validation-test/compiler_crashers_2_fixed/0176-sr-8094.swift
@@ -1,0 +1,14 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+@objc protocol Foo {
+    associatedtype Bar
+    var property: Generic<Bar> { get }
+}
+
+class Generic<Element> {
+}
+
+class FooImpl<T>: NSObject, Foo {
+    let property: Generic<T>
+}
+

--- a/validation-test/compiler_crashers_fixed/28859-resolver-unable-to-resolve-type-witness.swift
+++ b/validation-test/compiler_crashers_fixed/28859-resolver-unable-to-resolve-type-witness.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 class a:P@objc protocol P{{}func a:a{}{}typealias a


### PR DESCRIPTION
As an optimization, we don't even look for associated types in @objc
protocols. However, this could lead to broken invariants like "every
associated type has a witness" in ill-formed @objc protocols that do
have associated types.

Implement this optimization by checking whether the protocol has a
Clang node. Fixes rdar://problem/41425828 / SR-8094.