### PR TITLE
Extend operator decls to allow any designated nominal type for lookup.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6383,24 +6383,24 @@ class OperatorDecl : public Decl {
   
   Identifier name;
 
-  Identifier DesignatedProtocolName;
-  SourceLoc DesignatedProtocolNameLoc;
-  ProtocolDecl *DesignatedProtocol = nullptr;
+  Identifier DesignatedNominalTypeName;
+  SourceLoc DesignatedNominalTypeNameLoc;
+  NominalTypeDecl *DesignatedNominalType = nullptr;
 
 public:
   OperatorDecl(DeclKind kind, DeclContext *DC, SourceLoc OperatorLoc,
                Identifier Name, SourceLoc NameLoc,
-               Identifier DesignatedProtocolName = Identifier(),
-               SourceLoc DesignatedProtocolNameLoc = SourceLoc())
+               Identifier DesignatedNominalTypeName = Identifier(),
+               SourceLoc DesignatedNominalTypeNameLoc = SourceLoc())
       : Decl(kind, DC), OperatorLoc(OperatorLoc), NameLoc(NameLoc), name(Name),
-        DesignatedProtocolName(DesignatedProtocolName),
-        DesignatedProtocolNameLoc(DesignatedProtocolNameLoc) {}
+        DesignatedNominalTypeName(DesignatedNominalTypeName),
+        DesignatedNominalTypeNameLoc(DesignatedNominalTypeNameLoc) {}
 
   OperatorDecl(DeclKind kind, DeclContext *DC, SourceLoc OperatorLoc,
                Identifier Name, SourceLoc NameLoc,
-               ProtocolDecl *DesignatedProtocol)
+               NominalTypeDecl *DesignatedNominalType)
       : Decl(kind, DC), OperatorLoc(OperatorLoc), NameLoc(NameLoc), name(Name),
-        DesignatedProtocol(DesignatedProtocol) {}
+        DesignatedNominalType(DesignatedNominalType) {}
 
   SourceLoc getLoc() const { return NameLoc; }
 
@@ -6408,18 +6408,20 @@ public:
   SourceLoc getNameLoc() const { return NameLoc; }
   Identifier getName() const { return name; }
 
-  Identifier getDesignatedProtocolName() const {
-    return DesignatedProtocolName;
+  Identifier getDesignatedNominalTypeName() const {
+    return DesignatedNominalTypeName;
   }
 
-  SourceLoc getDesignatedProtocolNameLoc() const {
-    return DesignatedProtocolNameLoc;
+  SourceLoc getDesignatedNominalTypeNameLoc() const {
+    return DesignatedNominalTypeNameLoc;
   }
 
-  ProtocolDecl *getDesignatedProtocol() const { return DesignatedProtocol; }
+  NominalTypeDecl *getDesignatedNominalType() const {
+    return DesignatedNominalType;
+  }
 
-  void setDesignatedProtocol(ProtocolDecl *protocol) {
-    DesignatedProtocol = protocol;
+  void setDesignatedNominalType(NominalTypeDecl *nominal) {
+    DesignatedNominalType = nominal;
   }
 
   static bool classof(const Decl *D) {
@@ -6455,9 +6457,9 @@ public:
   InfixOperatorDecl(DeclContext *DC, SourceLoc operatorLoc, Identifier name,
                     SourceLoc nameLoc, SourceLoc colonLoc,
                     Identifier firstIdentifier, SourceLoc firstIdentifierLoc,
-                    ProtocolDecl *designatedProtocol)
+                    NominalTypeDecl *designatedNominalType)
       : OperatorDecl(DeclKind::InfixOperator, DC, operatorLoc, name, nameLoc,
-                     designatedProtocol),
+                     designatedNominalType),
         ColonLoc(colonLoc), FirstIdentifierLoc(firstIdentifierLoc),
         FirstIdentifier(firstIdentifier) {}
 
@@ -6504,15 +6506,15 @@ class PrefixOperatorDecl : public OperatorDecl {
 public:
   PrefixOperatorDecl(DeclContext *DC, SourceLoc OperatorLoc, Identifier Name,
                      SourceLoc NameLoc,
-                     Identifier DesignatedProtocolName = Identifier(),
-                     SourceLoc DesignatedProtocolNameLoc = SourceLoc())
+                     Identifier DesignatedNominalTypeName = Identifier(),
+                     SourceLoc DesignatedNominalTypeNameLoc = SourceLoc())
       : OperatorDecl(DeclKind::PrefixOperator, DC, OperatorLoc, Name, NameLoc,
-                     DesignatedProtocolName, DesignatedProtocolNameLoc) {}
+                     DesignatedNominalTypeName, DesignatedNominalTypeNameLoc) {}
 
   PrefixOperatorDecl(DeclContext *DC, SourceLoc OperatorLoc, Identifier Name,
-                     SourceLoc NameLoc, ProtocolDecl *DesignatedProtocol)
+                     SourceLoc NameLoc, NominalTypeDecl *DesignatedNominalType)
       : OperatorDecl(DeclKind::PrefixOperator, DC, OperatorLoc, Name, NameLoc,
-                     DesignatedProtocol) {}
+                     DesignatedNominalType) {}
 
   SourceRange getSourceRange() const {
     return { getOperatorLoc(), getNameLoc() };
@@ -6538,15 +6540,15 @@ class PostfixOperatorDecl : public OperatorDecl {
 public:
   PostfixOperatorDecl(DeclContext *DC, SourceLoc OperatorLoc, Identifier Name,
                       SourceLoc NameLoc,
-                      Identifier DesignatedProtocolName = Identifier(),
-                      SourceLoc DesignatedProtocolNameLoc = SourceLoc())
+                      Identifier DesignatedNominalTypeName = Identifier(),
+                      SourceLoc DesignatedNominalTypeNameLoc = SourceLoc())
       : OperatorDecl(DeclKind::PostfixOperator, DC, OperatorLoc, Name, NameLoc,
-                     DesignatedProtocolName, DesignatedProtocolNameLoc) {}
+                     DesignatedNominalTypeName, DesignatedNominalTypeNameLoc) {}
 
   PostfixOperatorDecl(DeclContext *DC, SourceLoc OperatorLoc, Identifier Name,
-                      SourceLoc NameLoc, ProtocolDecl *DesignatedProtocol)
+                      SourceLoc NameLoc, NominalTypeDecl *DesignatedNominalType)
       : OperatorDecl(DeclKind::PostfixOperator, DC, OperatorLoc, Name, NameLoc,
-                     DesignatedProtocol) {}
+                     DesignatedNominalType) {}
 
   SourceRange getSourceRange() const {
     return { getOperatorLoc(), getNameLoc() };

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -432,7 +432,7 @@ ERROR(operator_decl_no_fixity,none,
       "operator must be declared as 'prefix', 'postfix', or 'infix'", ())
 
 ERROR(operator_decl_trailing_comma,none,
-      "expected designated protocol in operator declaration", ())
+      "expected designated type in operator declaration", ())
 
 // PrecedenceGroup
 ERROR(precedencegroup_not_infix,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -706,10 +706,6 @@ ERROR(unspaced_unary_operator,none,
       "unary operators must not be juxtaposed; parenthesize inner expression",
       ())
 
-ERROR(operators_designated_protocol_not_a_protocol,none,
-      "type %0 unexpected; expected a protocol type",
-      (Type))
-
 ERROR(use_unresolved_identifier,none,
       "use of unresolved %select{identifier|operator}1 %0", (DeclName, bool))
 ERROR(use_unresolved_identifier_corrected,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -193,12 +193,12 @@ namespace swift {
     /// Disable constraint system performance hacks.
     bool DisableConstraintSolverPerformanceHacks = false;
 
-    /// \brief Enable experimental operator protocol designator feature.
-    bool EnableOperatorDesignatedProtocols = false;
+    /// \brief Enable experimental operator designated types feature.
+    bool EnableOperatorDesignatedTypes = false;
 
     /// \brief Enable constraint solver support for experimental
     ///        operator protocol designator feature.
-    bool SolverEnableOperatorDesignatedProtocols = false;
+    bool SolverEnableOperatorDesignatedTypes = false;
 
     /// The maximum depth to which to test decl circularity.
     unsigned MaxCircularityDepth = 500;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -373,13 +373,13 @@ def solver_disable_shrink :
 def disable_constraint_solver_performance_hacks : Flag<["-"], "disable-constraint-solver-performance-hacks">,
   HelpText<"Disable all the hacks in the constraint solver">;
 
-def enable_operator_designated_protocols :
-  Flag<["-"], "enable-operator-designated-protocols">,
-  HelpText<"Enable operator designated protocols">;
+def enable_operator_designated_types :
+  Flag<["-"], "enable-operator-designated-types">,
+  HelpText<"Enable operator designated types">;
 
-def solver_enable_operator_designated_protocols :
-  Flag<["-"], "solver-enable-operator-designated-protocols">,
-  HelpText<"Enable operator designated protocols in constraint solver">;
+def solver_enable_operator_designated_types :
+  Flag<["-"], "solver-enable-operator-designated-types">,
+  HelpText<"Enable operator designated types in constraint solver">;
 
 def switch_checking_invocation_threshold_EQ : Joined<["-"],
     "switch-checking-invocation-threshold=">;

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 451; // Last change: pattern initializer text
+const uint16_t VERSION_MINOR = 452; // Last change: nominal types for operators
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2949,8 +2949,8 @@ void PrintAST::visitPrefixOperatorDecl(PrefixOperatorDecl *decl) {
     [&]{
       Printer.printName(decl->getName());
     });
-  if (!decl->getDesignatedProtocolName().empty())
-    Printer << " : " << decl->getDesignatedProtocolName();
+  if (!decl->getDesignatedNominalTypeName().empty())
+    Printer << " : " << decl->getDesignatedNominalTypeName();
 }
 
 void PrintAST::visitPostfixOperatorDecl(PostfixOperatorDecl *decl) {
@@ -2960,8 +2960,8 @@ void PrintAST::visitPostfixOperatorDecl(PostfixOperatorDecl *decl) {
     [&]{
       Printer.printName(decl->getName());
     });
-  if (!decl->getDesignatedProtocolName().empty())
-    Printer << " : " << decl->getDesignatedProtocolName();
+  if (!decl->getDesignatedNominalTypeName().empty())
+    Printer << " : " << decl->getDesignatedNominalTypeName();
 }
 
 void PrintAST::visitModuleDecl(ModuleDecl *decl) { }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -161,11 +161,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalPropertyBehaviors |=
     Args.hasArg(OPT_enable_experimental_property_behaviors);
 
-  Opts.EnableOperatorDesignatedProtocols |=
-      Args.hasArg(OPT_enable_operator_designated_protocols);
+  Opts.EnableOperatorDesignatedTypes |=
+      Args.hasArg(OPT_enable_operator_designated_types);
 
-  Opts.SolverEnableOperatorDesignatedProtocols |=
-      Args.hasArg(OPT_solver_enable_operator_designated_protocols);
+  Opts.SolverEnableOperatorDesignatedTypes |=
+      Args.hasArg(OPT_solver_enable_operator_designated_types);
 
   if (auto A = Args.getLastArg(OPT_enable_deserialization_recovery,
                                OPT_disable_deserialization_recovery)) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6503,11 +6503,12 @@ Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
   if (Tok.is(tok::colon)) {
     SyntaxParsingContext GroupCtxt(SyntaxContext, SyntaxKind::InfixOperatorGroup);
     colonLoc = consumeToken();
-    if (Tok.is(tok::identifier)) {
-      firstIdentifierName = Context.getIdentifier(Tok.getText());
-      firstIdentifierNameLoc = consumeToken(tok::identifier);
 
-      if (Context.LangOpts.EnableOperatorDesignatedProtocols) {
+    if (Context.LangOpts.EnableOperatorDesignatedTypes) {
+      if (Tok.is(tok::identifier)) {
+        firstIdentifierName = Context.getIdentifier(Tok.getText());
+        firstIdentifierNameLoc = consumeToken(tok::identifier);
+
         if (consumeIf(tok::comma)) {
           if (isPrefix || isPostfix)
             diagnose(colonLoc, diag::precedencegroup_not_infix)
@@ -6521,7 +6522,12 @@ Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
             diagnose(otherTokLoc, diag::operator_decl_trailing_comma);
           }
         }
-      } else if (isPrefix || isPostfix) {
+      }
+    } else if (Tok.is(tok::identifier)) {
+      firstIdentifierName = Context.getIdentifier(Tok.getText());
+      firstIdentifierNameLoc = consumeToken(tok::identifier);
+
+      if (isPrefix || isPostfix) {
         diagnose(colonLoc, diag::precedencegroup_not_infix)
             .fixItRemove({colonLoc, firstIdentifierNameLoc});
       }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2061,9 +2061,9 @@ PrecedenceGroupDecl *TypeChecker::lookupPrecedenceGroup(DeclContext *dc,
   return group;
 }
 
-static void checkDesignatedProtocol(OperatorDecl *OD, Identifier name,
-                                    SourceLoc loc, TypeChecker &tc,
-                                    ASTContext &ctx) {
+static void checkDesignatedTypes(OperatorDecl *OD, Identifier name,
+                                 SourceLoc loc, TypeChecker &tc,
+                                 ASTContext &ctx) {
   auto *dc = OD->getDeclContext();
   auto *TyR = new (ctx) SimpleIdentTypeRepr(loc, name);
   TypeLoc typeLoc = TypeLoc(TyR);
@@ -2074,17 +2074,11 @@ static void checkDesignatedProtocol(OperatorDecl *OD, Identifier name,
   }
 
   if (!typeLoc.isError()) {
-    auto *decl = typeLoc.getType()->getNominalOrBoundGenericNominal();
-    if (!decl || !isa<ProtocolDecl>(decl)) {
-      tc.diagnose(typeLoc.getLoc(),
-                  diag::operators_designated_protocol_not_a_protocol,
-                  typeLoc.getType());
-      OD->setInvalid();
-    } else {
-      OD->setDesignatedProtocol(cast<ProtocolDecl>(decl));
-      // FIXME: verify this operator has a declaration within this
-      //        protocol with the same arity and fixity
-    }
+    auto *decl = typeLoc.getType()->getAnyNominal();
+    assert(decl);
+    OD->setDesignatedNominalType(decl);
+    // FIXME: verify this operator has a declaration within this
+    //        protocol with the same arity and fixity
   }
 }
 
@@ -2099,17 +2093,16 @@ void TypeChecker::validateDecl(OperatorDecl *OD) {
 
   auto IOD = dyn_cast<InfixOperatorDecl>(OD);
 
-  auto enableOperatorDesignatedProtocols =
-      getLangOpts().EnableOperatorDesignatedProtocols;
+  auto enableOperatorDesignatedTypes =
+      getLangOpts().EnableOperatorDesignatedTypes;
 
   // Pre- or post-fix operator?
   if (!IOD) {
-    auto *protocol = OD->getDesignatedProtocol();
-    auto protocolId = OD->getDesignatedProtocolName();
-    if (!protocol && !protocolId.empty() &&
-        enableOperatorDesignatedProtocols) {
-      auto protocolIdLoc = OD->getDesignatedProtocolNameLoc();
-      checkDesignatedProtocol(OD, protocolId, protocolIdLoc, *this, Context);
+    auto *protocol = OD->getDesignatedNominalType();
+    auto protocolId = OD->getDesignatedNominalTypeName();
+    if (!protocol && !protocolId.empty() && enableOperatorDesignatedTypes) {
+      auto protocolIdLoc = OD->getDesignatedNominalTypeNameLoc();
+      checkDesignatedTypes(OD, protocolId, protocolIdLoc, *this, Context);
     }
     return;
   }
@@ -2127,20 +2120,20 @@ void TypeChecker::validateDecl(OperatorDecl *OD) {
     }
 
     auto secondId = IOD->getSecondIdentifier();
-    auto *protocol = IOD->getDesignatedProtocol();
-    if (!protocol && enableOperatorDesignatedProtocols) {
+    auto *protocol = IOD->getDesignatedNominalType();
+    if (!protocol && enableOperatorDesignatedTypes) {
       auto secondIdLoc = IOD->getSecondIdentifierLoc();
       assert(secondId.empty() || !firstId.empty());
 
       auto protocolId = group ? secondId : firstId;
       auto protocolIdLoc = group ? secondIdLoc : firstIdLoc;
       if (!protocolId.empty())
-        checkDesignatedProtocol(IOD, protocolId, protocolIdLoc, *this, Context);
+        checkDesignatedTypes(IOD, protocolId, protocolIdLoc, *this, Context);
     }
 
     if (!group && !IOD->isInvalid()) {
       if (!firstId.empty() &&
-          (!secondId.empty() || !IOD->getDesignatedProtocol())) {
+          (!secondId.empty() || !IOD->getDesignatedNominalType())) {
         diagnose(firstIdLoc, diag::unknown_precedence_group, firstId);
         IOD->setInvalid();
       }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2098,11 +2098,11 @@ void TypeChecker::validateDecl(OperatorDecl *OD) {
 
   // Pre- or post-fix operator?
   if (!IOD) {
-    auto *protocol = OD->getDesignatedNominalType();
-    auto protocolId = OD->getDesignatedNominalTypeName();
-    if (!protocol && !protocolId.empty() && enableOperatorDesignatedTypes) {
-      auto protocolIdLoc = OD->getDesignatedNominalTypeNameLoc();
-      checkDesignatedTypes(OD, protocolId, protocolIdLoc, *this, Context);
+    auto *nominal = OD->getDesignatedNominalType();
+    auto nominalId = OD->getDesignatedNominalTypeName();
+    if (!nominal && !nominalId.empty() && enableOperatorDesignatedTypes) {
+      auto nominalIdLoc = OD->getDesignatedNominalTypeNameLoc();
+      checkDesignatedTypes(OD, nominalId, nominalIdLoc, *this, Context);
     }
     return;
   }
@@ -2120,15 +2120,15 @@ void TypeChecker::validateDecl(OperatorDecl *OD) {
     }
 
     auto secondId = IOD->getSecondIdentifier();
-    auto *protocol = IOD->getDesignatedNominalType();
-    if (!protocol && enableOperatorDesignatedTypes) {
+    auto *nominal = IOD->getDesignatedNominalType();
+    if (!nominal && enableOperatorDesignatedTypes) {
       auto secondIdLoc = IOD->getSecondIdentifierLoc();
       assert(secondId.empty() || !firstId.empty());
 
-      auto protocolId = group ? secondId : firstId;
-      auto protocolIdLoc = group ? secondIdLoc : firstIdLoc;
-      if (!protocolId.empty())
-        checkDesignatedTypes(IOD, protocolId, protocolIdLoc, *this, Context);
+      auto nominalId = group ? secondId : firstId;
+      auto nominalIdLoc = group ? secondIdLoc : firstIdLoc;
+      if (!nominalId.empty())
+        checkDesignatedTypes(IOD, nominalId, nominalIdLoc, *this, Context);
     }
 
     if (!group && !IOD->isInvalid()) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3399,19 +3399,19 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
   case decls_block::PREFIX_OPERATOR_DECL: {
     IdentifierID nameID;
     DeclContextID contextID;
-    DeclID protoID;
+    DeclID nominalID;
 
     decls_block::PrefixOperatorLayout::readRecord(scratch, nameID, contextID,
-                                                  protoID);
+                                                  nominalID);
     auto DC = getDeclContext(contextID);
 
-    Expected<Decl *> protocol = getDeclChecked(protoID);
-    if (!protocol)
-      return protocol.takeError();
+    Expected<Decl *> nominal = getDeclChecked(nominalID);
+    if (!nominal)
+      return nominal.takeError();
 
     auto result = createDecl<PrefixOperatorDecl>(
         DC, SourceLoc(), getIdentifier(nameID), SourceLoc(),
-        cast_or_null<ProtocolDecl>(protocol.get()));
+        cast_or_null<NominalTypeDecl>(nominal.get()));
 
     declOrOffset = result;
     break;
@@ -3420,20 +3420,20 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
   case decls_block::POSTFIX_OPERATOR_DECL: {
     IdentifierID nameID;
     DeclContextID contextID;
-    DeclID protoID;
+    DeclID nominalID;
 
     decls_block::PostfixOperatorLayout::readRecord(scratch, nameID, contextID,
-                                                   protoID);
+                                                   nominalID);
 
     auto DC = getDeclContext(contextID);
 
-    Expected<Decl *> protocol = getDeclChecked(protoID);
-    if (!protocol)
-      return protocol.takeError();
+    Expected<Decl *> nominal = getDeclChecked(nominalID);
+    if (!nominal)
+      return nominal.takeError();
 
     auto result = createDecl<PostfixOperatorDecl>(
         DC, SourceLoc(), getIdentifier(nameID), SourceLoc(),
-        cast_or_null<ProtocolDecl>(protocol.get()));
+        cast_or_null<NominalTypeDecl>(nominal.get()));
 
     declOrOffset = result;
     break;
@@ -3443,10 +3443,10 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
     IdentifierID nameID;
     DeclContextID contextID;
     DeclID precedenceGroupID;
-    DeclID protoID;
+    DeclID nominalID;
 
     decls_block::InfixOperatorLayout::readRecord(scratch, nameID, contextID,
-                                                 precedenceGroupID, protoID);
+                                                 precedenceGroupID, nominalID);
 
     PrecedenceGroupDecl *precedenceGroup = nullptr;
     Identifier precedenceGroupName;
@@ -3460,14 +3460,14 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
 
     auto DC = getDeclContext(contextID);
 
-    Expected<Decl *> protocol = getDeclChecked(protoID);
-    if (!protocol)
-      return protocol.takeError();
+    Expected<Decl *> nominal = getDeclChecked(nominalID);
+    if (!nominal)
+      return nominal.takeError();
 
     auto result = createDecl<InfixOperatorDecl>(
         DC, SourceLoc(), getIdentifier(nameID), SourceLoc(), SourceLoc(),
         precedenceGroupName, SourceLoc(),
-        cast_or_null<ProtocolDecl>(protocol.get()));
+        cast_or_null<NominalTypeDecl>(nominal.get()));
     result->setPrecedenceGroup(precedenceGroup);
 
     declOrOffset = result;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2878,7 +2878,7 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(op->getDeclContext());
     auto nameID = addDeclBaseNameRef(op->getName());
     auto groupID = addDeclRef(op->getPrecedenceGroup());
-    auto protoID = addDeclRef(op->getDesignatedProtocol());
+    auto protoID = addDeclRef(op->getDesignatedNominalType());
 
     unsigned abbrCode = DeclTypeAbbrCodes[InfixOperatorLayout::Code];
     InfixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode, nameID,
@@ -2891,7 +2891,7 @@ void Serializer::writeDecl(const Decl *D) {
     verifyAttrSerializable(op);
 
     auto contextID = addDeclContextRef(op->getDeclContext());
-    auto protoID = addDeclRef(op->getDesignatedProtocol());
+    auto protoID = addDeclRef(op->getDesignatedNominalType());
 
     unsigned abbrCode = DeclTypeAbbrCodes[PrefixOperatorLayout::Code];
     PrefixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
@@ -2905,7 +2905,7 @@ void Serializer::writeDecl(const Decl *D) {
     verifyAttrSerializable(op);
 
     auto contextID = addDeclContextRef(op->getDeclContext());
-    auto protoID = addDeclRef(op->getDesignatedProtocol());
+    auto protoID = addDeclRef(op->getDesignatedNominalType());
 
     unsigned abbrCode = DeclTypeAbbrCodes[PostfixOperatorLayout::Code];
     PostfixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2878,11 +2878,11 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(op->getDeclContext());
     auto nameID = addDeclBaseNameRef(op->getName());
     auto groupID = addDeclRef(op->getPrecedenceGroup());
-    auto protoID = addDeclRef(op->getDesignatedNominalType());
+    auto nominalID = addDeclRef(op->getDesignatedNominalType());
 
     unsigned abbrCode = DeclTypeAbbrCodes[InfixOperatorLayout::Code];
     InfixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode, nameID,
-                                    contextID, groupID, protoID);
+                                    contextID, groupID, nominalID);
     break;
   }
 
@@ -2891,12 +2891,12 @@ void Serializer::writeDecl(const Decl *D) {
     verifyAttrSerializable(op);
 
     auto contextID = addDeclContextRef(op->getDeclContext());
-    auto protoID = addDeclRef(op->getDesignatedNominalType());
+    auto nominalID = addDeclRef(op->getDesignatedNominalType());
 
     unsigned abbrCode = DeclTypeAbbrCodes[PrefixOperatorLayout::Code];
     PrefixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                      addDeclBaseNameRef(op->getName()),
-                                     contextID, protoID);
+                                     contextID, nominalID);
     break;
   }
 
@@ -2905,12 +2905,12 @@ void Serializer::writeDecl(const Decl *D) {
     verifyAttrSerializable(op);
 
     auto contextID = addDeclContextRef(op->getDeclContext());
-    auto protoID = addDeclRef(op->getDesignatedNominalType());
+    auto nominalID = addDeclRef(op->getDesignatedNominalType());
 
     unsigned abbrCode = DeclTypeAbbrCodes[PostfixOperatorLayout::Code];
     PostfixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                       addDeclBaseNameRef(op->getName()),
-                                      contextID, protoID);
+                                      contextID, nominalID);
     break;
   }
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -13,7 +13,7 @@ if(SWIFT_RUNTIME_USE_SANITIZERS)
   endif()
 endif()
 
-list(APPEND SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "-Xfrontend" "-verify-syntax-tree" "-Xfrontend" "-enable-operator-designated-protocols")
+list(APPEND SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "-Xfrontend" "-verify-syntax-tree" "-Xfrontend" "-enable-operator-designated-types")
 
 # Build the runtime with -Wall to catch, e.g., uninitialized variables
 # warnings.

--- a/test/Constraints/fast-operator-typechecking.swift
+++ b/test/Constraints/fast-operator-typechecking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-enable-operator-designated-protocols -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-enable-operator-designated-types -solver-disable-shrink -disable-constraint-solver-performance-hacks
 
 // rdar://problem/32998180
 func checksum(value: UInt16) -> UInt16 {

--- a/test/Parse/operator_decl_designated_types.swift
+++ b/test/Parse/operator_decl_designated_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-operator-designated-protocols
+// RUN: %target-typecheck-verify-swift -enable-operator-designated-types
 
 precedencegroup LowPrecedence {
   associativity: right
@@ -47,23 +47,16 @@ postfix operator +*+> : UndeclaredProtocol
 struct Struct {}
 class Class {}
 infix operator *>*> : Struct
-// expected-error@-1 {{type 'Struct' unexpected; expected a protocol type}}
-
 infix operator >**> : Class
-// expected-error@-1 {{type 'Class' unexpected; expected a protocol type}}
 
 prefix operator **>> : Struct
-// expected-error@-1 {{type 'Struct' unexpected; expected a protocol type}}
 prefix operator *>*> : Class
-// expected-error@-1 {{type 'Class' unexpected; expected a protocol type}}
 
 postfix operator >*>* : Struct
-// expected-error@-1 {{type 'Struct' unexpected; expected a protocol type}}
 postfix operator >>** : Class
-// expected-error@-1 {{type 'Class' unexpected; expected a protocol type}}
 
 infix operator  <*<<< : MediumPrecedence, &
-// expected-error@-1 {{expected designated protocol in operator declaration}}
+// expected-error@-1 {{expected designated type in operator declaration}}
 
 infix operator **^^ : MediumPrecedence // expected-note {{previous operator declaration here}}
 infix operator **^^ : InfixMagicOperatorProtocol // expected-error {{operator redeclared}}

--- a/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
+++ b/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-protocols
+// RUN: %target-typecheck-verify-swift -swift-version 4 -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(_ i: Int, _ j: Int) -> Int {

--- a/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-protocols
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let _: (Character) -> Bool = { c in

--- a/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-protocols
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 _ = [1, 3, 5, 7, 11].filter{ $0 == 1 || $0 == 3 || $0 == 11 || $0 == 1 || $0 == 3 || $0 == 11 } == [ 1, 3, 11 ]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-protocols
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(n: Int) -> Int {

--- a/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-protocols
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let a = 1

--- a/validation-test/Sema/type_checker_perf/fast/rdar31742586.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31742586.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-protocols
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func rdar31742586() -> Double {

--- a/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-protocols
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test() {

--- a/validation-test/Sema/type_checker_perf/fast/rdar42672946.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar42672946.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-protocols
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 func f(tail: UInt64, byteCount: UInt64) {
   if tail & ~(1 << ((byteCount & 7) << 3) - 1) == 0 { }
 }


### PR DESCRIPTION
Rather than limiting this to protocols, allow any nominal type.

Rename -enable-operator-designated-protocols to
-enable-operator-designated-types to reflect the change.
