### PR TITLE
[Differentiability] Add differentiability to ExtInfo and an @autodiff type attribute

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -52,6 +52,9 @@ TYPE_ATTR(convention)
 TYPE_ATTR(noreturn)
 TYPE_ATTR(noescape)
 TYPE_ATTR(escaping)
+// SWIFT_ENABLE_TENSORFLOW
+TYPE_ATTR(autodiff)
+TYPE_ATTR(nodiff)
 
 // SIL-specific attributes
 TYPE_ATTR(block_storage)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -63,6 +63,8 @@ public:
   SourceLoc AtLoc;
   Optional<StringRef> convention = None;
   Optional<StringRef> conventionWitnessMethodProtocol = None;
+  // SWIFT_ENABLE_TENSORFLOW
+  Optional<std::pair<StringRef, int>> differentiabilityAndOrder = None;
 
   // For an opened existential type, the known ID.
   Optional<UUID> OpenedID;
@@ -109,6 +111,14 @@ public:
   
   bool hasConvention() const { return convention.hasValue(); }
   StringRef getConvention() const { return *convention; }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  bool hasDifferentiability() const {
+    return differentiabilityAndOrder.hasValue();
+  }
+  std::pair<StringRef, int> getDifferentiabilityAndOrder() const {
+    return *differentiabilityAndOrder;
+  }
 
   bool hasOwnership() const {
     return getOwnership() != ReferenceOwnership::Strong;

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -78,6 +78,47 @@ public:
   }
 };
 
+class AnyFunctionType;
+
+/// Differentiability of a function specifies the differentiation mode,
+/// parameter indices at which the function is differentiable with respect to,
+/// and indices of results which can be differentiated.
+class Differentiability {
+private:
+  // The differentiation mode.
+  AutoDiffMode mode;
+  // Differentiable with respect to `self`, applicable to methods only.
+  bool wrtSelf;
+  // Indices of parameters that are differentiable with respect to.
+  llvm::SmallBitVector parameterIndices;
+  // Indices of results that are differentiable.
+  llvm::SmallBitVector resultIndices;
+
+public:
+  Differentiability(AutoDiffMode mode,
+                    bool wrtSelf,
+                    llvm::SmallBitVector parameterIndices,
+                    llvm::SmallBitVector resultIndices);
+
+  Differentiability(AutoDiffMode mode, AnyFunctionType *type);
+
+  AutoDiffMode getMode() const {
+    return mode;
+  }
+
+  bool isWithRespectToSelf() const {
+    return wrtSelf;
+  }
+
+  const llvm::SmallBitVector &getParameterIndices() const {
+    return parameterIndices;
+  }
+
+  const llvm::SmallBitVector &getResultIndices() const {
+    return resultIndices;
+  }
+};
+
 /// SIL-level automatic differentiation indices. Consists of a source index,
 /// i.e. index of the dependent result to differentiate from, and parameter
 /// indices, i.e. index of independent parameters to differentiate with

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1382,6 +1382,15 @@ ERROR(convention_attribute_witness_method_expected_colon,none,
 ERROR(convention_attribute_witness_method_expected_protocol,none,
       "expected protocol name in 'witness_method' 'convention' attribute", ())
 
+// SWIFT_ENABLE_TENSORFLOW
+// autodiff
+ERROR(autodiff_attribute_expected_mode,none,
+      "expected differentiation mode in 'convention' attribute", ())
+ERROR(autodiff_attribute_expected_rparen,none,
+      "expected ')' after convention name for 'autodiff' attribute", ())
+ERROR(autodiff_attribute_order_expected_unsigned_integer,none,
+      "expected an unsigned integer as the differentiation order", ())
+
 // objc
 ERROR(attr_objc_missing_colon,none,
       "missing ':' after selector piece in @objc attribute", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1382,15 +1382,6 @@ ERROR(convention_attribute_witness_method_expected_colon,none,
 ERROR(convention_attribute_witness_method_expected_protocol,none,
       "expected protocol name in 'witness_method' 'convention' attribute", ())
 
-// SWIFT_ENABLE_TENSORFLOW
-// autodiff
-ERROR(autodiff_attribute_expected_mode,none,
-      "expected differentiation mode in 'convention' attribute", ())
-ERROR(autodiff_attribute_expected_rparen,none,
-      "expected ')' after convention name for 'autodiff' attribute", ())
-ERROR(autodiff_attribute_order_expected_unsigned_integer,none,
-      "expected an unsigned integer as the differentiation order", ())
-
 // objc
 ERROR(attr_objc_missing_colon,none,
       "missing ':' after selector piece in @objc attribute", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3679,6 +3679,15 @@ ERROR(unsupported_convention,none,
 ERROR(unreferenced_generic_parameter,none,
       "generic parameter '%0' is not used in function signature", (StringRef))
 
+// SWIFT_ENABLE_TENSORFLOW
+// Function differentiability
+ERROR(autodiff_attr_invalid_differentiability,none,
+      "invalid differentiability '%0' in '@autodiff' attribute; expected 'forward', 'reverse', 'linear', 'constant', or 'bidirectional'", (StringRef))
+ERROR(autodiff_attr_order_cannot_be_zero,none,
+      "differentiation order cannot be zero; it should be at least first-order", ())
+ERROR(autodiff_attr_order_cannot_be_specified_in_mode,none,
+      "differentiation order cannot be specified in '%0' mode", (StringRef))
+
 // SIL
 ERROR(opened_non_protocol,none,
       "@opened cannot be applied to non-protocol type %0", (Type))

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2866,7 +2866,7 @@ public:
     }
     // SWIFT_ENABLE_TENSORFLOW
     Differentiability getDifferentiability() const {
-      unsigned rawDiffability = Bits & DifferentiabilityMask;
+      unsigned rawDiffability = (Bits & DifferentiabilityMask) >> 7;
       return Differentiability(rawDiffability);
     }
 
@@ -3693,7 +3693,7 @@ public:
     bool isDifferentiable() const { return Bits & DifferentiabilityMask; }
 
     Differentiability getDifferentiability() const {
-      return Differentiability(Bits & DifferentiabilityMask);
+      return Differentiability((Bits & DifferentiabilityMask) >> 6);
     }
 
     /// What is the abstract representation of this function value?

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2836,6 +2836,8 @@ public:
     // Constructor with all defaults.
     ExtInfo() : Bits(0) {
       assert(getRepresentation() == Representation::Swift);
+      // SWIFT_ENABLE_TENSORFLOW
+      assert(getDifferentiability() == Differentiability::None);
     }
 
     // Constructor for polymorphic type.
@@ -2859,6 +2861,7 @@ public:
     bool isAutoClosure() const { return Bits & AutoClosureMask; }
     bool isNoEscape() const { return Bits & NoEscapeMask; }
     bool throws() const { return Bits & ThrowsMask; }
+    // SWIFT_ENABLE_TENSORFLOW
     bool isDifferentiable() const { return Bits & DifferentiabilityMask; }
     Representation getRepresentation() const {
       unsigned rawRep = Bits & RepresentationMask;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2821,7 +2821,8 @@ public:
       NoEscapeMask           = 1 << 5,
       ThrowsMask             = 1 << 6,
       // SWIFT_ENABLE_TENSORFLOW
-      DifferentiabilityMask  = 0b111 << 7,
+      DifferentiabilityOffset = 7,
+      DifferentiabilityMask  = 0b111 << DifferentiabilityOffset,
       NumMaskBits            = 10
     };
 
@@ -2851,7 +2852,8 @@ public:
       Bits |= (IsAutoClosure ? AutoClosureMask : 0);
       Bits |= (IsNoEscape ? NoEscapeMask : 0);
       // SWIFT_ENABLE_TENSORFLOW
-      Bits |= ((unsigned)Diff << 7 & DifferentiabilityMask);
+      Bits |=
+          (((unsigned)Diff << DifferentiabilityOffset) & DifferentiabilityMask);
     }
 
     bool isAutoClosure() const { return Bits & AutoClosureMask; }
@@ -2866,8 +2868,8 @@ public:
     }
     // SWIFT_ENABLE_TENSORFLOW
     Differentiability getDifferentiability() const {
-      unsigned rawDiffability = (Bits & DifferentiabilityMask) >> 7;
-      return Differentiability(rawDiffability);
+      return Differentiability(
+          (Bits & DifferentiabilityMask) >> DifferentiabilityOffset);
     }
 
     bool hasSelfParam() const {
@@ -2936,6 +2938,12 @@ public:
         return ExtInfo(Bits | ThrowsMask);
       else
         return ExtInfo(Bits & ~ThrowsMask);
+    }
+    // SWIFT_ENABLE_TENSORFLOW
+    LLVM_NODISCARD
+    ExtInfo withDifferentiability(Differentiability diff) const {
+      return ExtInfo((Bits & ~DifferentiabilityMask) |
+                     (unsigned)diff << DifferentiabilityOffset);
     }
 
     unsigned getFuncAttrKey() const {
@@ -3657,7 +3665,8 @@ public:
       PseudogenericMask  = 1 << 4,
       NoEscapeMask       = 1 << 5,
       // SWIFT_ENABLE_TENSORFLOW
-      DifferentiabilityMask = 0b111 << 6,
+      DifferentiabilityOffset = 6,
+      DifferentiabilityMask = 0b111 << DifferentiabilityOffset,
       NumMaskBits        = 9
     };
 
@@ -3679,7 +3688,7 @@ public:
              (isPseudogeneric ? PseudogenericMask : 0) |
              // SWIFT_ENABLE_TENSORFLOW
              (isNoEscape ? NoEscapeMask : 0) |
-             ((unsigned) diff);
+             ((unsigned)diff << DifferentiabilityOffset);
     }
 
     /// Is this function pseudo-generic?  A pseudo-generic function
@@ -3693,7 +3702,8 @@ public:
     bool isDifferentiable() const { return Bits & DifferentiabilityMask; }
 
     Differentiability getDifferentiability() const {
-      return Differentiability((Bits & DifferentiabilityMask) >> 6);
+      return Differentiability(
+          (Bits & DifferentiabilityMask) >> DifferentiabilityOffset);
     }
 
     /// What is the abstract representation of this function value?
@@ -3760,6 +3770,11 @@ public:
         return ExtInfo(Bits | NoEscapeMask);
       else
         return ExtInfo(Bits & ~NoEscapeMask);
+    }
+    // SWIFT_ENABLE_TENSORFLOW
+    ExtInfo withDifferentiability(Differentiability diff) const {
+      return ExtInfo((Bits & ~DifferentiabilityMask) |
+                     (unsigned)diff << DifferentiabilityOffset);
     }
 
     unsigned getFuncAttrKey() const {

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -812,7 +812,9 @@ namespace decls_block {
     TypeIDField,         // output
     FunctionTypeRepresentationField, // representation
     BCFixed<1>,          // throws?
-    GenericSignatureIDField // generic signture
+    // SWIFT_ENABLE_TENSORFLOW
+    GenericSignatureIDField, // generic signture
+    BCFixed<3>           // differentiability
 
     // trailed by parameters
   >;

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -205,6 +205,19 @@ enum class SILFunctionTypeRepresentation : uint8_t {
 };
 using SILFunctionTypeRepresentationField = BCFixed<4>;
 
+// SWIFT_ENABLE_TENSORFLOW
+// These IDs must \em not be renumbered or reordered without incrementing
+// VERSION_MAJOR.
+enum class FunctionTypeDifferentiability : uint8_t {
+  None = 0,
+  Forward,
+  Reverse,
+  Bidirectional,
+  Linear,
+  Constant,
+};
+using FunctionTypeDifferentiabilityField = BCFixed<3>;
+
 // These IDs must \em not be renumbered or reordered without incrementing
 // VERSION_MAJOR.
 enum class SILCoroutineKind : uint8_t {
@@ -739,7 +752,7 @@ namespace decls_block {
     BCFixed<1>,  // noescape?
     // SWIFT_ENABLE_TENSORFLOW
     BCFixed<1>,  // throws?
-    BCFixed<1>   // autodiff?
+    FunctionTypeDifferentiabilityField // differentiability
     // trailed by parameters
   >;
 
@@ -812,7 +825,7 @@ namespace decls_block {
     BCFixed<1>,            // pseudogeneric?
     BCFixed<1>,            // noescape?
     // SWIFT_ENABLE_TENSORFLOW
-    BCFixed<1>,            // autodiff?
+    FunctionTypeDifferentiabilityField, // differentiability
     BCFixed<1>,            // error result?
     BCFixed<30>,           // number of parameters
     BCFixed<30>,           // number of yields

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 451; // Last change: add graph_op serialization
+const uint16_t VERSION_MINOR = 452; // Last change: @autodiff type attribute
 
 using DeclIDField = BCFixed<31>;
 
@@ -737,8 +737,9 @@ namespace decls_block {
     FunctionTypeRepresentationField, // representation
     BCFixed<1>,  // auto-closure?
     BCFixed<1>,  // noescape?
-    BCFixed<1>   // throws?
-
+    // SWIFT_ENABLE_TENSORFLOW
+    BCFixed<1>,  // throws?
+    BCFixed<1>   // autodiff?
     // trailed by parameters
   >;
 
@@ -810,6 +811,8 @@ namespace decls_block {
     SILFunctionTypeRepresentationField, // representation
     BCFixed<1>,            // pseudogeneric?
     BCFixed<1>,            // noescape?
+    // SWIFT_ENABLE_TENSORFLOW
+    BCFixed<1>,            // autodiff?
     BCFixed<1>,            // error result?
     BCFixed<30>,           // number of parameters
     BCFixed<30>,           // number of yields

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/AutoDiff.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/STLExtras.h"
 
@@ -43,4 +44,29 @@ bool SILReverseAutoDiffIndices::operator==(
   buffer ^= parameters;
   buffer ^= other.parameters;
   return buffer.none();
+}
+
+Differentiability::Differentiability(AutoDiffMode mode,
+                                     bool wrtSelf,
+                                     llvm::SmallBitVector parameterIndices,
+                                     llvm::SmallBitVector resultIndices)
+    : mode(mode), wrtSelf(wrtSelf), parameterIndices(parameterIndices),
+      resultIndices(resultIndices) {
+}
+
+Differentiability::Differentiability(AutoDiffMode mode,
+                                     AnyFunctionType *type)
+    : mode(mode), wrtSelf(type->getExtInfo().hasSelfParam()),
+      // For now, we assume exactly one result until we figure out how to
+      // model result selection.
+      resultIndices(1) {
+  // If function has self, it must be a curried method type.
+  if (wrtSelf) {
+    auto methodTy = type->getResult()->castTo<AnyFunctionType>();
+    parameterIndices = llvm::SmallBitVector(methodTy->getNumParams());
+  } else {
+    parameterIndices = llvm::SmallBitVector(type->getNumParams());
+  }
+  parameterIndices.set();
+  resultIndices.set();
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2032,7 +2032,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
   StringRef conventionName;
   StringRef witnessMethodProtocol;
   // SWIFT_ENABLE_TENSORFLOW
-  StringRef differentiationMode;
+  StringRef differentiabilityName;
   int differentiationOrder = -1;
 
   // Handle @autoclosure(escaping)
@@ -2129,7 +2129,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
         return false;
       };
       if (!tryParseOrder()) {
-        differentiationMode = Tok.getText();
+        differentiabilityName = Tok.getText();
         consumeToken(tok::identifier);
         if (consumeIf(tok::comma))
           tryParseOrder();
@@ -2139,7 +2139,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
       // If parsing failed, clean up the states.
       if (backtrack.willBacktrack()) {
         differentiationOrder = -1;
-        differentiationMode = StringRef();
+        differentiabilityName = StringRef();
       }
     }
   }
@@ -2280,7 +2280,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
   // @autodiff(...) attribute.
   case TAK_autodiff:
     Attributes.differentiabilityAndOrder = {
-      differentiationMode, differentiationOrder
+      differentiabilityName, differentiationOrder
     };
     break;
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2136,6 +2136,11 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
       }
       if (consumeIf(tok::r_paren) && Tok.isNot(tok::arrow))
         backtrack.cancelBacktrack();
+      // If parsing failed, clean up the states.
+      if (backtrack.willBacktrack()) {
+        differentiationOrder = -1;
+        differentiationMode = StringRef();
+      }
     }
   }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3071,7 +3071,9 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
   auto signature = SILFunctionType::get(genericSig,
     SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
                              /*pseudogeneric*/ false,
-                             /*noescape*/ false),
+                             // SWIFT_ENABLE_TENSORFLOW
+                             /*noescape*/ false,
+                             FunctionType::Differentiability::None),
     SILCoroutineKind::None,
     ParameterConvention::Direct_Unowned,
     params, {}, result, None, SGM.getASTContext());
@@ -3207,7 +3209,9 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
   auto signature = SILFunctionType::get(genericSig,
     SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
                              /*pseudogeneric*/ false,
-                             /*noescape*/ false),
+                             // SWIFT_ENABLE_TENSORFLOW
+                             /*noescape*/ false,
+                             FunctionType::Differentiability::None),
     SILCoroutineKind::None,
     ParameterConvention::Direct_Unowned,
     params, {}, {}, None, SGM.getASTContext());
@@ -3374,7 +3378,9 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
     auto signature = SILFunctionType::get(genericSig,
       SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
                                /*pseudogeneric*/ false,
-                               /*noescape*/ false),
+                               // SWIFT_ENABLE_TENSORFLOW
+                               /*noescape*/ false,
+                               FunctionType::Differentiability::None),
       SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned,
       params, /*yields*/ {}, results, None, C);
@@ -3539,7 +3545,9 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
     auto signature = SILFunctionType::get(genericSig,
       SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
                                /*pseudogeneric*/ false,
-                               /*noescape*/ false),
+                               // SWIFT_ENABLE_TENSORFLOW
+                               /*noescape*/ false,
+                               FunctionType::Differentiability::None),
       SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned,
       params, /*yields*/ {}, results, None, C);

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -304,7 +304,9 @@ CanSILFunctionType BridgedProperty::getOutlinedFunctionType(SILModule &M) {
                       ResultConvention::Owned));
   auto ExtInfo =
       SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
-                               /*pseudogeneric*/ false, /*noescape*/ false);
+                               // SWIFT_ENABLE_TENSORFLOW
+                               /*pseudogeneric*/ false, /*noescape*/ false,
+                               FunctionType::Differentiability::None);
   auto FunctionType = SILFunctionType::get(
       nullptr, ExtInfo, SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned, Parameters, /*yields*/ {},
@@ -1121,7 +1123,9 @@ CanSILFunctionType ObjCMethodCall::getOutlinedFunctionType(SILModule &M) {
   auto ExtInfo =
       SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
                                /*pseudogeneric*/ false,
-                               /*noescape*/ false);
+                               // SWIFT_ENABLE_TENSORFLOW
+                               /*noescape*/ false,
+                               FunctionType::Differentiability::None);
 
   SmallVector<SILResultInfo, 4> Results;
   // If we don't have a bridged return we changed from @autoreleased to @owned

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -85,7 +85,9 @@ class BugReducerTester : public SILFunctionTransform {
     auto FuncType = SILFunctionType::get(
         nullptr, SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
                                           false /*isPseudoGeneric*/,
-                                          false /*noescape*/),
+                                          // SWIFT_ENABLE_TENSORFLOW
+                                          false /*noescape*/,
+                                         FunctionType::Differentiability::None),
         SILCoroutineKind::None, ParameterConvention::Direct_Unowned,
         ArrayRef<SILParameterInfo>(), ArrayRef<SILYieldInfo>(),
         ResultInfoArray, None, getFunction()->getModule().getASTContext());

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1564,7 +1564,7 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
                               /*noescape*/ true,
                               // SWIFT_ENABLE_TENSORFLOW
                               /*throws*/ true,
-                              /*autodiff*/ false));
+                  /*differentiability*/ FunctionType::Differentiability::None));
     FunctionType::Param args[] = {
       FunctionType::Param(noescapeClosure),
       FunctionType::Param(bodyClosure, CS.getASTContext().getIdentifier("do")),
@@ -1576,7 +1576,7 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
                             /*noescape*/ false,
                             // SWIFT_ENABLE_TENSORFLOW
                             /*throws*/ true,
-                            /*autodiff*/ false));
+                  /*differentiability*/ FunctionType::Differentiability::None));
     openedFullType = refType;
     return true;
   }
@@ -1599,7 +1599,7 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
                               /*noescape*/ true,
                               // SWIFT_ENABLE_TENSORFLOW
                               /*throws*/ true,
-                              /*autodiff*/ false));
+                  /*differentiability*/ FunctionType::Differentiability::None));
     FunctionType::Param args[] = {
       FunctionType::Param(existentialTy),
       FunctionType::Param(bodyClosure, CS.getASTContext().getIdentifier("do")),
@@ -1610,7 +1610,7 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
                             /*noescape*/ false,
                             // SWIFT_ENABLE_TENSORFLOW
                             /*throws*/ true,
-                            /*autodiff*/ false));
+                  /*differentiability*/ FunctionType::Differentiability::None));
     openedFullType = refType;
     return true;
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1562,7 +1562,9 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
         FunctionType::ExtInfo(FunctionType::Representation::Swift,
                               /*autoclosure*/ false,
                               /*noescape*/ true,
-                              /*throws*/ true));
+                              // SWIFT_ENABLE_TENSORFLOW
+                              /*throws*/ true,
+                              /*autodiff*/ false));
     FunctionType::Param args[] = {
       FunctionType::Param(noescapeClosure),
       FunctionType::Param(bodyClosure, CS.getASTContext().getIdentifier("do")),
@@ -1572,7 +1574,9 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
       FunctionType::ExtInfo(FunctionType::Representation::Swift,
                             /*autoclosure*/ false,
                             /*noescape*/ false,
-                            /*throws*/ true));
+                            // SWIFT_ENABLE_TENSORFLOW
+                            /*throws*/ true,
+                            /*autodiff*/ false));
     openedFullType = refType;
     return true;
   }
@@ -1593,7 +1597,9 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
         FunctionType::ExtInfo(FunctionType::Representation::Swift,
                               /*autoclosure*/ false,
                               /*noescape*/ true,
-                              /*throws*/ true));
+                              // SWIFT_ENABLE_TENSORFLOW
+                              /*throws*/ true,
+                              /*autodiff*/ false));
     FunctionType::Param args[] = {
       FunctionType::Param(existentialTy),
       FunctionType::Param(bodyClosure, CS.getASTContext().getIdentifier("do")),
@@ -1602,7 +1608,9 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
       FunctionType::ExtInfo(FunctionType::Representation::Swift,
                             /*autoclosure*/ false,
                             /*noescape*/ false,
-                            /*throws*/ true));
+                            // SWIFT_ENABLE_TENSORFLOW
+                            /*throws*/ true,
+                            /*autodiff*/ false));
     openedFullType = refType;
     return true;
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1949,6 +1949,67 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
   // Function attributes require a syntactic function type.
   auto *fnRepr = dyn_cast<FunctionTypeRepr>(repr);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  // Resolve differentiability from a parsed @autodiff attribute.
+  auto resolveDifferentiability = [&]() -> FunctionType::Differentiability {
+    if (!attrs.hasDifferentiability()) {
+      return FunctionType::Differentiability::None;
+    }
+    // WHen empty, it means the user did not specify any differentiation mode.
+    StringRef diffModeString;
+    // When negative, it means the user did not specify any order.
+    int order = -1;
+    std::tie(diffModeString, order) = attrs.getDifferentiabilityAndOrder();
+    // If `diffabilityString` is empty, then differentiability is bidirectional.
+    auto diffability =
+        llvm::StringSwitch<Optional<FunctionType::Differentiability>>
+            (diffModeString)
+            .Case("", FunctionType::Differentiability::Bidirectional)
+            .Case("forward", FunctionType::Differentiability::Forward)
+            .Case("reverse", FunctionType::Differentiability::Reverse)
+            .Case("linear", FunctionType::Differentiability::Linear)
+            .Case("const", FunctionType::Differentiability::Constant)
+          .Case("bidirectional", FunctionType::Differentiability::Bidirectional)
+            .Default(None);
+    // Invalid differentiability.
+    if (!diffability) {
+      diagnose(attrs.getLoc(TAK_autodiff),
+               diag::autodiff_attr_invalid_differentiability,
+               diffModeString);
+      attrs.clearAttribute(TAK_autodiff);
+      return FunctionType::Differentiability::None;
+    }
+    if (order >= 0) {
+      switch (*diffability) {
+      // Linear functions are smooth, and thus do not need a specific
+      // differentiation order.
+      case FunctionType::Differentiability::Linear:
+        diagnose(attrs.getLoc(TAK_autodiff),
+                 diag::autodiff_attr_order_cannot_be_specified_in_mode,
+                 "linear");
+        attrs.clearAttribute(TAK_autodiff);
+        return FunctionType::Differentiability::None;
+      // Constant functions are smooth, and thus do not need a specific
+      // differentiation order.
+      case FunctionType::Differentiability::Constant:
+        diagnose(attrs.getLoc(TAK_autodiff),
+                 diag::autodiff_attr_order_cannot_be_specified_in_mode,
+                 "const");
+        attrs.clearAttribute(TAK_autodiff);
+        return FunctionType::Differentiability::None;
+      default:
+        break;
+      }
+    }
+    if (order == 0) {
+      diagnose(attrs.getLoc(TAK_autodiff),
+               diag::autodiff_attr_order_cannot_be_zero);
+      attrs.clearAttribute(TAK_autodiff);
+      return FunctionType::Differentiability::None;
+    }
+    return *diffability;
+  };
+
   if (!fnRepr) {
     if (attrs.has(TAK_autoclosure)) {
       diagnose(attrs.getLoc(TAK_autoclosure), diag::autoclosure_function_type);
@@ -2011,9 +2072,11 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
       }
     }
 
+    auto diffability = resolveDifferentiability();
+
     // Resolve the function type directly with these attributes.
     SILFunctionType::ExtInfo extInfo(rep, attrs.has(TAK_pseudogeneric),
-                                     attrs.has(TAK_noescape));
+                                     attrs.has(TAK_noescape), diffability);
 
     ty = resolveSILFunctionType(fnRepr, options, coroutineKind,
                                 extInfo, calleeConvention,
@@ -2068,34 +2131,26 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
           .fixItRemove(attrRange)
           .fixItReplace(resultRange, "Never");
     }
-    
-    // SWIFT_ENABLE_TENSORFLOW
-    // @nodiff is only valid on parameters.
-    if (!isParam && attrs.has(TAK_nodiff)) {
-      TC.diagnose(attrs.getLoc(TAK_nodiff),
-                  isVariadicFunctionParam
-                      ? diag::attr_not_on_variadic_parameters
-                      : diag::attr_not_on_variadic_parameters, "@nodiff");
-      attrs.clearAttribute(TAK_autoclosure);
-    }
 
     // SWIFT_ENABLE_TENSORFLOW
     // @nodiff is only valid on parameters.
     if (!isParam && attrs.has(TAK_nodiff)) {
-      TC.diagnose(attrs.getLoc(TAK_nodiff),
-                  isVariadicFunctionParam
-                      ? diag::attr_not_on_variadic_parameters
-                      : diag::attr_not_on_variadic_parameters, "@nodiff");
+      diagnose(attrs.getLoc(TAK_nodiff),
+               isVariadicFunctionParam
+                   ? diag::attr_not_on_variadic_parameters
+                   : diag::attr_not_on_variadic_parameters, "@nodiff");
       attrs.clearAttribute(TAK_autoclosure);
     }
+
+    auto diffability = resolveDifferentiability();
 
     // Resolve the function type directly with these attributes.
     FunctionType::ExtInfo extInfo(rep,
                                   attrs.has(TAK_autoclosure),
                                   attrs.has(TAK_noescape),
                                   // SWIFT_ENABLE_TENSORFLOW
-                                  attrs.has(TAK_autodiff),
-                                  fnRepr->throws());
+                                  fnRepr->throws(),
+                                  diffability);
 
     ty = resolveASTFunctionType(fnRepr, options, extInfo);
     if (!ty || ty->hasError()) return ty;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4461,7 +4461,9 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
                                                          resultID,
                                                          rawRepresentation,
                                                          throws,
-                                                         rawGenericSig);
+                                                         // SWIFT_ENABLE_TENSORFLOW
+                                                         rawGenericSig,
+                                                         rawDifferentiability);
       genericSig = getGenericSignature(rawGenericSig);
     }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4421,7 +4421,9 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
   case decls_block::GENERIC_FUNCTION_TYPE: {
     TypeID resultID;
     uint8_t rawRepresentation;
-    bool autoClosure = false, noescape = false, throws;
+    // SWIFT_ENABLE_TENSORFLOW
+    bool autoClosure = false, noescape = false, throws = false,
+         autodiff = false;
     GenericSignature *genericSig = nullptr;
 
     if (recordID == decls_block::FUNCTION_TYPE) {
@@ -4429,7 +4431,9 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
                                                   rawRepresentation,
                                                   autoClosure,
                                                   noescape,
-                                                  throws);
+                                                  // SWIFT_ENABLE_TENSORFLOW
+                                                  throws,
+                                                  autodiff);
     } else {
       GenericSignatureID rawGenericSig;
       decls_block::GenericFunctionTypeLayout::readRecord(scratch,
@@ -4447,7 +4451,8 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     }
     
     auto info = FunctionType::ExtInfo(*representation, autoClosure, noescape,
-                                      throws);
+                                      // SWIFT_ENABLE_TENSORFLOW
+                                      throws, autodiff);
 
     auto resultTy = getTypeChecked(resultID);
     if (!resultTy)
@@ -4777,6 +4782,8 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     uint8_t rawRepresentation;
     bool pseudogeneric = false;
     bool noescape;
+    // SWIFT_ENABLE_TENSORFLOW
+    bool autodiff;
     bool hasErrorResult;
     unsigned numParams;
     unsigned numYields;
@@ -4790,6 +4797,8 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
                                              rawRepresentation,
                                              pseudogeneric,
                                              noescape,
+                                             // SWIFT_ENABLE_TENSORFLOW
+                                             autodiff,
                                              hasErrorResult,
                                              numParams,
                                              numYields,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3886,7 +3886,9 @@ void Serializer::writeType(Type ty) {
              getRawStableFunctionTypeRepresentation(fnTy->getRepresentation()),
              fnTy->isAutoClosure(),
              fnTy->isNoEscape(),
-             fnTy->throws());
+             // SWIFT_ENABLE_TENSORFLOW
+             fnTy->throws(),
+             fnTy->isAutoDiff());
     } else {
       assert(!fnTy->isAutoClosure());
       assert(!fnTy->isNoEscape());
@@ -3977,9 +3979,10 @@ void Serializer::writeType(Type ty) {
         Out, ScratchRecord, abbrCode,
         stableCoroutineKind, stableCalleeConvention,
         stableRepresentation, fnTy->isPseudogeneric(), fnTy->isNoEscape(),
-        fnTy->hasErrorResult(), fnTy->getParameters().size(),
-        fnTy->getNumYields(), fnTy->getNumResults(),
-        addGenericSignatureRef(sig), variableData);
+        // SWIFT_ENABLE_TENSORFLOW
+        fnTy->isAutoDiff(), fnTy->hasErrorResult(),
+        fnTy->getParameters().size(), fnTy->getNumYields(),
+        fnTy->getNumResults(), addGenericSignatureRef(sig), variableData);
 
     if (auto conformance = fnTy->getWitnessMethodConformanceOrNone())
       writeConformance(*conformance, DeclTypeAbbrCodes);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3916,7 +3916,9 @@ void Serializer::writeType(Type ty) {
               addTypeRef(fnTy->getResult()),
               getRawStableFunctionTypeRepresentation(fnTy->getRepresentation()),
               fnTy->throws(),
-              addGenericSignatureRef(genericSig));
+              // SWIFT_ENABLE_TENSORFLOW
+              addGenericSignatureRef(genericSig),
+       getRawStableFunctionTypeDifferentiability(fnTy->getDifferentiability()));
     }
 
     unsigned abbrCode = DeclTypeAbbrCodes[FunctionParamLayout::Code];

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3607,6 +3607,22 @@ static uint8_t getRawStableSILFunctionTypeRepresentation(
   llvm_unreachable("bad calling convention");
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+/// Translate from the AST function type differentiability enum to the
+/// Serialization enum values, which are guaranteed to be stable.
+static uint8_t getRawStableFunctionTypeDifferentiability(
+                           swift::FunctionType::Differentiability diffability) {
+  switch (diffability) {
+  SIMPLE_CASE(FunctionTypeDifferentiability, None)
+  SIMPLE_CASE(FunctionTypeDifferentiability, Forward)
+  SIMPLE_CASE(FunctionTypeDifferentiability, Reverse)
+  SIMPLE_CASE(FunctionTypeDifferentiability, Bidirectional)
+  SIMPLE_CASE(FunctionTypeDifferentiability, Linear)
+  SIMPLE_CASE(FunctionTypeDifferentiability, Constant)
+  }
+  llvm_unreachable("bad differentiability");
+}
+
 /// Translate from the AST coroutine-kind enum to the Serialization enum
 /// values, which are guaranteed to be stable.
 static uint8_t getRawStableSILCoroutineKind(
@@ -3888,7 +3904,8 @@ void Serializer::writeType(Type ty) {
              fnTy->isNoEscape(),
              // SWIFT_ENABLE_TENSORFLOW
              fnTy->throws(),
-             fnTy->isAutoDiff());
+             getRawStableFunctionTypeDifferentiability(
+                 fnTy->getDifferentiability()));
     } else {
       assert(!fnTy->isAutoClosure());
       assert(!fnTy->isNoEscape());
@@ -3974,13 +3991,17 @@ void Serializer::writeType(Type ty) {
     auto stableCalleeConvention =
       getRawStableParameterConvention(fnTy->getCalleeConvention());
 
+    // SWIFT_ENABLE_TENSORFLOW
+    auto stableDifferentiability =
+      getRawStableFunctionTypeDifferentiability(fnTy->getDifferentiability());
+
     unsigned abbrCode = DeclTypeAbbrCodes[SILFunctionTypeLayout::Code];
     SILFunctionTypeLayout::emitRecord(
         Out, ScratchRecord, abbrCode,
         stableCoroutineKind, stableCalleeConvention,
         stableRepresentation, fnTy->isPseudogeneric(), fnTy->isNoEscape(),
         // SWIFT_ENABLE_TENSORFLOW
-        fnTy->isAutoDiff(), fnTy->hasErrorResult(),
+        stableDifferentiability, fnTy->hasErrorResult(),
         fnTy->getParameters().size(), fnTy->getNumYields(),
         fnTy->getNumResults(), addGenericSignatureRef(sig), variableData);
 

--- a/test/AutoDiff/differentiable_func_type_parse.swift
+++ b/test/AutoDiff/differentiable_func_type_parse.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -parse -verify %s
+
+// NOTE: The grammar of the '@autodiff' attribute is often ambiguous in a
+// function type context. Things in parentheses can be interpreted as type
+// names. To resolve this, the parser has to do fair amounts of backtracking,
+// and parse failures in a '@autodiff(...)' often fall back to parsing the
+// primary function type. This is why we don't add tests for diagnostics yet.
+
+let _: @autodiff (T) -> U // okay
+let _: @autodiff(blah) (T) -> U // okay
+let _: @autodiff(order: 10) (T) -> U // okay
+let _: @autodiff(forward, order: 10) (T) -> U // okay
+let _: @autodiff (order) -> U // okay, parsed as a function type
+let _: @autodiff (reverse, reverse) // okay, just a tuple
+let _: @autodiff (reverse) -> U // okay, parsed as a function type
+let _: @autodiff T // okay

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -3,11 +3,7 @@
 // expected-error @+1 {{invalid differentiability 'blah' in '@autodiff' attribute; expected 'forward', 'reverse', 'linear', 'constant', or 'bidirectional'}}
 let _: @autodiff(blah) (Float) -> Float
 
-// FIXME: The type checker thinks "Float" is the differentiability name. This
-// means something's wrong in the parser.
-//
-// let _: @autodiff (Float) -> Float
-
+let _: @autodiff (Float) -> Float
 let _: @autodiff(bidirectional) (Float) -> Float
 let _: @autodiff(forward) (Float) -> Float
 let _: @autodiff(reverse) (Float) -> Float

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// expected-error @+1 {{invalid differentiability 'blah' in '@autodiff' attribute; expected 'forward', 'reverse', 'linear', 'constant', or 'bidirectional'}}
+let _: @autodiff(blah) (Float) -> Float
+
+// FIXME: The type checker thinks "Float" is the differentiability name. This
+// means something's wrong in the parser.
+//
+// let _: @autodiff (Float) -> Float
+
+let _: @autodiff(bidirectional) (Float) -> Float
+let _: @autodiff(forward) (Float) -> Float
+let _: @autodiff(reverse) (Float) -> Float
+let _: @autodiff(linear) (Float) -> Float
+let _: @autodiff(const) (Float) -> Float
+let _: @autodiff(bidirectional) (Float) -> Float
+
+let _: @autodiff(bidirectional, order: 3) (Float) -> Float
+let _: @autodiff(forward, order: 4) (Float) -> Float
+let _: @autodiff(reverse, order: 5) (Float) -> Float
+
+// expected-error @+1 {{differentiation order cannot be specified in 'linear' mode}}
+let _: @autodiff(linear, order: 6) (Float) -> Float
+// expected-error @+1 {{differentiation order cannot be specified in 'const' mode}}
+let _: @autodiff(const, order: 7) (Float) -> Float
+
+// expected-error @+1 {{differentiation order cannot be zero; it should be at least first-order}}
+let _: @autodiff(order: 0) (Float) -> Float
+// expected-error @+1 {{differentiation order cannot be zero; it should be at least first-order}}
+let _: @autodiff(forward, order: 0) (Float) -> Float


### PR DESCRIPTION
## Generalized Differentiability: Add differentiability to function types

This patch is initial progress towards the "Generalized Differentiability" model (documentation coming soon). At a high level, this model enables cross-module differentiation without serialization and expressing high-level mathematical APIs using protocols and differentiable protocol requirements. There are two parts at the function type level.

### Implementation

#### 1. Add differentiability to function type attributes
This patch adds differentiability to function types as a 3-bit field in `AnyFunctionType::ExtInfo` and `SILFunctionType::ExtInfo`. `Differentiability` is like `Representation`, and it has these variants:
* **None**: The function is not known to be differentiable. No differential operators will work on it unless this function's body is available in the current module, in which case the AD system will try to differentiate it.
* **Forward**: The function is forward-mode differentiable. Differentiating this function using a forward-mode differential operator (likely going to be `#derivatives(...)`) produces a function that computes Jacobian-vector products.
* **Reverse**: The function is reverse-mode differentiable. Differentiating this function using the reverse-mode differential operator `#gradient(...)` produces a function that computes vector-Jacobian products.
* **Bidirectional**: This function can be differentiated by both `#derivatives(...)` and `#gradient(...)`.
* **Linear**: This function is a linear map and it can be differentiated by any differential operator. The derivative is always a constant.
* **Constant**: This function is a constant function and it can be differentiated by any differential operator. The derivative is always zero.

There are two remaining steps towards finishing the layout of full differentiability in function types:
1. Add an optional unsigned integer to represent the function's max differentiation order.
2. Add a per-parameter flag that indicates whether this parameter is a differentiation parameter of the function.

#### 2. Add an `@autodiff` attribute on function types.

The syntax corresponds roughly to `FunctionType::Differentiability`, except for an optional differentiation `order`.

```
diff-order ::= 'order' ':' integer-literal
differentiability ::= 'forward' | 'reverse' | 'linear' | 'const' | 'bidirectional'
autodiff-attr ::= '@autodiff' '(' (differentiability ',')? diff-order ')'
```

For example, here's a linear function:
```swift
let f: @autodiff(linear) (T) -> U = ...
_ = #gradient(#gradient(#gradient(f))) // ok!
```

Here's a forward-differentiable function that is second-order differentiable:
```swift
let f: @autodiff(forward, order: 2) (T) -> U = ...
_ = #derivatives(#derivatives(f)) // ok!
```

When there's no parentheses, an `@autodiff` attribute implies bidirectional differentiability.
```swift
let f: @autodiff (T) -> U = ...
_ = #derivatives(f) // ok!
_ = #gradient(f) // ok!
```

#### 3. Add a `@nodiff` attribute on function type parameters.

When `@nodiff` is used on a function type parameter, the function's `@autodiff` attribute will not apply to this parameter. When `@autodiff` is not specified on the parent function, the use of `@nodiff` is illegal. The attribute AST node is implemented in this patch, but type checking is to be added.

```swift
let f: @autodiff (T, @nodiff U, V) -> W
_ = #gradient(f) // (T, U, V) -> (T.CotangentVector, V.CotangentVector)
```