### PR TITLE
[Sema]Allow associated type inference for requirement returning dynamic Self...

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -545,9 +545,10 @@ swift::matchWitness(
     // Result types must match.
     // FIXME: Could allow (trivial?) subtyping here.
     if (!ignoreReturnType) {
-      if (reqResultType->is<DynamicSelfType>()) {
+      if (reqResultType->hasDynamicSelfType()) {
         auto classDecl = witness->getDeclContext()->getSelfClassDecl();
-        if (!classDecl || classDecl->isFinal() || witnessResultType->is<DynamicSelfType>())
+        if (!classDecl || classDecl->isFinal() ||
+            witnessResultType->hasDynamicSelfType())
           reqResultType = reqResultType->eraseDynamicSelfType();
         witnessResultType = witnessResultType->eraseDynamicSelfType();
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -545,6 +545,13 @@ swift::matchWitness(
     // Result types must match.
     // FIXME: Could allow (trivial?) subtyping here.
     if (!ignoreReturnType) {
+      if (reqResultType->is<DynamicSelfType>()) {
+        auto classDecl = witness->getDeclContext()->getSelfClassDecl();
+        if (!classDecl || classDecl->isFinal() || witnessResultType->is<DynamicSelfType>())
+          reqResultType = reqResultType->eraseDynamicSelfType();
+        witnessResultType = witnessResultType->eraseDynamicSelfType();
+      }
+
       auto reqTypeIsIUO =
           req->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
       auto witnessTypeIsIUO =

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -723,19 +723,6 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitness(ValueDecl *req,
       return true;
     }
 
-    // Allow match of dynamic Self to the conforming type, if it's
-    // a non-class or final class.
-    bool mismatch(DynamicSelfType *firstType, TypeBase *secondType,
-                  Type sugaredFirstType) {
-      if (secondType->is<DynamicSelfType>())
-        return true;
-      if (secondType->isEqual(Conformance->getType())) {
-        auto classDecl = Conformance->getType()->getClassOrBoundGenericClass();
-        return !classDecl || classDecl->isFinal();
-      }
-      return false;
-    }
-
     /// FIXME: Recheck the type of Self against the second type?
     bool mismatch(GenericTypeParamType *selfParamType,
                   TypeBase *secondType, Type sugaredFirstType) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -723,6 +723,17 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitness(ValueDecl *req,
       return true;
     }
 
+    // Allow match of dynamic Self to the conforming type, if it's
+    // a non-class or final class.
+    bool mismatch(DynamicSelfType *firstType, TypeBase *secondType,
+                  Type sugaredFirstType) {
+      if (secondType->isEqual(Conformance->getType())) {
+        auto classDecl = Conformance->getType()->getClassOrBoundGenericClass();
+        return !classDecl || classDecl->isFinal();
+      }
+      return false;
+    }
+
     /// FIXME: Recheck the type of Self against the second type?
     bool mismatch(GenericTypeParamType *selfParamType,
                   TypeBase *secondType, Type sugaredFirstType) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -727,6 +727,8 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitness(ValueDecl *req,
     // a non-class or final class.
     bool mismatch(DynamicSelfType *firstType, TypeBase *secondType,
                   Type sugaredFirstType) {
+      if (secondType->is<DynamicSelfType>())
+        return true;
       if (secondType->isEqual(Conformance->getType())) {
         auto classDecl = Conformance->getType()->getClassOrBoundGenericClass();
         return !classDecl || classDecl->isFinal();

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -104,4 +104,11 @@ final class C8902b : P8902 {
 class C8902c : P8902 {
     func f(_ x: Bool) -> Self { fatalError() }
 }
+protocol P8902complex {
+  associatedtype A
+  func f() -> (A, Self?)
+}
+final class C8902complex : P8902complex {
+  func f() -> (Bool, C8902complex?) { fatalError() }
+}
 

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -101,4 +101,7 @@ class C8902 : P8902 { // expected-error {{type 'C8902' does not conform to proto
 final class C8902b : P8902 {
     func f(_ x: Bool) -> C8902b { fatalError() }
 }
+class C8902c : P8902 {
+    func f(_ x: Bool) -> Self { fatalError() }
+}
 

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -86,3 +86,19 @@ extension Node {
 }
 
 class IntNode: Node {}
+
+// SR-8902
+protocol P8902 {
+    associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+    func f(_ x: A) -> Self
+}
+struct S : P8902 {
+    func f(_ x: Bool) -> S { fatalError() }
+}
+class C8902 : P8902 { // expected-error {{type 'C8902' does not conform to protocol 'P8902'}}
+    func f(_ x: Bool) -> C8902 { fatalError() }
+}
+final class C8902b : P8902 {
+    func f(_ x: Bool) -> C8902b { fatalError() }
+}
+

--- a/validation-test/compiler_crashers_2_fixed/0155-sr7364.swift
+++ b/validation-test/compiler_crashers_2_fixed/0155-sr7364.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -emit-ir
+// RUN: %target-swift-frontend %s -emit-ir
 
 
 public protocol E {


### PR DESCRIPTION
… when witness returns it's own type and isn't a class or is a final class. (Same restrictions as meeting the requirement.)

Resolves [SR-8902](https://bugs.swift.org/browse/SR-8902).

