### PR TITLE
[RFC] [prototype] Dynamic attribute GPE support

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -257,6 +257,10 @@ ERROR(tf_convention_tf_host_code_not_allowed, none,
       "host code is not allowed in a TensorFlow function", ())
 ERROR(tf_no_captures_in_tf_functions, none,
       "TensorFlow functions cannot capture values", ())
+ERROR(tf_unsupported_dynamic_attr, none,
+      "this dynamic attribute is not supported in graph mode (consider "
+      "turning on eager mode)",
+      ())
 
 WARNING(tf_value_implicitly_copied_to_accel, none,
         "%0 implicitly copied to the accelerator, use .toAccelerator() to make "

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -36,6 +36,10 @@ extern cl::opt<bool> TFDynamicCompilation;
 namespace swift {
 namespace tf {
 
+/// Maps a SIL value to a placeholder attribute name in the graph function.
+// e.g. map %9 to "MyBoolAttr".
+using DynAttrValueNameMap = llvm::DenseMap<SILValue, std::string>;
+
 // TODO: reformat the code below to remove indentation.
 
 /// If the -tf-dump-intermediates flag has been passed, return a pointer to
@@ -236,8 +240,12 @@ public:
   /// single SessionRun() call. Those N-1 helper functions take no input or
   /// output tensors, and are executed for their side-effects of
   /// sending/receiving tensors with the function of `entryFnBaseName`.
+  ///
+  /// For each dynamatic attribute in `dynAttrInsts`, add a function-level
+  /// attribute based on their name and type info.
   bool lowerTFGraph(StringRef hostFnName, SILFunction *fn,
-                    const GraphFunctionDeviceInfo &deviceInfo);
+                    const GraphFunctionDeviceInfo &deviceInfo,
+                    const DynAttrValueNameMap &dynAttrInsts);
 
   /// Serialize `graph` into a binary protobuf into `bytes`.
   /// Return true on error, with an error diagnostic already emitted at
@@ -261,7 +269,8 @@ private:
   bool lowerTFGraphOrFunction(StringRef hostFnName, SILFunction *fn,
                               const std::string &graphFnNameForCaller,
                               bool isAcceleratorOnly,
-                              const GraphFunctionDeviceInfo &deviceInfo);
+                              const GraphFunctionDeviceInfo &deviceInfo,
+                              const DynAttrValueNameMap &dynAttrInsts);
 };
 
 } // end namespace tf

--- a/test/TensorFlowRuntime/dynamic_attr.swift
+++ b/test/TensorFlowRuntime/dynamic_attr.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+
+// This file contains testing over dynamic attributes.
+
+import CTensorFlow
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+var DynamicAttributeTests = TestSuite("DynamicAttribute")
+
+// TODO: support this test in eager mode.
+var val: Bool = true
+_RuntimeConfig.usesTFEagerAPI = true // TODO: turn on by default
+DynamicAttributeTests.testCPUOrGPU("DynAttr") {
+  @inline(never)
+  func dynAttrTest(x: Tensor<Float>, y: Tensor<Float>) {
+    _RuntimeConfig.usesTFEagerAPI = true // TODO: turn on by default
+    _RuntimeConfig.printsDebugLog = true
+    // TODO: fix silgen crash when we replace `b` and use `val` directly.
+    let b = val
+    let z: TensorHandle<Float> = #tfop("MatMul", x, y, transpose_a: b)
+    _hostOp(z)
+    let z_tensor = Tensor(handle: z)
+    expectEqual([1,1], z_tensor.shape)
+    expectPointwiseNearlyEqual([2.0], z_tensor.scalars)
+  }
+  dynAttrTest(x: Tensor([[1]]), y: Tensor([[2]]))
+}
+
+runAllTests()


### PR DESCRIPTION
See the newly added `dynamic_attr.swift` for a test example.

# Introduction

The main challenge is that we need to create graph functions at compile time,
where the values of dynamic attributes are not known.

We therefore need a way to create templated (parameterized) graph functions
without specifying those attribute values, and defer the value binding till
function binding/invocation time (runtime).

One mechanism explored in this PR to implement this is the "placeholder
attribute" feature in TF graph functions (proto field
https://github.com/tensorflow/tensorflow/blob/367f7d651f19c5b111ea0292243eab81fb4058c7/tensorflow/core/framework/attr_value.proto#L53;
see "$T" as an example at
https://github.com/tensorflow/tensorflow/blob/367f7d651f19c5b111ea0292243eab81fb4058c7/tensorflow/core/framework/function_test.cc#L78))
to represent dynamic attrs at graph construction (S4TF compile) time, and then
bind these attr values at function instantiation/invocation time (S4TF runtime).

For example, given
```swift
#tfop("MatMul", x, y, transpose_a: b)
```

where `b` is not a compile-time constant, we cannot set a bool-type tfop attr
`transpose_a` when creating the matmul graph node. Instead, we create a
placeholder attribute with a synthesized name, same "MyBoolAttr", with type set
to "bool".  In the constructed graph function proto, the matmul node looks like:

```
node_def {
  name: "z"
  op: "MatMul"
  input: "x"
  input: "y"
  device: "/job:localhost/replica:0/task:0/device:CPU:0"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "transpose_a"
    value {
      placeholder: "MyBoolAttr"
    }
  }
  attr {
    key: "transpose_b"
    value {
      b: false
    }
  }
}
```

The graph function has an added bool-typed attribute "MyBoolAttr", so that its
signature (https://github.com/tensorflow/tensorflow/blob/367f7d651f19c5b111ea0292243eab81fb4058c7/tensorflow/core/framework/function.proto#L28)
looks like:

```
signature {
  name: "graph_func"
  input_arg {
    name: "arg_0"
    type: DT_FLOAT
  }
  input_arg {
    name: "arg_1"
    type: DT_FLOAT
  }
  output_arg {
    name: "some_output"
    type: DT_FLOAT
  }
  attr {
    name: "MyBoolAttr"
    type: "bool"
  }
}
```

At runtime, after loading the graph function into eager context, before
executing it, we use `TFE_OpSetAttrBool(op, "MyBoolAttr", <true or false>)` to
set that function-level attr.

# Design summary

To implement the above idea, the changes are:

1. In the deabstraction pass, do not error out when we see a dynamic tfop attr
under graph mode. Let it flow into the partition pass (we already do this in
eager mode).

2. In partition/lowering pass:

a) When we mark tfop (graph_op) insts, detect those insts with dynamic attrs,
and rewrite them to replace the dynamic attrs with placeholder attrs (in
`maybeRewriteForDynAttr()`). Also store those dynamic attrs along with the
synthesized placeholder attr names in `dynAttrInsts`.

b) Once we determine tensor start point (TSP), hoist all those instructions that
produce dynamic attrs above TSP (in `TFFunctionPartition::markFunction()`). This
is required for GPE support. If this fails, reject the program. It has to be
compiled in eager mode instead.

c) When lowering the accelerator function to a graph function, create
function-level attributes for those dynamic attrs, by passing the placeholder
attribute names and types into the `TF_GraphToFunctionWithAttrs()` call.

d) When generating calls to compiler runtime entrypoints (in
`insertTensorComputationStartEndTerminate()`), pass these dynamic attr values
into the `_swift_tfc_StartTensorComputation()` call.

3. At runtime:

The compiler entrypoint `_TFCStartTensorComputation()` passes the dynamic attr
names (placeholder names) and their values into TFEState.init(), which then sets
them in the operator created for the graph function call (e.g. by calling
`TFE_OpSetAttrBool(op, "MyBoolAttr", dynAttrValue)`).

# Limitations

This prototype PR explores the compile and runtime workflows in supporting
dynamic attrs. It only supports 0 or 1 dyn attr, and the attr must be a bool
type. These restrictions can be lifted when we "productize" the PR.
