### PR TITLE
[Sema][CS] Add SK_Deprecated score for deprecated overload choices

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -44,6 +44,10 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
       log << "use of an unavailable declaration";
       break;
 
+    case SK_Deprecated:
+      log << "use of a deprecated declaration";
+      break;
+
     case SK_Fix:
       log << "attempting to fix the source";
       break;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1766,6 +1766,9 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     if (choice.getDecl()->getAttrs().isUnavailable(getASTContext())) {
       increaseScore(SK_Unavailable);
     }
+    if (choice.getDecl()->getAttrs().getDeprecated(getASTContext())) {
+      increaseScore(SK_Deprecated);
+    }
 
     if (kind == OverloadChoiceKind::DynamicMemberLookup) {
       // DynamicMemberLookup results are always a (dynamicMember:T1)->T2

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -441,6 +441,8 @@ enum ScoreKind {
   SK_Fix,
   /// A reference to an @unavailable declaration.
   SK_Unavailable,
+  /// A reference to a deprecated declaration.
+  SK_Deprecated,
   /// An implicit force of an implicitly unwrapped optional value.
   SK_ForceUnchecked,
   /// A user-defined conversion.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -449,10 +449,10 @@ enum ScoreKind {
   SK_FunctionConversion,
   /// A literal expression bound to a non-default literal type.
   SK_NonDefaultLiteral,
-  /// An implicit upcast conversion between collection types.
-  SK_CollectionUpcastConversion,
   /// A value-to-optional conversion.
   SK_ValueToOptional,
+  /// An implicit upcast conversion between collection types.
+  SK_CollectionUpcastConversion,
   /// A conversion to an empty existential type ('Any' or '{}').
   SK_EmptyExistentialConversion,
   /// A key path application subscript.

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -236,3 +236,16 @@ func autoclosure1<T>(_: [T], _: X) { }
 func test_autoclosure1(ia: [Int]) {
   autoclosure1(ia, X()) // okay: resolves to the second function
 }
+
+// SR-8791
+struct Bar {
+    func strs() -> [String] {
+        return ["foo", "bar"]
+    }
+}
+struct Foo {
+    func anArray() -> [Any]? {
+        let bars = [Bar(), Bar()]
+        return bars.flatMap { $0.strs() } // Okay: resolves to correct flatMap, not deprecated
+    }
+}


### PR DESCRIPTION
This code currently chooses the incorrect (deprecated) overload of `flatMap`:
```
struct Bar {
	func strs() -> [String] {
		return ["foo", "bar"]
	}
}
struct Foo {
	func anArray() -> [Any]? {
		let bars = [Bar(), Bar()]
		return bars.flatMap { $0.strs() }
	}
}
```
Both overloads are ending up with `[Any]` and performing a value-to-optional to convert to `[Any]?`, but before that:
The desired overload has to do a collection-upcast to convert `[String]` to `[Any]` in the closure.
 The wrong overload is doing an empty-existential-conversion to convert `[String]` to `Any` in the closure, plus a value-to-optional to convert `Any` to `Any?`.

But the order of scoring was: collection-upcast is checked before value-to-optional. 

This is obviously highly subjective, but I think that value-to-optional is more of a structural change and thus more likely than an upcast to be the wrong thing to do when deciding on a disjunction, as it is in this case.

Resolves [SR-8791](https://bugs.swift.org/browse/SR-8791).
