### PR TITLE
[vim] Add swiftCaseLabelRegion

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -12,7 +12,6 @@ syn keyword swiftKeyword
       \ break
       \ catch
       \ continue
-      \ default
       \ defer
       \ do
       \ else
@@ -144,6 +143,8 @@ syn match swiftKeyword
       \ /\<case\>/
 syn region swiftCaseLabelRegion
       \ matchgroup=swiftKeyword start=/\<case\>/ matchgroup=Delimiter end=/:/ oneline contains=TOP
+syn region swiftDefaultLabelRegion
+      \ matchgroup=swiftKeyword start=/\<default\>/ matchgroup=Delimiter end=/:/
 
 syn region swiftParenthesisRegion matchgroup=NONE start=/(/ end=/)/ contains=TOP
 

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -10,7 +10,6 @@ endif
 syn keyword swiftKeyword
       \ associatedtype
       \ break
-      \ case
       \ catch
       \ continue
       \ default
@@ -140,6 +139,11 @@ syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftType,swiftInOu
       \ /:/
 syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftType
       \ /->/
+
+syn match swiftKeyword
+      \ /\<case\>/
+syn region swiftCaseLabelRegion
+      \ matchgroup=swiftKeyword start=/\<case\>/ matchgroup=Delimiter end=/:/ oneline contains=TOP
 
 syn region swiftParenthesisRegion matchgroup=NONE start=/(/ end=/)/ contains=TOP
 


### PR DESCRIPTION
**Update only utils/vim/syntax/swift.vim**

Fix the problem that the statement following `:` in switch-cases is highlighted as swiftType.

## Problematic patterns

![image](https://user-images.githubusercontent.com/629993/46593978-1dcf3e00-cb0b-11e8-8a7d-add5a95ff457.png)

## Expects

![2018-10-08 14 49 58](https://user-images.githubusercontent.com/629993/46593939-cf21a400-cb0a-11e8-8f4f-fb2e51f2d22b.png)
