### PR TITLE
metatype -> TF_DataType

### DIFF
--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -28,6 +28,7 @@
 
 namespace swift {
 class GraphOperationInst;
+class SymbolicValue;
 
 namespace tf {
 /// Holds information about a TensorFlow operation as represented in SIL
@@ -44,9 +45,8 @@ public:
     Input,
 
     /// This should be lowered to an attribute, in the most direct way. e.g.
-    /// integers should be lowered to integer attributes, metatypes should be
-    /// lowered to type attributes, TensorShapes should be lowered to shape
-    /// attributes, etc.
+    /// integers should be lowered to integer attributes, TensorShapes should
+    /// be lowered to shape attributes, etc.
     ///
     /// Written as named argument without "$" suffix.
     NormalAttribute,
@@ -69,10 +69,17 @@ public:
     UnknownShapeListAttribute,
 
     /// A metatype of a TensorFlow value type or aggregate of TensorFlow value
-    /// types that should be lowered into a list of type attributes.
+    /// types. Deabstraction lowers this to TFDataTypeAttribute.
     ///
     /// Written as named argument with "$typeList" suffix.
     TypeListAttribute,
+
+    /// An integer, or an aggregate containing a single integer, representing a
+    /// TF_DataType attribute. Or a list of such elements, representing a
+    /// TF_DataType list attribute.
+    ///
+    /// Written as named argument with "$dtype" suffix.
+    TFDataTypeAttribute,
 
     /// An argument specifying the address where an indirect output should be
     /// stored. This occurs when the graph_op exists in a context where its
@@ -246,6 +253,13 @@ bool isShapeArrayPseudoAttr(StringRef attrName, SymbolicValue attrValue);
 /// that case.
 int decodeShapeAttr(const ASTContext &ctx, SymbolicValue attr,
                     SmallVectorImpl<int64_t> &result);
+
+/// Return the TF_DataType represented by `value`.
+unsigned getTFDataType(SymbolicValue value);
+
+/// Return a SymbolicValue that represents the TF_DataType for the given swift
+/// type.
+SymbolicValue convertSwiftTypeToTFSymbolicValue(Type type);
 
 } // end namespace tf
 } // end namespace swift

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -66,17 +66,21 @@ public:
     /// types that should be lowered into a list of unknown shape attributes.
     ///
     /// Written as named argument with "$unknownShapeList" suffix.
+    ///
+    /// TODO(SR-8830): Remove this when we have a TensorAggregate protocol.
     UnknownShapeListAttribute,
 
     /// A metatype of a TensorFlow value type or aggregate of TensorFlow value
     /// types. Deabstraction lowers this to TFDataTypeAttribute.
     ///
     /// Written as named argument with "$typeList" suffix.
+    ///
+    /// TODO(SR-8830): Remove this when we have a TensorAggregate protocol.
     TypeListAttribute,
 
-    /// An integer, or an aggregate containing a single integer, representing a
-    /// TF_DataType attribute. Or a list of such elements, representing a
-    /// TF_DataType list attribute.
+    /// A TensorDataType (which is two nested structs wrapping a UInt32), a
+    /// UInt32 representing a TensorDataType, or a list of such elements.
+    /// Should be lowered to a type attribute or type list attribute.
     ///
     /// Written as named argument with "$dtype" suffix.
     TFDataTypeAttribute,
@@ -254,12 +258,14 @@ bool isShapeArrayPseudoAttr(StringRef attrName, SymbolicValue attrValue);
 int decodeShapeAttr(const ASTContext &ctx, SymbolicValue attr,
                     SmallVectorImpl<int64_t> &result);
 
-/// Return the TF_DataType represented by `value`.
+/// Return the TF_DataType represented by `value`. `value` must be a 32-bit
+/// unsigned integer value, or a single element aggregate of a 32-bit unsigned
+/// integer value.
 unsigned getTFDataType(SymbolicValue value);
 
-/// Return a SymbolicValue that represents the TF_DataType for the given swift
-/// type.
-SymbolicValue convertSwiftTypeToTFSymbolicValue(Type type);
+/// Return a constant integer representing the TensorDataType for the given
+/// Swift type. `type` must be a valid TensorFlow type.
+SymbolicValue convertSwiftTypeToConstantTFDataType(Type type);
 
 } // end namespace tf
 } // end namespace swift

--- a/lib/AST/GraphOperationInfo.cpp
+++ b/lib/AST/GraphOperationInfo.cpp
@@ -197,15 +197,21 @@ int tf::decodeShapeAttr(const ASTContext &ctx, SymbolicValue attr,
   return arrayValue.size();
 }
 
-/// Return the TF_DataType represented by `value`.
+/// Return the TF_DataType value represented by `value`. `value` must be a
+/// valid tensorflow type ID.
 unsigned tf::getTFDataType(SymbolicValue value) {
   value = value.lookThroughSingleElementAggregates();
   assert(value.getKind() == SymbolicValue::Integer);
-  return value.getIntegerValue().sextOrTrunc(32).getLimitedValue();
+  assert(value.getIntegerValue().isIntN(32));
+  unsigned tfType = value.getIntegerValue().getLimitedValue();
+  assert(tfType > 0 && "0 is invalid TF_DataType");
+  return tfType;
 }
 
-/// Return a SymbolicValue that represents the TF_DataType for the given swift
-/// type.
-SymbolicValue tf::convertSwiftTypeToTFSymbolicValue(Type type) {
-  return SymbolicValue::getInteger(convertSwiftTypeToTF(type), 32);
+/// Return a constant integer representing the TF_DataType value for the given
+/// Swift type. `type` must be a valid TensorFlow type.
+SymbolicValue tf::convertSwiftTypeToConstantTFDataType(Type type) {
+  unsigned tfType = convertSwiftTypeToTF(type);
+  assert(tfType != 0);
+  return SymbolicValue::getInteger(tfType, 32);
 }

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -306,7 +306,7 @@ static SILValue createTFIntegerConst(GraphFunctionDeviceInfo &deviceInfo,
   GraphOperationBuilder opBuilder("Const");
   opBuilder.addAttribute(
       {context.getIdentifier("dtype$dtype"),
-       convertSwiftTypeToTFSymbolicValue(intType.getASTType())});
+       convertSwiftTypeToConstantTFDataType(intType.getASTType())});
   opBuilder.addAttribute(
       {context.getIdentifier("value$tensor"),
        SymbolicValue::getInteger(APInt(bitwidth, value),

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -305,8 +305,8 @@ static SILValue createTFIntegerConst(GraphFunctionDeviceInfo &deviceInfo,
   // Literals take attributes specifying the dtype, value, and device.
   GraphOperationBuilder opBuilder("Const");
   opBuilder.addAttribute(
-      {context.getIdentifier("dtype"),
-       SymbolicValue::getMetatype(intType.getASTType())});
+      {context.getIdentifier("dtype$dtype"),
+       convertSwiftTypeToTFSymbolicValue(intType.getASTType())});
   opBuilder.addAttribute(
       {context.getIdentifier("value$tensor"),
        SymbolicValue::getInteger(APInt(bitwidth, value),

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2205,13 +2205,13 @@ static bool collectInnermostTensorFlowDTypes(
     CanType type, SmallVectorImpl<SymbolicValue> &result) {
 
   if (isTensorFlowDType(type)) {
-    result.push_back(convertSwiftTypeToTFSymbolicValue(type));
+    result.push_back(convertSwiftTypeToConstantTFDataType(type));
     return true;
   }
   if (tf::isTensorHandle(type)) {
     auto eltType = getTensorHandleElementType(type)->getCanonicalType();
     assert(tf::isTensorFlowDType(eltType));
-    result.push_back(convertSwiftTypeToTFSymbolicValue(eltType));
+    result.push_back(convertSwiftTypeToConstantTFDataType(eltType));
     return true;
   }
   if (auto tupleTy = type->getAs<TupleType>())

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2199,18 +2199,19 @@ static bool unpackTensorAggregates(
   return recurse(unwrapAggregateInstructions(rootAggregate, unwrapCache));
 }
 
-/// Given a type, recursively collect all innermost element types if it's an
-/// aggregate of TensorHandle's or dtypes.
+/// Given a type that is an aggregate of TF types, recursively collect all
+/// innermost TF types as SymbolicValue integers representing TF_DataTypes.
 static bool collectInnermostTensorFlowDTypes(
     CanType type, SmallVectorImpl<SymbolicValue> &result) {
+
   if (isTensorFlowDType(type)) {
-    result.push_back(SymbolicValue::getMetatype(type));
+    result.push_back(convertSwiftTypeToTFSymbolicValue(type));
     return true;
   }
   if (tf::isTensorHandle(type)) {
     auto eltType = getTensorHandleElementType(type)->getCanonicalType();
     assert(tf::isTensorFlowDType(eltType));
-    result.push_back(SymbolicValue::getMetatype(eltType));
+    result.push_back(convertSwiftTypeToTFSymbolicValue(eltType));
     return true;
   }
   if (auto tupleTy = type->getAs<TupleType>())
@@ -2443,12 +2444,26 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
         diagnoseInvalidAttr("cannot be an enum, struct, or tuple");
         return true;
 
+      case SymbolicValue::Metatype:
+        diagnoseInvalidAttr("cannot be a metatype");
+        return true;
+
       case SymbolicValue::Integer:
       case SymbolicValue::Float:
-      case SymbolicValue::Metatype:
       case SymbolicValue::String:
       case SymbolicValue::Function:
+        break;
+
       case SymbolicValue::Array:
+        // Best effort check for common problems.
+        CanType eltTy;
+        for (auto elt : constValue.getArrayValue(eltTy)) {
+          elt = elt.lookThroughSingleElementAggregates();
+          if (elt.getKind() == SymbolicValue::Metatype) {
+            diagnoseInvalidAttr("cannot be an array of metatypes");
+            return true;
+          }
+        }
         break;
       }
       return false;
@@ -2509,15 +2524,14 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
                                             dtypes))
         return diagnoseInvalidAttr("requires a TensorFlow value or an "
                                    "aggregate of TensorFlow values");
-      // Drop '$typeList' from the attribute name.
+      // Change "$typeList" to "$dtype".
       currentAttr.name = context.getIdentifier(
-          std::get<0>(argumentNameAndLowering));
-      // Replace the single metatype with a list of metatypes each
-      // representing a dtype.
-      auto *dtypeProto =
-          context.getProtocol(KnownProtocolKind::AccelerableByTensorFlow);
+          (std::get<0>(argumentNameAndLowering) + "$dtype").str());
+      // Replace the single metatype with a list of UInt32s each representing a
+      // TF_DataType.
       currentAttr.value = SymbolicValue::getArray(
-          dtypes, dtypeProto->getInterfaceType()->getCanonicalType(),
+          dtypes,
+          context.getUInt32Decl()->getDeclaredType()->getCanonicalType(),
           context.getAllocator());
       break;
     }
@@ -2550,7 +2564,7 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
                                                   context.getAllocator());
       break;
     }
-    case GraphOperationInfo::ArgumentLowering::TensorAttribute:
+    case GraphOperationInfo::ArgumentLowering::TensorAttribute: {
       if (constValue.getKind() == SymbolicValue::Integer ||
           constValue.getKind() == SymbolicValue::Float   ||
           constValue.getKind() == SymbolicValue::String)
@@ -2627,6 +2641,27 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
                                    " floating point, string, or array thereof");
       }
       break;
+    }
+    case GraphOperationInfo::ArgumentLowering::TFDataTypeAttribute: {
+      // Integers are ok.
+      if (constValue.getKind() == SymbolicValue::Integer)
+        break;
+
+      // Arrays of integers are ok.
+      if (constValue.getKind() == SymbolicValue::Array) {
+        CanType eltTy;
+        for (auto elt : constValue.getArrayValue(eltTy)) {
+          elt = elt.lookThroughSingleElementAggregates();
+          if (elt.getKind() != SymbolicValue::Integer)
+            return diagnoseInvalidAttr("requires an integer or array of "
+                                       "integers");
+        }
+        break;
+      }
+
+      // Everything else is bad.
+      return diagnoseInvalidAttr("requires an integer or array of integers");
+    }
     }
   }
 

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1778,6 +1778,8 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
       case SymbolicValue::EnumWithPayload:
       case SymbolicValue::Address:
       case SymbolicValue::Aggregate: // Tuples and structs
+      case SymbolicValue::Metatype:
+        llvm::dbgs() << name << " " << attrValue << "\n";
         assert(0 && "These attribute kinds cannot happen here");
       case SymbolicValue::Integer: {
         auto value = attrValue.getIntegerValue();
@@ -1797,11 +1799,6 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
         TF_SetAttrFloat(op, name.c_str(), value.convertToFloat());
         break;
       }
-      case SymbolicValue::Metatype:
-        dtypeAttr = convertSwiftTypeToTF(attrValue.getMetatypeValue());
-        assert(dtypeAttr && "expected a valid tensorflow type");
-        TF_SetAttrType(op, name.c_str(), (TF_DataType)dtypeAttr);
-        break;
       case SymbolicValue::String: {
         auto value = attrValue.getStringValue();
         if (name != DEVICE_ATTR) {
@@ -1852,18 +1849,6 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
         elements.reserve(rawElements.size());
         for (auto elt : rawElements)
           elements.push_back(elt.lookThroughSingleElementAggregates());
-
-        if (elementType->is<AnyMetatypeType>()) {
-          SmallVector<TF_DataType, 4> types;
-          for (auto elt : elements) {
-            auto dtype = convertSwiftTypeToTF(elt.getMetatypeValue());
-            assert(dtype && "expected a valid tensorflow type");
-            types.push_back((TF_DataType)dtype);
-          }
-
-          TF_SetAttrTypeList(op, name.c_str(), types.data(), types.size());
-          break;
-        }
 
         if (elementTypeString == "String") {
           SmallVector<const void *, 4> pointers;
@@ -1981,6 +1966,24 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
     case GraphOperationInfo::ArgumentLowering::TypeListAttribute:
       llvm_unreachable("TypeListAttribute should have been eliminated by "
                        "deabstraction");
+    case GraphOperationInfo::ArgumentLowering::TFDataTypeAttribute:
+      switch (attrValue.getKind()) {
+        case SymbolicValue::Integer:
+          dtypeAttr = getTFDataType(attrValue);
+          TF_SetAttrType(op, name.c_str(), (TF_DataType)dtypeAttr);
+          break;
+        case SymbolicValue::Array: {
+          CanType eltTy;
+          SmallVector<TF_DataType, 4> types;
+          for (auto elt : attrValue.getArrayValue(eltTy))
+            types.push_back((TF_DataType)getTFDataType(elt));
+          TF_SetAttrTypeList(op, name.c_str(), types.data(), types.size());
+          break;
+        }
+        default:
+          llvm_unreachable(
+              "only integers and arrays are possible for TF_DataType attrs");
+      }
     }
   }
 

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1968,21 +1968,21 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
                        "deabstraction");
     case GraphOperationInfo::ArgumentLowering::TFDataTypeAttribute:
       switch (attrValue.getKind()) {
-        case SymbolicValue::Integer:
-          dtypeAttr = getTFDataType(attrValue);
-          TF_SetAttrType(op, name.c_str(), (TF_DataType)dtypeAttr);
-          break;
-        case SymbolicValue::Array: {
-          CanType eltTy;
-          SmallVector<TF_DataType, 4> types;
-          for (auto elt : attrValue.getArrayValue(eltTy))
-            types.push_back((TF_DataType)getTFDataType(elt));
-          TF_SetAttrTypeList(op, name.c_str(), types.data(), types.size());
-          break;
-        }
-        default:
-          llvm_unreachable(
-              "only integers and arrays are possible for TF_DataType attrs");
+      case SymbolicValue::Integer:
+        dtypeAttr = getTFDataType(attrValue);
+        TF_SetAttrType(op, name.c_str(), (TF_DataType)dtypeAttr);
+        break;
+      case SymbolicValue::Array: {
+        CanType eltTy;
+        SmallVector<TF_DataType, 4> types;
+        for (auto elt : attrValue.getArrayValue(eltTy))
+          types.push_back((TF_DataType)getTFDataType(elt));
+        TF_SetAttrTypeList(op, name.c_str(), types.data(), types.size());
+        break;
+      }
+      default:
+        llvm_unreachable(
+            "only integers and arrays are possible for TF_DataType attrs");
       }
     }
   }

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2449,8 +2449,8 @@ static void createConstTensorAttrsOnAccel(
     GraphOperationBuilder *opBuilder) {
   // Literals take attributes specifying the dtype and value.
   opBuilder->addAttribute(
-      {ctx.getIdentifier("dtype"),
-       SymbolicValue::getMetatype(valTy.getASTType()->getCanonicalType())});
+      {ctx.getIdentifier("dtype$dtype"),
+       convertSwiftTypeToTFSymbolicValue(valTy.getASTType())});
   opBuilder->addAttribute({ctx.getIdentifier("value$tensor"), constVal});
 }
 
@@ -2553,9 +2553,8 @@ void PartitionCloner::visitScalarInst(SingleValueInstruction *inst) {
   case PromotedScalarKind::Conversion: {
     // Conversions get an attribute specifying the result dtype, named "DstT".
     opBuilder.addAttribute(
-        {ctx.getIdentifier("DstT"),
-         SymbolicValue::getMetatype(
-             inst->getType().getASTType()->getCanonicalType())});
+        {ctx.getIdentifier("DstT$dtype"),
+         convertSwiftTypeToTFSymbolicValue(inst->getType().getASTType())});
     break;
   }
   }

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2450,7 +2450,7 @@ static void createConstTensorAttrsOnAccel(
   // Literals take attributes specifying the dtype and value.
   opBuilder->addAttribute(
       {ctx.getIdentifier("dtype$dtype"),
-       convertSwiftTypeToTFSymbolicValue(valTy.getASTType())});
+       convertSwiftTypeToConstantTFDataType(valTy.getASTType())});
   opBuilder->addAttribute({ctx.getIdentifier("value$tensor"), constVal});
 }
 
@@ -2554,7 +2554,7 @@ void PartitionCloner::visitScalarInst(SingleValueInstruction *inst) {
     // Conversions get an attribute specifying the result dtype, named "DstT".
     opBuilder.addAttribute(
         {ctx.getIdentifier("DstT$dtype"),
-         convertSwiftTypeToTFSymbolicValue(inst->getType().getASTType())});
+         convertSwiftTypeToConstantTFDataType(inst->getType().getASTType())});
     break;
   }
   }

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -278,8 +278,8 @@ tf::createConstTensor(Type elementType, SymbolicValue scalars,
 
   // Add a dtype attribute for the array element.
   opBuilder.addAttribute(
-      {context.getIdentifier("dtype"),
-       SymbolicValue::getMetatype(elementType->getCanonicalType())});
+      {context.getIdentifier("dtype$dtype"),
+       convertSwiftTypeToTFSymbolicValue(elementType)});
 
   // Add an attribute for the value$tensor attribute.
   auto tensorSuffix = GraphOperationInfo::getArgumentLoweringSuffix(

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -279,7 +279,7 @@ tf::createConstTensor(Type elementType, SymbolicValue scalars,
   // Add a dtype attribute for the array element.
   opBuilder.addAttribute(
       {context.getIdentifier("dtype$dtype"),
-       convertSwiftTypeToTFSymbolicValue(elementType)});
+       convertSwiftTypeToConstantTFDataType(elementType)});
 
   // Add an attribute for the value$tensor attribute.
   auto tensorSuffix = GraphOperationInfo::getArgumentLoweringSuffix(

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -23,9 +23,11 @@ import CTensorFlow
 
 @_fixed_layout
 public struct _TensorDataType {
+  @usableFromInline
   internal var cDataType: TF_DataType
 
-  fileprivate init(_ cDataType: TF_DataType) {
+  @inlinable
+  internal init(_ cDataType: TF_DataType) {
     self.cDataType = cDataType
   }
 }
@@ -37,6 +39,7 @@ public struct _TensorDataType {
 public protocol AccelerableByTensorFlow {
   /// The underlying TensorFlow data type.
   /// - Note: This is not intended for general use.
+  @inlinable
   static var _tensorFlowDataType: _TensorDataType { get }
 
   // Hooks used by the TFPartition pass for primitive operations on tensors.
@@ -85,13 +88,14 @@ private func _TFGetScalarImpl<Scalar>(
 }
 
 internal extension AccelerableByTensorFlow {
-  @usableFromInline
+  @inlinable
   static var cDataType: TF_DataType {
     return _tensorFlowDataType.cDataType
   }
 }
 
 extension Bool : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_BOOL)
   }
@@ -115,6 +119,7 @@ extension Bool : AccelerableByTensorFlow {
 }
 
 extension Int8 : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_INT8)
   }
@@ -138,6 +143,7 @@ extension Int8 : AccelerableByTensorFlow {
 }
 
 extension UInt8 : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_UINT8)
   }
@@ -161,6 +167,7 @@ extension UInt8 : AccelerableByTensorFlow {
 }
 
 extension Int16 : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_INT16)
   }
@@ -184,6 +191,7 @@ extension Int16 : AccelerableByTensorFlow {
 }
 
 extension UInt16 : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_UINT16)
   }
@@ -208,6 +216,7 @@ extension UInt16 : AccelerableByTensorFlow {
 }
 
 extension Int32 : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_INT32)
   }
@@ -231,6 +240,7 @@ extension Int32 : AccelerableByTensorFlow {
 }
 
 extension UInt32 : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_UINT32)
   }
@@ -255,6 +265,7 @@ extension UInt32 : AccelerableByTensorFlow {
 }
 
 extension Int64 : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_INT64)
   }
@@ -278,6 +289,7 @@ extension Int64 : AccelerableByTensorFlow {
 }
 
 extension UInt64 : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_UINT64)
   }
@@ -308,6 +320,7 @@ public struct BFloat16 {
 }
 
 extension BFloat16 : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_BFLOAT16)
   }
@@ -336,6 +349,7 @@ extension BFloat16 : AccelerableByTensorFlow {
 }
 
 extension Float : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_FLOAT)
   }
@@ -359,6 +373,7 @@ extension Float : AccelerableByTensorFlow {
 }
 
 extension Double : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_DOUBLE)
   }
@@ -383,6 +398,7 @@ extension Double : AccelerableByTensorFlow {
 }
 
 extension String : AccelerableByTensorFlow {
+  @inlinable
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_STRING)
   }

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -21,10 +21,11 @@
 
 import CTensorFlow
 
-/// Wraps a TF_DataType.
-///
-/// This allows user code to handle TF_DataTypes without importing CTensorFlow,
-/// which would import a bunch of distracting declarations from the TF C API.
+/// A TensorFlow dynamic type value. Can be created from types that conform to
+/// `AccelerableByTensorFlow`.
+// This simply wraps TF_DataTypes, which allows user code to handle TF_DataTypes
+// without importing CTensorFlow, which would import a bunch of distracting
+// declarations from the TF C API.
 @_fixed_layout
 public struct TensorDataType {
   @usableFromInline

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -21,8 +21,12 @@
 
 import CTensorFlow
 
+/// Wraps a TF_DataType.
+///
+/// This allows user code to handle TF_DataTypes without importing CTensorFlow,
+/// which would import a bunch of distracting declarations from the TF C API.
 @_fixed_layout
-public struct _TensorDataType {
+public struct TensorDataType {
   @usableFromInline
   internal var cDataType: TF_DataType
 
@@ -38,9 +42,8 @@ public struct _TensorDataType {
 /// associated type of `Tensor`, `Tensor1D`, `Tensor2D`, etc.
 public protocol AccelerableByTensorFlow {
   /// The underlying TensorFlow data type.
-  /// - Note: This is not intended for general use.
   @inlinable
-  static var _tensorFlowDataType: _TensorDataType { get }
+  static var tensorFlowDataType: TensorDataType { get }
 
   // Hooks used by the TFPartition pass for primitive operations on tensors.
   // These should not be called directly or implemented.
@@ -87,17 +90,10 @@ private func _TFGetScalarImpl<Scalar>(
   return handle.makeHostCopy().scalar
 }
 
-internal extension AccelerableByTensorFlow {
-  @inlinable
-  static var cDataType: TF_DataType {
-    return _tensorFlowDataType.cDataType
-  }
-}
-
 extension Bool : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_BOOL)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_BOOL)
   }
   @_silgen_name("__tf_get_scalar_or_die_Bool") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<Bool>) -> Bool {
@@ -120,8 +116,8 @@ extension Bool : AccelerableByTensorFlow {
 
 extension Int8 : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_INT8)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_INT8)
   }
   @_silgen_name("__tf_get_scalar_or_die_Int8") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<Int8>) -> Int8 {
@@ -144,8 +140,8 @@ extension Int8 : AccelerableByTensorFlow {
 
 extension UInt8 : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_UINT8)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_UINT8)
   }
   @_silgen_name("__tf_get_scalar_or_die_UInt8") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<UInt8>) -> UInt8 {
@@ -168,8 +164,8 @@ extension UInt8 : AccelerableByTensorFlow {
 
 extension Int16 : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_INT16)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_INT16)
   }
   @_silgen_name("__tf_get_scalar_or_die_Int16") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<Int16>) -> Int16 {
@@ -192,8 +188,8 @@ extension Int16 : AccelerableByTensorFlow {
 
 extension UInt16 : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_UINT16)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_UINT16)
   }
   @_silgen_name("__tf_get_scalar_or_die_UInt16") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<UInt16>) -> UInt16 {
@@ -217,8 +213,8 @@ extension UInt16 : AccelerableByTensorFlow {
 
 extension Int32 : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_INT32)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_INT32)
   }
   @_silgen_name("__tf_get_scalar_or_die_Int32") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<Int32>) -> Int32 {
@@ -241,8 +237,8 @@ extension Int32 : AccelerableByTensorFlow {
 
 extension UInt32 : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_UINT32)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_UINT32)
   }
   @_silgen_name("__tf_get_scalar_or_die_UInt32") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<UInt32>) -> UInt32 {
@@ -266,8 +262,8 @@ extension UInt32 : AccelerableByTensorFlow {
 
 extension Int64 : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_INT64)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_INT64)
   }
   @_silgen_name("__tf_get_scalar_or_die_Int64") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<Int64>) -> Int64 {
@@ -290,8 +286,8 @@ extension Int64 : AccelerableByTensorFlow {
 
 extension UInt64 : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_UINT64)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_UINT64)
   }
   @_silgen_name("__tf_get_scalar_or_die_UInt64") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<UInt64>) -> UInt64 {
@@ -321,8 +317,8 @@ public struct BFloat16 {
 
 extension BFloat16 : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_BFLOAT16)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_BFLOAT16)
   }
   @_silgen_name("__tf_get_scalar_or_die_BFloat16") @inline(never)
   public static func _getScalarOrDie
@@ -350,8 +346,8 @@ extension BFloat16 : AccelerableByTensorFlow {
 
 extension Float : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_FLOAT)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_FLOAT)
   }
   @_silgen_name("__tf_get_scalar_or_die_Float") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<Float>) -> Float {
@@ -374,8 +370,8 @@ extension Float : AccelerableByTensorFlow {
 
 extension Double : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_DOUBLE)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_DOUBLE)
   }
   @_silgen_name("__tf_get_scalar_or_die_Double") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<Double>) -> Double {
@@ -399,8 +395,8 @@ extension Double : AccelerableByTensorFlow {
 
 extension String : AccelerableByTensorFlow {
   @inlinable
-  public static var _tensorFlowDataType: _TensorDataType {
-    return _TensorDataType(TF_STRING)
+  public static var tensorFlowDataType: TensorDataType {
+    return TensorDataType(TF_STRING)
   }
   @_silgen_name("__tf_get_scalar_or_die_String") @inline(never)
   public static func _getScalarOrDie(_ handle: TensorHandle<String>) -> String {

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -110,7 +110,7 @@ public extension Dataset where Element == Tensor<Float> {
     return Dataset(
       _handle: #tfop(
         "MapDataset", _handle, [Tensor<Int32>(0)], f: transform,
-        Targuments$dtype: [Int32.cDataType],
+        Targuments$dtype: [Int32.tensorFlowDataType],
         output_types$typeList: Element.self,
         output_shapes$unknownShapeList: Element.self
       )
@@ -129,7 +129,7 @@ public extension Dataset where Element == Tensor<Float> {
     return Dataset(
       _handle: #tfop(
         "FilterDataset", _handle, [Tensor<Int32>(0)],
-        predicate: isIncluded, Targuments$dtype: [Int32.cDataType],
+        predicate: isIncluded, Targuments$dtype: [Int32.tensorFlowDataType],
         output_types$typeList: Element.self,
         output_shapes$unknownShapeList: Element.self
       )

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -110,7 +110,7 @@ public extension Dataset where Element == Tensor<Float> {
     return Dataset(
       _handle: #tfop(
         "MapDataset", _handle, [Tensor<Int32>(0)], f: transform,
-        Targuments: [Int32.self],
+        Targuments$dtype: [Int32.cDataType],
         output_types$typeList: Element.self,
         output_shapes$unknownShapeList: Element.self
       )
@@ -129,7 +129,7 @@ public extension Dataset where Element == Tensor<Float> {
     return Dataset(
       _handle: #tfop(
         "FilterDataset", _handle, [Tensor<Int32>(0)],
-        predicate: isIncluded, Targuments: [Int32.self],
+        predicate: isIncluded, Targuments$dtype: [Int32.cDataType],
         output_types$typeList: Element.self,
         output_shapes$unknownShapeList: Element.self
       )

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -160,7 +160,7 @@ public extension Tensor {
     let ret: TensorHandle<Scalar> = #tfop(
       "Identity",
       tensor,
-      T: Scalar.self,
+      T$dtype: Scalar.cDataType,
       __shapes: [shape],
       __device: "/job:localhost/replica:0/task:0/device:CPU:0")
     return Tensor(handle: ret)
@@ -182,7 +182,7 @@ public extension Tensor {
     // device first, before outfeeding the tensor to CPU, a required step for
     // sending the tensor to the host.
     let tensor: TensorHandle<Scalar> =
-      #tfop("Identity", self, T: Scalar.self, __shapes: [shape])
+      #tfop("Identity", self, T$dtype: Scalar.cDataType, __shapes: [shape])
     return Tensor(handle: tensor).toHost()
   }
 
@@ -452,7 +452,8 @@ extension TensorElementLiteral : ExpressibleByArrayLiteral {
     // Attr T (non-optional in the op definition) need not be specified when we
     // run the op as part of a graph function, but need to be specified when we
     // run it via eager C API.
-    let handle: TensorHandle<Scalar> = #tfop("Pack", elements, T: Scalar.self)
+    let handle: TensorHandle<Scalar> = #tfop("Pack", elements,
+                                             T$dtype: Scalar.cDataType)
     tensor = Tensor(handle: handle)
   }
 }
@@ -468,7 +469,7 @@ extension Tensor : ExpressibleByArrayLiteral {
   internal init(
     tensorElementLiterals elements: [TensorElementLiteral<Scalar>]
   ) {
-    self.init(handle: #tfop("Pack", elements, T: Scalar.self))
+    self.init(handle: #tfop("Pack", elements, T$dtype: Scalar.cDataType))
   }
 
   /// Creates a tensor initialized with the given elements.

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -160,7 +160,7 @@ public extension Tensor {
     let ret: TensorHandle<Scalar> = #tfop(
       "Identity",
       tensor,
-      T$dtype: Scalar.cDataType,
+      T$dtype: Scalar.tensorFlowDataType,
       __shapes: [shape],
       __device: "/job:localhost/replica:0/task:0/device:CPU:0")
     return Tensor(handle: ret)
@@ -182,7 +182,8 @@ public extension Tensor {
     // device first, before outfeeding the tensor to CPU, a required step for
     // sending the tensor to the host.
     let tensor: TensorHandle<Scalar> =
-      #tfop("Identity", self, T$dtype: Scalar.cDataType, __shapes: [shape])
+      #tfop("Identity", self, T$dtype: Scalar.tensorFlowDataType,
+            __shapes: [shape])
     return Tensor(handle: tensor).toHost()
   }
 
@@ -453,7 +454,7 @@ extension TensorElementLiteral : ExpressibleByArrayLiteral {
     // run the op as part of a graph function, but need to be specified when we
     // run it via eager C API.
     let handle: TensorHandle<Scalar> = #tfop("Pack", elements,
-                                             T$dtype: Scalar.cDataType)
+                                             T$dtype: Scalar.tensorFlowDataType)
     tensor = Tensor(handle: handle)
   }
 }
@@ -469,7 +470,8 @@ extension Tensor : ExpressibleByArrayLiteral {
   internal init(
     tensorElementLiterals elements: [TensorElementLiteral<Scalar>]
   ) {
-    self.init(handle: #tfop("Pack", elements, T$dtype: Scalar.cDataType))
+    self.init(handle: #tfop("Pack", elements,
+                            T$dtype: Scalar.tensorFlowDataType))
   }
 
   /// Creates a tensor initialized with the given elements.

--- a/stdlib/public/TensorFlow/TensorHandle.swift
+++ b/stdlib/public/TensorFlow/TensorHandle.swift
@@ -77,7 +77,7 @@ public final class TensorHandle<Scalar> : _AnyTensorHandle
     // Initialize tensor and copy data.
     // TF_AllocateTensor() never returns nil.
     let cTensor = TF_AllocateTensor(
-      Scalar.cDataType,
+      Scalar.tensorFlowDataType.cDataType,
       shape.map(Int64.init),
       Int32(shape.count),
       byteCount
@@ -114,7 +114,8 @@ extension TensorHandle : TensorSendableReceivable {
     if _RuntimeConfig.usesTFEagerAPI {
       let context = _ExecutionContext.global
       let cTensorHandle = TFE_DequeueNamedTensorFromCtx(
-        context.eagerContext, Int32(tensorID), Scalar.cDataType, status)
+        context.eagerContext, Int32(tensorID),
+        Scalar.tensorFlowDataType.cDataType, status)
       checkOk(status)
       tensorHandle = TensorHandle<Scalar>(owning: cTensorHandle!)
     } else {
@@ -163,7 +164,8 @@ extension TensorHandle : TensorSendableReceivable {
   @inlinable
   static func scalar(_ scalar: Scalar) -> TensorHandle<Scalar> {
     debugLog("Creating a tensor from scalar \(scalar).")
-    let cTensorHandle = _TFCCreateCTensorHandle(scalar, Scalar.cDataType)
+    let cTensorHandle = _TFCCreateCTensorHandle(
+        scalar, Scalar.tensorFlowDataType.cDataType)
     return TensorHandle<Scalar>(owning: cTensorHandle)
   }
 }

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -172,7 +172,7 @@ public func _scalarTensorWithShape<Scalar>(
   _ x: Tensor<Scalar>
 ) -> Tensor<Scalar> {
   let ret: TensorHandle<Scalar> =
-    #tfop("Identity", x, T: Scalar.self, __shapes: [TensorShape()])
+    #tfop("Identity", x, T$dtype: Scalar.cDataType, __shapes: [TensorShape()])
   return Tensor<Scalar>(handle: ret)
 }
 
@@ -182,6 +182,6 @@ public func _addScalarTensorsWithShape<Scalar>(
   _ y: Tensor<Scalar>
 ) -> Tensor<Scalar> {
   let ret: TensorHandle<Scalar> =
-    #tfop("Add", x, y, T: Scalar.self, __shapes: [TensorShape()])
+    #tfop("Add", x, y, T$dtype: Scalar.cDataType, __shapes: [TensorShape()])
   return Tensor<Scalar>(handle: ret)
 }

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -172,7 +172,8 @@ public func _scalarTensorWithShape<Scalar>(
   _ x: Tensor<Scalar>
 ) -> Tensor<Scalar> {
   let ret: TensorHandle<Scalar> =
-    #tfop("Identity", x, T$dtype: Scalar.cDataType, __shapes: [TensorShape()])
+    #tfop("Identity", x, T$dtype: Scalar.tensorFlowDataType,
+          __shapes: [TensorShape()])
   return Tensor<Scalar>(handle: ret)
 }
 
@@ -182,6 +183,7 @@ public func _addScalarTensorsWithShape<Scalar>(
   _ y: Tensor<Scalar>
 ) -> Tensor<Scalar> {
   let ret: TensorHandle<Scalar> =
-    #tfop("Add", x, y, T$dtype: Scalar.cDataType, __shapes: [TensorShape()])
+    #tfop("Add", x, y, T$dtype: Scalar.tensorFlowDataType,
+          __shapes: [TensorShape()])
   return Tensor<Scalar>(handle: ret)
 }

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -153,7 +153,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   func genericAttr<T : AccelerableByTensorFlow>(axis: T) -> Tensor {
     // expected-error @+1 {{op named 'ExampleOp' is not registered in TensorFlow}}
-    let ret: TensorHandle<Scalar> = #tfop("ExampleOp", handle, axis: axis, axisType$dtype: T._tensorFlowDataType)
+    let ret: TensorHandle<Scalar> = #tfop("ExampleOp", handle, axis: axis, axisType$dtype: T.tensorFlowDataType)
     return Tensor<Scalar>(handle: ret)
   }
 }

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -153,7 +153,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   func genericAttr<T : AccelerableByTensorFlow>(axis: T) -> Tensor {
     // expected-error @+1 {{op named 'ExampleOp' is not registered in TensorFlow}}
-    let ret: TensorHandle<Scalar> = #tfop("ExampleOp", handle, axis: axis, axisType: T.self)
+    let ret: TensorHandle<Scalar> = #tfop("ExampleOp", handle, axis: axis, axisType$dtype: T._tensorFlowDataType)
     return Tensor<Scalar>(handle: ret)
   }
 }

--- a/test/TensorFlow/dataset.swift
+++ b/test/TensorFlow/dataset.swift
@@ -15,7 +15,7 @@ public func createMockDataSet() -> VariantHandle {
   //   .Attr("output_shapes: list(shape) >= 1")
   let dataset : VariantHandle = #tfop("TensorSliceDataset",
                                       [values],
-                                      Toutput_types$dtype: [Float._tensorFlowDataType],
+                                      Toutput_types$dtype: [Float.tensorFlowDataType],
                                       output_shapes: [TensorShape()])
   return dataset
 }
@@ -35,7 +35,7 @@ public func model() {
     "OneShotIterator",
     container: "some_container",
     dataset_factory : /*datasetCreator*/createMockDataSet,
-    output_types$dtype: [Float._tensorFlowDataType],
+    output_types$dtype: [Float.tensorFlowDataType],
     output_shapes: [TensorShape()],
     shared_name: "some_name"
   )
@@ -47,7 +47,7 @@ public func model() {
   //   .Attr("output_shapes: list(shape) >= 1")
   let one: TensorHandle<Float> = #tfop("IteratorGetNext",
                                        iterator,
-                                       output_types$dtype: [Float._tensorFlowDataType],
+                                       output_types$dtype: [Float.tensorFlowDataType],
                                        output_shapes: [TensorShape()])
   _hostOp(one)
 }

--- a/test/TensorFlow/dataset.swift
+++ b/test/TensorFlow/dataset.swift
@@ -15,7 +15,7 @@ public func createMockDataSet() -> VariantHandle {
   //   .Attr("output_shapes: list(shape) >= 1")
   let dataset : VariantHandle = #tfop("TensorSliceDataset",
                                       [values],
-                                      Toutput_types: [Float.self],
+                                      Toutput_types$dtype: [Float._tensorFlowDataType],
                                       output_shapes: [TensorShape()])
   return dataset
 }
@@ -35,7 +35,7 @@ public func model() {
     "OneShotIterator",
     container: "some_container",
     dataset_factory : /*datasetCreator*/createMockDataSet,
-    output_types: [Float.self],
+    output_types$dtype: [Float._tensorFlowDataType],
     output_shapes: [TensorShape()],
     shared_name: "some_name"
   )
@@ -47,7 +47,7 @@ public func model() {
   //   .Attr("output_shapes: list(shape) >= 1")
   let one: TensorHandle<Float> = #tfop("IteratorGetNext",
                                        iterator,
-                                       output_types: [Float.self],
+                                       output_types$dtype: [Float._tensorFlowDataType],
                                        output_shapes: [TensorShape()])
   _hostOp(one)
 }

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -10,11 +10,11 @@ public func trivialAdd(a: Tensor<Float>) -> Tensor<Float> {
 
 /*
 CHECK-LABEL: --- INPUT FUNCTION {{.*}}trivialAdd
-CHECK: graph_op "Add"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {T: $Float, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+CHECK: graph_op "Add"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {T$dtype: i32 1, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
 
 CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}trivialAdd
 CHECK:      bb0(%0 : @unowned $TensorHandle<Float>):
-CHECK-NEXT:   %1 = graph_op "Add"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) {T: $Float, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+CHECK-NEXT:   %1 = graph_op "Add"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) {T$dtype: i32 1, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
 CHECK-NEXT:   return %1 : $TensorHandle<Float>
 
 CHECK-LABEL: --- TFPartition Host Result: {{.*}}trivialAdd
@@ -33,10 +33,10 @@ public func constexprCall(a: Tensor<Float>, idx: Tensor<Int32>) -> Tensor<Float>
 
 /*
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}constexprCall
- CHECK: [[A:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: i32 0
+ CHECK: [[A:%.*]] = graph_op "Const"() {dtype$dtype: i32 3, value$tensor: i32 0
  CHECK: [[B:%.*]] = graph_op "Const"
  CHECK: [[C:%.*]] = graph_op "Const"
- CHECK: [[RESULT:%.*]] = graph_op "OneHot"(%0 : $TensorHandle<Int32>, [[A]] : $TensorHandle<Int32>, [[B]] : $TensorHandle<Float>, [[C]] : $TensorHandle<Float>) {T: $Float, TI: $Int32, axis: i64 1, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+ CHECK: [[RESULT:%.*]] = graph_op "OneHot"(%0 : $TensorHandle<Int32>, [[A]] : $TensorHandle<Int32>, [[B]] : $TensorHandle<Float>, [[C]] : $TensorHandle<Float>) {T$dtype: i32 1, TI$dtype: i32 3, axis: i64 1, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
   CHECK: return [[RESULT]]
 */
 
@@ -96,7 +96,7 @@ CHECK-LABEL: --- INPUT FUNCTION {{.*}}stringAttributes
 public func tensorShape() -> Tensor<Float> {
   let shape : TensorShape = [1, 2]
 
-  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape$shape: shape))
+  return Tensor(handle: #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: [17.0 as Float, 18.0], shape$shape: shape))
 }
 
 // b/75407624
@@ -110,14 +110,14 @@ public func test75407624() {
   _ = a+b+c+d
 }
 /* CHECK-LABEL: ---- INPUT FUNCTION {{.*}}test75407624
- * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */)], shape$shape: [$Int32: i32 1]
- * CHECK: [[B1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], shape$shape: [$Int32: i32 1],
- * CHECK: [[BX2:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */
+ * CHECK: graph_op "Const"() {dtype$dtype: i32 1, value$tensor: [$Float: (f32 0x3F800000 /* 1 */)], shape$shape: [$Int32: i32 1]
+ * CHECK: [[B1X:%.*]] = graph_op "Const"() {dtype$dtype: i32 3, value$tensor: [$Int32: (i32 1)], shape$shape: [$Int32: i32 1],
+ * CHECK: [[BX2:%.*]] = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */
  * CHECK:  graph_op "Fill"([[B1X]] : $TensorHandle<Int32>, [[BX2]] : $TensorHandle<Float>)
- * CHECK: [[C1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], shape$shape: [$Int32: i32 1],
- * CHECK: [[CX2:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */
+ * CHECK: [[C1X:%.*]] = graph_op "Const"() {dtype$dtype: i32 3, value$tensor: [$Int32: (i32 1)], shape$shape: [$Int32: i32 1],
+ * CHECK: [[CX2:%.*]] = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */
  * CHECK:  graph_op "Fill"([[C1X]] : $TensorHandle<Int32>, [[CX2]] : $TensorHandle<Float>)
- * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */), (f32 0x40400000 /* 3 */), (f32 0x40800000 /* 4 */)], shape$shape: [$Int32: (i32 2), (i32 2)],
+ * CHECK: graph_op "Const"() {dtype$dtype: i32 1, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */), (f32 0x40400000 /* 3 */), (f32 0x40800000 /* 4 */)], shape$shape: [$Int32: (i32 2), (i32 2)],
  * CHECK-LABEL: ---- END OF
 */
 
@@ -128,7 +128,7 @@ public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<F
 }
 
 /* CHECK-LABEL: ---- INPUT FUNCTION {{.*}}testConvolution
- * CHECK: graph_op "Conv2D"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {T: $Float, strides: [$Int32: (i32 1), (i32 2), (i32 3), (i32 4)], use_cudnn_on_gpu: i1 -1, padding: "SAME", data_format: "NHWC", dilations: [$Int32: (i32 1), (i32 1), (i32 1), (i32 1)],
+ * CHECK: graph_op "Conv2D"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {T$dtype: i32 1, strides: [$Int32: (i32 1), (i32 2), (i32 3), (i32 4)], use_cudnn_on_gpu: i1 -1, padding: "SAME", data_format: "NHWC", dilations: [$Int32: (i32 1), (i32 1), (i32 1), (i32 1)],
  * CHECK-LABEL: ---- END OF
 */
 
@@ -149,12 +149,12 @@ public func testShapeList() {
   let t = Tensor<Int32>([0])
   let handle: VariantHandle = #tfop(
     "TensorSliceDataset", [t],
-    Toutput_types: [Int32.self],
+    Toutput_types$dtype: [Int32._tensorFlowDataType],
     output_shapes: [TensorShape()]
   )
   let dataset = SimpleDataset(handle: handle, elementShape: TensorShape())
   _ = #tfop("AnonymousIterator",
-            output_types: [Int32.self],
+            output_types$dtype: [Int32._tensorFlowDataType],
             output_shapes: [dataset.elementShape]) as ResourceHandle
 }
 
@@ -165,7 +165,7 @@ struct SimpleIterator {
 
   mutating func next() -> Tensor<Float> {
     return #tfop("IteratorGetNext", handle,
-                 output_types: [Int32.self],
+                 output_types$dtype: [Int32._tensorFlowDataType],
                  output_shapes: [elementShape])
   }
 }
@@ -174,12 +174,12 @@ public func testShapeList2() {
   let t = Tensor<Int32>([0])
   let handle: VariantHandle = #tfop(
     "TensorSliceDataset", [t],
-    Toutput_types: [Int32.self],
+    Toutput_types$dtype: [Int32._tensorFlowDataType],
     output_shapes: [TensorShape()]
   )
   let dataset = SimpleDataset(handle: handle, elementShape: TensorShape())
   let resource = #tfop("AnonymousIterator",
-                       output_types: [Int32.self],
+                       output_types$dtype: [Int32._tensorFlowDataType],
                        output_shapes: [dataset.elementShape]) as ResourceHandle
 
   var it = SimpleIterator(handle: resource, elementShape: dataset.elementShape)
@@ -187,7 +187,7 @@ public func testShapeList2() {
 }
 
 // CHECK-LABEL: ---- INPUT FUNCTION {{.*}}testShapeList
-// CHECK: graph_op "AnonymousIterator"() {output_types: [$Int32.Type: $Int32], output_shapes: [$TensorShape: ([$Int32: ])]
+// CHECK: graph_op "AnonymousIterator"() {output_types$dtype: [$_TensorDataType: (((i32 3)))], output_shapes: [$TensorShape: ([$Int32: ])]
 
 @TensorFlowGraph
 func isZero(_ x: Tensor<Float>) -> Tensor<Bool> {
@@ -198,12 +198,12 @@ public func noescapeFuncAsAttr(_ f: @convention(tensorflow) (Tensor<Float>) -> T
   let t = Tensor<Int32>([0])
   let dataset: VariantHandle = #tfop(
     "TensorSliceDataset", [t],
-    Toutput_types: [Int32.self],
+    Toutput_types$dtype: [Int32._tensorFlowDataType],
     output_shapes: [TensorShape()]
   )
   let _: VariantHandle = #tfop(
     "FilterDataset", dataset, [Tensor<Int32>(0)], predicate: isZero,
-    Targuments: [Int32.self], output_types: [Float.self], output_shapes: [TensorShape()]
+    Targuments$dtype: [Int32._tensorFlowDataType], output_types$dtype: [Float._tensorFlowDataType], output_shapes: [TensorShape()]
   )
 }
 // Ensure that private functions are partitioned and lowered
@@ -211,7 +211,7 @@ public func noescapeFuncAsAttr(_ f: @convention(tensorflow) (Tensor<Float>) -> T
 // CHECK-LABEL:--- TFPartition Accelerator Result: {{.*}}isZero{{.*}}
 // CHECK: bb0(%0 : @unowned $TensorHandle<Float>):
 // CHECK:  [[A:%.*]] = graph_op "Const"()
-// CHECK:  [[B:%.*]] = graph_op "Equal"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Bool>
+// CHECK:  [[B:%.*]] = graph_op "Equal"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T$dtype: i32 1, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Bool>
 // CHECK:  return [[B]] : $TensorHandle<Bool>                 // id: %3
 
 // CHECK-LABEL: ---- INPUT FUNCTION {{.*}}noescapeFuncAsAttr
@@ -244,7 +244,7 @@ public func testTensorFlowClosures(_ a: Float) -> Tensor<Int32>{
 // CHECK: sil private {{.*}}testTensorFlowClosures{{.*}} : $@callee_owned (TensorHandle<Builtin.FPIEEE32>) -> TensorHandle<Int32> {
 // CHECK: bb0(%0 : @unowned $TensorHandle<Builtin.FPIEEE32>):
 // CHECK:  [[A:%.*]] = unchecked_ref_cast %0 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
-// CHECK:  [[B:%.*]] = graph_op "Cast"([[A]] : $TensorHandle<Float>) {SrcT: $Float, DstT: $Int32, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Int32>
+// CHECK:  [[B:%.*]] = graph_op "Cast"([[A]] : $TensorHandle<Float>) {SrcT$dtype: i32 1, DstT$dtype: i32 3, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Int32>
 // CHECK:  return [[B]] : $TensorHandle<Int32>
 // CHECK: } 
 
@@ -252,7 +252,7 @@ public func testTensorFlowClosures(_ a: Float) -> Tensor<Int32>{
 // sil private @[[NAME]] : $@callee_owned (TensorHandle<Builtin.FPIEEE32>) -> TensorHandle<Int32> {
 // bb0(%0 : @unowned $TensorHandle<Builtin.FPIEEE32>):
 //   [[A:%.*]] = unchecked_ref_cast %0 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
-//   [[B:%.*]] = graph_op "Cast"([[A]] : $TensorHandle<Float>) {SrcT: $Float, DstT: $Int32, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Int32>
+//   [[B:%.*]] = graph_op "Cast"([[A]] : $TensorHandle<Float>) {SrcT$dtype: i32 1, DstT: $Int32, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Int32>
 //   return [[B]] : $TensorHandle<Int32>
 // } // end sil function '[[NAME]]'
 
@@ -268,7 +268,7 @@ public func testExtractDTypeList() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExtractDTypeList{{.*}}
-// CHECK: graph_op "TensorSliceDataset"([{{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>]) {Toutput_types: [$AccelerableByTensorFlow.Protocol: $Float, $Float], output_shapes: [$TensorShape: ([$Int32: ])], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $VariantHandle
+// CHECK: graph_op "TensorSliceDataset"([{{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>]) {Toutput_types$dtype: [$UInt32: i32 1, i32 1], output_shapes: [$TensorShape: ([$Int32: ])], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $VariantHandle
 
 public func testExtractTupleDTypeList() {
     let bar: (a: Tensor<Int32>, b: Tensor<Int32>) = (Tensor(0), Tensor(1))
@@ -278,18 +278,18 @@ public func testExtractTupleDTypeList() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExtractTupleDTypeList{{.*}}
-// CHECK: graph_op "TensorSliceDataset"([{{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>]) {Toutput_types: [$AccelerableByTensorFlow.Protocol: $Int32, $Int32], output_shapes: [$TensorShape: ([$Int32: ])], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $VariantHandle
+// CHECK: graph_op "TensorSliceDataset"([{{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>]) {Toutput_types$dtype: [$UInt32: i32 3, i32 3], output_shapes: [$TensorShape: ([$Int32: ])], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $VariantHandle
 
 public func testExtractUnknownShapeList() {
   struct Foo { let a, b: Tensor<Float> }
   let elements = Foo(a: Tensor([1]), b: Tensor([2]))
   let _: VariantHandle = #tfop("TensorSliceDataset", [elements.a, elements.b],
-                               Toutput_types: [Float.self, Float.self],
+                               Toutput_types$dtype: [Float._tensorFlowDataType, Float._tensorFlowDataType],
                                output_shapes$unknownShapeList: Foo.self)
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExtractUnknownShapeList{{.*}}
-// CHECK: graph_op "TensorSliceDataset"([{{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>]) {Toutput_types: [$Float.Type: $Float, $Float], output_shapes: [$Optional<TensorShape>: #Optional.none!enumelt, #Optional.none!enumelt], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $VariantHandle
+// CHECK: graph_op "TensorSliceDataset"([{{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>]) {Toutput_types$dtype: [$_TensorDataType: (((i32 1))), (((i32 1)))], output_shapes: [$Optional<TensorShape>: #Optional.none!enumelt, #Optional.none!enumelt], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $VariantHandle
 
 // Tests that private functions operating on Tensors are partitioned
 // if they are only referred in code.  In this case, addOne should be

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -96,7 +96,7 @@ CHECK-LABEL: --- INPUT FUNCTION {{.*}}stringAttributes
 public func tensorShape() -> Tensor<Float> {
   let shape : TensorShape = [1, 2]
 
-  return Tensor(handle: #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: [17.0 as Float, 18.0], shape$shape: shape))
+  return Tensor(handle: #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: [17.0 as Float, 18.0], shape$shape: shape))
 }
 
 // b/75407624
@@ -149,12 +149,12 @@ public func testShapeList() {
   let t = Tensor<Int32>([0])
   let handle: VariantHandle = #tfop(
     "TensorSliceDataset", [t],
-    Toutput_types$dtype: [Int32._tensorFlowDataType],
+    Toutput_types$dtype: [Int32.tensorFlowDataType],
     output_shapes: [TensorShape()]
   )
   let dataset = SimpleDataset(handle: handle, elementShape: TensorShape())
   _ = #tfop("AnonymousIterator",
-            output_types$dtype: [Int32._tensorFlowDataType],
+            output_types$dtype: [Int32.tensorFlowDataType],
             output_shapes: [dataset.elementShape]) as ResourceHandle
 }
 
@@ -165,7 +165,7 @@ struct SimpleIterator {
 
   mutating func next() -> Tensor<Float> {
     return #tfop("IteratorGetNext", handle,
-                 output_types$dtype: [Int32._tensorFlowDataType],
+                 output_types$dtype: [Int32.tensorFlowDataType],
                  output_shapes: [elementShape])
   }
 }
@@ -174,12 +174,12 @@ public func testShapeList2() {
   let t = Tensor<Int32>([0])
   let handle: VariantHandle = #tfop(
     "TensorSliceDataset", [t],
-    Toutput_types$dtype: [Int32._tensorFlowDataType],
+    Toutput_types$dtype: [Int32.tensorFlowDataType],
     output_shapes: [TensorShape()]
   )
   let dataset = SimpleDataset(handle: handle, elementShape: TensorShape())
   let resource = #tfop("AnonymousIterator",
-                       output_types$dtype: [Int32._tensorFlowDataType],
+                       output_types$dtype: [Int32.tensorFlowDataType],
                        output_shapes: [dataset.elementShape]) as ResourceHandle
 
   var it = SimpleIterator(handle: resource, elementShape: dataset.elementShape)
@@ -187,7 +187,7 @@ public func testShapeList2() {
 }
 
 // CHECK-LABEL: ---- INPUT FUNCTION {{.*}}testShapeList
-// CHECK: graph_op "AnonymousIterator"() {output_types$dtype: [$_TensorDataType: (((i32 3)))], output_shapes: [$TensorShape: ([$Int32: ])]
+// CHECK: graph_op "AnonymousIterator"() {output_types$dtype: [$TensorDataType: (((i32 3)))], output_shapes: [$TensorShape: ([$Int32: ])]
 
 @TensorFlowGraph
 func isZero(_ x: Tensor<Float>) -> Tensor<Bool> {
@@ -198,12 +198,12 @@ public func noescapeFuncAsAttr(_ f: @convention(tensorflow) (Tensor<Float>) -> T
   let t = Tensor<Int32>([0])
   let dataset: VariantHandle = #tfop(
     "TensorSliceDataset", [t],
-    Toutput_types$dtype: [Int32._tensorFlowDataType],
+    Toutput_types$dtype: [Int32.tensorFlowDataType],
     output_shapes: [TensorShape()]
   )
   let _: VariantHandle = #tfop(
     "FilterDataset", dataset, [Tensor<Int32>(0)], predicate: isZero,
-    Targuments$dtype: [Int32._tensorFlowDataType], output_types$dtype: [Float._tensorFlowDataType], output_shapes: [TensorShape()]
+    Targuments$dtype: [Int32.tensorFlowDataType], output_types$dtype: [Float.tensorFlowDataType], output_shapes: [TensorShape()]
   )
 }
 // Ensure that private functions are partitioned and lowered
@@ -284,12 +284,12 @@ public func testExtractUnknownShapeList() {
   struct Foo { let a, b: Tensor<Float> }
   let elements = Foo(a: Tensor([1]), b: Tensor([2]))
   let _: VariantHandle = #tfop("TensorSliceDataset", [elements.a, elements.b],
-                               Toutput_types$dtype: [Float._tensorFlowDataType, Float._tensorFlowDataType],
+                               Toutput_types$dtype: [Float.tensorFlowDataType, Float.tensorFlowDataType],
                                output_shapes$unknownShapeList: Foo.self)
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExtractUnknownShapeList{{.*}}
-// CHECK: graph_op "TensorSliceDataset"([{{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>]) {Toutput_types$dtype: [$_TensorDataType: (((i32 1))), (((i32 1)))], output_shapes: [$Optional<TensorShape>: #Optional.none!enumelt, #Optional.none!enumelt], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $VariantHandle
+// CHECK: graph_op "TensorSliceDataset"([{{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>]) {Toutput_types$dtype: [$TensorDataType: (((i32 1))), (((i32 1)))], output_shapes: [$Optional<TensorShape>: #Optional.none!enumelt, #Optional.none!enumelt], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $VariantHandle
 
 // Tests that private functions operating on Tensors are partitioned
 // if they are only referred in code.  In this case, addOne should be

--- a/test/TensorFlow/debugging.swift
+++ b/test/TensorFlow/debugging.swift
@@ -21,14 +21,14 @@ public func noCopyForOpaqueHandles() {
   let values = Tensor<Float>([1.0])
   let dataset: VariantHandle =
     #tfop("TensorSliceDataset", [values],
-          Toutput_types: [Float.self], output_shapes: [TensorShape()])
+          Toutput_types$dtype: [Float._tensorFlowDataType], output_shapes: [TensorShape()])
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}basicDebugValues
 // CHECK: @{{.*}}basicDebugValues{{.*}}.tf
 // CHECK: [[ONE:%.*]] = graph_op "Const"
 // CHECK: [[ADD_RESULT:%.*]] = graph_op "Add"
-// CHECK: graph_op "Square"([[ADD_RESULT]] : $TensorHandle<Float>) {T: $Float, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+// CHECK: graph_op "Square"([[ADD_RESULT]] : $TensorHandle<Float>) {T$dtype: i32 1, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
 
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}debugValuesInLoop

--- a/test/TensorFlow/debugging.swift
+++ b/test/TensorFlow/debugging.swift
@@ -21,7 +21,7 @@ public func noCopyForOpaqueHandles() {
   let values = Tensor<Float>([1.0])
   let dataset: VariantHandle =
     #tfop("TensorSliceDataset", [values],
-          Toutput_types$dtype: [Float._tensorFlowDataType], output_shapes: [TensorShape()])
+          Toutput_types$dtype: [Float.tensorFlowDataType], output_shapes: [TensorShape()])
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}basicDebugValues

--- a/test/TensorFlow/device_placement.swift
+++ b/test/TensorFlow/device_placement.swift
@@ -3,7 +3,7 @@
 import TensorFlow
 
 public func implicitDevicePlacement() {
-  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0)
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: 1.0)
   _hostOp(x)
 }
 
@@ -56,7 +56,7 @@ public func explicitDeviceConfigTPU() {
 
 // This involves cross-device sends/recvs.
 public func explicitDevicePlacementGPU() {
-  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0, __device: "/job:localhost/replica:0/task:0/device:GPU:0")
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: 1.0, __device: "/job:localhost/replica:0/task:0/device:GPU:0")
   _hostOp(x)
 }
 
@@ -103,11 +103,11 @@ public func explicitDevicePlacementGPU() {
 // Instead, we check on the _Send node in the next test.
 
 public func explicitDevicePlacementAll() {
-  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0, __device: "/job:localhost/replica:0/task:0/device:GPU:0")
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: 1.0, __device: "/job:localhost/replica:0/task:0/device:GPU:0")
   // For GPU -> TPU transfer, always go through CPU first. Compiler can be
   // extended to generate this Identity op if needed.
   let x_cpu: TensorHandle<Float> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
-  let y_cpu: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
+  let y_cpu: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
   // y is sent from CPU to TPU.
   let z_tpu: TensorHandle<Float> = #tfop("Add", x_cpu, y_cpu , __shapes: [TensorShape()], __device: "TPU_SYSTEM")
   _hostOp(z_tpu)
@@ -165,7 +165,7 @@ public func explicitDevicePlacementAll() {
 // CHECK-NEXT:       device: "/job:localhost/replica:0/task:0/device:CPU:0"
 
 public func GPUToTPUTransfer_Unsupported() {
-  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:GPU:0")
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:GPU:0")
   // expected-error @+1 {{TPU infeed enqueue cannot run on this device}}
   let _: TensorHandle<Float> = #tfop("Identity", x, __device: "TPU_SYSTEM")
 }

--- a/test/TensorFlow/device_placement.swift
+++ b/test/TensorFlow/device_placement.swift
@@ -3,12 +3,12 @@
 import TensorFlow
 
 public func implicitDevicePlacement() {
-  let x: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0)
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0)
   _hostOp(x)
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}implicitDevicePlacement{{.*}}
-// CHECK: graph_op "Const"() {dtype: $Float, value$tensor: f64 0x3FF0000000000000 /* 1 */, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+// CHECK: graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f64 0x3FF0000000000000 /* 1 */, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
 
 public func implicitDeviceConfig() {
   let x = Tensor<Float>(1.0)
@@ -16,7 +16,7 @@ public func implicitDeviceConfig() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}implicitDeviceConfig{{.*}}
-// CHECK: graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
+// CHECK: graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
 
 public func explicitDeviceConfigGPU() {
   TensorFlow.enableGPU()
@@ -25,7 +25,7 @@ public func explicitDeviceConfigGPU() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}explicitDeviceConfigGPU{{.*}}
-// CHECK: graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
+// CHECK: graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
 
 // Check that in the TF graph, both the function node itself, and ops in the
 // function, are placed on GPU.
@@ -56,12 +56,12 @@ public func explicitDeviceConfigTPU() {
 
 // This involves cross-device sends/recvs.
 public func explicitDevicePlacementGPU() {
-  let x: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/job:localhost/replica:0/task:0/device:GPU:0")
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0, __device: "/job:localhost/replica:0/task:0/device:GPU:0")
   _hostOp(x)
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}explicitDevicePlacementGPU{{.*}}
-// CHECK: graph_op "Const"() {dtype: $Float, value$tensor: f64 0x3FF0000000000000 /* 1 */, __device: "/job:localhost/replica:0/task:0/device:GPU:0"} : $TensorHandle<Float>
+// CHECK: graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f64 0x3FF0000000000000 /* 1 */, __device: "/job:localhost/replica:0/task:0/device:GPU:0"} : $TensorHandle<Float>
 
 // CHECK-LABEL: --- TFDevicePartition Cross Device Tensor Transfer Annotation Result: {{.*}}explicitDevicePlacementGPU{{.*}}
 // CHECK: graph_op "tfc.TensorTransfer
@@ -103,11 +103,11 @@ public func explicitDevicePlacementGPU() {
 // Instead, we check on the _Send node in the next test.
 
 public func explicitDevicePlacementAll() {
-  let x: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/job:localhost/replica:0/task:0/device:GPU:0")
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0, __device: "/job:localhost/replica:0/task:0/device:GPU:0")
   // For GPU -> TPU transfer, always go through CPU first. Compiler can be
   // extended to generate this Identity op if needed.
   let x_cpu: TensorHandle<Float> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
-  let y_cpu: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
+  let y_cpu: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
   // y is sent from CPU to TPU.
   let z_tpu: TensorHandle<Float> = #tfop("Add", x_cpu, y_cpu , __shapes: [TensorShape()], __device: "TPU_SYSTEM")
   _hostOp(z_tpu)
@@ -165,7 +165,7 @@ public func explicitDevicePlacementAll() {
 // CHECK-NEXT:       device: "/job:localhost/replica:0/task:0/device:CPU:0"
 
 public func GPUToTPUTransfer_Unsupported() {
-  let x: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:GPU:0")
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:GPU:0")
   // expected-error @+1 {{TPU infeed enqueue cannot run on this device}}
   let _: TensorHandle<Float> = #tfop("Identity", x, __device: "TPU_SYSTEM")
 }

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -54,13 +54,13 @@ public func invalidAttrTensor(a: Tensor<Float>) {
 
 public func noTensorShape() -> Tensor<Float> {
   // expected-error @+1 {{attribute 'value' must be followed by a shape attribute}}
-  return Tensor(handle: #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: [17.0 as Float, 18.0]))
+  return Tensor(handle: #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: [17.0 as Float, 18.0]))
 }
 
 public func badTensorShape() -> Tensor<Float> {
   let badShape : TensorShape = [1]
   // expected-error @+1 {{attribute 'value' does not match the shape attribute in the number of scalar elements}}
-  return Tensor(handle: #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: [17.0 as Float, 18.0], shape$shape: badShape))
+  return Tensor(handle: #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: [17.0 as Float, 18.0], shape$shape: badShape))
 }
 
 public func metatypeAttrs() {

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -54,12 +54,25 @@ public func invalidAttrTensor(a: Tensor<Float>) {
 
 public func noTensorShape() -> Tensor<Float> {
   // expected-error @+1 {{attribute 'value' must be followed by a shape attribute}}
-  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0]))
+  return Tensor(handle: #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: [17.0 as Float, 18.0]))
 }
 
 public func badTensorShape() -> Tensor<Float> {
   let badShape : TensorShape = [1]
   // expected-error @+1 {{attribute 'value' does not match the shape attribute in the number of scalar elements}}
-  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape$shape: badShape))
+  return Tensor(handle: #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: [17.0 as Float, 18.0], shape$shape: badShape))
 }
 
+public func metatypeAttrs() {
+  // expected-error @+1 {{attribute 'T' cannot be a metatype}}
+  #tfop("DummyOp", T: Float.self) as Void
+
+  // expected-error @+1 {{attribute 'T' cannot be an array of metatypes}}
+  #tfop("DummyOp", T: [Float.self]) as Void
+
+  // expected-error @+1 {{attribute 'T' requires an integer or array of integers}}
+  #tfop("DummyOp", T$dtype: Float.self) as Void
+
+  // expected-error @+1 {{attribute 'T' requires an integer or array of integers}}
+  #tfop("DummyOp", T$dtype: [Float.self]) as Void
+}

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -18,8 +18,8 @@ public func testTensor(a: Tensor<Float>, b: Tensor<Float>) {
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testTensor{{.*}}
 // CHECK:  sil private @{{.*}}testTensor{{.*}} : $@callee_owned (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
 // CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
-// CHECK-NEXT:   [[A:%.*]] = graph_op "Add"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) {T: $Float, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
-// CHECK-NEXT:   {{.*}} = graph_op "Sub"([[A]] : $TensorHandle<Float>, [[A]] : $TensorHandle<Float>) {T: $Float, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+// CHECK-NEXT:   [[A:%.*]] = graph_op "Add"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) {T$dtype: i32 1, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+// CHECK-NEXT:   {{.*}} = graph_op "Sub"([[A]] : $TensorHandle<Float>, [[A]] : $TensorHandle<Float>) {T$dtype: i32 1, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
 // CHECK:        graph_op "tfc.SendToHost
 // CHECK:        [[RESULT:%.*]] = graph_op "Add"(%1 : $TensorHandle<Float>, %1 : $TensorHandle<Float>
 // CHECK-NEXT:   return [[RESULT]] : $TensorHandle<Float>
@@ -53,7 +53,7 @@ public func testScalar(f: Float) {
 // CHECK: sil private @{{.*}}testScalar{{.*}} : $@callee_owned (TensorHandle<Builtin.FPIEEE32>) -> TensorHandle<Float> {
 // CHECK: bb0(%0 : @unowned $TensorHandle<Builtin.FPIEEE32>):
 // CHECK-NEXT:   %1 = unchecked_ref_cast %0 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
-// CHECK:        [[CONST:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
+// CHECK:        [[CONST:%.*]] = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
 // CHECK:        [[ADD1:%.*]] = graph_op "Add"(%1 : $TensorHandle<Float>, [[CONST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK:        [[ADD2:%.*]] = graph_op "Add"([[ADD1]] : $TensorHandle<Float>, [[ADD1:%.*]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK-NEXT:   return [[ADD2]] : $TensorHandle<Float>
@@ -92,7 +92,7 @@ public func testExitBranch1(i: Int) {
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExitBranch1{{.*}}
 // CHECK: sil private @{{.*}}testExitBranch1{{.*}} : $@callee_owned () -> TensorHandle<Float> {
 // CHECK: bb0:
-// CHECK-NEXT:   [[CONST:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
+// CHECK-NEXT:   [[CONST:%.*]] = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
 // CHECK:        [[RET:%.*]] = graph_op "Add"([[CONST]] : $TensorHandle<Float>, [[CONST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK-NEXT:   return [[RET]] : $TensorHandle<Float>
 // CHECK-NEXT: }
@@ -252,7 +252,7 @@ public func test_while1(maxCount: Int, arg1: Tensor<Float>, arg2: Tensor<Float>)
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}test_while1{{.*}}
 // CHECK: sil private @{{.*}}test_while1{{.*}}
 // CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>, %2 : @unowned $TensorHandle<Builtin.Int1>, %3 : @unowned $TensorHandle<Builtin.Int64>):
-// CHECK-NEXT: graph_op "Const"() {dtype: $Builtin.Int64, value$tensor: i64 0
+// CHECK-NEXT: graph_op "Const"() {dtype$dtype: i32 9, value$tensor: i64 0
 // CHECK:      graph_op "Add"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>
 // CHECK-NEXT: graph_op "tf_tensor_to_i1"(
 // CHECK-NEXT: cond_br {{.*}}, bb2, bb1
@@ -294,7 +294,7 @@ public func scalar_manipulation(a : Float) -> Tensor<Float> {
 // CHECK: sil private @{{.*}}scalar_manipulation{{.*}} : $@callee_owned (TensorHandle<Builtin.FPIEEE32>) -> TensorHandle<Float> {
 // CHECK: bb0(%0 : @unowned $TensorHandle<Builtin.FPIEEE32>):
 // CHECK-NEXT:  %1 = unchecked_ref_cast %0 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
-// CHECK-NEXT:  [[CONST:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
+// CHECK-NEXT:  [[CONST:%.*]] = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
 // CHECK:       graph_op "Add"(%1 : $TensorHandle<Float>, [[CONST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK:       graph_op "tfc.SendToHost
 // CHECK-NEXT:  graph_op "Const"()
@@ -378,7 +378,8 @@ public func testResourceAndVariants() {
   //     .Attr("output_shapes: list(shape) >= 1")
   let dataset: VariantHandle =
     // expected-error @+1 {{op named 'TensorDataSet' is not registered in TensorFlow}}
-    #tfop("TensorDataSet", values, Toutput_types: [Float.self],
+    #tfop("TensorDataSet", values,
+          Toutput_types$dtype: [Float._tensorFlowDataType],
           output_shapes: [TensorShape(1)])
 
   // REGISTER_OP("Iterator")
@@ -390,7 +391,7 @@ public func testResourceAndVariants() {
   //     .SetShapeFn(shape_inference::ScalarShape);
   let iterator: ResourceHandle =
     #tfop("Iterator", shared_name: "foo", container: "bar",
-          output_types: [Float.self], output_shapes: [TensorShape(1)])
+          output_types$dtype: [Float._tensorFlowDataType], output_shapes: [TensorShape(1)])
 
   // REGISTER_OP("MakeIterator")
   //     .Input("dataset: variant")
@@ -400,7 +401,7 @@ public func testResourceAndVariants() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testResourceAndVariantsyyF
-// CHECK:  [[VALUES:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */),
+// CHECK:  [[VALUES:%.*]] = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */),
 // CHECK:  [[DATASET:%.*]] = graph_op "TensorDataSet"([[VALUES]] : $TensorHandle<Float>
 // CHECK:  [[ITERATOR:%.*]] = graph_op "Iterator"()
 // CHECK:  graph_op "MakeIterator"([[DATASET]] : $VariantHandle, [[ITERATOR]] : $ResourceHandle) {{.*}}
@@ -409,25 +410,24 @@ public func testResourceAndVariants() {
 
 public func testStringHandle() {
   let str: TensorHandle<String> = #tfop(
-    "Const", dtype: String.self, value$tensor: "foo"
+    "Const", dtype$dtype: String._tensorFlowDataType, value$tensor: "foo"
   )
   let _: TensorHandle<String> = #tfop(
     "Substr", str, Tensor<Int32>(0), Tensor<Int32>(1)
   )
   let _: TensorHandle<String> = #tfop(
-    "Const", dtype:
-    String.self,
+    "Const", dtype$dtype: String._tensorFlowDataType,
     value$tensor: ["foo", "bar"],
     shape$shape: TensorShape(2)
   )
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testStringHandle
-// CHECK: [[STR:%.*]] = graph_op "Const"() {dtype: $String, value$tensor: "foo", __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<String>
-// CHECK: [[POS:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Int32>
-// CHECK: [[LEN:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Int32>
+// CHECK: [[STR:%.*]] = graph_op "Const"() {dtype$dtype: i32 7, value$tensor: "foo", __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<String>
+// CHECK: [[POS:%.*]] = graph_op "Const"() {dtype$dtype: i32 3, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Int32>
+// CHECK: [[LEN:%.*]] = graph_op "Const"() {dtype$dtype: i32 3, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Int32>
 // CHECK: graph_op "Substr"([[STR]] : $TensorHandle<String>, [[POS]] : $TensorHandle<Int32>, [[LEN]] : $TensorHandle<Int32>) {__device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<String>
-// CHECK: graph_op "Const"() {dtype: $String, value$tensor: [$String: "foo", "bar"], shape$shape: [$Int32: (i32 2)], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<String>
+// CHECK: graph_op "Const"() {dtype$dtype: i32 7, value$tensor: [$String: "foo", "bar"], shape$shape: [$Int32: (i32 2)], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<String>
 
 
 // b/76117368
@@ -518,21 +518,21 @@ public func test77437755(_ hiddenSize: Float) {
 public func graphFuncReturningOpaqueHandles() -> (ResourceHandle, ResourceHandle) {
   let iterator : ResourceHandle =
     #tfop("Iterator", shared_name: "foo", container: "bar",
-    output_shapes: [TensorShape()], output_types: [Float.self])
+    output_shapes: [TensorShape()], output_types$dtype: [Float._tensorFlowDataType])
   let iterator2 : ResourceHandle =
     #tfop("Iterator", shared_name: "foo", container: "bar",
-    output_shapes: [TensorShape()], output_types: [Float.self])
+    output_shapes: [TensorShape()], output_types$dtype: [Float._tensorFlowDataType])
   return (iterator, iterator2)
 }
 // CHECK-LABEL --- TFPartition Accelerator Result: {{.*}}graphFuncReturningOpaqueHandles{{.*}}
 // CHECK: bb0:
-// CHECK:  [[A:%.*]] = graph_op "Iterator"() {shared_name: "foo", container: "bar", output_shapes: [$TensorShape: ([$Int32: ])], output_types: [$Float.Type: $Float], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $ResourceHandle 
-// CHECK:  [[B:%.*]] = graph_op "Iterator"() {shared_name: "foo", container: "bar", output_shapes: [$TensorShape: ([$Int32: ])], output_types: [$Float.Type: $Float], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $ResourceHandle 
+// CHECK:  [[A:%.*]] = graph_op "Iterator"() {shared_name: "foo", container: "bar", output_shapes: [$TensorShape: ([$Int32: ])], output_types$dtype: [$_TensorDataType: (((i32 1)))], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $ResourceHandle 
+// CHECK:  [[B:%.*]] = graph_op "Iterator"() {shared_name: "foo", container: "bar", output_shapes: [$TensorShape: ([$Int32: ])], output_types$dtype: [$_TensorDataType: (((i32 1)))], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $ResourceHandle 
 // CHECK:  [[C:%.*]] = tuple ([[A]] : $ResourceHandle, [[B]] : $ResourceHandle)
 // CHECK:  return [[C]] : $(ResourceHandle, ResourceHandle)   
 
 // Allow Any.Type as a type list member for empty type lists.
 public func testSR8570() {
-  () = #tfop("FooOp", Targuments: [] as [Any.Type]) // expected-error {{op named 'FooOp' is not registered in TensorFlow}}
+  () = #tfop("FooOp", Targuments$dtype: [] as [UInt32]) // expected-error {{op named 'FooOp' is not registered in TensorFlow}}
 }
 

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -379,7 +379,7 @@ public func testResourceAndVariants() {
   let dataset: VariantHandle =
     // expected-error @+1 {{op named 'TensorDataSet' is not registered in TensorFlow}}
     #tfop("TensorDataSet", values,
-          Toutput_types$dtype: [Float._tensorFlowDataType],
+          Toutput_types$dtype: [Float.tensorFlowDataType],
           output_shapes: [TensorShape(1)])
 
   // REGISTER_OP("Iterator")
@@ -391,7 +391,7 @@ public func testResourceAndVariants() {
   //     .SetShapeFn(shape_inference::ScalarShape);
   let iterator: ResourceHandle =
     #tfop("Iterator", shared_name: "foo", container: "bar",
-          output_types$dtype: [Float._tensorFlowDataType], output_shapes: [TensorShape(1)])
+          output_types$dtype: [Float.tensorFlowDataType], output_shapes: [TensorShape(1)])
 
   // REGISTER_OP("MakeIterator")
   //     .Input("dataset: variant")
@@ -410,13 +410,13 @@ public func testResourceAndVariants() {
 
 public func testStringHandle() {
   let str: TensorHandle<String> = #tfop(
-    "Const", dtype$dtype: String._tensorFlowDataType, value$tensor: "foo"
+    "Const", dtype$dtype: String.tensorFlowDataType, value$tensor: "foo"
   )
   let _: TensorHandle<String> = #tfop(
     "Substr", str, Tensor<Int32>(0), Tensor<Int32>(1)
   )
   let _: TensorHandle<String> = #tfop(
-    "Const", dtype$dtype: String._tensorFlowDataType,
+    "Const", dtype$dtype: String.tensorFlowDataType,
     value$tensor: ["foo", "bar"],
     shape$shape: TensorShape(2)
   )
@@ -518,16 +518,16 @@ public func test77437755(_ hiddenSize: Float) {
 public func graphFuncReturningOpaqueHandles() -> (ResourceHandle, ResourceHandle) {
   let iterator : ResourceHandle =
     #tfop("Iterator", shared_name: "foo", container: "bar",
-    output_shapes: [TensorShape()], output_types$dtype: [Float._tensorFlowDataType])
+    output_shapes: [TensorShape()], output_types$dtype: [Float.tensorFlowDataType])
   let iterator2 : ResourceHandle =
     #tfop("Iterator", shared_name: "foo", container: "bar",
-    output_shapes: [TensorShape()], output_types$dtype: [Float._tensorFlowDataType])
+    output_shapes: [TensorShape()], output_types$dtype: [Float.tensorFlowDataType])
   return (iterator, iterator2)
 }
 // CHECK-LABEL --- TFPartition Accelerator Result: {{.*}}graphFuncReturningOpaqueHandles{{.*}}
 // CHECK: bb0:
-// CHECK:  [[A:%.*]] = graph_op "Iterator"() {shared_name: "foo", container: "bar", output_shapes: [$TensorShape: ([$Int32: ])], output_types$dtype: [$_TensorDataType: (((i32 1)))], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $ResourceHandle 
-// CHECK:  [[B:%.*]] = graph_op "Iterator"() {shared_name: "foo", container: "bar", output_shapes: [$TensorShape: ([$Int32: ])], output_types$dtype: [$_TensorDataType: (((i32 1)))], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $ResourceHandle 
+// CHECK:  [[A:%.*]] = graph_op "Iterator"() {shared_name: "foo", container: "bar", output_shapes: [$TensorShape: ([$Int32: ])], output_types$dtype: [$TensorDataType: (((i32 1)))], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $ResourceHandle 
+// CHECK:  [[B:%.*]] = graph_op "Iterator"() {shared_name: "foo", container: "bar", output_shapes: [$TensorShape: ([$Int32: ])], output_types$dtype: [$TensorDataType: (((i32 1)))], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $ResourceHandle 
 // CHECK:  [[C:%.*]] = tuple ([[A]] : $ResourceHandle, [[B]] : $ResourceHandle)
 // CHECK:  return [[C]] : $(ResourceHandle, ResourceHandle)   
 

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -39,7 +39,7 @@ public func testEmptyScalarsArray() {
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testEmptyScalarsArray
  CHECK: sil private @{{.*}}testEmptyScalarsArray{{.*}} : $@callee_owned () -> () {
  CHECK: bb0:
- CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: ], shape$shape: [$Int32: (i32 0), (i32 20), (i32 30)],
+ CHECK: graph_op "Const"() {dtype$dtype: i32 3, value$tensor: [$Int32: ], shape$shape: [$Int32: (i32 0), (i32 20), (i32 30)],
  CHECK: graph_op "Add"({{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>
  */
 
@@ -52,25 +52,25 @@ public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<F
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testConvolution
 // CHECK: sil private @{{.*}}testConvolution{{.*}} : $@callee_owned (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
 // CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
-// CHECK: [[A:%.*]] = graph_op "Conv2D"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float, strides: [$Int32: (i32 1), (i32 2), (i32 3), (i32 4)], use_cudnn_on_gpu: i1 -1, padding: "SAME", data_format: "NHWC", dilations: [$Int32: (i32 1), (i32 1), (i32 1), (i32 1)], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+// CHECK: [[A:%.*]] = graph_op "Conv2D"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T$dtype: i32 1, strides: [$Int32: (i32 1), (i32 2), (i32 3), (i32 4)], use_cudnn_on_gpu: i1 -1, padding: "SAME", data_format: "NHWC", dilations: [$Int32: (i32 1), (i32 1), (i32 1), (i32 1)], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
 // CHECK-NEXT:  return [[A]] : $TensorHandle<Float>
 // CHECK-NEXT:}
 
 // Testcase for an op that uses the $tensor and $shape modifiers.
 public func testConstantArray() -> TensorHandle<Float> {
-  return #tfop("Const", dtype: Float.self, value$tensor: [1.0, 2.0], shape$shape: [2])
+  return #tfop("Const", dtype$dtype: 1, value$tensor: [1.0, 2.0], shape$shape: [2])
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testConstantArray
 // CHECK: sil private @{{.*}}testConstantArray{{.*}} : $@callee_owned () -> TensorHandle<Float> {
 // CHECK: bb0:
-// CHECK:  %0 = graph_op "Const"() {dtype: $Float, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], shape$shape: [$Int: (i64 2)], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+// CHECK:  %0 = graph_op "Const"() {dtype$dtype: i64 1, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], shape$shape: [$Int: (i64 2)], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
 // CHECK-NEXT:  return %0 : $TensorHandle<Float>
 
 // Testcase for an op that uses the $shape modifier.
 public func tensorShapeModifier() {
   let _ : TensorHandle<Float> = #tfop("ImmutableConst",
-                                      dtype: Float.self,
+                                      dtype$dtype: 1,
                                       shape$shape: [2, 2],
                                       memory_region_name: "abc")
 }
@@ -258,7 +258,7 @@ func createStringTensorConst(_ str: String) -> TensorHandle<String> {
   // Const tfops with String cannot be placed on GPU/TPU. 
   // TODO: Find a better API to write string consts.
   return #tfop("Const",
-               dtype: String.self,
+               dtype$dtype: 7,
                value$tensor: str,
                __device: "/job:localhost/replica:0/task:0/device:CPU:0")
 }

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -58,19 +58,20 @@ public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<F
 
 // Testcase for an op that uses the $tensor and $shape modifiers.
 public func testConstantArray() -> TensorHandle<Float> {
-  return #tfop("Const", dtype$dtype: 1, value$tensor: [1.0, 2.0], shape$shape: [2])
+  return #tfop("Const", dtype$dtype: Float.tensorFlowDataType,
+               value$tensor: [1.0, 2.0], shape$shape: [2])
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testConstantArray
 // CHECK: sil private @{{.*}}testConstantArray{{.*}} : $@callee_owned () -> TensorHandle<Float> {
 // CHECK: bb0:
-// CHECK:  %0 = graph_op "Const"() {dtype$dtype: i64 1, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], shape$shape: [$Int: (i64 2)], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
+// CHECK:  %0 = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], shape$shape: [$Int: (i64 2)], __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>
 // CHECK-NEXT:  return %0 : $TensorHandle<Float>
 
 // Testcase for an op that uses the $shape modifier.
 public func tensorShapeModifier() {
   let _ : TensorHandle<Float> = #tfop("ImmutableConst",
-                                      dtype$dtype: 1,
+                                      dtype$dtype: Float.tensorFlowDataType,
                                       shape$shape: [2, 2],
                                       memory_region_name: "abc")
 }

--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -8,8 +8,8 @@ public func testArrayValues() -> Tensor<Float> {
 
 /*
 CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testArrayValues
-CHECK: %0 = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
-CHECK: %1 = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x40000000 /* 2 */
+CHECK: %0 = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
+CHECK: %1 = graph_op "Const"() {dtype$dtype: i32 1, value$tensor: f32 0x40000000 /* 2 */
 CHECK-LABEL: ----
 */
 

--- a/test/TensorFlow/sese_loop_canonicalization.sil
+++ b/test/TensorFlow/sese_loop_canonicalization.sil
@@ -34,8 +34,8 @@ public func loopTest(breakCount:Int32) -> Int32 {
 //-- Preheader sets up the undefs, exit index, and stayInLoop flag.
 // CHECK: [[PHDR]](%0 : $Builtin.Int32):
 // CHECK: [[CONST_ONE:%.*]] =  integer_literal $Builtin.Int32, 1
-// CHECK: [[PHDR_EXIT:%.*]] = graph_op "Const"() {dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"}
-// CHECK: [[PHDR_FLAG:%.*]] = graph_op "Const"() {dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"}
+// CHECK: [[PHDR_EXIT:%.*]] = graph_op "Const"() {dtype$dtype: i32 3, value$tensor: i32 0, __device: "ALL_DEVICES"}
+// CHECK: [[PHDR_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: i32 10, value$tensor: i1 -1, __device: "ALL_DEVICES"}
 // CHECK: br [[HDR]]([[A:%.*]] : $Builtin.Int32, [[A]] : $Builtin.Int32, [[A]] : $Builtin.Int32, [[PHDR_EXIT]] : $TensorHandle<Builtin.Int32>, [[PHDR_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 // Original header
@@ -45,8 +45,8 @@ public func loopTest(breakCount:Int32) -> Int32 {
 
 //- Sets up index to 1 and flag to false on the exit branch of the original header to latch.
 // CHECK: [[ORIG_EXIT]]:
-// CHECK:   [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype: $Builtin.Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
-// CHECK:   [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype: $Builtin.Int1, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
+// CHECK:   [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: i32 3, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK:   [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: i32 10, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
 // CHECK:  br [[LATCH]]([[SUM_AT_HDR:%.*]] : $Builtin.Int32, [[COUNT_AT_HDR:%.*]] : $Builtin.Int32, [[SUM_AT_HDR]] : $Builtin.Int32, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 // CHECK: [[BRK_COND]]:
@@ -56,14 +56,14 @@ public func loopTest(breakCount:Int32) -> Int32 {
 
 //- Sets up index to 0 and flag to true on the false branch of the if with break to latch.
 // CHECK: [[BRK_FALSE]]:
-// CHECK: [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
-// CHECK: [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
+// CHECK: [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: i32 3, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK: [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: i32 10, value$tensor: i1 -1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
 // CHECK:  br [[LATCH]]([[SUM_ESCAPING]] : $Builtin.Int32, [[COUNT_ESCAPING]] : $Builtin.Int32, [[SUM_ESCAPING_AT_HDR:%.*]] : $Builtin.Int32, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 //- Sets up index to 1 and flag to false on the true branch of the if with break to latch.
 // CHECK: [[BRK_TRUE]]:
-// CHECK:  [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype: $Builtin.Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
-// CHECK:  [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype: $Builtin.Int1, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
+// CHECK:  [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: i32 3, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK:  [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: i32 10, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
 // CHECK: br [[LATCH]]([[SUM_AT_HDR]] : $Builtin.Int32, [[COUNT_AT_HDR]] : $Builtin.Int32, [[SUM_ESCAPING]] : $Builtin.Int32, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 //-- New Header simply checks flag

--- a/test/TensorFlow/shape_lowering/shape_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shape_rank0.swift
@@ -11,7 +11,7 @@ import TensorFlow
 
 public func test() {
   let _: TensorHandle<Float> = #tfop("Placeholder",
-                                     dtype$dtype: Float._tensorFlowDataType,
+                                     dtype$dtype: Float.tensorFlowDataType,
                                      shape: TensorShape([]))
 }
 

--- a/test/TensorFlow/shape_lowering/shape_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shape_rank0.swift
@@ -11,7 +11,7 @@ import TensorFlow
 
 public func test() {
   let _: TensorHandle<Float> = #tfop("Placeholder",
-                                     dtype: Float.self,
+                                     dtype$dtype: Float._tensorFlowDataType,
                                      shape: TensorShape([]))
 }
 

--- a/test/TensorFlow/shape_lowering/shape_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shape_unknownrank.swift
@@ -11,7 +11,7 @@ import TensorFlow
 
 public func test() {
   let _: TensorHandle<Float> = #tfop("Placeholder",
-                                     dtype: Float.self,
+                                     dtype$dtype: Float._tensorFlowDataType,
                                      shape: nil as TensorShape?)
 }
 

--- a/test/TensorFlow/shape_lowering/shape_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shape_unknownrank.swift
@@ -11,7 +11,7 @@ import TensorFlow
 
 public func test() {
   let _: TensorHandle<Float> = #tfop("Placeholder",
-                                     dtype$dtype: Float._tensorFlowDataType,
+                                     dtype$dtype: Float.tensorFlowDataType,
                                      shape: nil as TensorShape?)
 }
 

--- a/test/TensorFlow/shape_lowering/shapelist_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank0.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types: [Float.self],
+                                output_types$dtype: [Float._tensorFlowDataType],
                                 output_shapes: [TensorShape([])])
 }
 

--- a/test/TensorFlow/shape_lowering/shapelist_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank0.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types$dtype: [Float._tensorFlowDataType],
+                                output_types$dtype: [Float.tensorFlowDataType],
                                 output_shapes: [TensorShape([])])
 }
 

--- a/test/TensorFlow/shape_lowering/shapelist_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types: [Float.self],
+                                output_types$dtype: [Float._tensorFlowDataType],
                                 output_shapes: [TensorShape([1])])
 
 }

--- a/test/TensorFlow/shape_lowering/shapelist_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types$dtype: [Float._tensorFlowDataType],
+                                output_types$dtype: [Float.tensorFlowDataType],
                                 output_shapes: [TensorShape([1])])
 
 }

--- a/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
@@ -8,8 +8,8 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types$dtype: [Float._tensorFlowDataType,
-                                                     Float._tensorFlowDataType],
+                                output_types$dtype: [Float.tensorFlowDataType,
+                                                     Float.tensorFlowDataType],
                                 output_shapes: [TensorShape([1]),
                                                 TensorShape([1])])
 

--- a/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
@@ -8,7 +8,8 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types: [Float.self],
+                                output_types$dtype: [Float._tensorFlowDataType,
+                                                     Float._tensorFlowDataType],
                                 output_shapes: [TensorShape([1]),
                                                 TensorShape([1])])
 

--- a/test/TensorFlow/shape_lowering/shapelist_rank3.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types$dtype: [Float._tensorFlowDataType],
+                                output_types$dtype: [Float.tensorFlowDataType],
                                 output_shapes: [TensorShape([1, 2, 3])])
 }
 

--- a/test/TensorFlow/shape_lowering/shapelist_rank3.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types: [Float.self],
+                                output_types$dtype: [Float._tensorFlowDataType],
                                 output_shapes: [TensorShape([1, 2, 3])])
 }
 

--- a/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types: [Float.self],
+                                output_types$dtype: [Float._tensorFlowDataType],
                                 output_shapes: [TensorShape([-1, 2, 3])])
 }
 

--- a/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types$dtype: [Float._tensorFlowDataType],
+                                output_types$dtype: [Float.tensorFlowDataType],
                                 output_shapes: [TensorShape([-1, 2, 3])])
 }
 

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types$dtype: [Float._tensorFlowDataType],
+                                output_types$dtype: [Float.tensorFlowDataType],
                                 output_shapes: [nil as TensorShape?])
 }
 

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
@@ -8,7 +8,7 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types: [Float.self],
+                                output_types$dtype: [Float._tensorFlowDataType],
                                 output_shapes: [nil as TensorShape?])
 }
 

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
@@ -8,8 +8,8 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types$dtype: [Float._tensorFlowDataType,
-                                                     Float._tensorFlowDataType],
+                                output_types$dtype: [Float.tensorFlowDataType,
+                                                     Float.tensorFlowDataType],
                                 output_shapes: [nil as TensorShape?,
                                                 TensorShape([1])])
 }

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
@@ -8,7 +8,8 @@ import TensorFlow
 
 public func test() {
   let _: ResourceHandle = #tfop("AnonymousIterator",
-                                output_types: [Float.self],
+                                output_types$dtype: [Float._tensorFlowDataType,
+                                                     Float._tensorFlowDataType],
                                 output_shapes: [nil as TensorShape?,
                                                 TensorShape([1])])
 }

--- a/test/TensorFlow/tfop_packing.swift
+++ b/test/TensorFlow/tfop_packing.swift
@@ -129,7 +129,7 @@ public func packResultsToAggregate_basic() {
 }
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}packResultsToAggregate_basic{{.*}}
 // CHECK:  ([[A0:%.*]], [[A1:%.*]], [[A2:%.*]], [[A3:%.*]], [[A4:%.*]]) = graph_op "SomeOp"() {__device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Float>, $TensorHandle<Float>, $TensorHandle<Int32>, $TensorHandle<Bool>, $TensorHandle<Double>
-// CHECK: graph_op "Add"({{.*}} : $TensorHandle<Int32>, [[A2]] : $TensorHandle<Int32>) {T: $Int32, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Int32>
+// CHECK: graph_op "Add"({{.*}} : $TensorHandle<Int32>, [[A2]] : $TensorHandle<Int32>) {T$dtype: i32 3, __device: "/job:localhost/replica:0/task:0/device:CPU:0"} : $TensorHandle<Int32>
 // CHECK:  [[PACKED:%.*]] = tuple ([[A0]] : $TensorHandle<Float>, [[A1]] : $TensorHandle<Float>, [[A2]] : $TensorHandle<Int32>, [[A3]] : $TensorHandle<Bool>, [[A4]] : $TensorHandle<Double>)
 // CHECK:  return [[PACKED]] : $(TensorHandle<Float>, TensorHandle<Float>, TensorHandle<Int32>, TensorHandle<Bool>, TensorHandle<Double>)
 

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -39,7 +39,7 @@ public func createMockDataSet() -> VariantHandle {
   //   .Attr("output_shapes: list(shape) >= 1")
   let dataset : VariantHandle = #tfop("TensorSliceDataset",
                                       [values],
-                                      Toutput_types: [Float.self],
+                                      Toutput_types$dtype: [Float._tensorFlowDataType],
                                       output_shapes: [nil as TensorShape?])
   return dataset
 }
@@ -52,7 +52,7 @@ func getNextScalarFloatTensor(_ iterator: ResourceHandle) -> Tensor<Float> {
   //   .Attr("output_shapes: list(shape) >= 1")
   let ret: TensorHandle<Float> = #tfop("IteratorGetNext",
                                        iterator,
-                                       output_types: [Float.self],
+                                       output_types$dtype: [Float._tensorFlowDataType],
                                        output_shapes: [nil as TensorShape?])
   return Tensor(handle: ret)
 }
@@ -68,7 +68,7 @@ public func model() {
   let iterator: ResourceHandle = #tfop(
     "OneShotIterator",
     dataset_factory : createMockDataSet,
-    output_types: [Float.self],
+    output_types$dtype: [Float._tensorFlowDataType],
     output_shapes: [nil as TensorShape?]
   )
 
@@ -90,7 +90,7 @@ public func model() {
 
   // let _: TensorHandle<Float> = #tfop("IteratorGetNext",
   //                                    iterator,
-  //                                    output_types: [Float.self],
+  //                                    output_types$dtype: [Float._tensorFlowDataType],
   //                                    output_shapes: [nil as TensorShape?])
 }
 
@@ -102,33 +102,33 @@ DatasetTests.testAllBackends("MultiValue") {
   enableCPU()
   let elements1: Tensor<Int32> = [0, 1, 2]
   let elements2: Tensor<Int32> = [10, 11, 12]
-  let outputTypes = [Int32.self, Int32.self]
+  let outputTypes = [Int32._tensorFlowDataType, Int32._tensorFlowDataType]
   let outputShapes: [TensorShape?] = [nil, nil]
   let dataset: VariantHandle = #tfop(
     "TensorSliceDataset", [elements1, elements2],
-    Toutput_types: outputTypes,
+    Toutput_types$dtype: outputTypes,
     output_shapes: outputShapes
   )
   let iterator: ResourceHandle = #tfop(
     "IteratorV2", shared_name: "blah", container: "earth",
-    output_types: outputTypes, output_shapes: outputShapes
+    output_types$dtype: outputTypes, output_shapes: outputShapes
   )
   #tfop("MakeIterator", dataset, iterator) as Void
   var next: (TensorHandle<Int32>, TensorHandle<Int32>) = #tfop(
     "IteratorGetNext", iterator,
-    output_types: outputTypes, output_shapes: outputShapes
+    output_types$dtype: outputTypes, output_shapes: outputShapes
   )
   expectEqual(0, Tensor(handle: next.0).scalarized())
   expectEqual(10, Tensor(handle: next.1).scalarized())
   next = #tfop(
     "IteratorGetNext", iterator,
-    output_types: outputTypes, output_shapes: outputShapes
+    output_types$dtype: outputTypes, output_shapes: outputShapes
   )
   expectEqual(1, Tensor(handle: next.0).scalarized())
   expectEqual(11, Tensor(handle: next.1).scalarized())
   next = #tfop(
     "IteratorGetNext", iterator,
-    output_types: outputTypes, output_shapes: outputShapes
+    output_types$dtype: outputTypes, output_shapes: outputShapes
   )
   expectEqual(2, Tensor(handle: next.0).scalarized())
   expectEqual(12, Tensor(handle: next.1).scalarized())

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -39,7 +39,7 @@ public func createMockDataSet() -> VariantHandle {
   //   .Attr("output_shapes: list(shape) >= 1")
   let dataset : VariantHandle = #tfop("TensorSliceDataset",
                                       [values],
-                                      Toutput_types$dtype: [Float._tensorFlowDataType],
+                                      Toutput_types$dtype: [Float.tensorFlowDataType],
                                       output_shapes: [nil as TensorShape?])
   return dataset
 }
@@ -52,7 +52,7 @@ func getNextScalarFloatTensor(_ iterator: ResourceHandle) -> Tensor<Float> {
   //   .Attr("output_shapes: list(shape) >= 1")
   let ret: TensorHandle<Float> = #tfop("IteratorGetNext",
                                        iterator,
-                                       output_types$dtype: [Float._tensorFlowDataType],
+                                       output_types$dtype: [Float.tensorFlowDataType],
                                        output_shapes: [nil as TensorShape?])
   return Tensor(handle: ret)
 }
@@ -68,7 +68,7 @@ public func model() {
   let iterator: ResourceHandle = #tfop(
     "OneShotIterator",
     dataset_factory : createMockDataSet,
-    output_types$dtype: [Float._tensorFlowDataType],
+    output_types$dtype: [Float.tensorFlowDataType],
     output_shapes: [nil as TensorShape?]
   )
 
@@ -90,7 +90,7 @@ public func model() {
 
   // let _: TensorHandle<Float> = #tfop("IteratorGetNext",
   //                                    iterator,
-  //                                    output_types$dtype: [Float._tensorFlowDataType],
+  //                                    output_types$dtype: [Float.tensorFlowDataType],
   //                                    output_shapes: [nil as TensorShape?])
 }
 
@@ -102,7 +102,7 @@ DatasetTests.testAllBackends("MultiValue") {
   enableCPU()
   let elements1: Tensor<Int32> = [0, 1, 2]
   let elements2: Tensor<Int32> = [10, 11, 12]
-  let outputTypes = [Int32._tensorFlowDataType, Int32._tensorFlowDataType]
+  let outputTypes = [Int32.tensorFlowDataType, Int32.tensorFlowDataType]
   let outputShapes: [TensorShape?] = [nil, nil]
   let dataset: VariantHandle = #tfop(
     "TensorSliceDataset", [elements1, elements2],

--- a/test/TensorFlowRuntime/device_placement_tpu.swift
+++ b/test/TensorFlowRuntime/device_placement_tpu.swift
@@ -16,8 +16,8 @@ var DevicePlacementTPUTests = TestSuite("DevicePlacementTPU")
 
 @inline(never)
 public func explicitDevicePlacement() {
-  let x_tpu : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: Float(1.0), __device: "TPU_SYSTEM")
-  let y_cpu : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: Float(2.0), __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
+  let x_tpu : TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: Float(1.0), __device: "TPU_SYSTEM")
+  let y_cpu : TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: Float(2.0), __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
   // y_cpu is sent from CPU to TPU. 
   let z_tpu : TensorHandle<Float> = #tfop("Add", x_tpu, y_cpu, __device: "TPU_SYSTEM")
   expectNearlyEqualWithScalarTensor(3, Tensor<Float>(handle: z_tpu))

--- a/test/TensorFlowRuntime/device_placement_tpu.swift
+++ b/test/TensorFlowRuntime/device_placement_tpu.swift
@@ -16,8 +16,8 @@ var DevicePlacementTPUTests = TestSuite("DevicePlacementTPU")
 
 @inline(never)
 public func explicitDevicePlacement() {
-  let x_tpu : TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: Float(1.0), __device: "TPU_SYSTEM")
-  let y_cpu : TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: Float(2.0), __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
+  let x_tpu : TensorHandle<Float> = #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: Float(1.0), __device: "TPU_SYSTEM")
+  let y_cpu : TensorHandle<Float> = #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: Float(2.0), __shapes: [TensorShape()], __device: "/job:localhost/replica:0/task:0/device:CPU:0")
   // y_cpu is sent from CPU to TPU. 
   let z_tpu : TensorHandle<Float> = #tfop("Add", x_tpu, y_cpu, __device: "TPU_SYSTEM")
   expectNearlyEqualWithScalarTensor(3, Tensor<Float>(handle: z_tpu))

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -16,7 +16,7 @@ var DynamicCompilationTests = TestSuite("DynamicCompilation")
 
 DynamicCompilationTests.testCPUOrGPU("Const") {
   _RuntimeConfig.printsDebugLog = true
-  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: Float(1.0))
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: Float(1.0))
   _hostOp(x)
   expectNearlyEqualWithScalarTensor(1.0, Tensor<Float>(handle: x))
 }

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -16,7 +16,7 @@ var DynamicCompilationTests = TestSuite("DynamicCompilation")
 
 DynamicCompilationTests.testCPUOrGPU("Const") {
   _RuntimeConfig.printsDebugLog = true
-  let x: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: Float(1.0))
+  let x: TensorHandle<Float> = #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: Float(1.0))
   _hostOp(x)
   expectNearlyEqualWithScalarTensor(1.0, Tensor<Float>(handle: x))
 }

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -11,7 +11,7 @@ var RuntimeEntryPointTests = TestSuite("RuntimeEntryPoint")
 
 RuntimeEntryPointTests.testCPUOrGPU("RoundTrip_CTensorHandle_AnyTensorHandle") {
   let zero: TensorHandle<Float> =
-    #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 0.0)
+    #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: 0.0)
   var cHandle = _TFCGetCTensorHandleFromSwift(zero as _AnyTensorHandle)
   let status = TF_NewStatus()
   // We must do a copy, i.e. a retain on the tensor handle, to make sure it won't

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -11,7 +11,7 @@ var RuntimeEntryPointTests = TestSuite("RuntimeEntryPoint")
 
 RuntimeEntryPointTests.testCPUOrGPU("RoundTrip_CTensorHandle_AnyTensorHandle") {
   let zero: TensorHandle<Float> =
-    #tfop("Const", dtype: Float.self, value$tensor: 0.0)
+    #tfop("Const", dtype$dtype: Float._tensorFlowDataType, value$tensor: 0.0)
   var cHandle = _TFCGetCTensorHandleFromSwift(zero as _AnyTensorHandle)
   let status = TF_NewStatus()
   // We must do a copy, i.e. a retain on the tensor handle, to make sure it won't

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -219,7 +219,7 @@
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-10-01-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
                 "tensorflow": "d493a7f2fdbbc29a292741135f4c1598352e876b",
-                "tensorflow-swift-bindings": "e1983bdac0c64ba02f8c5c850f7c82436b5622e5"
+                "tensorflow-swift-bindings": "2e5e37ea76d44cd91bcca5e764b187a6859058cb"
             }
         }
     }


### PR DESCRIPTION
Changes metatype attribues on `#tfop`s to integer attributes representing `TF_DataType`s.

This will make it easier to IRGen dynamic attributes that represent TF_DataTypes, because IRGen will only have to get the integer and pass it to tensorflow, instead of having to extract information from a runtime metatype.

It is still possible to pass metatypes to `#tfop` as `$unknownShapeList` and as `$typeList`, but once https://bugs.swift.org/browse/SR-8830 is done, we can remove those.

Corresponding generated ops changes in https://github.com/tensorflow/swift-bindings/pull/8.