### PR TITLE
test: use llvm-strings instead of strings

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,7 +47,8 @@ function(get_test_dependencies SDK result_var_name)
   if(NOT SWIFT_BUILT_STANDALONE)
     list(APPEND deps_binaries FileCheck arcmt-test c-arcmt-test c-index-test
          clang llc llvm-cov llvm-dwarfdump llvm-link llvm-as llvm-dis
-         llvm-bcanalyzer llvm-nm llvm-readobj llvm-profdata count not)
+         llvm-bcanalyzer llvm-nm llvm-readobj llvm-profdata count not
+         llvm-strings)
   endif()
   if(SWIFT_BUILD_SOURCEKIT)
     list(APPEND deps_binaries sourcekitd-test complete-test)

--- a/test/Serialization/comments-params.swift
+++ b/test/Serialization/comments-params.swift
@@ -3,7 +3,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -group-info-path %S/Inputs/comments-params.json %s
-// RUN: strings %t/comments.swiftdoc > %t.txt
+// RUN: %llvm-strings %t/comments.swiftdoc > %t.txt
 // RUN: %FileCheck %s < %t.txt
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.txt
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -267,6 +267,7 @@ config.llvm_link = inferSwiftBinary('llvm-link')
 config.swift_llvm_opt = inferSwiftBinary('swift-llvm-opt')
 config.llvm_profdata = inferSwiftBinary('llvm-profdata')
 config.llvm_cov = inferSwiftBinary('llvm-cov')
+config.llvm_strings = inferSwiftBinary('llvm-strings')
 config.filecheck = inferSwiftBinary('FileCheck')
 config.llvm_dwarfdump = inferSwiftBinary('llvm-dwarfdump')
 config.llvm_dis = inferSwiftBinary('llvm-dis')
@@ -374,6 +375,7 @@ config.substitutions.append( ('%llvm-dis', config.llvm_dis) )
 config.substitutions.append( ('%swift-demangle-yamldump', config.swift_demangle_yamldump) )
 config.substitutions.append( ('%Benchmark_O', config.benchmark_o) )
 config.substitutions.append( ('%Benchmark_Driver', config.benchmark_driver) )
+config.substitutions.append( ('%llvm-strings', config.llvm_strings) )
 
 # This must come after all substitutions containing "%swift".
 config.substitutions.append(


### PR DESCRIPTION
We should have the LLVM build which provides most of the tools that we need.
`strings` is amongst them.  Add a new `llvm-strings` substitution from lit and
use that instead of `strings`.  This helps with Windows which does not have a
`strings` tool.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
