### PR TITLE
[stdlib][DNM] Remove customization points from Sequence and Collection

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
@@ -77,9 +77,7 @@ public class SequenceLog {
   // Sequence
   public static var makeIterator = TypeIndexed(0)
   public static var underestimatedCount = TypeIndexed(0)
-  public static var map = TypeIndexed(0)
   public static var filter = TypeIndexed(0)
-  public static var forEach = TypeIndexed(0)
   public static var dropFirst = TypeIndexed(0)
   public static var dropLast = TypeIndexed(0)
   public static var dropWhile = TypeIndexed(0)
@@ -107,14 +105,12 @@ public class SequenceLog {
   public static var isEmpty = TypeIndexed(0)
   public static var count = TypeIndexed(0)
   public static var _customIndexOfEquatableElement = TypeIndexed(0)
-  public static var first = TypeIndexed(0)
   public static var advance = TypeIndexed(0)
   public static var advanceLimit = TypeIndexed(0)
   public static var distance = TypeIndexed(0)
   // BidirectionalCollection
   public static var predecessor = TypeIndexed(0)
   public static var formPredecessor = TypeIndexed(0)
-  public static var last = TypeIndexed(0)
   // MutableCollection
   public static var subscriptIndexSet = TypeIndexed(0)
   public static var subscriptRangeSet = TypeIndexed(0)
@@ -222,23 +218,11 @@ extension LoggingSequence: Sequence {
     return base.underestimatedCount
   }
 
-  public func map<T>(
-    _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    SequenceLog.map[selfType] += 1
-    return try base.map(transform)
-  }
-
   public func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     SequenceLog.filter[selfType] += 1
     return try base.filter(isIncluded)
-  }
-
-  public func forEach(_ body: (Element) throws -> Void) rethrows {
-    SequenceLog.forEach[selfType] += 1
-    try base.forEach(body)
   }
 
   public func dropFirst(_ n: Int) -> SubSequence {
@@ -406,11 +390,6 @@ extension LoggingCollection: Collection {
     return base._customIndexOfEquatableElement(element)
   }
 
-  public var first: Element? {
-    CollectionLog.first[selfType] += 1
-    return base.first
-  }
-
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     CollectionLog.advance[selfType] += 1
     return base.index(i, offsetBy: n)
@@ -442,11 +421,6 @@ extension LoggingBidirectionalCollection: BidirectionalCollection {
   public func formIndex(before i: inout Index) {
     BidirectionalCollectionLog.formPredecessor[selfType] += 1
     base.formIndex(before: &i)
-  }
-
-  public var last: Element? {
-    BidirectionalCollectionLog.last[selfType] += 1
-    return base.last
   }
 }
 

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -185,20 +185,6 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   ///     // c == MyFancyCollection([2, 4, 6, 8, 10])
   override var indices: Indices { get }
   
-  // TODO: swift-3-indexing-model: tests.
-  /// The last element of the collection.
-  ///
-  /// If the collection is empty, the value of this property is `nil`.
-  ///
-  ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let lastNumber = numbers.last {
-  ///         print(lastNumber)
-  ///     }
-  ///     // Prints "50"
-  ///     
-  /// - Complexity: O(1)
-  var last: Element? { get }
-
   /// Accesses a contiguous subrange of the collection's elements.
   ///
   /// The accessed slice uses the same indices for the same elements as the

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -632,22 +632,6 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// - Complexity: Hopefully less than O(`count`).
   func _customLastIndexOfEquatableElement(_ element: Element) -> Index??
 
-  // FIXME(move-only types): `first` might not be implementable by collections
-  // with move-only elements, since they would need to be able to somehow form
-  // a temporary `Optional<Element>` value from a nonoptional Element without
-  // modifying the collection.
-
-  /// The first element of the collection.
-  ///
-  /// If the collection is empty, the value of this property is `nil`.
-  /// 
-  ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let firstNumber = numbers.first {
-  ///         print(firstNumber)
-  ///     }
-  ///     // Prints "10"
-  var first: Element? { get }
-
   /// Returns an index that is the specified distance from the given index.
   ///
   /// The following example obtains an index advanced four positions from a
@@ -1346,8 +1330,7 @@ extension Collection {
   @inlinable
   public __consuming func dropFirst(_ k: Int) -> SubSequence {
     _precondition(k >= 0, "Can't drop a negative number of elements from a collection")
-    let start = index(startIndex,
-      offsetBy: k, limitedBy: endIndex) ?? endIndex
+    let start = index(startIndex, offsetBy: k, limitedBy: endIndex) ?? endIndex
     return self[start..<endIndex]
   }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -728,19 +728,6 @@ extension Dictionary: Collection {
   public var isEmpty: Bool {
     return count == 0
   }
-
-  /// The first element of the dictionary.
-  ///
-  /// The first element of the dictionary is not necessarily the first element
-  /// added to the dictionary. Don't expect any particular ordering of
-  /// dictionary elements.
-  ///
-  /// If the dictionary is empty, the value of this property is `nil`.
-  @inlinable
-  public var first: Element? {
-    var it = makeIterator()
-    return it.next()
-  }
 }
 
 extension Dictionary {

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -352,9 +352,6 @@ internal class _AnyRandomAccessCollectionBox<Element>
   func _customLastIndexOfEquatableElement(element: Element) -> Index??
   */
 
-  @inlinable // FIXME(sil-serialize-all)
-  internal var _first: Element? { _abstract() }
-
   @inlinable
   internal init(
     _startIndex: _AnyIndexBox,
@@ -385,8 +382,6 @@ internal class _AnyRandomAccessCollectionBox<Element>
   internal func _index(before i: _AnyIndexBox) -> _AnyIndexBox { _abstract() }
   @inlinable
   internal func _formIndex(before i: _AnyIndexBox) { _abstract() }
-  @inlinable
-  internal var _last: Element? { _abstract() }
 %   end
 }
 
@@ -617,11 +612,6 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
     return numericCast(_base.count)
   }
 
-  @inlinable
-  internal override var _first: Element? {
-    return _base.first
-  }
-
 %     if Kind in ['BidirectionalCollection', 'RandomAccessCollection']:
   @inlinable
   internal override func _index(before position: _AnyIndexBox) -> _AnyIndexBox {
@@ -636,10 +626,6 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
     fatalError("Index type mismatch!")
   }
 
-  @inlinable
-  internal override var _last: Element? {
-    return _base.last
-  }
 %     end
 
 %   end
@@ -1118,11 +1104,6 @@ extension ${Self}: ${SelfProtocol} {
     return _box._count
   }
 
-  @inlinable
-  public var first: Element? {
-    return _box._first
-  }
-
 %   if Traversal == 'Bidirectional' or Traversal == 'RandomAccess':
   @inlinable
   public func index(before i: Index) -> Index {
@@ -1137,11 +1118,6 @@ extension ${Self}: ${SelfProtocol} {
     else {
       i = index(before: i)
     }
-  }
-
-  @inlinable
-  public var last: Element? {
-    return _box._last
   }
 %   end
 }

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -201,12 +201,6 @@ extension LazyCollection : Collection {
     return _base._customLastIndexOfEquatableElement(element)
   }
 
-  /// Returns the first element of `self`, or `nil` if `self` is empty.
-  @inlinable
-  public var first: Element? {
-    return _base.first
-  }
-
   // TODO: swift-3-indexing-model - add docs
   @inlinable
   public func index(_ i: Index, offsetBy n: Int) -> Index {
@@ -234,11 +228,6 @@ extension LazyCollection : BidirectionalCollection
   @inlinable
   public func index(before i: Index) -> Index {
     return _base.index(before: i)
-  }
-
-  @inlinable
-  public var last: Element? {
-    return _base.last
   }
 }
 

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -188,9 +188,6 @@ extension LazyMapCollection: LazyCollectionProtocol {
   }
 
   @inlinable
-  public var first: Element? { return _base.first.map(_transform) }
-
-  @inlinable
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     return _base.index(i, offsetBy: n)
   }
@@ -223,9 +220,6 @@ extension LazyMapCollection : BidirectionalCollection
   public func formIndex(before i: inout Index) {
     _base.formIndex(before: &i)
   }
-
-  @inlinable
-  public var last: Element? { return _base.last.map(_transform) }
 }
 
 extension LazyMapCollection : RandomAccessCollection

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -348,29 +348,6 @@ public protocol Sequence {
   ///   In this case, see the documentation of `Collection.underestimatedCount`.
   var underestimatedCount: Int { get }
 
-  /// Returns an array containing the results of mapping the given closure
-  /// over the sequence's elements.
-  ///
-  /// In this example, `map` is used first to convert the names in the array
-  /// to lowercase strings and then to count their characters.
-  ///
-  ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
-  ///     let lowercaseNames = cast.map { $0.lowercased() }
-  ///     // 'lowercaseNames' == ["vivien", "marlon", "kim", "karl"]
-  ///     let letterCounts = cast.map { $0.count }
-  ///     // 'letterCounts' == [6, 6, 3, 4]
-  ///
-  /// - Parameter transform: A mapping closure. `transform` accepts an
-  ///   element of this sequence as its parameter and returns a transformed
-  ///   value of the same or of a different type.
-  /// - Returns: An array containing the transformed elements of this
-  ///   sequence.
-  ///
-  /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  func map<T>(
-    _ transform: (Element) throws -> T
-  ) rethrows -> [T]
-
   /// Returns an array containing, in order, the elements of the sequence
   /// that satisfy the given predicate.
   ///
@@ -391,37 +368,6 @@ public protocol Sequence {
   __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element]
-
-  /// Calls the given closure on each element in the sequence in the same order
-  /// as a `for`-`in` loop.
-  ///
-  /// The two loops in the following example produce the same output:
-  ///
-  ///     let numberWords = ["one", "two", "three"]
-  ///     for word in numberWords {
-  ///         print(word)
-  ///     }
-  ///     // Prints "one"
-  ///     // Prints "two"
-  ///     // Prints "three"
-  ///
-  ///     numberWords.forEach { word in
-  ///         print(word)
-  ///     }
-  ///     // Same as above
-  ///
-  /// Using the `forEach` method is distinct from a `for`-`in` loop in two
-  /// important ways:
-  ///
-  /// 1. You cannot use a `break` or `continue` statement to exit the current
-  ///    call of the `body` closure or skip subsequent calls.
-  /// 2. Using the `return` statement in the `body` closure will exit only from
-  ///    the current call to `body`, not from any outer scope, and won't skip
-  ///    subsequent calls.
-  ///
-  /// - Parameter body: A closure that takes an element of the sequence as a
-  ///   parameter.
-  func forEach(_ body: (Element) throws -> Void) rethrows
 
   // Note: The complexity of Sequence.dropFirst(_:) requirement
   // is documented as O(n) because Collection.dropFirst(_:) is

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -391,18 +391,6 @@ extension Set: Collection {
   public var isEmpty: Bool {
     return count == 0
   }
-
-  /// The first element of the set.
-  ///
-  /// The first element of the set is not necessarily the first element added
-  /// to the set. Don't expect any particular ordering of set elements.
-  ///
-  /// If the set is empty, the value of this property is `nil`.
-  @inlinable
-  public var first: Element? {
-    var iterator = makeIterator()
-    return iterator.next()
-  }
 }
 
 // FIXME: rdar://problem/23549059 (Optimize == for Set)

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -12,12 +12,33 @@ Struct _PrefixSequence has generic signature change from <τ_0_0 where τ_0_0 : 
 /* Removed Decls */
 Constructor _DropFirstSequence.init(_iterator:limit:dropped:) has been removed
 Constructor _PrefixSequence.init(_iterator:maxLength:taken:) has been removed
+Func Sequence.forEach(_:) has been removed
+Func Sequence.map(_:) has been removed
 Func _DropFirstSequence.next() has been removed
 Func _PrefixSequence.next() has been removed
+Var AnyBidirectionalCollection.first has been removed
+Var AnyBidirectionalCollection.last has been removed
+Var AnyCollection.first has been removed
+Var AnyRandomAccessCollection.first has been removed
+Var AnyRandomAccessCollection.last has been removed
+Var BidirectionalCollection.last has been removed
+Var Dictionary.first has been removed
+Var LazyCollection.first has been removed
+Var LazyCollection.last has been removed
+Var LazyMapCollection.first has been removed
+Var LazyMapCollection.last has been removed
+Var Set.first has been removed
+Var _AnyBidirectionalCollectionBox._last has been removed
+Var _AnyCollectionBox._first has been removed
+Var _BidirectionalCollectionBox._first has been removed
+Var _BidirectionalCollectionBox._last has been removed
+Var _CollectionBox._first has been removed
 Var _DropFirstSequence._dropped has been removed
 Var _DropFirstSequence._iterator has been removed
 Var _PrefixSequence._iterator has been removed
 Var _PrefixSequence._taken has been removed
+Var _RandomAccessCollectionBox._first has been removed
+Var _RandomAccessCollectionBox._last has been removed
 
 /* Moved Decls */
 Struct _DropFirstSequence has been renamed to Struct DropFirstSequence

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -4,6 +4,20 @@
 /* RawRepresentable Changes */
 
 /* Removed Decls */
+Func Sequence.forEach(_:) has been removed
+Func Sequence.map(_:) has been removed
+Var AnyBidirectionalCollection.first has been removed
+Var AnyBidirectionalCollection.last has been removed
+Var AnyCollection.first has been removed
+Var AnyRandomAccessCollection.first has been removed
+Var AnyRandomAccessCollection.last has been removed
+Var BidirectionalCollection.last has been removed
+Var Dictionary.first has been removed
+Var LazyCollection.first has been removed
+Var LazyCollection.last has been removed
+Var LazyMapCollection.first has been removed
+Var LazyMapCollection.last has been removed
+Var Set.first has been removed
 
 /* Moved Decls */
 

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -196,11 +196,7 @@ CollectionTypeTests.test("filter/Collection/${Implementation}Implementation/${di
 //===----------------------------------------------------------------------===//
 var MinimalCollectionWithCustomMap_timesMapWasCalled: Int = 0
 
-% for Implementation in [ 'Default', 'Custom' ]:
-
-struct MinimalCollectionWith${Implementation}Map<Element>
-  : Collection {
-
+struct MinimalCollectionWithDefaultMap<Element>: Collection {
   init(_ data: [Element], underestimatedCount: UnderestimatedCountBehavior) {
     self._data = MinimalCollection(
       elements: data, underestimatedCount: underestimatedCount)
@@ -227,43 +223,10 @@ struct MinimalCollectionWith${Implementation}Map<Element>
   }
 
   var _data: MinimalCollection<Element>
-
-
-%   if Implementation == 'Custom':
-
-  static var timesMapWasCalled: Int {
-    get {
-      return MinimalCollectionWithCustomMap_timesMapWasCalled
-    }
-    set {
-      MinimalCollectionWithCustomMap_timesMapWasCalled = newValue
-    }
-  }
-
-  func map<T>(
-    _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    MinimalCollectionWithCustomMap.timesMapWasCalled += 1
-    return try _data.map(transform)
-  }
-
-%   end
-
 }
-
-% end
 
 func callStaticCollectionMap<T>(
   _ collection: MinimalCollectionWithDefaultMap<OpaqueValue<Int>>,
-  transform: (OpaqueValue<Int>) -> T
-) -> [T] {
-  var result = collection.map(transform)
-  expectType([T].self, &result)
-  return result
-}
-
-func callStaticCollectionMap<T>(
-  _ collection: MinimalCollectionWithCustomMap<OpaqueValue<Int>>,
   transform: (OpaqueValue<Int>) -> T
 ) -> [T] {
   var result = collection.map(transform)
@@ -280,9 +243,7 @@ func callGenericCollectionMap<C : Collection, T>(
   return result
 }
 
-% for Implementation in [ 'Default', 'Custom' ]:
-
-%   for dispatch in [ 'Static', 'Generic' ]:
+% for dispatch in [ 'Static', 'Generic' ]:
 
 CollectionTypeTests.test(
   "map/Collection/${Implementation}Implementation/${dispatch}"
@@ -293,19 +254,12 @@ CollectionTypeTests.test(
       UnderestimatedCountBehavior.half,
       UnderestimatedCountBehavior.value(0)
     ] {
-      let s = MinimalCollectionWith${Implementation}Map<
-        OpaqueValue<Int>
-      >(
+      let s = MinimalCollectionWithDefaultMap<OpaqueValue<Int>>(
         test.sequence.map(OpaqueValue.init),
         underestimatedCount: underestimatedCountBehavior)
       let closureLifetimeTracker = LifetimeTracked(0)
       expectEqual(1, LifetimeTracked.instances)
       var timesClosureWasCalled = 0
-%     if Implementation == 'Custom':
-      MinimalCollectionWithCustomMap<
-        OpaqueValue<Int>
-      >.timesMapWasCalled = 0
-%     end
       var result = call${dispatch}CollectionMap(s) {
         (element: OpaqueValue<Int>) -> OpaqueValue<Int32> in
         _blackHole(closureLifetimeTracker)
@@ -314,12 +268,6 @@ CollectionTypeTests.test(
       }
       expectType([OpaqueValue<Int32>].self, &result)
       expectEqual(test.expected, result.map { $0.value })
-%     if Implementation == 'Custom':
-      expectEqual(
-        1, MinimalCollectionWithCustomMap<
-          OpaqueValue<Int>
-        >.timesMapWasCalled)
-%     end
       expectEqual(test.sequence, s.map { $0.value },
         "collection should not be consumed")
       expectEqual(test.sequence.count, timesClosureWasCalled,
@@ -328,8 +276,6 @@ CollectionTypeTests.test(
     }
   }
 }
-
-%   end
 
 % end
 
@@ -603,15 +549,6 @@ CollectionTypeTests.test("isEmpty/dispatch") {
   expectCustomizable(tester, tester.log.isEmpty)
 }
 
-//===----------------------------------------------------------------------===//
-// first
-//===----------------------------------------------------------------------===//
-
-CollectionTypeTests.test("first/dispatch") {
-  let tester = CollectionLog.dispatchTester([OpaqueValue(1)])
-  _ = tester.first
-  expectCustomizable(tester, tester.log.first)
-}
 
 //===----------------------------------------------------------------------===//
 // count

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -151,16 +151,8 @@ tests.test("${TestedType}: dispatch to wrapped, SequenceLog") {
     _ = s.underestimatedCount
   }
 
-  Log.map.expectIncrement(Base.self) {
-    _ = s.map { $0 }
-  }
-
   Log.filter.expectIncrement(Base.self) {
     _ = s.filter { (_) in true }
-  }
-
-  Log.forEach.expectIncrement(Base.self) {
-    _ = s.forEach { (_) in }
   }
 
   Log.dropFirst.expectIncrement(Base.self) {
@@ -331,23 +323,6 @@ tests.test("${TestedType}: dispatch to wrapped, CollectionLog") {
     _blackHole(x)
   }
 %   end
-
-  Log.first.expectIncrement(Base.self) {
-    Log.startIndex.expectUnchanged(Base.self) {
-      Log.makeIterator.expectUnchanged(Base.self) {
-        _ = c.first
-      }
-    }
-  }
-
-%   if Traversal in ['Bidirectional', 'RandomAccess']:
-  BidirectionalCollectionLog.last.expectIncrement(Base.self) {
-    Log.endIndex.expectUnchanged(Base.self) {
-      _ = c.last
-    }
-  }
-%   end
-
 }
 %   end
 % end

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -745,7 +745,6 @@ tests.test("LazyCollection/Passthrough") {
   CollectionLog._customIndexOfEquatableElement.expectIncrement(baseType) {
     _ = s._customIndexOfEquatableElement(OpaqueValue(0))
   }
-  CollectionLog.first.expectIncrement(baseType) { _ = s.first }
 }
 
 //===--- Map --------------------------------------------------------------===//
@@ -842,9 +841,6 @@ tests.test("LazyMapCollection/Passthrough") {
   }
   CollectionLog.isEmpty.expectIncrement(type(of: base)) {
     _ = mapped.isEmpty
-  }
-  CollectionLog.first.expectIncrement(type(of: base)) {
-    _ = mapped.first
   }
   CollectionLog.underestimatedCount.expectIncrement(type(of: base)) {
     _ = mapped.underestimatedCount

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -838,9 +838,7 @@ func callGenericSequenceMap<S : Sequence, T>(
   return result
 }
 
-% for Implementation in ['Default', 'Custom']:
-
-%   for dispatch in ['Static', 'Generic']:
+% for dispatch in ['Static', 'Generic']:
 
 SequenceTypeTests.test(
   "map/Sequence/${Implementation}Implementation/${dispatch}"
@@ -857,9 +855,6 @@ SequenceTypeTests.test(
       let closureLifetimeTracker = LifetimeTracked(0)
       expectEqual(1, LifetimeTracked.instances)
       var timesClosureWasCalled = 0
-%     if Implementation == 'Custom':
-      MinimalSequenceWithCustomMap<OpaqueValue<Int>>.timesMapWasCalled = 0
-%     end
       var result = call${dispatch}SequenceMap(s) {
         (element: OpaqueValue<Int>) -> OpaqueValue<Int32> in
         _blackHole(closureLifetimeTracker)
@@ -868,20 +863,13 @@ SequenceTypeTests.test(
       }
       expectType([OpaqueValue<Int32>].self, &result)
       expectEqual(test.expected, result.map { $0.value })
-%     if Implementation == 'Custom':
-      expectEqual(
-        1, MinimalSequenceWithCustomMap<OpaqueValue<Int>>.timesMapWasCalled)
-%     end
       expectEqual([], s.map { $0.value }, "sequence should be consumed")
-      expectEqual(
-        test.sequence.count, timesClosureWasCalled,
+      expectEqual(        test.sequence.count, timesClosureWasCalled,
         "map() should be eager and should only call its predicate"
         + "once per element")
     }
   }
 }
-
-%   end
 
 % end
 
@@ -959,16 +947,6 @@ SequenceTypeTests.test("flatMap/Sequence/TransformProducesOptional") {
         "flatMap() should not reserve capacity")
     }
   }
-}
-
-//===----------------------------------------------------------------------===//
-// forEach()
-//===----------------------------------------------------------------------===//
-
-SequenceTypeTests.test("forEach/dispatch") {
-  let tester = SequenceLog.dispatchTester([OpaqueValue(1)])
-  tester.forEach { print($0) }
-  expectCustomizable(tester, tester.log.forEach)
 }
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/SequenceWrapperTest.swift
+++ b/validation-test/stdlib/SequenceWrapperTest.swift
@@ -60,11 +60,6 @@ sequenceWrapperTests.test("Dispatch/underestimatedCount") {
     dispatchLog.underestimatedCount)
 }
 
-sequenceWrapperTests.test("Dispatch/map") {
-  expectWrapperDispatch(
-    direct.map { $0 }, indirect.map { $0 }, dispatchLog.map)
-}
-
 sequenceWrapperTests.test("Dispatch/filter") {
   expectWrapperDispatch(
     direct.filter { _ in true },


### PR DESCRIPTION
This removes some unnecessary customization points on standard library protocols:

**`map` and `forEach` on `Sequence`**

It is unrealistic that a collection would be able to implement `map` (which takes a transformation closure) to create a mapped array faster than the default implementation.

While it is possible that a type's `forEach` implementation might be able to eek out a small performance benefit (for example, to avoid the reference count bump of putting `self` into an iterator), it is generally harmful to encourage this kind of "maybe `forEach` could be faster" micro-optimization (for example, see [here](https://github.com/apple/swift/pull/17387) where error control flow was used in order to break out of the for-each early).

**`first` on `Collection` and `last` on `BidirectionalCollection`**

It's important to remove these in order for collections of move-only types to be able to implement these protocols. Returning a single element of the collection inside an optional would otherwise need to consume the _entire_ collection.

While it is conceivable that faster implementations of `first` for particular collections could exist, it's unlikely to be material and experience in benchmarking so far suggests that where they did exist, those implementations were actually slower.
