### PR TITLE
stdlib: correct declaration for `malloc_usable_size` on android

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -99,7 +99,13 @@ static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
 #elif defined(__linux__) || defined(__CYGWIN__) || defined(__ANDROID__) \
    || defined(__HAIKU__) || defined(__FreeBSD__)
 static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
+#if defined(__ANDROID__)
+#if __ANDROID_API__ >= 17
+  extern __swift_size_t malloc_usable_size(const void *ptr);
+#endif
+#else
   extern __swift_size_t malloc_usable_size(void *ptr);
+#endif
   return malloc_usable_size(CONST_CAST(void *, ptr));
 }
 #elif defined(_WIN32)


### PR DESCRIPTION
`malloc_usable_size` is provided on Android with API Level 17 or newer.
However, the signature between bionic and glibc is slightly different, with
android marking the parameter as `const`.  This results in a type mismatch error
when building the standard library for android.  Adjust it to match the target
system.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
