### PR TITLE
build: fix compatibility with VS2017 and VS2015

### DIFF
--- a/cmake/modules/SwiftWindowsSupport.cmake
+++ b/cmake/modules/SwiftWindowsSupport.cmake
@@ -47,14 +47,24 @@ function(swift_windows_lib_for_arch arch var)
   swift_windows_arch_spelling(${arch} ARCH)
 
   set(paths)
-  if(${ARCH} STREQUAL x86)
-    list(APPEND paths "$ENV{VCToolsInstallDir}/Lib")
+
+  # NOTE(compnerd) provide compatibility with VS2015 which had the libraries in
+  # a directory called "Lib" rather than VS2017 which normalizes the layout and
+  # places them in a directory named "lib".
+  if(IS_DIRECTORY "$ENV{VCToolsInstallDir}/Lib")
+    if(${ARCH} STREQUAL x86)
+      list(APPEND paths "$ENV{VCToolsInstallDir}/Lib/")
+    else()
+      list(APPEND paths "$ENV{VCToolsInstallDir}/Lib/${ARCH}")
+    endif()
   else()
-    list(APPEND paths "$ENV{VCToolsInstallDir}/Lib/${ARCH}")
+    list(APPEND paths "$ENV{VCToolsInstallDir}/lib/${ARCH}")
   endif()
+
   list(APPEND paths
           "$ENV{UniversalCRTSdkDir}/Lib/$ENV{UCRTVersion}/ucrt/${ARCH}"
           "$ENV{UniversalCRTSdkDir}/Lib/$ENV{UCRTVersion}/um/${ARCH}")
+
   set(${var} ${paths} PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
Adjust the build to work with the VS2017 layout while maintaining the
compatibility with VS2015.  The library location changed which results in the
link failing due to not finding system libraries.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
