### PR TITLE
[ownership] Accept @owned partial apply in callee_guaranteed context.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -844,8 +844,12 @@ OperandOwnershipKindMap OperandOwnershipKindClassifier::visitCallee(
     if (substCalleeType->isNoEscape())
       return Map::compatibilityMap(ValueOwnershipKind::Trivial,
                                    UseLifetimeConstraint::MustBeLive);
-    return Map::compatibilityMap(ValueOwnershipKind::Guaranteed,
-                                 UseLifetimeConstraint::MustBeLive);
+    // We want to accept guaranteed/owned in this position since we
+    // treat the use of an owned parameter as an instantaneously
+    // borrowed value for the duration of the call.
+    return Map::compatibilityMap(
+        {{ValueOwnershipKind::Guaranteed, UseLifetimeConstraint::MustBeLive},
+         {ValueOwnershipKind::Owned, UseLifetimeConstraint::MustBeLive}});
   }
 
   llvm_unreachable("Unhandled ParameterConvention in switch.");

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -1112,3 +1112,15 @@ bb0k(%0 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
+sil @owned_partial_apply_used_as_callee_guaranteed : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @allocate_object : $@convention(thin) () -> @owned Builtin.NativeObject
+  %1 = partial_apply %0() : $@convention(thin) () -> @owned Builtin.NativeObject
+  %2 = convert_function %1 : $@callee_owned () -> @owned Builtin.NativeObject to $@callee_guaranteed () -> @owned Builtin.NativeObject
+  %3 = apply %2() : $@callee_guaranteed () -> @owned Builtin.NativeObject
+  destroy_value %3 : $Builtin.NativeObject
+  destroy_value %2 : $@callee_guaranteed () -> @owned Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+


### PR DESCRIPTION
We already allow for "instantaneous borrowing" for passing @owned values as
@guaranteed arguments. There is no reason why we shouldn't do this for
partial_apply as well.

rdar://29791263
