### PR TITLE
Update UUID to take advantage of SE-0205

### DIFF
--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -77,7 +77,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     public var hashValue: Int {
         return withUnsafePointer(to: uuid) {
               $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
-                  return Int(bitPattern: CFHashBytes($0, CFIndex(MemoryLayout<uuid_t>.size)))
+                  return Int(bitPattern: CFHashBytes(UnsafeMutablePointer(mutating: $0), CFIndex(MemoryLayout<uuid_t>.size)))
               }
         }
     }

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -62,8 +62,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     /// Returns a string created from the UUID, such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
     public var uuidString: String {
         var bytes: uuid_string_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        var localValue = uuid
-        return withUnsafeMutablePointer(to: &localValue) {
+        return withUnsafePointer(to: uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: 16) { val in
                 withUnsafeMutablePointer(to: &bytes) {
                     $0.withMemoryRebound(to: Int8.self, capacity: 37) { str in
@@ -76,8 +75,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     }
     
     public var hashValue: Int {
-        var localValue = uuid
-        return withUnsafeMutablePointer(to: &localValue) {
+        return withUnsafePointer(to: uuid) {
               $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
                   return Int(bitPattern: CFHashBytes($0, CFIndex(MemoryLayout<uuid_t>.size)))
               }

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -93,8 +93,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     // MARK: - Bridging Support
     
     fileprivate var reference: NSUUID {
-        var bytes = uuid
-        return withUnsafePointer(to: &bytes) {
+        return withUnsafePointer(to: uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
                 return NSUUID(uuidBytes: $0)
             }


### PR DESCRIPTION
This updates UUID to use `withUnsafePointer` for `let`s

<!-- What's in this pull request? -->

Now that SE-0205 has landed, we don't need to make local copies of the uuid byte tuples, in order to get pointers to them. We can use the new `withUnsafePointer` that works with `let`s.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->