### PR TITLE
[5.0] Cherry-pick fix and test case for indexing crash in IndexSwiftASTWalker::walkToExprPre

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -226,7 +226,7 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
     return printObjCUSR(D, OS);
   }
 
-  if (!D->hasInterfaceType() || D->getInterfaceType()->is<ErrorType>())
+  if (!D->hasInterfaceType())
     return true;
 
   // Invalid code.

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -226,7 +226,7 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
     return printObjCUSR(D, OS);
   }
 
-  if (!D->hasInterfaceType())
+  if (!D->hasInterfaceType() || D->getInterfaceType()->is<ErrorType>())
     return true;
 
   // Invalid code.

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -247,6 +247,8 @@ static SemaReferenceKind getReferenceKind(Expr *Parent, Expr *E) {
 }
 
 std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
+  assert(E);
+
   if (isDone())
     return { false, nullptr };
 
@@ -409,11 +411,11 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       llvm::SaveAndRestore<Optional<AccessKind>>
         C(this->OpAccess, AccessKind::Write);
 
-      if (!AE->getDest()->walk(*this))
+      if (AE->getDest() && !AE->getDest()->walk(*this))
         return { false, nullptr };
     }
 
-    if (!AE->getSrc()->walk(*this))
+    if (AE->getSrc() && !AE->getSrc()->walk(*this))
       return { false, nullptr };
 
     // We already visited the children.

--- a/test/Index/invalid_code.swift
+++ b/test/Index/invalid_code.swift
@@ -3,6 +3,12 @@
 // CHECK: [[@LINE+1]]:8 | struct/Swift | Int | {{.*}} | Ref | rel: 0
 var _: Int { get { return 1 } }
 
+func test() {
+  for o in allObjects {
+    _ = o.something // don't crash
+  }
+}
+
 class CrashTest {
   var something = 0
   func returnSelf(_ h: [AnyHashable: Any?]) -> CrashTest {

--- a/test/Index/invalid_code.swift
+++ b/test/Index/invalid_code.swift
@@ -18,3 +18,15 @@ class CrashTest {
 }
 // CHECK: [[@LINE+1]]:13 | instance-method/Swift | returnSelf
 CrashTest().returnSelf(["": 0]).something()
+
+class CrashTest2 {
+// CHECK: [[@LINE+1]]:8 | instance-method/Swift | bar
+  func bar() {
+    someClosure { [weak self] in
+      guard let sSelf = self else { return }
+
+      let newDataProvider = Foo()
+      newDataProvider.delegate = sSelf
+    }
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Cherry-pick fix and test case for crash in `IndexSwiftASTWalker::walkToExprPre` (due to missing check in `SourceEntityWalker::walkToExprPre`)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/45039252
