### PR TITLE
build: fix the variable name

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -258,7 +258,7 @@ macro(configure_sdk_unix name architectures)
   _report_sdk("${prefix}")
 endmacro()
 
-macro(configure_sdk_windows sdk_name environment architectures)
+macro(configure_sdk_windows name environment architectures)
   # Note: this has to be implemented as a macro because it sets global
   # variables.
 


### PR DESCRIPTION
The parameter name was not changed, resulting in the string conversion
not working properly for the Windows builds.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
