### PR TITLE
SIL: Correctly substitute type parameters in opened existential types

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -174,6 +174,12 @@ protected:
     return asImpl().remapASTType(ty);
   }
 
+  void remapOpenedType(CanArchetypeType archetypeTy) {
+    auto existentialTy = archetypeTy->getOpenedExistentialType()->getCanonicalType();
+    auto replacementTy = ArchetypeType::getOpened(getOpASTType(existentialTy));
+    registerOpenedExistentialRemapping(archetypeTy, replacementTy);
+  }
+
   ProtocolConformanceRef getOpConformance(Type ty,
                                           ProtocolConformanceRef conformance) {
     // If we have open existentials to substitute, do so now.
@@ -1644,10 +1650,7 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitOpenExistentialAddrInst(OpenExistentialAddrInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
-  registerOpenedExistentialRemapping(
-      archetypeTy,
-      ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
+  remapOpenedType(Inst->getType().castTo<ArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(Inst,
@@ -1661,10 +1664,7 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::visitOpenExistentialValueInst(
     OpenExistentialValueInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
-  registerOpenedExistentialRemapping(
-      archetypeTy,
-      ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
+  remapOpenedType(Inst->getType().castTo<ArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(Inst, getBuilder().createOpenExistentialValue(
@@ -1684,10 +1684,7 @@ visitOpenExistentialMetatypeInst(OpenExistentialMetatypeInst *Inst) {
     exType = exMetatype.getInstanceType();
     openedType = cast<MetatypeType>(openedType).getInstanceType();
   }
-  auto archetypeTy = cast<ArchetypeType>(openedType);
-  registerOpenedExistentialRemapping(
-      archetypeTy,
-      ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
+  remapOpenedType(cast<ArchetypeType>(openedType));
 
   if (!Inst->getOperand()->getType().canUseExistentialRepresentation(
           Inst->getModule(), ExistentialRepresentation::Class)) {
@@ -1711,10 +1708,7 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialRefInst(OpenExistentialRefInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
-  registerOpenedExistentialRemapping(
-      archetypeTy,
-      ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
+  remapOpenedType(Inst->getType().castTo<ArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(Inst,
@@ -1728,10 +1722,7 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialBoxInst(OpenExistentialBoxInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
-  registerOpenedExistentialRemapping(
-      archetypeTy,
-      ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
+  remapOpenedType(Inst->getType().castTo<ArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(Inst,
@@ -1745,10 +1736,7 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialBoxValueInst(OpenExistentialBoxValueInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
-  registerOpenedExistentialRemapping(
-      archetypeTy,
-      ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
+  remapOpenedType(Inst->getType().castTo<ArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(Inst,

--- a/test/SILOptimizer/inline_subclass_existential.swift
+++ b/test/SILOptimizer/inline_subclass_existential.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-sil -primary-file %s | %FileCheck %s
+
+class C<T> {}
+protocol P {
+  func f()
+}
+
+// CHECK-LABEL: sil hidden [transparent] @$s27inline_subclass_existential3fooyyAA1P_AA1CCyxGXclF : $@convention(thin) <T> (@guaranteed C<T> & P) -> () {
+// CHECK: open_existential_ref %0 : $C<T> & P to $@opened("{{.*}}") C<T> & P
+// CHECK: return
+@_transparent
+func foo<T>(_ x: C<T> & P) {
+  x.f()
+}
+
+// CHECK-LABEL: sil hidden @$s27inline_subclass_existential3baryyAA1P_AA1CCySiGXcF : $@convention(thin) (@guaranteed C<Int> & P) -> () {
+// CHECK: open_existential_ref %0 : $C<Int> & P to $@opened("{{.*}}") C<Int> & P
+// CHECK: return
+func bar(_ x: C<Int> & P) {
+  foo(x)
+}


### PR DESCRIPTION
This wasn't possible when the SIL cloner was first written, but subclass
existentials can involve generic classes, so you can have an opened
archetype type with a superclass constraint involving a type constraint.