### PR TITLE
Do not restore the precedencegroup name when deserializing them.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6456,12 +6456,11 @@ public:
 
   InfixOperatorDecl(DeclContext *DC, SourceLoc operatorLoc, Identifier name,
                     SourceLoc nameLoc, SourceLoc colonLoc,
-                    Identifier firstIdentifier, SourceLoc firstIdentifierLoc,
+                    PrecedenceGroupDecl *precedenceGroup,
                     NominalTypeDecl *designatedNominalType)
       : OperatorDecl(DeclKind::InfixOperator, DC, operatorLoc, name, nameLoc,
                      designatedNominalType),
-        ColonLoc(colonLoc), FirstIdentifierLoc(firstIdentifierLoc),
-        FirstIdentifier(firstIdentifier) {}
+        ColonLoc(colonLoc), PrecedenceGroup(precedenceGroup) {}
 
   SourceLoc getEndLoc() const {
     if (!SecondIdentifier.empty())

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2873,8 +2873,8 @@ void PrintAST::visitInfixOperatorDecl(InfixOperatorDecl *decl) {
     [&]{
       Printer.printName(decl->getName());
     });
-  if (!decl->getFirstIdentifier().empty())
-    Printer << " : " << decl->getFirstIdentifier();
+  if (auto *group = decl->getPrecedenceGroup())
+    Printer << " : " << group->getName();
   if (!decl->getSecondIdentifier().empty())
     Printer << ", " << decl->getSecondIdentifier();
 }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3448,15 +3448,9 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
     decls_block::InfixOperatorLayout::readRecord(scratch, nameID, contextID,
                                                  precedenceGroupID, nominalID);
 
-    PrecedenceGroupDecl *precedenceGroup = nullptr;
-    Identifier precedenceGroupName;
-    if (precedenceGroupID) {
-      precedenceGroup =
-        dyn_cast_or_null<PrecedenceGroupDecl>(getDecl(precedenceGroupID));
-      if (precedenceGroup) {
-        precedenceGroupName = precedenceGroup->getName();
-      }
-    }
+    Expected<Decl *> precedenceGroup = getDeclChecked(precedenceGroupID);
+    if (!precedenceGroup)
+      return precedenceGroup.takeError();
 
     auto DC = getDeclContext(contextID);
 
@@ -3466,9 +3460,8 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
 
     auto result = createDecl<InfixOperatorDecl>(
         DC, SourceLoc(), getIdentifier(nameID), SourceLoc(), SourceLoc(),
-        precedenceGroupName, SourceLoc(),
+        cast_or_null<PrecedenceGroupDecl>(precedenceGroup.get()),
         cast_or_null<NominalTypeDecl>(nominal.get()));
-    result->setPrecedenceGroup(precedenceGroup);
 
     declOrOffset = result;
     break;

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1113,7 +1113,7 @@ infix operator %%%
 func %%%(lhs: inout d2601_TestAssignment, rhs: d2601_TestAssignment) -> Int {
   return 0
 }
-// PASS_2500-LABEL: {{^}}infix operator %%%{{$}}
+// PASS_2500-LABEL: {{^}}infix operator %%% : DefaultPrecedence{{$}}
 // PASS_2500: {{^}}func %%% (lhs: inout d2601_TestAssignment, rhs: d2601_TestAssignment) -> Int{{$}}
 
 precedencegroup BoringPrecedence {


### PR DESCRIPTION
We only need to have the identifier during type checking of operator
declarations, so we do not need to restore it from the
PrecedenceGroupDecl during deserialization. We can just use the
deserialized name from the PrecedenceGroupDecl directly if needed.

This does result in one change in behavior. When printing modules, we
previously didn't print 'DefaultPrecedence' for items that had no
precedence specified, but now we will as seen in the test update for
IDE/print_ast_tc_decls.swift.
