### PR TITLE
[AST] Imported classes have no stored properties.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3233,10 +3233,7 @@ public:
                                                      ToStoredProperty>;
 
   /// Return a collection of the stored member variables of this type.
-  StoredPropertyRange getStoredProperties(bool skipInaccessible = false) const {
-    return StoredPropertyRange(getMembers(),
-                               ToStoredProperty(skipInaccessible));
-  }
+  StoredPropertyRange getStoredProperties(bool skipInaccessible = false) const;
 
 private:
   /// Predicate used to filter StoredPropertyRange.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3000,6 +3000,17 @@ void NominalTypeDecl::addExtension(ExtensionDecl *extension) {
   LastExtension = extension;
 }
 
+auto NominalTypeDecl::getStoredProperties(bool skipInaccessible) const
+    -> StoredPropertyRange {
+  // Clang-imported classes never have stored properties.
+  if (hasClangNode() && isa<ClassDecl>(this))
+    return StoredPropertyRange(DeclRange(nullptr, nullptr),
+                               ToStoredProperty(skipInaccessible));
+
+  return StoredPropertyRange(getMembers(),
+                             ToStoredProperty(skipInaccessible));
+}
+
 bool NominalTypeDecl::isOptionalDecl() const {
   return this == getASTContext().getOptionalDecl();
 }


### PR DESCRIPTION
Avoid triggering the import of all of the members of an Objective-C
class to determine its stored properties, because we don't import
instance variables of Objective-C classes. rdar://problem/45060773
