### PR TITLE
[CodeCompletion] Handle TupleShuffleExpr in completion context analyzer

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -948,7 +948,7 @@ static CodeCompletionResult::ExpectedTypeRelation calculateTypeRelation(
   if (!Ty->hasTypeParameter() && !ExpectedTy->hasTypeParameter()) {
     if (Ty->isEqual(ExpectedTy))
       return CodeCompletionResult::ExpectedTypeRelation::Identical;
-    if (isConvertibleTo(Ty, ExpectedTy, *DC))
+    if (!ExpectedTy->isAny() && isConvertibleTo(Ty, ExpectedTy, *DC))
       return CodeCompletionResult::ExpectedTypeRelation::Convertible;
   }
   if (auto FT = Ty->getAs<AnyFunctionType>()) {
@@ -3892,6 +3892,9 @@ public:
 
   static bool getPositionInArgs(DeclContext &DC, Expr *Args, Expr *CCExpr,
                                 unsigned &Position, bool &HasName) {
+    if (auto TSE = dyn_cast<TupleShuffleExpr>(Args))
+      Args = TSE->getSubExpr();
+
     if (isa<ParenExpr>(Args)) {
       HasName = false;
       Position = 0;
@@ -3914,6 +3917,38 @@ public:
     return false;
   }
 
+  /// Translate argument index in \p Args to parameter index.
+  /// Does nothing unless \p Args is \c TupleShuffleExpr.
+  static bool translateArgIndexToParamIndex(Expr *Args,
+                                            unsigned &Position, bool &HasName) {
+    auto TSE = dyn_cast<TupleShuffleExpr>(Args);
+    if (!TSE)
+      return true;
+
+    auto mapping = TSE->getElementMapping();
+    for (unsigned destIdx = 0, e = mapping.size(); destIdx != e; ++destIdx) {
+      auto srcIdx = mapping[destIdx];
+      if (srcIdx == (signed)Position) {
+        Position = destIdx;
+        return true;
+      }
+      if (srcIdx == TupleShuffleExpr::Variadic &&
+          llvm::is_contained(TSE->getVariadicArgs(), Position)) {
+        // The arg is a part of variadic args.
+        Position = destIdx;
+        HasName = false;
+        if (auto Args = dyn_cast<TupleExpr>(TSE->getSubExpr())) {
+          // Check if the first variadiac argument has the label.
+          auto firstVarArgIdx = TSE->getVariadicArgs().front();
+          HasName = Args->getElementNameLoc(firstVarArgIdx).isValid();
+        }
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   static bool
   collectArgumentExpectation(DeclContext &DC, ApplyExpr *CallE, Expr *CCExpr,
                              std::vector<Type> &ExpectedTypes,
@@ -3927,6 +3962,8 @@ public:
     unsigned Position;
     bool HasName;
     if (!getPositionInArgs(DC, CallE->getArg(), CCExpr, Position, HasName))
+      return false;
+    if (!translateArgIndexToParamIndex(CallE->getArg(), Position, HasName))
       return false;
 
     // Collect possible types (or labels) at the position.
@@ -4989,7 +5026,7 @@ namespace  {
   class ExprParentFinder : public ASTWalker {
     friend class CodeCompletionTypeContextAnalyzer;
     Expr *ChildExpr;
-    llvm::function_ref<bool(ParentTy)> Predicate;
+    llvm::function_ref<bool(ParentTy, ParentTy)> Predicate;
 
     bool arePositionsSame(Expr *E1, Expr *E2) {
       return E1->getSourceRange().Start == E2->getSourceRange().Start &&
@@ -5001,10 +5038,14 @@ namespace  {
     ParentTy ParentClosest;
     ParentTy ParentFarthest;
     ExprParentFinder(Expr* ChildExpr,
-                     llvm::function_ref<bool(ParentTy)> Predicate) :
+                     llvm::function_ref<bool(ParentTy, ParentTy)> Predicate) :
                      ChildExpr(ChildExpr), Predicate(Predicate) {}
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+      if (E != ChildExpr && Predicate(E, Parent)) {
+        Ancestors.push_back(E);
+        return { true, E };
+      }
       if (E == ChildExpr || arePositionsSame(E, ChildExpr)) {
         if (!Ancestors.empty()) {
           ParentClosest = Ancestors.back();
@@ -5012,49 +5053,47 @@ namespace  {
         }
         return {false, nullptr};
       }
-      if (Predicate(E))
-        Ancestors.push_back(E);
       return { true, E };
     }
 
     Expr *walkToExprPost(Expr *E) override {
-      if (Predicate(E))
+      if (Predicate(E, Parent))
         Ancestors.pop_back();
       return E;
     }
 
     std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-      if (Predicate(S))
+      if (Predicate(S, Parent))
         Ancestors.push_back(S);
       return { true, S };
     }
 
     Stmt *walkToStmtPost(Stmt *S) override {
-      if (Predicate(S))
+      if (Predicate(S, Parent))
         Ancestors.pop_back();
       return S;
     }
 
     bool walkToDeclPre(Decl *D) override {
-      if (Predicate(D))
+      if (Predicate(D, Parent))
         Ancestors.push_back(D);
       return true;
     }
 
     bool walkToDeclPost(Decl *D) override {
-      if (Predicate(D))
+      if (Predicate(D, Parent))
         Ancestors.pop_back();
       return true;
     }
 
     std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override {
-      if (Predicate(P))
+      if (Predicate(P, Parent))
         Ancestors.push_back(P);
       return { true, P };
     }
 
     Pattern *walkToPatternPost(Pattern *P) override {
-      if (Predicate(P))
+      if (Predicate(P, Parent))
         Ancestors.pop_back();
       return P;
     }
@@ -5074,7 +5113,7 @@ public:
   CodeCompletionTypeContextAnalyzer(DeclContext *DC, Expr *ParsedExpr) : DC(DC),
     ParsedExpr(ParsedExpr), SM(DC->getASTContext().SourceMgr),
     Context(DC->getASTContext()),
-    Finder(ParsedExpr,  [](ASTWalker::ParentTy Node) {
+    Finder(ParsedExpr,  [](ASTWalker::ParentTy Node, ASTWalker::ParentTy Parent) {
       if (auto E = Node.getAsExpr()) {
         switch(E->getKind()) {
         case ExprKind::Call:
@@ -5082,6 +5121,12 @@ public:
         case ExprKind::PrefixUnary:
         case ExprKind::Assign:
           return true;
+        case ExprKind::Tuple: {
+          auto ParentE = Parent.getAsExpr();
+          return !ParentE || (!isa<CallExpr>(ParentE) &&
+                              !isa<BinaryExpr>(ParentE)&&
+                              !isa<TupleShuffleExpr>(ParentE));
+        }
         default:
           return false;
         }
@@ -5147,6 +5192,16 @@ public:
             if (auto *decl = DRE->getDecl())
               Callback(decl->getInterfaceType());
           }
+        }
+        break;
+      }
+      case ExprKind::Tuple: {
+        if (!Parent->getType() || !Parent->getType()->is<TupleType>())
+          return;
+        unsigned Position = 0;
+        bool HasName;
+        if (CompletionLookup::getPositionInArgs(*DC, Parent, ParsedExpr, Position, HasName)) {
+          Callback(Parent->getType()->castTo<TupleType>()->getElementType(Position));
         }
         break;
       }

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -48,6 +48,10 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TO_GENERIC | %FileCheck %s -check-prefix=GENERIC_TO_GENERIC
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NESTED_CLOSURE | %FileCheck %s -check-prefix=NESTED_CLOSURE
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SHUFFLE_1 | %FileCheck %s -check-prefix=SHUFFLE_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SHUFFLE_2 | %FileCheck %s -check-prefix=SHUFFLE_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SHUFFLE_3 | %FileCheck %s -check-prefix=SHUFFLE_3
+
 var i1 = 1
 var i2 = 2
 var oi1 : Int?
@@ -90,6 +94,10 @@ class Gen {
 }
 
 func GenGenerator(_ i : Int) -> Gen { return Gen() }
+
+enum SimpleEnum {
+  case foo, bar, baz
+}
 
 class C1 {
   func f1() {
@@ -181,7 +189,7 @@ class C2 {
 // EXPECT_STRING-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
 // EXPECT_STRING-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: f2()[#Void#]; name=f2()
 // EXPECT_STRING-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: stringGen()[#String#]; name=stringGen()
-// EXPECT_STRING-DAT: Decl[Struct]/OtherModule[Swift]/TypeRelation[Identical]: String[#String#]
+// EXPECT_STRING-DAG: Decl[Struct]/OtherModule[Swift]/TypeRelation[Identical]: String[#String#]
 // EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s1[#String#]; name=s1
 // EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s2[#String#]; name=s2
 // EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule:         os1[#String?#]; name=os1
@@ -435,3 +443,22 @@ func trailingClosureLocal(x: Int, fn: (Int) -> Void) {
   // TRAILING_CLOSURE_LOCAL: Decl[LocalVar]/Local: localArg[#Int#]; name=localArg
   // TRAILING_CLOSURE_LOCAL: Decl[LocalVar]/Local: localVar[#Int#]; name=localVar
 }
+
+func shuffled(_ x: Int ..., y: String = "", z: SimpleEnum = .foo) {}
+func testTupleShuffle() {
+  let _ = shuffled(1, 2, 3, 4, #^SHUFFLE_1^#, z: .foo)
+  let _ = shuffled(1, 2, 3, y: #^SHUFFLE_2^#
+  let _ = shuffled(z: .#^SHUFFLE_3^#)
+}
+// SHUFFLE_1: Begin completions
+// SHUFFLE_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: i1[#Int#]; name=i1
+// SHUFFLE_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: i2[#Int#]; name=i2
+
+// SHUFFLE_2: Begin completions
+// SHUFFLE_2-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s1[#String#]; name=s1
+// SHUFFLE_2-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s2[#String#]; name=s2
+
+// SHUFFLE_3: Begin completions, 3 items
+// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific:     foo[#SimpleEnum#]; name=foo
+// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific:     bar[#SimpleEnum#]; name=bar
+// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific:     baz[#SimpleEnum#]; name=baz

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -62,15 +62,18 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_3 | %FileCheck %s -check-prefix=IN_FOR_EACH_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_4 | %FileCheck %s -check-prefix=IN_FOR_EACH_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_5 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_6 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_6 | %FileCheck %s -check-prefix=IN_FOR_EACH_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_7 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_8 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_9 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_9 | %FileCheck %s -check-prefix=IN_FOR_EACH_4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_10 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_11 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_12 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_12 | %FileCheck %s -check-prefix=IN_FOR_EACH_2
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPRECATED_1 | %FileCheck %s -check-prefix=DEPRECATED_1
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_1 | %FileCheck %s -check-prefix=IN_TUPLE_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_2 | %FileCheck %s -check-prefix=IN_TUPLE_2
 
 //
 // Test code completion at the beginning of expr-postfix.
@@ -497,6 +500,13 @@ func testInForEach9(arg: Int) {
   let local = 2
   for index in [#^IN_FOR_EACH_9^#:2] {}
   let after = 4
+// NOTE: [Convertible] to AnyHashable.
+// IN_FOR_EACH_4-NOT: Decl[LocalVar]
+// IN_FOR_EACH_4: Decl[LocalVar]/Local/TypeRelation[Convertible]: local[#Int#];
+// FIXME: shouldn't show 'after' here.
+// IN_FOR_EACH_4: Decl[LocalVar]/Local/TypeRelation[Convertible]: after[#Int#];
+// IN_FOR_EACH_4: Decl[LocalVar]/Local/TypeRelation[Convertible]: arg[#Int#];
+// IN_FOR_EACH_4-NOT: Decl[LocalVar]
 }
 func testInForEach10(arg: Int) {
   let local = 2
@@ -530,3 +540,18 @@ struct Deprecated {
 // DEPRECATED_1-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: testDeprecated()[#Void#];
 // DEPRECATED_1-DAG: Decl[Struct]/CurrModule/NotRecommended: Deprecated[#Deprecated#];
 // DEPRECATED_1: End completions
+
+func testTuple(localInt: Int) {
+  let localStr: String = "foo"
+  let _: (Int, String) = (1, #^IN_TUPLE_1^#)
+  let _: (Int, String) = (#^IN_TUPLE_2^#, "foo")
+}
+// IN_TUPLE_1: Begin completions
+// IN_TUPLE_1: Decl[LocalVar]/Local/TypeRelation[Identical]: localStr[#String#]; name=localStr
+// IN_TUPLE_1: Decl[LocalVar]/Local:               localInt[#Int#]; name=localInt
+// IN_TUPLE_1: End completions
+
+// IN_TUPLE_2: Begin completions
+// IN_TUPLE_2: Decl[LocalVar]/Local:               localStr[#String#]; name=localStr
+// IN_TUPLE_2: Decl[LocalVar]/Local/TypeRelation[Identical]: localInt[#Int#]; name=localInt
+// IN_TUPLE_2: End completions

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -37,6 +37,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_28 | %FileCheck %s -check-prefix=UNRESOLVED_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_29 | %FileCheck %s -check-prefix=UNRESOLVED_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_30 | %FileCheck %s -check-prefix=UNRESOLVED_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_31 | %FileCheck %s -check-prefix=UNRESOLVED_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_32 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_33 | %FileCheck %s -check-prefix=UNRESOLVED_3
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_AVAIL_1 | %FileCheck %s -check-prefix=ENUM_AVAIL_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OPTIONS_AVAIL_1 | %FileCheck %s -check-prefix=OPTIONS_AVAIL_1
@@ -305,6 +308,11 @@ let TopLevelVar1 = OptionSetTaker7([.#^UNRESOLVED_28^#], Op2: [.Option4])
 let TopLevelVar2 = OptionSetTaker1([.#^UNRESOLVED_29^#])
 
 let TopLevelVar3 = OptionSetTaker7([.Option1], Op2: [.#^UNRESOLVED_30^#])
+let TopLevelVar4 = OptionSetTaker7([.Option1], Op2: [.Option4, .#^UNRESOLVED_31^#])
+
+let _: [SomeEnum1] = [.#^UNRESOLVED_32^#]
+let _: [SomeEnum1] = [.South, .#^UNRESOLVED_33^#]
+let _: [SomeEnum1:SomeEnum2] = [.South:.West, .#^UNRESOLVED_34^#:]
 
 func testAvail1(_ x: EnumAvail1) {
   testAvail1(.#^ENUM_AVAIL_1^#)


### PR DESCRIPTION
(and `TupleExpr` at non-call argument position).
Now, unresolved member completion in array/dictionary literal should work.
For example:
```swift
enum SimpleEnum {
  case foo, bar, baz
}

let ary: [SimpleEnum] = [.foo, .<HERE>

let dict: [SimpleEnum: Any] = [
  .foo: 42,
  .bar: "other",
  .<HERE>: something
]
```

Also, Don't calculate convertibility to `Any` type. That would be a noise to type relation because anything is convertible to `Any`.

rdar://problem/43302814