### PR TITLE
[Differentiability] Add @nondiff which allows for parameters not to be differentiated w.r.t.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -781,6 +781,8 @@ class TargetFunctionTypeFlags {
     ThrowsMask        = 0x01000000U,
     ParamFlagsMask    = 0x02000000U,
     EscapingMask      = 0x04000000U,
+    // SWIFT_ENABLE_TENSORFLOW
+    DifferentiabilityMask = 0x38000000U,
   };
   int_type Data;
   

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -928,7 +928,7 @@ public:
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Determine whether the given type conforms to `Differentiable`.
+  /// Determine whether the given type is differentiable.
   bool isDifferentiable(CanType type, ModuleDecl *module);
 
   /// Compute the tangent space of this manifold, if the given type represents a

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -928,6 +928,9 @@ public:
   }
 
   // SWIFT_ENABLE_TENSORFLOW
+  /// Determine whether the given type conforms to `Differentiable`.
+  bool isDifferentiable(CanType type, ModuleDecl *module);
+
   /// Compute the tangent space of this manifold, if the given type represents a
   /// differentiable manifold.
   Optional<TangentSpace> getTangentSpace(CanType type, ModuleDecl *module);

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -54,7 +54,7 @@ TYPE_ATTR(noescape)
 TYPE_ATTR(escaping)
 // SWIFT_ENABLE_TENSORFLOW
 TYPE_ATTR(autodiff)
-TYPE_ATTR(nodiff)
+TYPE_ATTR(nondiff)
 
 // SIL-specific attributes
 TYPE_ATTR(block_storage)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3687,6 +3687,12 @@ ERROR(autodiff_attr_order_cannot_be_zero,none,
       "differentiation order cannot be zero; it should be at least first-order", ())
 ERROR(autodiff_attr_order_cannot_be_specified_in_mode,none,
       "differentiation order cannot be specified in '%0' mode", (StringRef))
+ERROR(autodiff_attr_argument_not_differentiable,none,
+      "argument is not differentiable, but the function type is marked '@autodiff'", ())
+ERROR(autodiff_attr_result_not_differentiable,none,
+      "result is not differentiable, but the function type is marked '@autodiff'", ())
+ERROR(nondiff_attr_invalid_on_nondifferentiable_function,none,
+      "'nondiff' cannot be applied to arguments of a non-differentiable function", ())
 
 // SIL
 ERROR(opened_non_protocol,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3688,7 +3688,7 @@ ERROR(autodiff_attr_order_cannot_be_zero,none,
 ERROR(autodiff_attr_order_cannot_be_specified_in_mode,none,
       "differentiation order cannot be specified in '%0' mode", (StringRef))
 ERROR(autodiff_attr_argument_not_differentiable,none,
-      "argument is not differentiable, but the function type is marked '@autodiff'", ())
+      "argument is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?", ())
 ERROR(autodiff_attr_result_not_differentiable,none,
       "result is not differentiable, but the function type is marked '@autodiff'", ())
 ERROR(nondiff_attr_invalid_on_nondifferentiable_function,none,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -758,12 +758,14 @@ namespace decls_block {
 
   using FunctionParamLayout = BCRecordLayout<
     FUNCTION_PARAM,
-    IdentifierIDField,  // name
-    TypeIDField,        // type
-    BCFixed<1>,         // vararg?
-    BCFixed<1>,         // autoclosure?
-    BCFixed<1>,         // escaping?
-    ValueOwnershipField // inout, shared or owned?
+    // SWIFT_ENABLE_TENSORFLOW
+    IdentifierIDField,   // name
+    TypeIDField,         // type
+    BCFixed<1>,          // vararg?
+    BCFixed<1>,          // autoclosure?
+    BCFixed<1>,          // escaping?
+    ValueOwnershipField, // inout, shared or owned?
+    BCFixed<1>           // nondifferentiable?
   >;
 
   using MetatypeTypeLayout = BCRecordLayout<

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3791,7 +3791,9 @@ void AnyFunctionType::decomposeInput(
   default:
     result.emplace_back(type->getInOutObjectType(), Identifier(),
                         ParameterTypeFlags::fromParameterType(
-                          type, false, ValueOwnership::Default));
+                          // SWIFT_ENABLE_TENSORFLOW
+                          type, false, ValueOwnership::Default,
+                          /*differentiable*/ false));
     return;
   }
 }
@@ -5159,6 +5161,12 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
 }
 
 // SWIFT_ENABLE_TENSORFLOW
+bool ASTContext::isDifferentiable(CanType type, ModuleDecl *module) {
+  auto *diffableProto = getProtocol(KnownProtocolKind::Differentiable);
+  auto maybeDiffableConf = module->lookupConformance(type, diffableProto);
+  return maybeDiffableConf.hasValue();
+}
+
 Optional<TangentSpace> ASTContext::getTangentSpace(CanType type,
                                                    ModuleDecl *module) {
   auto lookup = getImpl().TangentSpaces.find(type);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3793,7 +3793,7 @@ void AnyFunctionType::decomposeInput(
                         ParameterTypeFlags::fromParameterType(
                           // SWIFT_ENABLE_TENSORFLOW
                           type, false, ValueOwnership::Default,
-                          /*differentiable*/ false));
+                          /*nonDifferentiable*/ false));
     return;
   }
 }
@@ -5162,9 +5162,7 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
 
 // SWIFT_ENABLE_TENSORFLOW
 bool ASTContext::isDifferentiable(CanType type, ModuleDecl *module) {
-  auto *diffableProto = getProtocol(KnownProtocolKind::Differentiable);
-  auto maybeDiffableConf = module->lookupConformance(type, diffableProto);
-  return maybeDiffableConf.hasValue();
+  return getTangentSpace(type, module).hasValue();
 }
 
 Optional<TangentSpace> ASTContext::getTangentSpace(CanType type,

--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -106,8 +106,10 @@ void ParameterList::getParams(
       type = ParamDecl::getVarargBaseTy(type);
 
     auto label = P->getArgumentName();
-    auto flags = ParameterTypeFlags::fromParameterType(type, P->isVariadic(),
-                                                       P->getValueOwnership());
+    // SWIFT_ENABLE_TENSORFLOW
+    auto flags = ParameterTypeFlags::fromParameterType(
+        type, P->isVariadic(), P->getValueOwnership(),
+        /*nondifferentiable*/ false);
     params.emplace_back(type, label, flags);
   }
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2201,6 +2201,10 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
       return false;
     }
     break;
+  // SWIFT_ENABLE_TENSORFLOW
+  case TAK_nondiff:
+    Attributes.setAttr(TAK_nondiff, Loc);
+    break;
   case TAK_out:
   case TAK_in:
   case TAK_owned:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2201,10 +2201,6 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
       return false;
     }
     break;
-  // SWIFT_ENABLE_TENSORFLOW
-  case TAK_nondiff:
-    Attributes.setAttr(TAK_nondiff, Loc);
-    break;
   case TAK_out:
   case TAK_in:
   case TAK_owned:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2443,6 +2443,7 @@ Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
     break;
   }
   
+  // SWIFT_ENABLE_TENSORFLOW
   // If the function is marked as `@autodiff`, the result must be a
   // differentiable type.
   if (extInfo.isDifferentiable() &&

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2136,13 +2136,13 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
     }
 
     // SWIFT_ENABLE_TENSORFLOW
-    // @nodiff is only valid on parameters.
+    // @nondiff is only valid on parameters.
     if (!isParam && attrs.has(TAK_nondiff)) {
       diagnose(attrs.getLoc(TAK_nondiff),
                isVariadicFunctionParam
                    ? diag::attr_not_on_variadic_parameters
-                   : diag::attr_not_on_variadic_parameters, "@nodiff");
-      attrs.clearAttribute(TAK_autoclosure);
+                   : diag::attr_not_on_variadic_parameters, "@nondiff");
+      attrs.clearAttribute(TAK_nondiff);
     }
 
     auto diffability = resolveDifferentiability();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2135,16 +2135,6 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
           .fixItReplace(resultRange, "Never");
     }
 
-    // SWIFT_ENABLE_TENSORFLOW
-    // @nondiff is only valid on parameters.
-    if (!isParam && attrs.has(TAK_nondiff)) {
-      diagnose(attrs.getLoc(TAK_nondiff),
-               isVariadicFunctionParam
-                   ? diag::attr_not_on_variadic_parameters
-                   : diag::attr_not_on_variadic_parameters, "@nondiff");
-      attrs.clearAttribute(TAK_nondiff);
-    }
-
     auto diffability = resolveDifferentiability();
 
     // Resolve the function type directly with these attributes.
@@ -2226,7 +2216,18 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
       attrs.clearAttribute(i);
     attrs.convention = None;
   }
-
+  
+  // SWIFT_ENABLE_TENSORFLOW
+  // @nondiff is only valid on parameters.
+  if (attrs.has(TAK_nondiff)) {
+    if (!isParam)
+        diagnose(attrs.getLoc(TAK_nondiff),
+                 isVariadicFunctionParam
+                     ? diag::attr_not_on_variadic_parameters
+                     : diag::attr_not_on_variadic_parameters, "@nondiff");
+    attrs.clearAttribute(TAK_nondiff);
+  }
+  
   // In SIL, handle @opened (n), which creates an existential archetype.
   if (attrs.has(TAK_opened)) {
     if (!ty->isExistentialType()) {
@@ -2353,6 +2354,16 @@ bool TypeResolver::resolveASTFunctionTypeParams(
           nondiff = true;
       }
     }
+    // If the outer function is differentiable, arguments that are not marked as
+    // `@nondiff` must be differentiable
+    if (isDifferentiable && !nondiff &&
+        !Context.isDifferentiable(ty->getCanonicalType(),
+                                  DC->getParentModule())) {
+      diagnose(eltTypeRepr->getLoc(),
+               diag::autodiff_attr_argument_not_differentiable)
+          .highlight(eltTypeRepr->getSourceRange())
+          .fixItInsert(eltTypeRepr->getLoc(), "@nondiff ");
+    }
 
     // SWIFT_ENABLE_TENSORFLOW
     ParameterTypeFlags paramFlags =
@@ -2432,6 +2443,15 @@ Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
     break;
   }
   
+  // If the function is marked as `@autodiff`, the result must be a
+  // differentiable type.
+  if (extInfo.isDifferentiable() &&
+      !Context.isDifferentiable(outputTy->getCanonicalType(),
+                                DC->getParentModule()))
+    diagnose(repr->getResultTypeRepr()->getLoc(),
+             diag::autodiff_attr_result_not_differentiable)
+        .highlight(repr->getResultTypeRepr()->getSourceRange());
+
   return fnTy;
 }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4503,11 +4503,14 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
 
       IdentifierID labelID;
       TypeID typeID;
-      bool isVariadic, isAutoClosure, isEscaping;
+      // SWIFT_ENABLE_TENSORFLOW
+      bool isVariadic, isAutoClosure, isEscaping, isNonDifferentiable;
       unsigned rawOwnership;
       decls_block::FunctionParamLayout::readRecord(scratch, labelID, typeID,
                                                    isVariadic, isAutoClosure,
-                                                   isEscaping, rawOwnership);
+                                                   // SWIFT_ENABLE_TENSORFLOW
+                                                   isEscaping, rawOwnership,
+                                                   isNonDifferentiable);
 
       auto ownership =
           getActualValueOwnership((serialization::ValueOwnership)rawOwnership);
@@ -4523,7 +4526,9 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
       params.emplace_back(paramTy.get(),
                           getIdentifier(labelID),
                           ParameterTypeFlags(isVariadic, isAutoClosure,
-                                             isEscaping, *ownership));
+                                             // SWIFT_ENABLE_TENSORFLOW
+                                             isEscaping, *ownership,
+                                             isNonDifferentiable));
     }
 
     if (recordID == decls_block::FUNCTION_TYPE) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3929,7 +3929,9 @@ void Serializer::writeType(Type ty) {
       FunctionParamLayout::emitRecord(
           Out, ScratchRecord, abbrCode, addDeclBaseNameRef(param.getLabel()),
           addTypeRef(param.getPlainType()), paramFlags.isVariadic(),
-          paramFlags.isAutoClosure(), paramFlags.isEscaping(), rawOwnership);
+          // SWIFT_ENABLE_TENSORFLOW
+          paramFlags.isAutoClosure(), paramFlags.isEscaping(), rawOwnership,
+          paramFlags.isNonDifferentiable());
     }
 
     break;

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -24,3 +24,22 @@ let _: @autodiff(const, order: 7) (Float) -> Float
 let _: @autodiff(order: 0) (Float) -> Float
 // expected-error @+1 {{differentiation order cannot be zero; it should be at least first-order}}
 let _: @autodiff(forward, order: 0) (Float) -> Float
+
+//
+// Type differentiability
+//
+
+// struct NonDiffType {}
+// TODO:
+// xpected-error {{argument is not differentiable, but the function type is marked '@autodiff'}}
+// let _: @autodiff (NonDiffType) -> Float
+
+//
+// Argument selection (@nondiff)
+//
+
+// expected-error @+1 {{'nondiff' cannot be applied to arguments of a non-differentiable function}}
+let _: (@nondiff Float, Float) -> Float
+
+let _: @autodiff (Float, @nondiff Float) -> Float // okay
+

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -29,10 +29,9 @@ let _: @autodiff(forward, order: 0) (Float) -> Float
 // Type differentiability
 //
 
-// struct NonDiffType {}
-// TODO:
-// xpected-error {{argument is not differentiable, but the function type is marked '@autodiff'}}
-// let _: @autodiff (NonDiffType) -> Float
+struct NonDiffType { var x: Int }
+// expected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@autodiff'; did you want to add '@nondiff' to this argument?}}
+let _: @autodiff (NonDiffType) -> Float
 
 //
 // Argument selection (@nondiff)


### PR DESCRIPTION
## Generalized differentiability: Part 2

Implement `@nondiff` attribute on function type parameters. When `@nondiff` is specified on some argument of a `@autodiff` function type, that argument is not to be differentiated with respect to.

```
let f: @autodiff (T, @nondiff U) -> V
#gradient(f) // (T, U) -> T.CotangentVector
```