### PR TITLE
Fix ExistentialSpecializer for cases when the argument is an Archetype

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -177,7 +177,8 @@ void ExistentialSpecializerCloner::cloneAndPopulateFunction() {
     } else {
       /// Arguments that are not rewritten.
       auto Ty = params[ArgDesc.Index].getType();
-      auto MappedTy = M.Types.getLoweredType(NewF.mapTypeIntoContext(Ty));
+      auto LoweredTy = M.Types.getLoweredType(NewF.mapTypeIntoContext(Ty));
+      auto MappedTy = LoweredTy.getCategoryType(ArgDesc.Arg->getType().getCategory());
       NewArg = ClonedEntryBB->createFunctionArgument(MappedTy, ArgDesc.Decl);
       NewArg->setOwnershipKind(ValueOwnershipKind(
           M, MappedTy, ArgDesc.Arg->getArgumentConvention()));

--- a/test/SILOptimizer/existential_transform.swift
+++ b/test/SILOptimizer/existential_transform.swift
@@ -331,6 +331,33 @@ func wrap_gcp<T:GP>(_ a:T,_ b:GP) -> Int {
   return wrap_gcp(a, k)
 }
 
+func wrap_gcp_arch<T:GP>(_ a:T,_ b:GP, _ c:inout Array<T>) -> Int {
+  return a.foo() + b.foo() + c[0].foo()
+}
+// CHECK-LABEL: sil hidden [noinline] @$s21existential_transform8gcp_archySix_SayxGztAA2GPRzlF : $@convention(thin) <T where T : GP> (@in_guaranteed T, @inout Array<T>) -> Int {
+// CHECK: bb0(%0 : $*T, %1 : $*Array<T>):
+// CHECK: debug_value_addr
+// CHECK: debug_value_addr
+// CHECK: alloc_ref
+// CHECK: debug_value
+// CHECK: debug_value
+// CHECK: alloc_stack
+// CHECK: init_existential_addr
+// CHECK: store
+// CHECK: function_ref @$s21existential_transform13wrap_gcp_archySix_AA2GP_pSayxGztAaCRzlFTf4nen_n : $@convention(thin) <τ_0_0 where τ_0_0 : GP><τ_1_0 where τ_1_0 : GP> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0, @inout Array<τ_0_0>) -> Int
+// CHECK: open_existential_addr
+// CHECK: strong_retain
+// CHECK: apply
+// CHECK: destroy_addr
+// CHECK: dealloc_stack
+// CHECK: strong_release
+// CHECK: return
+// CHECK-LABEL: } // end sil function '$s21existential_transform8gcp_archySix_SayxGztAA2GPRzlF'
+@inline(never) func gcp_arch<T:GP>(_ a:T, _ b:inout Array<T>) -> Int {
+  let k:GC = GC()
+  return wrap_gcp_arch(a, k, &b)
+}
+
 @_optimize(none) public func foo() -> Int {
 cp()
 ncp()
@@ -342,5 +369,7 @@ do_not_optimize_inout_cp()
 inout_ncp()
 struct_inout_ncp()
 let y:Int = gcp(GC())
-return x + y
+var a:Array<GC> = [GC()]
+let z:Int = gcp_arch(GC(), &a) 
+return x + y + z
 }


### PR DESCRIPTION
The following code sequence breaks when the argument is an ArchetypeType :
```
      auto Ty = params[ArgDesc.Index].getType();
      auto MappedTy = M.Types.getLoweredType(NewF.mapTypeIntoContext(Ty));
      NewArg = ClonedEntryBB->createFunctionArgument(MappedTy, ArgDesc.Decl);
```
The following gets generated 
bb0(%0 : $Int, %1 : $τ_0_0, %2 : $Array<T>):
instead of 
bb0(%0 : $Int, %1 : $τ_0_0, %2 : $*Array<T>):

The fix is simple:
```
      auto Ty = params[ArgDesc.Index].getType();
      auto LoweredTy = M.Types.getLoweredType(NewF.mapTypeIntoContext(Ty));
      auto MappedTy = LoweredTy.getCategoryType(ArgDesc.Arg->getType().getCategory());
       NewArg = ClonedEntryBB->createFunctionArgument(MappedTy, ArgDesc.Decl);
```