### PR TITLE
swift-module-digester: add a flag to include Swift decls specifically.

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -608,6 +608,16 @@ getCallArgInfo(SourceManager &SM, Expr *Arg, LabelRangeEndAt EndKind);
 std::vector<CharSourceRange>
 getCallArgLabelRanges(SourceManager &SM, Expr *Arg, LabelRangeEndAt EndKind);
 
+/// Whether a decl is defined from clang source.
+bool isFromClang(const Decl *D);
+
+/// Retrieve the effective Clang node for the given declaration, which
+/// copes with the odd case of imported Error enums.
+ClangNode getEffectiveClangNode(const Decl *decl);
+
+/// Retrieve the Clang node for the given extension, if it has one.
+ClangNode extensionGetClangNode(const ExtensionDecl *ext);
+
 } // namespace ide
 } // namespace swift
 

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -220,50 +220,10 @@ swift::ide::collectModuleGroups(ModuleDecl *M, std::vector<StringRef> &Scratch) 
   return llvm::makeArrayRef(Scratch);
 }
 
-/// Retrieve the effective Clang node for the given declaration, which
-/// copes with the odd case of imported Error enums.
-static ClangNode getEffectiveClangNode(const Decl *decl) {
-  // Directly...
-  if (auto clangNode = decl->getClangNode())
-    return clangNode;
-
-  // Or via the nested "Code" enum.
-  if (auto nominal =
-        const_cast<NominalTypeDecl *>(dyn_cast<NominalTypeDecl>(decl))) {
-    auto &ctx = nominal->getASTContext();
-    auto flags = OptionSet<NominalTypeDecl::LookupDirectFlags>();
-    flags |= NominalTypeDecl::LookupDirectFlags::IgnoreNewExtensions;
-    for (auto code : nominal->lookupDirect(ctx.Id_Code, flags)) {
-      if (auto clangDecl = code->getClangDecl())
-        return clangDecl;
-    }
-  }
-
-  return ClangNode();
-}
-
-/// Retrieve the Clang node for the given extension, if it has one.
-static ClangNode extensionGetClangNode(ExtensionDecl *ext) {
-  // If it has a Clang node (directly), 
-  if (ext->hasClangNode()) return ext->getClangNode();
-
-  // Check whether it was syntheszed into a module-scope context.
-  if (!isa<ClangModuleUnit>(ext->getModuleScopeContext()))
-    return ClangNode();
-
-  // It may have a global imported as a member.
-  for (auto member : ext->getMembers()) {
-    if (auto clangNode = getEffectiveClangNode(member))
-      return clangNode;
-  }
-
-  return ClangNode();
-}
-
 /// Determine whether the given extension has a Clang node that
 /// created it (vs. being a Swift extension).
 static bool extensionHasClangNode(ExtensionDecl *ext) {
-  return static_cast<bool>(extensionGetClangNode(ext));
+  return static_cast<bool>(swift::ide::extensionGetClangNode(ext));
 }
 
 Optional<StringRef>
@@ -822,7 +782,7 @@ void ClangCommentPrinter::printDeclPre(const Decl *D,
   // single line.
   // FIXME: we should fix that, since it also affects struct members, etc.
   if (!isa<ParamDecl>(D)) {
-    if (auto ClangN = getEffectiveClangNode(D)) {
+    if (auto ClangN = swift::ide::getEffectiveClangNode(D)) {
       printCommentsUntil(ClangN);
       if (shouldPrintNewLineBefore(ClangN)) {
         *this << "\n";
@@ -846,7 +806,7 @@ void ClangCommentPrinter::printDeclPost(const Decl *D,
     *this << " " << ASTPrinter::sanitizeUtf8(CommentText);
   }
   PendingComments.clear();
-  if (auto ClangN = getEffectiveClangNode(D))
+  if (auto ClangN = swift::ide::getEffectiveClangNode(D))
     updateLastEntityLine(ClangN.getSourceRange().getEnd());
 }
 

--- a/test/api-digester/Inputs/ClangCake/Cake.apinotes
+++ b/test/api-digester/Inputs/ClangCake/Cake.apinotes
@@ -1,0 +1,14 @@
+Name: APINotesTest
+Globals:
+  - Name: ANTGlobalValue
+    SwiftName: NewType.newMember
+Protocols:
+  - Name: TypeWithMethod
+    SwiftName: SwiftTypeWithMethodRight
+
+SwiftVersions:
+- Version: 3
+  Typedefs:
+  - Name: AnimalAttributeName
+    SwiftName: AnimalAttributeName
+    SwiftWrapper: none

--- a/test/api-digester/Inputs/ClangCake/Cake.h
+++ b/test/api-digester/Inputs/ClangCake/Cake.h
@@ -1,0 +1,32 @@
+#import <objc_generics.h>
+extern int ANTGlobalValue;
+
+@interface NewType
+@end
+@interface OldType
+@end
+
+@protocol TypeWithMethod
+  -(void) minusPrint;
+  +(void) plusPrint;
+  @property int PropertyA;
+@end
+
+@protocol ObjcProt
+  -(void) ProtMemberFunc;
+@end
+
+typedef NSString * AnimalAttributeName NS_STRING_ENUM;
+
+@interface AnimalStatusDescriptor
+- (nonnull AnimalStatusDescriptor *)animalStatusDescriptorByAddingAttributes:(nonnull NSDictionary<AnimalAttributeName, id> *)attributes;
+- (nonnull AnimalStatusDescriptor *)animalStatusDescriptorByAddingOptionalAttributes:(nullable NSDictionary<AnimalAttributeName, id> *)attributes;
+- (nonnull AnimalStatusDescriptor *)animalStatusDescriptorByAddingAttributesArray:(nonnull NSArray<AnimalAttributeName> *)attributes;
+- (nonnull AnimalStatusDescriptor *)animalStatusDescriptorByAddingOptionalAttributesArray:(nullable NSArray<AnimalAttributeName> *)attributes;
++ (nonnull AnimalStatusDescriptor *)animalStatusSingleOptionalAttribute:(nullable AnimalAttributeName)attributes;
++ (nonnull AnimalStatusDescriptor *)animalStatusSingleAttribute:(nonnull AnimalAttributeName)attributes;
+@end
+
+extern AnimalAttributeName globalAttributeName;
+
+typedef NSString * CatAttributeName NS_STRING_ENUM;

--- a/test/api-digester/Inputs/ClangCake/module.modulemap
+++ b/test/api-digester/Inputs/ClangCake/module.modulemap
@@ -1,0 +1,3 @@
+module cake {
+  header "Cake.h"
+}

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -1,3 +1,5 @@
+@_exported import cake
+
 public protocol P1 {}
 public protocol P2 {}
 

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library
-// RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -sdk %t.sdk -I %t.mod
+// RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
 // RUN: diff -u %S/Outputs/cake.json %t.dump.json
-// RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -sdk %t.sdk -I %t.mod -abi
+// RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -abi -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
 // RUN: diff -u %S/Outputs/cake-abi.json %t.dump.json
 // RUN: %api-digester -diagnose-sdk --input-paths %t.dump.json -input-paths %S/Outputs/cake.json
 

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1261,6 +1261,10 @@ SwiftDeclCollector::constructInitNode(ConstructorDecl *CD) {
 
 bool swift::ide::api::
 SDKContext::shouldIgnore(Decl *D, const Decl* Parent) const {
+  // Exclude all clang nodes if we're comparing Swift decls specifically.
+  if (Opts.SwiftOnly && isFromClang(D)) {
+    return true;
+  }
   if (checkingABI()) {
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       // Private vars with fixed binary orders can have ABI-impact, so we should

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -142,6 +142,7 @@ struct CheckerOptions {
   bool Verbose;
   bool AbortOnModuleLoadFailure;
   bool PrintModule;
+  bool SwiftOnly;
   StringRef LocationFilter;
 };
 

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -100,6 +100,11 @@ static llvm::cl::opt<bool>
 Abi("abi", llvm::cl::desc("Dumping ABI interface"),  llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
+SwiftOnly("swift-only",
+          llvm::cl::desc("Only include APIs defined from Swift source"),
+          llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
 PrintModule("print-module", llvm::cl::desc("Print module names in diagnostics"));
 
 static llvm::cl::opt<ActionType>
@@ -2288,6 +2293,7 @@ static CheckerOptions getCheckOpts() {
   Opts.AbortOnModuleLoadFailure = options::AbortOnModuleLoadFailure;
   Opts.LocationFilter = options::LocationFilter;
   Opts.PrintModule = options::PrintModule;
+  Opts.SwiftOnly = options::SwiftOnly;
   return Opts;
 }
 


### PR DESCRIPTION
This flag allows us to diagnose the overlay part exclusively without digesting
the entire SDK framework.
