### PR TITLE
SourceKit: re-package libdispatch, BlocksRuntime

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -158,6 +158,13 @@ if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
                             INTERFACE_INCLUDE_DIRECTORIES
                               ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
 
+    swift_install_in_component(sourcekit-inproc
+                               FILES
+                                 $<TARGET_FILE:dispatch>
+                                 $<TARGET_FILE:BlocksRuntime>
+                               DESTINATION
+                                 lib${LLVM_LIBDIR_SUFFIX})
+
     # FIXME(compnerd) this should be taken care of by the
     # INTERFACE_INCLUDE_DIRECTORIES above
     include_directories(AFTER


### PR DESCRIPTION
The SourceKit component requires libdispatch and BlocksRuntime to run.
We build the libraries as part of the build and use it via imported
targets.  Ensure that the dependencies get installed for use at runtime.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
