### PR TITLE
cast graph_op IRGen value to correct type

### DIFF
--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // TODO: Revert to %target-run-simple-swift once we fold dynamic compilation into -Onone.
 // RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test

--- a/test/TensorFlowRuntime/gpu_negative_tests.swift
+++ b/test/TensorFlowRuntime/gpu_negative_tests.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // XFAIL: *

--- a/test/TensorFlowRuntime/hangers.swift
+++ b/test/TensorFlowRuntime/hangers.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/models.swift
+++ b/test/TensorFlowRuntime/models.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/random.swift
+++ b/test/TensorFlowRuntime/random.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/raw_ops.swift
+++ b/test/TensorFlowRuntime/raw_ops.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow_swift_bindings

--- a/test/TensorFlowRuntime/retain_release_1.swift
+++ b/test/TensorFlowRuntime/retain_release_1.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sync_runtime.swift
+++ b/test/TensorFlowRuntime/sync_runtime.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_debuglog.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_xla_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_xla_debuglog.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/top_level_1.swift
+++ b/test/TensorFlowRuntime/top_level_1.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/top_level_2.swift
+++ b/test/TensorFlowRuntime/top_level_2.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 


### PR DESCRIPTION
This makes "loops", "control_flow_1", and "models" pass under dynamic compilation.

This PR also enables dynamic compilation for a bunch of other tests that were already passing under dynamic compilation.