### PR TITLE
[AutoDiff] Bring back covectors

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -136,6 +136,7 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
 
 extension Tensor : Differentiable where Scalar : FloatingPoint {
   public typealias TangentVector = Tensor
+  public typealias CotangentVector = Tensor
 }
 
 public extension Tensor where Scalar : Numeric {


### PR DESCRIPTION
After discussions with @mattjj and @dougalm, we've decided to keep `CotangentVector` as a separate associated type. We assume both `TangentVector` and `CotangentVector` to be finite-dimensional, and `CotangentVector` will conform to `VectorNumeric` and be customizable. `CotangentVector` is intentionally _not_ modeled as `TangentVector -> ℝ`  for practical reasons.