### PR TITLE
NFC: Clean up term "parameter aggregate" and use "parameter group" in the infra

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2447,7 +2447,7 @@ ERROR(broken_encodable_requirement,none,
 ERROR(broken_decodable_requirement,none,
       "Decodable protocol is broken: unexpected requirement", ())
 // SWIFT_ENABLE_TENSORFLOW
-ERROR(broken_parameter_aggregate_requirement,none,
+ERROR(broken_parameter_group_requirement,none,
       "ParameterGroup protocol is broken: unexpected requirement", ())
 ERROR(broken_parameterized_requirement,none,
       "Parameterized protocol is broken: unexpected requirement", ())

--- a/lib/Sema/DerivedConformanceParameterGroup.cpp
+++ b/lib/Sema/DerivedConformanceParameterGroup.cpp
@@ -253,7 +253,7 @@ DerivedConformance::deriveParameterGroup(ValueDecl *requirement) {
     return deriveParameterGroup_update(*this);
   }
   TC.diagnose(requirement->getLoc(),
-              diag::broken_parameter_aggregate_requirement);
+              diag::broken_parameter_group_requirement);
   return nullptr;
 }
 
@@ -264,6 +264,6 @@ Type DerivedConformance::deriveParameterGroup(
     return deriveParameterGroup_Parameter(Nominal);
   }
   TC.diagnose(requirement->getLoc(),
-              diag::broken_parameter_aggregate_requirement);
+              diag::broken_parameter_group_requirement);
   return nullptr;
 }

--- a/lib/Sema/DerivedConformanceParameterized.cpp
+++ b/lib/Sema/DerivedConformanceParameterized.cpp
@@ -332,8 +332,8 @@ static Type deriveParameterized_Parameters(DerivedConformance &derived) {
   auto nominal = derived.Nominal;
   auto &C = nominal->getASTContext();
 
-  auto *paramAggProto = C.getProtocol(KnownProtocolKind::ParameterGroup);
-  auto paramAggType = TypeLoc::withoutLoc(paramAggProto->getDeclaredType());
+  auto *paramGroupProto = C.getProtocol(KnownProtocolKind::ParameterGroup);
+  auto paramGroupType = TypeLoc::withoutLoc(paramGroupProto->getDeclaredType());
   auto *parametersDecl =
       new (C) StructDecl(SourceLoc(), C.Id_Parameters, SourceLoc(),
                          /*Inherited*/ {}, /*GenericParams*/ {}, parentDC);
@@ -373,7 +373,7 @@ static Type deriveParameterized_Parameters(DerivedConformance &derived) {
   // Add conformance to the ParameterGroup protocol, if possible.
   // The ParameterGroup protocol requirements will be derived.
   if (DerivedConformance::canDeriveParameterGroup(parametersDecl)) {
-    TypeLoc inherited[1] = {paramAggType};
+    TypeLoc inherited[1] = {paramGroupType};
     parametersDecl->setInherited(C.AllocateCopy(inherited));
   }
 


### PR DESCRIPTION
Addresses remaining comments in https://github.com/apple/swift/pull/19791.