### PR TITLE
[Lexer] Allow '$x' to be parsed as identifier in debugger mode.

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -936,6 +936,8 @@ void Lexer::lexDollarIdent() {
     // independent of language mode.
     return formToken(tok::identifier, tokStart);
   } else {
+    if (LangOpts.EnableDollarIdentifiers && !LangOpts.Playground)
+      return formToken(tok::identifier, tokStart);
     return formToken(tok::dollarident, tokStart);
   }
 }


### PR DESCRIPTION
This is needed to support `print $0` in lldb where `$0` is the
shortcut for a closure argument. The associated lldb change
will be merged together with this one and will contain a test.

<rdar://problem/201719448>

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
