### PR TITLE
SESE canonicalization: unroll loop to eliminate undefs.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -1316,8 +1316,14 @@ void SingleExitLoopTransformer::unrollLoopBodyOnce() {
       worklist.insert(succ);
     }
   }
+
+  SILLoop *parentLoop = loop->getParentLoop();
   for (SILBasicBlock *bb : initializedBlocks) {
     cloner.cloneBlock(bb);
+    SILBasicBlock *clonedBlock = cloner.cloneBlock(bb);
+    if (parentLoop) {
+      parentLoop->addBasicBlockToLoop(clonedBlock, LI->getBase());
+    }
   }
 
   // Get the clone for the original and new header.

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -1295,7 +1295,7 @@ void SingleExitLoopTransformer::unrollLoopBody() {
       // latch block and pick one that is suitable to be used here.
       auto destBBArg = newLatch->getArgument(argIndex);
       SmallVector<SILValue, 8> incomingValues;
-      destBBArg->getIncomingValues(incomingValues);
+      destBBArg->getIncomingPhiValues(incomingValues);
       for (auto value : incomingValues) {
         if (value != arg && DI->properlyDominates(value, predTermInst)) {
           // A suitable value is found. Update the edge value in the unrolled

--- a/test/TensorFlow/sese_loop_canonicalization.sil
+++ b/test/TensorFlow/sese_loop_canonicalization.sil
@@ -231,6 +231,11 @@ public func nestedLoopWithBreak(breakCount:Int32) -> Int32 {
 
 // CHECK-LABEL: --- XLA CFG Canonicalize: $doWhileLoop
 // CHECK: [sequence
+// CHECK:   {condition Header: {{bb[0-9]+}}
+// CHECK:     {condition Header: {{bb[0-9]+}}
+// CHECK:       block {{bb[0-9]+}}
+// CHECK:       block {{bb[0-9]+}}}
+// CHECK:     block {{bb[0-9]+}}}
 // CHECK:   <while Preheader: [[PHDR:bb[0-9]+]], Header: [[HDR:bb[0-9]+]], exit: [[EXIT:bb[0-9]+]]
 // CHECK:     [sequence
 // CHECK:       {condition Header: {{bb[0-9]+}}
@@ -243,8 +248,8 @@ public func nestedLoopWithBreak(breakCount:Int32) -> Int32 {
 
 // Make sure undef is still left in this case for now.
 // CHECK: sil @$doWhileLoop : {{.*}} (Builtin.Int32) -> Builtin.Int32 {
-// CHECK: [[PHDR]]({{.*}} : $Builtin.Int32):
-// CHECK: br [[HDR]]({{.*}} : $Builtin.Int32, undef : $Builtin.Int32, {{.*}} : $TensorHandle<Builtin.Int32>, {{.*}} : $TensorHandle<Builtin.Int1>)
+// CHECK: [[PHDR]]({{.*}} : $TensorHandle<Builtin.Int1>):
+// CHECK: br [[HDR]]({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $TensorHandle<Builtin.Int32>, {{.*}} : $TensorHandle<Builtin.Int1>)
 
 sil @$doWhileLoop : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
 bb0(%0 : $Builtin.Int32):
@@ -299,19 +304,19 @@ bb3 (%9 : $Builtin.Int32):
 //
 // CHECK-LABEL: --- XLA CFG Canonicalize: $loopThatRequiresNodeCloning
 // CHECK: [sequence
-// CHECK:   {condition Header: bb0
-// CHECK:     block bb1
+// CHECK:   {condition Header: {{bb[0-9]+}}
+// CHECK:     block {{bb[0-9]+}}
 // CHECK:     [sequence
-// CHECK:       <while Preheader: bb2, Header: bb9, exit: bb11
+// CHECK:       <while Preheader: {{bb[0-9]+}}, Header: {{bb[0-9]+}}, exit: {{bb[0-9]+}}
 // CHECK:         [sequence
-// CHECK:           {condition Header: bb3
-// CHECK:             block bb4
-// CHECK:             {condition Header: bb5
-// CHECK:               block bb7
-// CHECK:               block bb6}}
-// CHECK:           block bb10]>
-// CHECK:       block bb11]}
-// CHECK:   block bb8]
+// CHECK:           {condition Header: {{bb[0-9]+}}
+// CHECK:             block {{bb[0-9]+}}
+// CHECK:             {condition Header: {{bb[0-9]+}}
+// CHECK:               block {{bb[0-9]+}}
+// CHECK:               block {{bb[0-9]+}}}}
+// CHECK:           block {{bb[0-9]+}}]>
+// CHECK:       block {{bb[0-9]+}}]}
+// CHECK:   block {{bb[0-9]+}}]
 // CHECK: --- XLA CFG Canonicalize end
 sil @$loopThatRequiresNodeCloning : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32 {
 bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -95,9 +95,9 @@ func doWhileLoopWithBreak(_ breakIndex:Int32) -> Tensor<Int32> {
   var i: Int32 = 1
   var sum = Tensor<Int32>(0)
   let maxCount: Int32 = 100
-	repeat {
+  repeat {
     sum += i
-    if (i == breakIndex) {
+    if i == breakIndex {
       break
     }
     i += 1

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -106,12 +106,39 @@ func doWhileLoopWithBreak(_ breakIndex:Int32) -> Tensor<Int32> {
 }
 
 ControlFlowTests.testAllBackends("doWhileLoopWithBreak") {
-  expectEqualWithScalarTensor(3, natSumWithBreak(2))
-  expectEqualWithScalarTensor(55, natSumWithBreak(10))
-  expectEqualWithScalarTensor(5050, natSumWithBreak(-300))
-  expectEqualWithScalarTensor(5050, natSumWithBreak(100))
-  expectEqualWithScalarTensor(5050, natSumWithBreak(200))
+  expectEqualWithScalarTensor(3, doWhileLoopWithBreak(2))
+  expectEqualWithScalarTensor(55, doWhileLoopWithBreak(10))
+  expectEqualWithScalarTensor(5050, doWhileLoopWithBreak(-300))
+  expectEqualWithScalarTensor(5050, doWhileLoopWithBreak(100))
+  expectEqualWithScalarTensor(5050, doWhileLoopWithBreak(200))
 }
+
+func nestedDoWhileLoopWithBreak(
+	_ breakIndex:Int32, _ repetitions: Int32) -> Tensor<Int32> {
+	var sum = Tensor<Int32>(0)
+	for j in 1...repetitions {
+		var i: Int32 = 1
+		let maxCount: Int32 = 100
+		repeat {
+			sum += i
+			if i == breakIndex {
+				break
+			}
+			i += 1
+		} while i <= maxCount
+	}
+	return sum
+}
+
+ControlFlowTests.testAllBackends("nestedDoWhileLoopWithBreak") {
+  expectEqualWithScalarTensor(3, nestedDoWhileLoopWithBreak(2, 1))
+  expectEqualWithScalarTensor(165, nestedDoWhileLoopWithBreak(10, 3))
+  expectEqualWithScalarTensor(5050, nestedDoWhileLoopWithBreak(-300, 1))
+  expectEqualWithScalarTensor(10100, nestedDoWhileLoopWithBreak(100, 2))
+  expectEqualWithScalarTensor(5050, nestedDoWhileLoopWithBreak(200, 1))
+}
+
+
 
 #endif // CUDA
 

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -89,6 +89,30 @@ ControlFlowTests.testAllBackends("sumOfProductsWithBound") {
   // Effectively no bound as natSum(3) * natSum(3) is 36.
   expectNearlyEqualWithScalarTensor(36, sumOfProductsWithBound(3, 3, 100))
 }
+
+
+func doWhileLoopWithBreak(_ breakIndex:Int32) -> Tensor<Int32> {
+  var i: Int32 = 1
+  var sum = Tensor<Int32>(0)
+  let maxCount: Int32 = 100
+	repeat {
+    sum += i
+    if (i == breakIndex) {
+      break
+    }
+    i += 1
+  } while i <= maxCount
+  return sum
+}
+
+ControlFlowTests.testAllBackends("doWhileLoopWithBreak") {
+  expectEqualWithScalarTensor(3, natSumWithBreak(2))
+  expectEqualWithScalarTensor(55, natSumWithBreak(10))
+  expectEqualWithScalarTensor(5050, natSumWithBreak(-300))
+  expectEqualWithScalarTensor(5050, natSumWithBreak(100))
+  expectEqualWithScalarTensor(5050, natSumWithBreak(200))
+}
+
 #endif // CUDA
 
 runAllTests()


### PR DESCRIPTION
This patch takes care of the case, where we can eliminate an undef only by unrolling the loop body once. The doWhileLoop example in test/TensorFlow/sese_canonicalization.sil has an example. 

The implementation is straightforward and simply uses the SILCloner. 