### PR TITLE
do not IRGen graph_ops that are not deabstracted

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -337,6 +337,15 @@ private:
          const SILDebugScope *DebugScope = nullptr);
 
 public:
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Whether TFDeabstraction deabstracted this function.
+  ///
+  /// This is a temporary flag that IRGen uses to determine if the graph_ops in
+  /// this function are safe to lower. Once IRGen is powerful enough to lower
+  /// every graph_op that it receives, we should remove this flag.
+  /// TODO: Remove this flag.
+  bool TFDeabstracted = false;
+
   ~SILFunction();
 
   SILModule &getModule() const { return Module; }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1939,9 +1939,12 @@ void IRGenSILFunction::createArrayAndSize(
 void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
   tf::GraphOperationInfo opInfo(i);
 
-  if (!llvm::TFDynamicCompilation) {
-    // graph_ops do make it here when building the TensorFlow module itself.
-    // For those cases, we abort here with an error message.
+  if (!CurSILFn->TFDeabstracted) {
+    // graph_ops do make it here when building functions that don't get
+    // deabstracted (e.g. TensorFlow stdlib functions).
+    // IRGen is currently not powerful enough to handle graph_ops in functions
+    // that don't get deabstractd. For these cases, we abort here with an error
+    // message.
     const std::string errMessage = "!!! Compiler bug -- graph_op " +
                               opInfo.getOperationName().str() +
                               " cannot be lowered to LLVM IR !!!\n";

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2798,6 +2798,8 @@ void TFDeabstraction::doIt() {
   cleanupDeadInstructions();
 
   logCurrentState("Result", /*detailed*/false);
+
+  fn.TFDeabstracted = true;
 }
 
 

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-sese-loops-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 


### PR DESCRIPTION
When deabstraction decides not to deabstract a function, IRGen often crashes on that function. This is blocking a lot of the tests from passing. So this PR tells IRGen not to handle graph_ops in non-deabstracted functions.

We should eventually be able to remove this by making IRGen powerful enough to deal with everything that it sees.

This makes "sese_loop_canonicalization" pass under dynamic compilation, and it also improves a few other tests that still fail for other reasons.