### PR TITLE
[Type checker] Stop (ab)using TypeChecker::Diags to suppress diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticSuppression.h
+++ b/include/swift/AST/DiagnosticSuppression.h
@@ -1,0 +1,43 @@
+//===--- InstrumenterSupport.cpp - Instrumenter Support -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the supporting functions for writing instrumenters of
+//  the Swift AST.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_DIAGNOSTIC_SUPPRESSION_H
+#define SWIFT_AST_DIAGNOSTIC_SUPPRESSION_H
+
+#include <vector>
+
+namespace swift {
+
+class DiagnosticConsumer;
+class DiagnosticEngine;
+
+/// RAII class that suppresses diagnostics by temporarily disabling all of
+/// the diagnostic consumers.
+class DiagnosticSuppression {
+  DiagnosticEngine &diags;
+  std::vector<DiagnosticConsumer *> consumers;
+
+  DiagnosticSuppression(const DiagnosticSuppression &) = delete;
+  DiagnosticSuppression &operator=(const DiagnosticSuppression &) = delete;
+
+public:
+  explicit DiagnosticSuppression(DiagnosticEngine &diags);
+  ~DiagnosticSuppression();
+};
+
+}
+#endif /* SWIFT_AST_DIAGNOSTIC_SUPPRESSION_H */

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticSuppression.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PrintOptions.h"
@@ -830,4 +831,15 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
 
 const char *DiagnosticEngine::diagnosticStringFor(const DiagID id) {
   return diagnosticStrings[(unsigned)id];
+}
+
+DiagnosticSuppression::DiagnosticSuppression(DiagnosticEngine &diags)
+  : diags(diags)
+{
+  consumers = diags.takeConsumers();
+}
+
+DiagnosticSuppression::~DiagnosticSuppression() {
+  for (auto consumer : consumers)
+    diags.addConsumer(*consumer);
 }

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "InstrumenterSupport.h"
+#include "swift/AST/DiagnosticSuppression.h"
 
 using namespace swift;
 using namespace swift::instrumenter_support;
@@ -77,10 +78,10 @@ void InstrumenterBase::anchor() {}
 
 bool InstrumenterBase::doTypeCheckImpl(ASTContext &Ctx, DeclContext *DC,
                                        Expr * &parsedExpr) {
-  DiagnosticEngine diags(Ctx.SourceMgr);
-  ErrorGatherer errorGatherer(diags);
+  DiagnosticSuppression suppression(Ctx.Diags);
+  ErrorGatherer errorGatherer(Ctx.Diags);
 
-  TypeChecker TC(Ctx, diags);
+  TypeChecker TC(Ctx);
 
   TC.typeCheckExpression(parsedExpr, DC);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -726,8 +726,7 @@ private:
   Expr* constructCallToSuperInit(ConstructorDecl *ctor, ClassDecl *ClDecl);
 
 public:
-  TypeChecker(ASTContext &Ctx) : TypeChecker(Ctx, Ctx.Diags) { }
-  TypeChecker(ASTContext &Ctx, DiagnosticEngine &Diags);
+  TypeChecker(ASTContext &Ctx);
   TypeChecker(const TypeChecker&) = delete;
   TypeChecker& operator=(const TypeChecker&) = delete;
   ~TypeChecker();

--- a/test/IRGen/playground.swift
+++ b/test/IRGen/playground.swift
@@ -9,6 +9,12 @@ import Swift
 
 @objc class C { }
 
+private func __builtin_log_scope_entry(_ startLine: Int, _ startColumn: Int,
+  _ endLine: Int, _ endColumn: Int) { }
+private func __builtin_log_scope_exit(_ startLine: Int, _ startColumn: Int,
+  _ endLine: Int, _ endColumn: Int) { }
+private func __builtin_send_data<T>(_ object: T) { }
+
 public func anchor() {}
 
 anchor()


### PR DESCRIPTION
Take away the type checker constructor that allows one to provide a
diagnostic engine different from the one associated with the ASTContext. It
doesn’t actually work to suppress diagnostics. Switch all clients over to
the constructor that takes only an ASTContext.

Introduce the DiagnosticSuppression RAII class so clients that want to
suppress diagnostics can suppress *all* diagnostics. Use it where we
were previously suppressing diagnostics.
