### PR TITLE
benchmarks: fix NSStringConversion benchmark

### DIFF
--- a/benchmark/single-source/NSStringConversion.swift
+++ b/benchmark/single-source/NSStringConversion.swift
@@ -23,7 +23,7 @@ public func run_NSStringConversion(_ N: Int) {
 #if _runtime(_ObjC)
 let test:NSString = NSString(cString: "test", encoding: String.Encoding.ascii.rawValue)!
   for _ in 1...N * 10000 {
-    _ = test as String
+    blackHole(identity(test) as String)
   }
 #endif
 }


### PR DESCRIPTION
Make sure that the result of the conversion is not optimized away

A follow-up on https://github.com/apple/swift/pull/19797