### PR TITLE
Towards s390x support

### DIFF
--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -171,9 +171,9 @@ static_assert(alignof(HeapObject) == alignof(void*),
 #define _swift_abi_SwiftSpareBitsMask                                          \
   (__swift_uintptr_t) SWIFT_ABI_S390X_SWIFT_SPARE_BITS_MASK
 #define _swift_abi_ObjCReservedBitsMask                                        \
-  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK
+  (__swift_uintptr_t) SWIFT_ABI_S390X_OBJC_RESERVED_BITS_MASK
 #define _swift_abi_ObjCReservedLowBits                                         \
-  (unsigned) SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS
+  (unsigned) SWIFT_ABI_S390X_OBJC_NUM_RESERVED_LOW_BITS
 #define _swift_BridgeObject_TaggedPointerBits                                  \
   (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_64
 

--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -164,6 +164,24 @@
 /*********************************** s390x ************************************/
 
 // Top byte of pointers is unused, and heap objects are eight-byte aligned.
-#define SWIFT_ABI_S390X_SWIFT_SPARE_BITS_MASK 0x0000000000000007ULL
+// On s390x it is theoretically possible to have high bit set but in practice
+// it is unlikely.
+#define SWIFT_ABI_S390X_SWIFT_SPARE_BITS_MASK 0xFF00000000000007ULL
+
+// Objective-C reserves just the high bit for tagged pointers.
+#define SWIFT_ABI_S390X_OBJC_RESERVED_BITS_MASK 0x8000000000000000ULL
+#define SWIFT_ABI_S390X_OBJC_NUM_RESERVED_LOW_BITS 0
+
+// BridgeObject uses this bit to indicate whether it holds an ObjC object or
+// not.
+#define SWIFT_ABI_S390X_IS_OBJC_BIT 0x4000000000000000ULL
+
+// ObjC weak reference discriminator is the high bit
+// reserved for ObjC tagged pointers plus the LSB.
+#define SWIFT_ABI_S390X_OBJC_WEAK_REFERENCE_MARKER_MASK  \
+  (SWIFT_ABI_S390X_OBJC_RESERVED_BITS_MASK |          \
+   1<<SWIFT_ABI_S390X_OBJC_NUM_RESERVED_LOW_BITS)
+#define SWIFT_ABI_S390X_OBJC_WEAK_REFERENCE_MARKER_VALUE \
+  (1<<SWIFT_ABI_S390X_OBJC_NUM_RESERVED_LOW_BITS)
 
 #endif /* SWIFT_ABI_SYSTEM_H */

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -82,6 +82,11 @@ public typealias CLongDouble = Double
 public typealias CLongDouble = Float80
 #endif
 // TODO: Fill in definitions for other OSes.
+#if arch(s390x)
+// On s390x '-mlong-double-64' option with size of 64-bits makes the
+// Long Double type equivalent to Double type.
+public typealias CLongDouble = Double
+#endif
 #endif
 
 // FIXME: Is it actually UTF-32 on Darwin?

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -61,9 +61,11 @@ using namespace swift;
 /// Returns true if the pointer passed to a native retain or release is valid.
 /// If false, the operation should immediately return.
 static inline bool isValidPointerForNativeRetain(const void *p) {
-#if defined(__x86_64__) || defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64)
-  // On these platforms, the upper half of address space is reserved for the
+#if defined(__x86_64__) || defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64) || defined(__s390x__)
+  // On these platforms, except s390x, the upper half of address space is reserved for the
   // kernel, so we can assume that pointer values in this range are invalid.
+  // On s390x it is theoretically possible to have high bit set but in practice
+  // it is unlikely.
   return (intptr_t)p > 0;
 #else
   return p != nullptr;


### PR DESCRIPTION
This PR partially enables s390x architecture support for Swift.

Specifically:

1. Modifies existing s390x SPARE_BIT_MASK
2. Adds s390x SWIFT_ABI_S390X_OBJC_RESERVED_BITS_MASK and supporting logic
3. Adds CLongDouble support on s390x
4. Updates isValidPointerForNativeRetain() function for s390x