### PR TITLE
[SE-NNNN] Remove Tuple Shuffles

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4223,8 +4223,6 @@ WARNING(override_nsobject_hashvalue,none,
 // MARK: Tuple Shuffle Diagnostics
 //------------------------------------------------------------------------------
 
-ERROR(reordering_tuple_shuffle_deprecated,none,
-      "expression shuffles the elements of this tuple", ())
 WARNING(warn_reordering_tuple_shuffle_deprecated,none,
         "expression shuffles the elements of this tuple; "
         "this behavior is deprecated in Swift 4", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4219,6 +4219,16 @@ WARNING(override_nsobject_hashvalue,none,
         "override of 'NSObject.hashValue' is deprecated; "
         "override 'NSObject.hash' to get consistent hashing behavior", ())
 
+//------------------------------------------------------------------------------
+// MARK: Tuple Shuffle Diagnostics
+//------------------------------------------------------------------------------
+
+ERROR(reordering_tuple_shuffle_deprecated,none,
+      "expression shuffles the elements of this tuple", ())
+WARNING(warn_reordering_tuple_shuffle_deprecated,none,
+        "expression shuffles the elements of this tuple; "
+        "this behavior is deprecated in Swift 4", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1509,7 +1509,8 @@ bool FailureDiagnosis::diagnoseGeneralConversionFailure(Constraint *constraint){
       // If the shuffle conversion is invalid (e.g. incorrect element labels),
       // then we have a type error.
       if (computeTupleShuffle(TEType->castTo<TupleType>()->getElements(),
-                              toTT->getElements(), sources, variadicArgs)) {
+                              toTT->getElements(), sources, variadicArgs,
+                              CS.getASTContext().isSwiftVersionAtLeast(5))) {
         diagnose(anchor->getLoc(), diag::tuple_types_not_convertible,
                  fromTT, toTT)
         .highlight(anchor->getSourceRange());
@@ -7611,7 +7612,8 @@ bool FailureDiagnosis::visitTupleExpr(TupleExpr *TE) {
   // it specifically here, but the general logic does a fine job so we let it
   // do it.
   if (computeTupleShuffle(TEType->castTo<TupleType>()->getElements(),
-                          contextualTT->getElements(), sources, variadicArgs))
+                          contextualTT->getElements(), sources, variadicArgs,
+                          CS.getASTContext().isSwiftVersionAtLeast(5)))
     return visitExpr(TE);
 
   // If we got a correct shuffle, we can perform the analysis of all of

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -999,7 +999,8 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   // Compute the element shuffles for conversions.
   SmallVector<int, 16> sources;
   SmallVector<unsigned, 4> variadicArguments;
-  if (computeTupleShuffle(tuple1, tuple2, sources, variadicArguments))
+  if (computeTupleShuffle(tuple1, tuple2, sources, variadicArguments,
+                          getASTContext().isSwiftVersionAtLeast(5)))
     return getTypeMatchFailure(locator);
 
   // Check each of the elements.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3317,17 +3317,25 @@ public:
 /// \c where \c consumed[i] is \c TupleShuffleExpr::Variadic). The values
 /// are indices into the source tuple.
 ///
+/// \param rejectReorderingShuffles Tuple shuffles that reorder element indices
+/// are no longer semantically valid in non-legacy Swift modes. However,
+/// computing such shuffles may be valuable for legacy and diagnostic purposes.
+/// Pass \c false if reordering tuple shuffles should be constructed, else any
+/// attempt to form one will report that no tuple conversion is possible.
+///
 /// \returns true if no tuple conversion is possible, false otherwise.
 bool computeTupleShuffle(ArrayRef<TupleTypeElt> fromTuple,
                          ArrayRef<TupleTypeElt> toTuple,
                          SmallVectorImpl<int> &sources,
-                         SmallVectorImpl<unsigned> &variadicArgs);
+                         SmallVectorImpl<unsigned> &variadicArgs,
+                         bool rejectReorderingShuffles);
 static inline bool computeTupleShuffle(TupleType *fromTuple,
                                        TupleType *toTuple,
                                        SmallVectorImpl<int> &sources,
-                                       SmallVectorImpl<unsigned> &variadicArgs){
+                                       SmallVectorImpl<unsigned> &variadicArgs,
+                                       bool rejectReorderingShuffles){
   return computeTupleShuffle(fromTuple->getElements(), toTuple->getElements(),
-                             sources, variadicArgs);
+                             sources, variadicArgs, rejectReorderingShuffles);
 }
 
 /// Describes the arguments to which a parameter binds.

--- a/test/Compatibility/tuple_shuffle.swift
+++ b/test/Compatibility/tuple_shuffle.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+func consume<T>(_ x: T) {} // Suppress unused variable warnings
+
+func shuffle_through_initialization() {
+  let a = (x: 1, y: 2)
+  let b: (y: Int, x: Int)
+  b = a // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
+  consume(b)
+}
+
+func shuffle_through_destructuring() {
+  let a = (x: 1, y: 2)
+  let (y: b, x: c) = a // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
+  consume((b, c))
+}
+
+func shuffle_through_call() {
+  func foo(_ : (x: Int, y: Int)) {}
+  foo((y: 5, x: 10)) // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
+}
+
+func shuffle_through_cast() {
+  let x = ((a: Int(), b: Int()) as (b: Int, a: Int)).0 // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
+  
+  // Ah, the famous double-shuffle
+  let (c1, (c2, c3)): (c: Int, (b: Int, a: Int)) = ((a: Int(), b: Int()), c: Int())
+  // expected-warning@-1 {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
+  // expected-warning@-2 {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
+  consume((x, c1, c2, c3))
+}

--- a/test/Constraints/tuple_shuffle.swift
+++ b/test/Constraints/tuple_shuffle.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+func consume<T>(_ x: T) {} // Suppress unused variable warnings
+
+func shuffle_through_initialization() {
+  let a = (x: 1, y: 2)
+  let b: (y: Int, x: Int)
+  b = a // expected-error {{cannot assign value of type '(x: Int, y: Int)' to type '(y: Int, x: Int)'}}
+  consume(b)
+}
+
+func shuffle_through_destructuring() {
+  let a = (x: 1, y: 2)
+  let (y: b, x: c) = a // expected-error {{tuple type '(x: Int, y: Int)' is not convertible to tuple '(y: _, x: _)'}}
+  consume((b, c))
+}
+
+func shuffle_through_call() {
+  func foo(_ : (x: Int, y: Int)) {}
+  foo((y: 5, x: 10)) // expected-error {{cannot convert value of type '(y: Int, x: Int)' to expected argument type '(x: Int, y: Int)'}}
+}
+
+func shuffle_through_cast() {
+  let x = ((a: Int(), b: Int()) as (b: Int, a: Int)).0 // expected-error {{cannot convert value of type '(a: Int, b: Int)' to type '(b: Int, a: Int)' in coercion}}
+
+  // Ah, the famous double-shuffle
+  let (c1, (c2, c3)): (c: Int, (b: Int, a: Int)) = ((a: Int(), b: Int()), c: Int())
+  // expected-error@-1 {{cannot convert value of type '((a: Int, b: Int), c: Int)' to specified type '(c: Int, (b: Int, a: Int))'}}
+  consume((x, c1, c2, c3))
+}

--- a/test/Sema/diag_unowned_immediate_deallocation.swift
+++ b/test/Sema/diag_unowned_immediate_deallocation.swift
@@ -448,9 +448,13 @@ func testGenericWeakClassDiag() {
 }
 
 // The diagnostic doesn't currently support tuple shuffles.
+// FIXME: This test can be removed when shuffling is no longer allowed.
 func testDontDiagnoseThroughTupleShuffles() {
   unowned let (c1, (c2, c3)): (c: C, (b: C, a: C)) = ((a: D(), b: C()), c: D())
+  // expected-warning@-1 {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
+  // expected-warning@-2 {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
   unowned let c4 = ((a: C(), b: C()) as (b: C, a: C)).0
+  // expected-warning@-1 {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
 
   _ = c1; _ = c2; _ = c3; _ = c4
 }

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -112,7 +112,7 @@ var f2 : (Int) -> Int = (+-+)
 var f3 : (inout Int) -> Int = (-+-) // expected-error{{ambiguous use of operator '-+-'}}
 var f4 : (inout Int, Int) -> Int = (+-+=)
 var r5 : (a : (Int, Int) -> Int, b : (Int, Int) -> Int) = (+, -)
-var r6 : (a : (Int, Int) -> Int, b : (Int, Int) -> Int) = (b : +, a : -)
+var r6 : (a : (Int, Int) -> Int, b : (Int, Int) -> Int) = (b : +, a : -) // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
 
 struct f6_S {
   subscript(op : (Int, Int) -> Int) -> Int {

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -52,7 +52,7 @@ func funcdecl5(_ a: Int, _ y: Int) {
   var b = a.1+a.f
 
   // Tuple expressions with named elements.
-  var i : (y : Int, x : Int) = (x : 42, y : 11)
+  var i : (y : Int, x : Int) = (x : 42, y : 11) // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}}
   funcdecl1(123, 444)
   
   // Calls.

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -189,7 +189,7 @@ func test5() {
 
 
   let c: (a: Int, b: Int) = (1,2)
-  let _: (b: Int, a: Int) = c  // Ok, reshuffle tuple.
+  let _: (b: Int, a: Int) = c  // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated in Swift 4}} 
 }
 
 


### PR DESCRIPTION
In accordance with the evolution proposal, reject forming tuple shuffles
that reorder the elements of a tuple with a warning in legacy mode and
an error in Swift 5.

<strike>The last commit is bogus.  I want to measure the impact of this change on the source compatibility suite first.</strike>