### PR TITLE
stdlib: install the image registrar in the static runtime

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -193,6 +193,8 @@ add_swift_library(swiftImageRegistrationObjectELF
                   LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
                   TARGET_SDKS ${ELFISH_SDKS}
                   INSTALL_IN_COMPONENT none)
+# FIXME(compnerd) this should be compiled twice, once for static and once for
+# shared.  The static version should be used for building the standard library.
 add_swift_library(swiftImageRegistrationObjectCOFF
                   OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
                   SwiftRT-COFF.cpp
@@ -212,20 +214,34 @@ foreach(sdk ${SWIFT_CONFIGURED_SDKS})
       # to a version which supports it.
       # set(swiftrtObject "$<TARGET_OBJECTS:swiftImageRegistrationObject${SWIFT_SDK_${sdk}_OBJECT_FORMAT}-${arch_suffix}>")
       set(swiftrtObject ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/swiftImageRegistrationObject${SWIFT_SDK_${sdk}_OBJECT_FORMAT}-${arch_suffix}.dir/SwiftRT-${SWIFT_SDK_${sdk}_OBJECT_FORMAT}.cpp${CMAKE_C_OUTPUT_EXTENSION})
-      set(swiftrtPath "${SWIFTLIB_DIR}/${arch_subdir}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")
+      set(shared_runtime_registrar "${SWIFTLIB_DIR}/${arch_subdir}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")
+      set(static_runtime_registrar "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")
 
       add_custom_command_target(swiftImageRegistration-${arch_suffix}
                                 COMMAND
-                                  "${CMAKE_COMMAND}" -E copy "${swiftrtObject}" "${swiftrtPath}"
+                                  "${CMAKE_COMMAND}" -E copy "${swiftrtObject}" "${shared_runtime_registrar}"
+                                COMMAND
+                                  "${CMAKE_COMMAND}" -E copy "${swiftrtObject}" "${static_runtime_registrar}"
                                 OUTPUT
-                                  "${swiftrtPath}"
+                                  "${shared_runtime_registrar}"
+                                  "${static_runtime_registrar}"
                                 DEPENDS
                                   "${swiftrtObject}")
-      swift_install_in_component(stdlib
-                                 FILES
-                                   "${swiftrtPath}"
-                                 DESTINATION
-                                   "lib/swift/${arch_subdir}")
+      if(SWIFT_BUILD_DYNAMIC_STDLIB)
+        swift_install_in_component(stdlib
+                                   FILES
+                                     "${shared_runtime_registrar}"
+                                   DESTINATION
+                                     "lib/swift/${arch_subdir}")
+      endif()
+      if(SWIFT_BUILD_STATIC_STDLIB)
+        swift_install_in_component(stdlib
+                                   FILES
+                                     "${static_runtime_registrar}"
+                                   DESTINATION
+                                     "lib/swift_static/${arch_subdir}")
+      endif()
+
       add_dependencies(swift-stdlib-${arch_suffix} ${swiftImageRegistration-${arch_suffix}})
 
       add_custom_target(swiftImageRegistration-${arch_suffix}


### PR DESCRIPTION
We were previously only installing the image registration helper in the shared
runtime location.  When building with a static runtime, we would look in the
wrong location.  Ensure that we install to both locations to repair the static
builds.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
