### PR TITLE
[Sema] When resolving type declarations, if there is an error with a typealias,...

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -689,10 +689,11 @@ ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
       (DeclName, unsigned))
 ERROR(unsupported_recursion_in_associated_type_reference,none,
-      "unsupported recursion for reference to associated type %0 of type %1",
-      (DeclName, Type))
+      "unsupported recursion for reference to %select{associated type|type alias}0 %1 of type %2",
+      (bool, DeclName, Type))
 ERROR(broken_associated_type_witness,none,
-      "reference to invalid associated type %0 of type %1", (DeclName, Type))
+      "reference to invalid %select{associated type|type alias}0 %1 of type %2",
+      (bool, DeclName, Type))
 
 ERROR(unspaced_binary_operator_fixit,none,
       "missing whitespace between %0 and %1 operators",

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -914,7 +914,8 @@ static Type resolveTypeDecl(TypeDecl *typeDecl, SourceLoc loc,
     return ErrorType::get(ctx);
   }
 
-  if (type->hasError() && (isa<AssociatedTypeDecl>(typeDecl) || isa<TypeAliasDecl>(typeDecl))) {
+  if (type->hasError() && foundDC &&
+      (isa<AssociatedTypeDecl>(typeDecl) || isa<TypeAliasDecl>(typeDecl))) {
     maybeDiagnoseBadConformanceRef(fromDC,
                                    foundDC->getDeclaredInterfaceType(),
                                    loc, typeDecl);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -924,7 +924,7 @@ static Type resolveTypeDecl(TypeDecl *typeDecl, SourceLoc loc,
         : callback(callback) {}
 
         bool walkToTypeReprPre(TypeRepr *TR) {
-          if (auto CITR = dyn_cast<ComponentIdentTypeRepr>(TR)) {
+          if (auto CITR = dyn_cast_or_null<ComponentIdentTypeRepr>(TR)) {
             if (auto associatedTypeDecl = dyn_cast_or_null<AssociatedTypeDecl>(CITR->getBoundDecl())) {
               callback(associatedTypeDecl);
             }
@@ -933,13 +933,14 @@ static Type resolveTypeDecl(TypeDecl *typeDecl, SourceLoc loc,
         }
       };
 
-      auto repr = aliasDecl->getUnderlyingTypeLoc().getTypeRepr();
-      AssociatedTypeReprWalker walker([&](AssociatedTypeDecl *associatedTypeDecl) {
-        maybeDiagnoseBadConformanceRef(fromDC,
-                                       foundDC->getDeclaredInterfaceType(),
-                                       loc, associatedTypeDecl);
-      });
-      repr->walk(walker);
+      if (auto repr = aliasDecl->getUnderlyingTypeLoc().getTypeRepr()) {
+        AssociatedTypeReprWalker walker([&](AssociatedTypeDecl *associatedTypeDecl) {
+          maybeDiagnoseBadConformanceRef(fromDC,
+                                         foundDC->getDeclaredInterfaceType(),
+                                         loc, associatedTypeDecl);
+        });
+        repr->walk(walker);
+      }
     }
   }
 

--- a/test/decl/protocol/typealias_inference.swift
+++ b/test/decl/protocol/typealias_inference.swift
@@ -12,7 +12,7 @@ protocol BaseProtocol {
 struct Base<Value>: BaseProtocol {
   private let closure: Closure
 
-  init(closure: Closure) { //expected-error {{reference to invalid associated type 'Value' of type 'Base<Value>'}}
+  init(closure: Closure) { //expected-error {{reference to invalid type alias 'Closure' of type 'Base<Value>'}}
     self.closure = closure
   }
 }

--- a/test/decl/protocol/typealias_inference.swift
+++ b/test/decl/protocol/typealias_inference.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+// SR-8813
+// By itself in this file because this particular expected error is omitted if there have been any other diagnostics.
+protocol BaseProtocol {
+  associatedtype Value
+  typealias Closure = () -> Value
+
+  init(closure: Closure)
+}
+
+struct Base<Value>: BaseProtocol {
+  private let closure: Closure
+
+  init(closure: Closure) { //expected-error {{reference to invalid associated type 'Value' of type 'Base<Value>'}}
+    self.closure = closure
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/0127-sr5546.swift
+++ b/validation-test/compiler_crashers_2_fixed/0127-sr5546.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 // REQUIRES: asserts
 
 public struct Foo<A, B, C> {}


### PR DESCRIPTION
... check to see if the type alias refers to any associated types to maybe display a bad conformance diagnostic.

Partially resolves [SR-8813](https://bugs.swift.org/browse/SR-8813). (Arguably, we should be inferring a valid witness for `Value` here, but since we aren't, we should definitely be diagnosing it.)

Rather than put the ASTWalker here, would it be better to move it into TypeRepr.cpp via adding a member `TypeRepr::visitTypeReprs(llvm::function_ref<void(TypeRepr *)>visitor)`?

Relatedly, I noticed that `TypeRepr::visitTopLevelTypeReprs()` currently has no callers. Should I remove it in this or separate PR?