### PR TITLE
[IRGen] Fix enumTagSinglePayload address issue for big endian platforms

### DIFF
--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -564,7 +564,7 @@ EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
       v = IGF.Builder.CreateBitOrPointerCast(v, intTy);
     
     if (isMasked) {
-      if( !IGF.IGM.Triple.isLittleEndian() && IGF.IGM.Triple.isArch64Bit() ){
+      if (!IGF.IGM.Triple.isLittleEndian() && IGF.IGM.Triple.isArch64Bit()) {
         v  = IGF.Builder.CreateLShr(v, 56);
       }
       auto maskConstant = llvm::ConstantInt::get(intTy, maskPiece);

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -564,6 +564,9 @@ EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
       v = IGF.Builder.CreateBitOrPointerCast(v, intTy);
     
     if (isMasked) {
+#if defined(__BIG_ENDIAN__) && defined(__LP64__)
+      v  = IGF.Builder.CreateLShr(v, 56);
+#endif
       auto maskConstant = llvm::ConstantInt::get(intTy, maskPiece);
       v = IGF.Builder.CreateAnd(v, maskConstant);
     }

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -564,9 +564,9 @@ EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
       v = IGF.Builder.CreateBitOrPointerCast(v, intTy);
     
     if (isMasked) {
-#if defined(__BIG_ENDIAN__) && defined(__LP64__)
-      v  = IGF.Builder.CreateLShr(v, 56);
-#endif
+      if( !IGF.IGM.Triple.isLittleEndian() && IGF.IGM.Triple.isArch64Bit() ){
+        v  = IGF.Builder.CreateLShr(v, 56);
+      }
       auto maskConstant = llvm::ConstantInt::get(intTy, maskPiece);
       v = IGF.Builder.CreateAnd(v, maskConstant);
     }

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -564,9 +564,6 @@ EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
       v = IGF.Builder.CreateBitOrPointerCast(v, intTy);
     
     if (isMasked) {
-      if (!IGF.IGM.Triple.isLittleEndian() && IGF.IGM.Triple.isArch64Bit()) {
-        v  = IGF.Builder.CreateLShr(v, 56);
-      }
       auto maskConstant = llvm::ConstantInt::get(intTy, maskPiece);
       v = IGF.Builder.CreateAnd(v, maskConstant);
     }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -429,10 +429,10 @@ static Address alignAddress(IRGenFunction &IGF,
   auto &Builder = IGF.Builder;
   auto &IGM = IGF.IGM;
   auto *alignedAddress = Builder.CreateBitCast(originAddress, IGM.Int8PtrTy).getAddress();
-#if defined(__linux__) && defined(__BIG_ENDIAN__)
-  alignedAddress = Builder.CreateConstGEP1_32(alignedAddress, 4);
-  alignedAddress = Builder.CreateGEP(alignedAddress, Builder.CreateNeg(shift));
-#endif
+  if (IGM.Triple.getOS() == llvm::Triple::Linux && !IGM.Triple.isLittleEndian()) {
+    alignedAddress = Builder.CreateConstGEP1_32(alignedAddress, 4);
+    alignedAddress = Builder.CreateGEP(alignedAddress, Builder.CreateNeg(shift));
+  }
   return Address(alignedAddress, Alignment(0));
 }
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -430,8 +430,7 @@ static Address alignAddress(IRGenFunction &IGF, Address originAddress,
   auto *alignedAddressValue =
       Builder.CreateBitCast(originAddress, IGM.Int8PtrTy).getAddress();
   Address alignedAddress = Builder.CreateBitCast(originAddress, IGM.Int8PtrTy);
-  if (IGM.Triple.getOS() == llvm::Triple::Linux &&
-      !IGM.Triple.isLittleEndian()) {
+  if (!IGM.Triple.isLittleEndian()) {
     alignedAddress = Builder.CreateConstByteArrayGEP(alignedAddress, Size(4));
     alignedAddressValue = alignedAddress.getAddress();
     alignedAddressValue =


### PR DESCRIPTION
This fixes the enum issues we saw before on big endian platforms. It adjusts several addresses in get/store enumTagSinglePayload functions for big endian platforms. 