### PR TITLE
[silgen] Add support for BorrowAlways, eliminate some bogus asserts, …

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -738,15 +738,17 @@ forwardIntoSubtree(SILGenFunction &SGF, SILLocation loc,
   ManagedValue outerMV = outerCMV.getFinalManagedValue();
   if (!outerMV.hasCleanup()) return outerCMV;
 
-  assert(outerCMV.getFinalConsumption() != CastConsumptionKind::CopyOnSuccess
-         && "copy-on-success value with cleanup?");
+  assert(outerCMV.getFinalConsumption() != CastConsumptionKind::CopyOnSuccess &&
+         outerCMV.getFinalConsumption() != CastConsumptionKind::BorrowAlways &&
+         "non-+1 consumption with a cleanup?");
   scope.pushCleanupState(outerMV.getCleanup(),
                          CleanupState::PersistentlyActive);
 
-  // If SILOwnership is enabled, we always forward down values as borrows that
-  // are copied on success.
-  if (SGF.F.getModule().getOptions().EnableSILOwnership) {
-    return {outerMV.borrow(SGF, loc), CastConsumptionKind::CopyOnSuccess};
+  // If SILOwnership is enabled and we have an object, borrow instead of take on
+  // success.
+  if (SGF.F.getModule().getOptions().EnableSILOwnership &&
+      outerMV.getType().isObject()) {
+    return {outerMV.borrow(SGF, loc), CastConsumptionKind::BorrowAlways};
   }
 
   // Success means that we won't end up in the other branch,
@@ -766,9 +768,6 @@ static void forwardIntoIrrefutableSubtree(SILGenFunction &SGF,
 
   assert(outerCMV.getFinalConsumption() != CastConsumptionKind::CopyOnSuccess
          && "copy-on-success value with cleanup?");
-  assert((!SGF.F.getModule().getOptions().EnableSILOwnership ||
-          outerCMV.getFinalConsumption() == CastConsumptionKind::TakeAlways) &&
-         "When semantic sil is enabled, we should never see TakeOnSuccess");
   scope.pushCleanupState(outerMV.getCleanup(),
                          CleanupState::PersistentlyActive);
 
@@ -899,7 +898,8 @@ public:
 
   static bool requiresUnforwarding(SILGenFunction &SGF,
                                    ConsumableManagedValue operand) {
-    if (SGF.F.getModule().getOptions().EnableSILOwnership) {
+    if (SGF.F.getModule().getOptions().EnableSILOwnership &&
+        operand.getType().isObject()) {
       assert(operand.getFinalConsumption() !=
                  CastConsumptionKind::TakeOnSuccess &&
              "When compiling with sil ownership take on success is disabled");
@@ -1356,9 +1356,6 @@ getManagedSubobject(SILGenFunction &SGF, SILValue value,
     return {ManagedValue::forUnmanaged(value), consumption};
   case CastConsumptionKind::TakeAlways:
   case CastConsumptionKind::TakeOnSuccess:
-    assert((!SGF.F.getModule().getOptions().EnableSILOwnership ||
-            consumption != CastConsumptionKind::TakeOnSuccess) &&
-           "TakeOnSuccess should never be used when sil ownership is enabled");
     return {SGF.emitManagedRValueWithCleanup(value, valueTL), consumption};
   }
 }
@@ -1882,8 +1879,6 @@ void PatternMatchEmission::emitEnumElementDispatch(
       break;
 
     case CastConsumptionKind::TakeOnSuccess:
-      assert(!SGF.F.getModule().getOptions().EnableSILOwnership &&
-             "TakeOnSuccess is not supported when compiling with ownership");
       // If any of the specialization cases is refutable, we must copy.
       if (!blocks.hasAnyRefutableCase())
         break;
@@ -1966,8 +1961,6 @@ void PatternMatchEmission::emitEnumElementDispatch(
       auto eltConsumption = src.getFinalConsumption();
       if (caseInfo.Irrefutable &&
           eltConsumption == CastConsumptionKind::TakeOnSuccess) {
-        assert(!SGF.F.getModule().getOptions().EnableSILOwnership &&
-               "TakeOnSuccess is not supported when compiling with ownership");
         eltConsumption = CastConsumptionKind::TakeAlways;
       }
 
@@ -2760,8 +2753,9 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
   // Set up an initial clause matrix.
   ClauseMatrix clauseMatrix(clauseRows);
   ConsumableManagedValue subject;
-  if (F.getModule().getOptions().EnableSILOwnership) {
-    subject = {exn.borrow(*this, S), CastConsumptionKind::CopyOnSuccess};
+  if (F.getModule().getOptions().EnableSILOwnership &&
+      exn.getType().isObject()) {
+    subject = {exn.borrow(*this, S), CastConsumptionKind::BorrowAlways};
   } else {
     subject = {exn, CastConsumptionKind::TakeOnSuccess};
   }


### PR DESCRIPTION
…and only use BorrowAlways with objects.

The reason why the asserts were bogus is that even with SILOwnership enabled, we
will use the old pattern to emit address only code. In that case, the asserts
will fire on good behavior.

I also fixed a latent bug where when ownership was enabled we were treating
address only values like objects. Found via inspection.

rdar://29791263

----

NOTE: As part of turning on SILGenPattern I am going to eliminate these EnableSILOwnership gates so that we always emit SILGenPattern in ownership form even if we don't verify. When that happens, this specific code will be exercised by the code already in the test suite.
