### PR TITLE
[SILOptimizer] Skip optimizing non-inlinable code in -emit-module

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -47,6 +47,10 @@ public:
   /// above but the interactions between all the flags are tricky.
   bool MergePartialModules = false;
 
+  /// Controls whether to optimize non-inlinable functions and whether to cut
+  /// off the pass pipelines after we've serialized the SIL.
+  bool IsEmittingModuleOnly = false;
+
   /// Remove all runtime assertions during optimizations.
   bool RemoveRuntimeAsserts = false;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -630,6 +630,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_sil_merge_partial_modules))
     Opts.MergePartialModules = true;
 
+  if (FEOpts.RequestedAction == FrontendOptions::ActionType::EmitModuleOnly)
+    Opts.IsEmittingModuleOnly = true;
+
   // Parse the optimization level.
   // Default to Onone settings if no option is passed.
   Opts.OptMode = OptimizationMode::NoOptimization;

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -187,6 +187,10 @@ OptimizationMode SILFunction::getEffectiveOptimizationMode() const {
 }
 
 bool SILFunction::shouldOptimize() const {
+  // If we're just emitting a module, don't optimize non-serialized functions,
+  // otherwise the work is wasted.
+  if (getModule().getOptions().IsEmittingModuleOnly && !isSerialized())
+    return false;
   return getEffectiveOptimizationMode() != OptimizationMode::NoOptimization;
 }
 


### PR DESCRIPTION
This patch avoids optimizing functions that won't be serialized in the
resulting module, which avoids a bunch of unnecessary work.

This could be improved by avoiding SILGenning the bodies of
non-inlinable functions, but this is a significant, low-risk win.

rdar://45196697