### PR TITLE
Sema: Allow protocols with 'Self' constraints again

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -501,7 +501,7 @@ public:
   /// lookup.
   ///
   /// \returns true if anything was found.
-  bool lookupQualified(ArrayRef<TypeDecl *> types, DeclName member,
+  bool lookupQualified(ArrayRef<NominalTypeDecl *> types, DeclName member,
                        NLOptions options,
                        SmallVectorImpl<ValueDecl *> &decls) const;
 

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -34,6 +34,7 @@ namespace swift {
   class Type;
   class TypeDecl;
   class ValueDecl;
+  struct SelfBounds;
 
 /// LookupResultEntry - One result of unqualified lookup.
 struct LookupResultEntry {
@@ -373,6 +374,12 @@ SmallVector<std::pair<SourceLoc, NominalTypeDecl *>, 4>
 getDirectlyInheritedNominalTypeDecls(
                       llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
                       bool &anyObject);
+
+/// Retrieve the set of nominal type declarations that appear as the
+/// constraint type of any "Self" constraints in the where clause of the
+/// given protocol or protocol extension.
+SelfBounds getSelfBoundsFromWhereClause(
+    llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl);
 
 } // end namespace swift
 

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -182,13 +182,18 @@ public:
   void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
+struct SelfBounds {
+  llvm::TinyPtrVector<NominalTypeDecl *> decls;
+  bool anyObject = false;
+};
+
 /// Request the nominal types that occur as the right-hand side of "Self: Foo"
 /// constraints in the "where" clause of a protocol extension.
 class SelfBoundsFromWhereClauseRequest :
     public SimpleRequest<SelfBoundsFromWhereClauseRequest,
                          CacheKind::Uncached,
-                         llvm::TinyPtrVector<NominalTypeDecl *>,
-                         ExtensionDecl *> {
+                         SelfBounds,
+                         llvm::PointerUnion<TypeDecl *, ExtensionDecl *>> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -196,12 +201,12 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::TinyPtrVector<NominalTypeDecl *> evaluate(Evaluator &evaluator,
-                                                  ExtensionDecl *ext) const;
+  SelfBounds evaluate(Evaluator &evaluator,
+                      llvm::PointerUnion<TypeDecl *, ExtensionDecl *>) const;
 
 public:
   // Cycle handling
-  llvm::TinyPtrVector<NominalTypeDecl *> breakCycle() const { return { }; }
+  SelfBounds breakCycle() const { return { }; }
   void diagnoseCycle(DiagnosticEngine &diags) const;
   void noteCycleStep(DiagnosticEngine &diags) const;
 };

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3642,7 +3642,7 @@ ProtocolDecl::getInheritedProtocols() const {
   SmallPtrSet<const ProtocolDecl *, 4> known;
   known.insert(this);
   bool anyObject = false;
-  for (const auto &found :
+  for (const auto found :
            getDirectlyInheritedNominalTypeDecls(
              const_cast<ProtocolDecl *>(this), anyObject)) {
     if (auto proto = dyn_cast<ProtocolDecl>(found.second)) {
@@ -3758,12 +3758,14 @@ bool ProtocolDecl::requiresClassSlow() {
     getDirectlyInheritedNominalTypeDecls(this, anyObject);
 
   // Quick check: do we inherit AnyObject?
-  if (anyObject)
-    return Bits.ProtocolDecl.RequiresClass = true;
+  if (anyObject) {
+    Bits.ProtocolDecl.RequiresClass = true;
+    return true;
+  }
 
   // Look through all of the inherited nominals for a superclass or a
   // class-bound protocol.
-  for (const auto &found : allInheritedNominals) {
+  for (const auto found : allInheritedNominals) {
     // Superclass bound.
     if (isa<ClassDecl>(found.second))
       return Bits.ProtocolDecl.RequiresClass = true;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7251,19 +7251,18 @@ void GenericSignatureBuilder::enumerateRequirements(
     // Enumerate conformance requirements.
     SmallVector<ProtocolDecl *, 4> protocols;
     DenseMap<ProtocolDecl *, const RequirementSource *> protocolSources;
-    if (equivClass) {
-      for (const auto &conforms : equivClass->conformsTo) {
-        protocols.push_back(conforms.first);
-        assert(protocolSources.count(conforms.first) == 0 && 
-               "redundant protocol requirement?");
 
-        protocolSources.insert(
-          {conforms.first,
-           *getBestConstraintSource<ProtocolDecl *>(conforms.second,
-             [&](ProtocolDecl *proto) {
-               return proto == conforms.first;
-             })});
-      }
+    for (const auto &conforms : equivClass->conformsTo) {
+      protocols.push_back(conforms.first);
+      assert(protocolSources.count(conforms.first) == 0 &&
+             "redundant protocol requirement?");
+
+      protocolSources.insert(
+        {conforms.first,
+         *getBestConstraintSource<ProtocolDecl *>(conforms.second,
+           [&](ProtocolDecl *proto) {
+             return proto == conforms.first;
+           })});
     }
 
     // Sort the protocols in canonical order.

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -121,15 +121,21 @@ void ExtendedNominalRequest::noteCycleStep(DiagnosticEngine &diags) const {
 void SelfBoundsFromWhereClauseRequest::diagnoseCycle(
                                               DiagnosticEngine &diags) const {
   // FIXME: Improve this diagnostic.
-  auto ext = std::get<0>(getStorage());
-  diags.diagnose(ext, diag::circular_reference);
+  auto subject = std::get<0>(getStorage());
+  Decl *decl = subject.dyn_cast<TypeDecl *>();
+  if (decl == nullptr)
+    decl = subject.get<ExtensionDecl *>();
+  diags.diagnose(decl, diag::circular_reference);
 }
 
 void SelfBoundsFromWhereClauseRequest::noteCycleStep(
                                               DiagnosticEngine &diags) const {
-  auto ext = std::get<0>(getStorage());
   // FIXME: Customize this further.
-  diags.diagnose(ext, diag::circular_reference_through);
+  auto subject = std::get<0>(getStorage());
+  Decl *decl = subject.dyn_cast<TypeDecl *>();
+  if (decl == nullptr)
+    decl = subject.get<ExtensionDecl *>();
+  diags.diagnose(decl, diag::circular_reference_through);
 }
 
 void TypeDeclsFromWhereClauseRequest::diagnoseCycle(

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3044,7 +3044,6 @@ public:
     checkAccessControl(TC, PD);
 
     checkInheritanceClause(PD);
-    checkProtocolSelfRequirements(PD, PD);
 
     TC.checkDeclCircularity(PD);
     if (PD->isResilient())

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -549,7 +549,7 @@ namespace {
 
     /// The set of declarations in which we'll look for overridden
     /// methods.
-    DirectlyReferencedTypeDecls superContexts;
+    SmallVector<NominalTypeDecl *, 2> superContexts;
 
     /// Cached member lookup results.
     SmallVector<ValueDecl *, 4> members;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3083,9 +3083,12 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
   Type sugaredBaseTy = baseTy;
 
   // For type members of a base class, make sure we use the right
-  // derived class as the parent type.
-  if (auto *ownerClass = member->getDeclContext()->getSelfClassDecl()) {
-    baseTy = baseTy->getSuperclassForDecl(ownerClass, useArchetypes);
+  // derived class as the parent type. If the base type is an error
+  // type, we have an invalid extension, so do nothing.
+  if (!baseTy->is<ErrorType>()) {
+    if (auto *ownerClass = member->getDeclContext()->getSelfClassDecl()) {
+      baseTy = baseTy->getSuperclassForDecl(ownerClass, useArchetypes);
+    }
   }
 
   if (baseTy->is<ModuleType>()) {

--- a/test/IRGen/protocol_with_superclass_where_clause.sil
+++ b/test/IRGen/protocol_with_superclass_where_clause.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -module-name protocol_with_superclass | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime -DINT=i%target-ptrsize
 
 sil_stage canonical
 
@@ -11,11 +11,11 @@ class Concrete {}
 
 class SubConcrete : Concrete {}
 
-protocol SuperProto : AnyObject {}
+protocol SuperProto where Self : AnyObject {}
 
-protocol ProtoRefinesClass : SuperProto, Concrete {}
+protocol ProtoRefinesClass where Self : SuperProto, Self : Concrete {}
 
-protocol SubProto : ProtoRefinesClass {}
+protocol SubProto where Self : ProtoRefinesClass {}
 
 protocol OtherProto {}
 

--- a/test/SILGen/protocol_with_superclass_where_clause.swift
+++ b/test/SILGen/protocol_with_superclass_where_clause.swift
@@ -1,0 +1,252 @@
+// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name protocol_with_superclass %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-sil-ownership %s
+
+// Protocols with superclass-constrained Self, written using a 'where' clause.
+
+class Concrete {
+  typealias ConcreteAlias = String
+
+  func concreteMethod(_: ConcreteAlias) {}
+}
+
+class Generic<T> : Concrete {
+  typealias GenericAlias = (T, T)
+
+  func genericMethod(_: GenericAlias) {}
+}
+
+protocol BaseProto {}
+
+protocol ProtoRefinesClass where Self : Generic<Int>, Self : BaseProto {
+  func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias)
+}
+
+extension ProtoRefinesClass {
+  // CHECK-LABEL: sil hidden @$s24protocol_with_superclass17ProtoRefinesClassPAAE019extensionMethodUsesF5TypesyySS_Si_SittF : $@convention(method) <Self where Self : ProtoRefinesClass> (@guaranteed String, Int, Int, @guaranteed Self) -> ()
+  func extensionMethodUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
+    _ = ConcreteAlias.self
+    _ = GenericAlias.self
+
+    // CHECK:      [[SELF:%.*]] = copy_value %3 : $Self
+    // CHECK-NEXT: [[UPCAST:%.*]] = upcast [[SELF]] : $Self to $Generic<Int>
+    // CHECK-NEXT: [[UPCAST2:%.*]] = upcast [[UPCAST]] : $Generic<Int> to $Concrete
+    // CHECK-NEXT: [[BORROW:%.*]] = begin_borrow [[UPCAST2]] : $Concrete
+    // CHECK-NEXT: [[METHOD:%.*]] = class_method [[BORROW:%.*]] : $Concrete, #Concrete.concreteMethod!1 : (Concrete) -> (String) -> (), $@convention(method) (@guaranteed String, @guaranteed Concrete) -> ()
+    // CHECK-NEXT: apply [[METHOD]](%0, [[BORROW]])
+    // CHECK-NEXT: end_borrow [[BORROW]]
+    // CHECK-NEXT: destroy_value [[UPCAST2]]
+    concreteMethod(x)
+
+    // CHECK:      [[SELF:%.*]] = copy_value %3 : $Self
+    // CHECK-NEXT: [[UPCAST:%.*]] = upcast [[SELF]] : $Self to $Generic<Int>
+    // CHECK-NEXT: [[BORROW:%.*]] = begin_borrow [[UPCAST]] : $Generic<Int>
+    // CHECK:      [[METHOD:%.*]] = class_method [[BORROW:%.*]] : $Generic<Int>, #Generic.genericMethod!1 : <T> (Generic<T>) -> ((T, T)) -> (), $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @guaranteed Generic<τ_0_0>) -> ()
+    // CHECK-NEXT: apply [[METHOD]]<Int>({{.*}}, [[BORROW]])
+    // CHECK:      end_borrow [[BORROW]]
+    // CHECK-NEXT: destroy_value [[UPCAST]]
+    genericMethod(y)
+
+    // CHECK:      [[SELF:%.*]] = copy_value %3 : $Self
+    // CHECK-NEXT: [[UPCAST:%.*]] = upcast [[SELF]] : $Self to $Generic<Int>
+    // CHECK-NEXT: destroy_value [[UPCAST]] : $Generic<Int>
+    let _: Generic<Int> = self
+
+    // CHECK:      [[SELF:%.*]] = copy_value %3 : $Self
+    // CHECK-NEXT: [[UPCAST:%.*]] = upcast [[SELF]] : $Self to $Generic<Int>
+    // CHECK-NEXT: [[UPCAST2:%.*]] = upcast [[UPCAST]] : $Generic<Int> to $Concrete
+    // CHECK-NEXT: destroy_value [[UPCAST2]] : $Concrete
+    let _: Concrete = self
+
+    // CHECK:      [[BOX:%.*]] = alloc_stack $BaseProto
+    // CHECK-NEXT: [[SELF:%.*]] = copy_value %3 : $Self
+    // CHECK-NEXT: [[ADDR:%.*]] = init_existential_addr [[BOX]] : $*BaseProto, $Self
+    // CHECK-NEXT: store [[SELF]] to [init] [[ADDR]] : $*Self
+    // CHECK-NEXT: destroy_addr [[BOX]] : $*BaseProto
+    // CHECK-NEXT: dealloc_stack [[BOX]] : $*BaseProto
+    let _: BaseProto = self
+
+    // CHECK:      [[SELF:%.*]] = copy_value %3 : $Self
+    // CHECK-NEXT: [[EXISTENTIAL:%.*]] = init_existential_ref [[SELF]] : $Self : $Self, $Generic<Int> & BaseProto
+    let _: BaseProto & Generic<Int> = self
+    
+    // CHECK:      [[SELF:%.*]] = copy_value %3 : $Self
+    // CHECK-NEXT: [[EXISTENTIAL:%.*]] = init_existential_ref [[SELF]] : $Self : $Self, $Concrete & BaseProto
+    let _: BaseProto & Concrete = self
+
+    // CHECK:      return
+  }
+}
+
+// CHECK-LABEL: sil hidden @$s24protocol_with_superclass22usesProtoRefinesClass1yyAA0eF5Class_pF : $@convention(thin) (@guaranteed ProtoRefinesClass) -> ()
+func usesProtoRefinesClass1(_ t: ProtoRefinesClass) {
+  let x: ProtoRefinesClass.ConcreteAlias = "hi"
+  _ = ProtoRefinesClass.ConcreteAlias.self
+
+  t.concreteMethod(x)
+
+  let y: ProtoRefinesClass.GenericAlias = (1, 2)
+  _ = ProtoRefinesClass.GenericAlias.self
+
+  t.genericMethod(y)
+
+  t.requirementUsesClassTypes(x, y)
+
+  let _: Generic<Int> = t
+  let _: Concrete = t
+  let _: BaseProto = t
+  let _: BaseProto & Generic<Int> = t
+  let _: BaseProto & Concrete = t
+}
+
+// CHECK-LABEL: sil hidden @$s24protocol_with_superclass22usesProtoRefinesClass2yyxAA0eF5ClassRzlF : $@convention(thin) <T where T : ProtoRefinesClass> (@guaranteed T) -> ()
+func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
+  let x: T.ConcreteAlias = "hi"
+  _ = T.ConcreteAlias.self
+
+  t.concreteMethod(x)
+
+  let y: T.GenericAlias = (1, 2)
+  _ = T.GenericAlias.self
+
+  t.genericMethod(y)
+
+  t.requirementUsesClassTypes(x, y)
+
+  let _: Generic<Int> = t
+  let _: Concrete = t
+  let _: BaseProto = t
+  let _: BaseProto & Generic<Int> = t
+  let _: BaseProto & Concrete = t
+}
+
+class GoodConformingClass : Generic<Int>, ProtoRefinesClass {
+  // CHECK-LABEL: sil hidden @$s24protocol_with_superclass19GoodConformingClassC015requirementUsesF5TypesyySS_Si_SittF : $@convention(method) (@guaranteed String, Int, Int, @guaranteed GoodConformingClass) -> ()
+  func requirementUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
+    _ = ConcreteAlias.self
+    _ = GenericAlias.self
+
+    concreteMethod(x)
+
+    genericMethod(y)
+  }
+}
+
+protocol ProtoRefinesProtoWithClass where Self : ProtoRefinesClass {}
+
+extension ProtoRefinesProtoWithClass {
+  // CHECK-LABEL: sil hidden @$s24protocol_with_superclass012ProtoRefinesD9WithClassPAAE026anotherExtensionMethodUsesG5TypesyySS_Si_SittF : $@convention(method) <Self where Self : ProtoRefinesProtoWithClass> (@guaranteed String, Int, Int, @guaranteed Self) -> () 
+  func anotherExtensionMethodUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
+    _ = ConcreteAlias.self
+    _ = GenericAlias.self
+
+    concreteMethod(x)
+    genericMethod(y)
+
+    let _: Generic<Int> = self
+    let _: Concrete = self
+    let _: BaseProto = self
+    let _: BaseProto & Generic<Int> = self
+    let _: BaseProto & Concrete = self
+  }
+}
+
+// CHECK-LABEL: sil hidden @$s24protocol_with_superclass016usesProtoRefinesE10WithClass1yyAA0efeG5Class_pF : $@convention(thin) (@guaranteed ProtoRefinesProtoWithClass) -> ()
+func usesProtoRefinesProtoWithClass1(_ t: ProtoRefinesProtoWithClass) {
+  let x: ProtoRefinesProtoWithClass.ConcreteAlias = "hi"
+  _ = ProtoRefinesProtoWithClass.ConcreteAlias.self
+
+  t.concreteMethod(x)
+
+  let y: ProtoRefinesProtoWithClass.GenericAlias = (1, 2)
+  _ = ProtoRefinesProtoWithClass.GenericAlias.self
+
+  t.genericMethod(y)
+
+  t.requirementUsesClassTypes(x, y)
+
+  let _: Generic<Int> = t
+  let _: Concrete = t
+  let _: BaseProto = t
+  let _: BaseProto & Generic<Int> = t
+  let _: BaseProto & Concrete = t
+}
+
+// CHECK-LABEL: sil hidden @$s24protocol_with_superclass016usesProtoRefinesE10WithClass2yyxAA0efeG5ClassRzlF : $@convention(thin) <T where T : ProtoRefinesProtoWithClass> (@guaranteed T) -> ()
+func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
+  let x: T.ConcreteAlias = "hi"
+  _ = T.ConcreteAlias.self
+
+  t.concreteMethod(x)
+
+  let y: T.GenericAlias = (1, 2)
+  _ = T.GenericAlias.self
+
+  t.genericMethod(y)
+
+  t.requirementUsesClassTypes(x, y)
+
+  let _: Generic<Int> = t
+  let _: Concrete = t
+  let _: BaseProto = t
+  let _: BaseProto & Generic<Int> = t
+  let _: BaseProto & Concrete = t
+}
+
+class ClassWithInits<T> {
+  init(notRequiredInit: ()) {}
+
+  required init(requiredInit: ()) {}
+}
+
+protocol ProtocolWithClassInits where Self : ClassWithInits<Int> {}
+
+// CHECK-LABEL: sil hidden @$s24protocol_with_superclass26useProtocolWithClassInits1yyAA0efG5Inits_pXpF : $@convention(thin) (@thick ProtocolWithClassInits.Type) -> ()
+func useProtocolWithClassInits1(_ t: ProtocolWithClassInits.Type) {
+  // CHECK: [[OPENED:%.*]] = open_existential_metatype %0 : $@thick ProtocolWithClassInits.Type
+  // CHECK-NEXT: [[UPCAST:%.*]] = upcast [[OPENED]] : $@thick (@opened("{{.*}}") ProtocolWithClassInits).Type to $@thick ClassWithInits<Int>.Type
+  // CHECK-NEXT: [[METHOD:%.*]] = class_method [[UPCAST]] : $@thick ClassWithInits<Int>.Type, #ClassWithInits.init!allocator.1 : <T> (ClassWithInits<T>.Type) -> (()) -> ClassWithInits<T>, $@convention(method) <τ_0_0> (@thick ClassWithInits<τ_0_0>.Type) -> @owned ClassWithInits<τ_0_0>
+  // CHECK-NEXT: [[RESULT:%.*]] = apply [[METHOD]]<Int>([[UPCAST]])
+  // CHECK-NEXT: [[CAST:%.*]] = unchecked_ref_cast [[RESULT]] : $ClassWithInits<Int> to $@opened("{{.*}}") ProtocolWithClassInits
+  // CHECK-NEXT: [[EXISTENTIAL:%.*]] = init_existential_ref [[CAST]] : $@opened("{{.*}}") ProtocolWithClassInits : $@opened("{{.*}}") ProtocolWithClassInits, $ProtocolWithClassInits
+  // CHECK-NEXT: destroy_value [[EXISTENTIAL]]
+  let _: ProtocolWithClassInits = t.init(requiredInit: ())
+}
+
+// CHECK-LABEL: sil hidden @$s24protocol_with_superclass26useProtocolWithClassInits2yyxmAA0efG5InitsRzlF : $@convention(thin) <T where T : ProtocolWithClassInits> (@thick T.Type) -> ()
+func useProtocolWithClassInits2<T : ProtocolWithClassInits>(_ t: T.Type) {
+  let _: T = T(requiredInit: ())
+
+  let _: T = t.init(requiredInit: ())
+}
+
+protocol ProtocolRefinesClassInits where Self : ProtocolWithClassInits {}
+
+// CHECK-LABEL: sil hidden @$s24protocol_with_superclass29useProtocolRefinesClassInits1yyAA0efG5Inits_pXpF : $@convention(thin) (@thick ProtocolRefinesClassInits.Type) -> ()
+func useProtocolRefinesClassInits1(_ t: ProtocolRefinesClassInits.Type) {
+  let _: ProtocolRefinesClassInits = t.init(requiredInit: ())
+}
+
+// CHECK-LABEL: sil hidden @$s24protocol_with_superclass29useProtocolRefinesClassInits2yyxmAA0efG5InitsRzlF : $@convention(thin) <T where T : ProtocolRefinesClassInits> (@thick T.Type) -> ()
+func useProtocolRefinesClassInits2<T : ProtocolRefinesClassInits>(_ t: T.Type) {
+  let _: T = T(requiredInit: ())
+
+  let _: T = t.init(requiredInit: ())
+}
+
+class ClassWithDefault<T> {
+  func makeT() -> T { while true {} }
+}
+
+protocol SillyDefault where Self : ClassWithDefault<Int> {
+  func makeT() -> Int
+}
+
+class ConformsToSillyDefault : ClassWithDefault<Int>, SillyDefault {}
+
+// CHECK-LABEL: sil private [transparent] [thunk] @$s24protocol_with_superclass22ConformsToSillyDefaultCAA0fG0A2aDP5makeTSiyFTW : $@convention(witness_method: SillyDefault) (@guaranteed ConformsToSillyDefault) -> Int
+// CHECK: class_method %1 : $ClassWithDefault<Int>, #ClassWithDefault.makeT!1 : <T> (ClassWithDefault<T>) -> () -> T, $@convention(method) <τ_0_0> (@guaranteed ClassWithDefault<τ_0_0>) -> @out τ_0_0
+// CHECK: return
+
+// CHECK-LABEL: sil_witness_table hidden ConformsToSillyDefault: SillyDefault module protocol_with_superclass {
+// CHECK-NEXT: method #SillyDefault.makeT!1: <Self where Self : SillyDefault> (Self) -> () -> Int : @$s24protocol_with_superclass22ConformsToSillyDefaultCAA0fG0A2aDP5makeTSiyFTW
+// CHECK-NEXT: }

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -313,3 +313,24 @@ class FirstConformer : FirstClass, SecondProtocol {}
 // expected-note@-2 {{requirement specified as 'Self' : 'SecondClass' [with Self = FirstConformer]}}
 
 class SecondConformer : SecondClass, SecondProtocol {}
+
+// Duplicate superclass
+// FIXME: Duplicate diagnostics
+protocol DuplicateSuper : Concrete, Concrete {}
+// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' written here}}
+// expected-warning@-2 {{redundant superclass constraint 'Self' : 'Concrete'}}
+// expected-error@-3 {{duplicate inheritance from 'Concrete'}}
+
+// Ambigous name lookup situation
+protocol Amb : Concrete {}
+// expected-note@-1 {{'Amb' previously declared here}}
+// expected-note@-2 {{found this candidate}}
+protocol Amb : Concrete {}
+// expected-error@-1 {{invalid redeclaration of 'Amb'}}
+// expected-note@-2 {{found this candidate}}
+
+extension Amb { // expected-error {{'Amb' is ambiguous for type lookup in this context}}
+  func extensionMethodUsesClassTypes() {
+    _ = ConcreteAlias.self
+  }
+}

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -1,0 +1,338 @@
+// RUN: %target-typecheck-verify-swift
+
+// Protocols with superclass-constrained Self.
+
+class Concrete {
+  typealias ConcreteAlias = String
+
+  func concreteMethod(_: ConcreteAlias) {}
+}
+
+class Generic<T> : Concrete {
+  typealias GenericAlias = (T, T)
+
+  func genericMethod(_: GenericAlias) {}
+}
+
+protocol BaseProto {}
+
+protocol ProtoRefinesClass where Self : Generic<Int>, Self : BaseProto {
+  func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias)
+  // expected-note@-1 {{protocol requires function 'requirementUsesClassTypes' with type '(Generic<Int>.ConcreteAlias, Generic<Int>.GenericAlias) -> ()' (aka '(String, (Int, Int)) -> ()'); do you want to add a stub?}}
+}
+
+func duplicateOverload<T : ProtoRefinesClass>(_: T) {}
+// expected-note@-1 {{'duplicateOverload' previously declared here}}
+
+func duplicateOverload<T : ProtoRefinesClass & Generic<Int>>(_: T) {}
+// expected-error@-1 {{invalid redeclaration of 'duplicateOverload'}}
+// expected-warning@-2 {{redundant superclass constraint 'T' : 'Generic<Int>'}}
+// expected-note@-3 {{superclass constraint 'T' : 'Generic<Int>' implied here}}
+
+extension ProtoRefinesClass {
+  func extensionMethodUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
+    _ = ConcreteAlias.self
+    _ = GenericAlias.self
+
+    concreteMethod(x)
+    genericMethod(y)
+
+    let _: Generic<Int> = self
+    let _: Concrete = self
+    let _: BaseProto = self
+    let _: BaseProto & Generic<Int> = self
+    let _: BaseProto & Concrete = self
+
+    let _: Generic<String> = self
+    // expected-error@-1 {{cannot convert value of type 'Self' to specified type 'Generic<String>'}}
+  }
+}
+
+func usesProtoRefinesClass1(_ t: ProtoRefinesClass) {
+  let x: ProtoRefinesClass.ConcreteAlias = "hi"
+  _ = ProtoRefinesClass.ConcreteAlias.self
+
+  t.concreteMethod(x)
+
+  let y: ProtoRefinesClass.GenericAlias = (1, 2)
+  _ = ProtoRefinesClass.GenericAlias.self
+
+  t.genericMethod(y)
+
+  t.requirementUsesClassTypes(x, y)
+
+  let _: Generic<Int> = t
+  let _: Concrete = t
+  let _: BaseProto = t
+  let _: BaseProto & Generic<Int> = t
+  let _: BaseProto & Concrete = t
+
+  let _: Generic<String> = t
+  // expected-error@-1 {{cannot convert value of type 'ProtoRefinesClass' to specified type 'Generic<String>'}}
+}
+
+func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
+  let x: T.ConcreteAlias = "hi"
+  _ = T.ConcreteAlias.self
+
+  t.concreteMethod(x)
+
+  let y: T.GenericAlias = (1, 2)
+  _ = T.GenericAlias.self
+
+  t.genericMethod(y)
+
+  t.requirementUsesClassTypes(x, y)
+
+  let _: Generic<Int> = t
+  let _: Concrete = t
+  let _: BaseProto = t
+  let _: BaseProto & Generic<Int> = t
+  let _: BaseProto & Concrete = t
+
+  let _: Generic<String> = t
+  // expected-error@-1 {{cannot convert value of type 'T' to specified type 'Generic<String>'}}
+}
+
+class BadConformingClass1 : ProtoRefinesClass {
+  // expected-error@-1 {{'ProtoRefinesClass' requires that 'BadConformingClass1' inherit from 'Generic<Int>'}}
+  // expected-note@-2 {{requirement specified as 'Self' : 'Generic<Int>' [with Self = BadConformingClass1]}}
+  func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias) {
+    // expected-error@-1 {{use of undeclared type 'ConcreteAlias'}}
+    // expected-error@-2 {{use of undeclared type 'GenericAlias'}}
+
+    _ = ConcreteAlias.self
+    // expected-error@-1 {{use of unresolved identifier 'ConcreteAlias'}}
+    _ = GenericAlias.self
+    // expected-error@-1 {{use of unresolved identifier 'GenericAlias'}}
+  }
+}
+
+class BadConformingClass2 : Generic<String>, ProtoRefinesClass {
+  // expected-error@-1 {{'ProtoRefinesClass' requires that 'BadConformingClass2' inherit from 'Generic<Int>'}}
+  // expected-note@-2 {{requirement specified as 'Self' : 'Generic<Int>' [with Self = BadConformingClass2]}}
+  // expected-error@-3 {{type 'BadConformingClass2' does not conform to protocol 'ProtoRefinesClass'}}
+  func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias) {
+    // expected-note@-1 {{candidate has non-matching type '(BadConformingClass2.ConcreteAlias, BadConformingClass2.GenericAlias) -> ()' (aka '(String, (String, String)) -> ()')}}
+    _ = ConcreteAlias.self
+    _ = GenericAlias.self
+  }
+}
+
+class GoodConformingClass : Generic<Int>, ProtoRefinesClass {
+  func requirementUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
+    _ = ConcreteAlias.self
+    _ = GenericAlias.self
+
+    concreteMethod(x)
+
+    genericMethod(y)
+  }
+}
+
+protocol ProtoRefinesProtoWithClass where Self : ProtoRefinesClass {}
+
+extension ProtoRefinesProtoWithClass {
+  func anotherExtensionMethodUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
+    _ = ConcreteAlias.self
+    _ = GenericAlias.self
+
+    concreteMethod(x)
+    genericMethod(y)
+
+    let _: Generic<Int> = self
+    let _: Concrete = self
+    let _: BaseProto = self
+    let _: BaseProto & Generic<Int> = self
+    let _: BaseProto & Concrete = self
+
+    let _: Generic<String> = self
+    // expected-error@-1 {{cannot convert value of type 'Self' to specified type 'Generic<String>'}}
+  }
+}
+
+func usesProtoRefinesProtoWithClass1(_ t: ProtoRefinesProtoWithClass) {
+  let x: ProtoRefinesProtoWithClass.ConcreteAlias = "hi"
+  _ = ProtoRefinesProtoWithClass.ConcreteAlias.self
+
+  t.concreteMethod(x)
+
+  let y: ProtoRefinesProtoWithClass.GenericAlias = (1, 2)
+  _ = ProtoRefinesProtoWithClass.GenericAlias.self
+
+  t.genericMethod(y)
+
+  t.requirementUsesClassTypes(x, y)
+
+  let _: Generic<Int> = t
+  let _: Concrete = t
+  let _: BaseProto = t
+  let _: BaseProto & Generic<Int> = t
+  let _: BaseProto & Concrete = t
+
+  let _: Generic<String> = t
+  // expected-error@-1 {{cannot convert value of type 'ProtoRefinesProtoWithClass' to specified type 'Generic<String>'}}
+}
+
+func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
+  let x: T.ConcreteAlias = "hi"
+  _ = T.ConcreteAlias.self
+
+  t.concreteMethod(x)
+
+  let y: T.GenericAlias = (1, 2)
+  _ = T.GenericAlias.self
+
+  t.genericMethod(y)
+
+  t.requirementUsesClassTypes(x, y)
+
+  let _: Generic<Int> = t
+  let _: Concrete = t
+  let _: BaseProto = t
+  let _: BaseProto & Generic<Int> = t
+  let _: BaseProto & Concrete = t
+
+  let _: Generic<String> = t
+  // expected-error@-1 {{cannot convert value of type 'T' to specified type 'Generic<String>'}}
+}
+
+class ClassWithInits<T> {
+  init(notRequiredInit: ()) {}
+  // expected-note@-1 6{{selected non-required initializer 'init(notRequiredInit:)'}}
+
+  required init(requiredInit: ()) {}
+}
+
+protocol ProtocolWithClassInits where Self : ClassWithInits<Int> {}
+
+func useProtocolWithClassInits1() {
+  _ = ProtocolWithClassInits(notRequiredInit: ())
+  // expected-error@-1 {{member 'init' cannot be used on type 'ProtocolWithClassInits'}}
+
+  _ = ProtocolWithClassInits(requiredInit: ())
+  // expected-error@-1 {{member 'init' cannot be used on type 'ProtocolWithClassInits'}}
+}
+
+func useProtocolWithClassInits2(_ t: ProtocolWithClassInits.Type) {
+  _ = t.init(notRequiredInit: ())
+  // expected-error@-1 {{constructing an object of class type 'ProtocolWithClassInits' with a metatype value must use a 'required' initializer}}
+
+  let _: ProtocolWithClassInits = t.init(requiredInit: ())
+}
+
+func useProtocolWithClassInits3<T : ProtocolWithClassInits>(_ t: T.Type) {
+  _ = T(notRequiredInit: ())
+  // expected-error@-1 {{constructing an object of class type 'T' with a metatype value must use a 'required' initializer}}
+
+  let _: T = T(requiredInit: ())
+
+  _ = t.init(notRequiredInit: ())
+  // expected-error@-1 {{constructing an object of class type 'T' with a metatype value must use a 'required' initializer}}
+
+  let _: T = t.init(requiredInit: ())
+}
+
+protocol ProtocolRefinesClassInits : ProtocolWithClassInits {}
+
+func useProtocolRefinesClassInits1() {
+  _ = ProtocolRefinesClassInits(notRequiredInit: ())
+  // expected-error@-1 {{member 'init' cannot be used on type 'ProtocolRefinesClassInits'}}
+
+  _ = ProtocolRefinesClassInits(requiredInit: ())
+  // expected-error@-1 {{member 'init' cannot be used on type 'ProtocolRefinesClassInits'}}
+}
+
+func useProtocolRefinesClassInits2(_ t: ProtocolRefinesClassInits.Type) {
+  _ = t.init(notRequiredInit: ())
+  // expected-error@-1 {{constructing an object of class type 'ProtocolRefinesClassInits' with a metatype value must use a 'required' initializer}}
+
+  let _: ProtocolRefinesClassInits = t.init(requiredInit: ())
+}
+
+func useProtocolRefinesClassInits3<T : ProtocolRefinesClassInits>(_ t: T.Type) {
+  _ = T(notRequiredInit: ())
+  // expected-error@-1 {{constructing an object of class type 'T' with a metatype value must use a 'required' initializer}}
+
+  let _: T = T(requiredInit: ())
+
+  _ = t.init(notRequiredInit: ())
+  // expected-error@-1 {{constructing an object of class type 'T' with a metatype value must use a 'required' initializer}}
+
+  let _: T = t.init(requiredInit: ())
+}
+
+// Make sure that we don't require 'mutating' when the protocol has a superclass
+// constraint.
+protocol HasMutableProperty : Concrete {
+  var mutableThingy: Any? { get set }
+}
+
+extension HasMutableProperty {
+  func mutateThingy() {
+    mutableThingy = nil
+  }
+}
+
+// Some pathological examples -- just make sure they don't crash.
+
+protocol RecursiveSelf where Self : Generic<Self> {}
+// expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self>' is recursive}}
+
+protocol RecursiveAssociatedType where Self : Generic<Self.X> {
+  // expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self.X>' is recursive}}
+  associatedtype X
+}
+
+protocol BaseProtocol {
+  typealias T = Int
+}
+
+class BaseClass : BaseProtocol {}
+
+protocol RefinedProtocol where Self : BaseClass {
+  func takesT(_: T)
+}
+
+class RefinedClass : BaseClass, RefinedProtocol {
+  func takesT(_: T) {
+    _ = T.self
+  }
+}
+
+class LoopClass : LoopProto {}
+protocol LoopProto where Self : LoopClass {}
+
+class FirstClass {}
+protocol FirstProtocol where Self : FirstClass {}
+class SecondClass : FirstClass {}
+protocol SecondProtocol where Self : SecondClass, Self : FirstProtocol {}
+
+class FirstConformer : FirstClass, SecondProtocol {}
+// expected-error@-1 {{'SecondProtocol' requires that 'FirstConformer' inherit from 'SecondClass'}}
+// expected-note@-2 {{requirement specified as 'Self' : 'SecondClass' [with Self = FirstConformer]}}
+
+class SecondConformer : SecondClass, SecondProtocol {}
+
+// Duplicate superclass
+// FIXME: Should be an error here too
+protocol DuplicateSuper1 : Concrete where Self : Concrete {}
+// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' written here}}
+// expected-warning@-2 {{redundant superclass constraint 'Self' : 'Concrete'}}
+protocol DuplicateSuper2 where Self : Concrete, Self : Concrete {}
+// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' written here}}
+// expected-warning@-2 {{redundant superclass constraint 'Self' : 'Concrete'}}
+
+// Ambiguous name lookup situation
+protocol Amb where Self : Concrete {}
+// expected-note@-1 {{'Amb' previously declared here}}
+// expected-note@-2 {{found this candidate}}
+protocol Amb where Self : Concrete {}
+// expected-error@-1 {{invalid redeclaration of 'Amb'}}
+// expected-note@-2 {{found this candidate}}
+
+extension Amb { // expected-error {{'Amb' is ambiguous for type lookup in this context}}
+  func extensionMethodUsesClassTypes() {
+    _ = ConcreteAlias.self
+  }
+}

--- a/test/decl/protocol/req/where_clause.swift
+++ b/test/decl/protocol/req/where_clause.swift
@@ -17,9 +17,12 @@ protocol P3 : P2 {
 
 func foo<S>(_: S) where S.SubSequence.Element == C1, S : P3 {}
 
-// Invalid where clauses
-protocol InvalidWhereClause1 where Self: AnyObject {}
-// expected-error@-1 {{constraint with subject type of 'Self' is not supported; consider adding requirement to protocol inheritance clause instead}}
+protocol SelfWhereClause where Self: AnyObject {}
+
+func takesAnyObject<T : AnyObject>(_: T) {}
+func takesSelfWhereClause<T : SelfWhereClause>(_ t: T) {
+  takesAnyObject(t)
+}
 
 class AlsoBad {}
 


### PR DESCRIPTION
This sort of worked in 4.2, then I banned it but it broke source comaptibility.
    
Now that protocol superclass constraints are fully supported, let's allow this again, with some minor refactoring to the request evaluator.

So both of these are equivalent and should work correctly:

```
protocol P : SomeClass {}
protocol P where Self : SomeClass {}
```
    
Fixes <rdar://problem/43028442>.