### PR TITLE
[android] Fix powl test in Android ARMv7/AArch64.

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -87,6 +87,12 @@ public typealias CLongDouble = Float80
 // Long Double type equivalent to Double type.
 public typealias CLongDouble = Double
 #endif
+#elseif os(Android)
+// On Android, long double is Float128 for AAPCS64, which we don't have yet in
+// Swift (SR-9072); and Double for ARMv7.
+#if arch(arm)
+public typealias CLongDouble = Double
+#endif
 #endif
 
 // FIXME: Is it actually UTF-32 on Darwin?

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -58,9 +58,13 @@ func test_pow() {
   pow(1.5, 2.5)
 }
 
+#if !((os(Android) || os(Linux)) && arch(arm64))
+// long doubles in AAPCS64 are 128 bits, which is not supported by
+// Swift, so don't test this. SR-9072.
 func test_powl() {
   powl(1.5, 2.5)
 }
+#endif
 
 func test_puts(_ s: String) {
   _ = s.withCString { puts($0) + 32 };


### PR DESCRIPTION
In Android ARMv7 there was no alias defined for CLongDouble, so
importing anything with long double was failing. Defining the alias
makes the test pass.

AAPCS64 defines long double as 128 bits, which is still unsupported by
Swift (SR-9072). Disable this particular test for Android and Linux in
AArch64 to not fail (but still test all the other tests).