### PR TITLE
[IRGen] Use symbolic references to (file)private entities in mangled names

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -87,19 +87,29 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
   llvm::SaveAndRestore<std::function<bool (const DeclContext *)>>
     SymbolicReferencesForLocalTypes(CanSymbolicReference);
   
-  if (IGM.CurSourceFile
-      && !isa<ClangModuleUnit>(IGM.CurSourceFile)
+  if ((!IGM.CurSourceFile || !isa<ClangModuleUnit>(IGM.CurSourceFile))
       && !IGM.getOptions().IntegratedREPL) {
     CanSymbolicReference = [&](const DeclContext *dc) -> bool {
+      // Can only symbolically reference nominal type declarations.
+      auto nominal = dyn_cast<NominalTypeDecl>(dc);
+      if (!nominal || isa<ProtocolDecl>(dc))
+        return false;
+
       // Symbolically reference types that are defined in the same file unit
       // as we're referencing from.
-      //
-      // We could eventually improve this to reference any type that ends
+      if (IGM.CurSourceFile &&
+          dc->getModuleScopeContext() == IGM.CurSourceFile)
+        return true;
+
+      // fileprivate and private entities are always in the same file unit
+      // that they're referenced from.
+      if (nominal->getEffectiveAccess() < AccessLevel::Internal)
+        return true;
+
+      // FIXME: We could eventually improve this to reference any type that ends
       // up with its nominal type descriptor in the same linked binary as us,
       // but IRGen doesn't know that with much certainty currently.
-      return dc->getModuleScopeContext() == IGM.CurSourceFile
-        && isa<NominalTypeDecl>(dc)
-        && !isa<ProtocolDecl>(dc);
+      return false;
     };
   }
   

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -12,6 +12,16 @@ protocol Assocked {
 
 struct Universal : P, Q {}
 
+
+// CHECK-LABEL: @"symbolic \01____ 23associated_type_witness12OuterPrivate{{.*}}V" = linkonce_odr hidden constant
+// CHECK-SAME: @"$s23associated_type_witness12OuterPrivate{{.*}}5InnerE0V9InnermostVMn"
+private struct OuterPrivate {
+  struct InnerPrivate: HasSimpleAssoc {
+    struct Innermost { }
+    typealias Assoc = Innermost
+  }
+}
+
 // CHECK: [[ASSOC_TYPE_NAMES:@.*]] = private constant [29 x i8] c"OneAssoc TwoAssoc ThreeAssoc\00"
 // CHECK: @"$s23associated_type_witness18HasThreeAssocTypesMp" =
 // CHECK-SAME: [[ASSOC_TYPE_NAMES]] to i64
@@ -120,7 +130,6 @@ protocol HasSimpleAssoc {
   associatedtype Assoc
 }
 protocol DerivedFromSimpleAssoc : HasSimpleAssoc {}
-
 
 //   Generic witness table pattern for GenericComputed : DerivedFromSimpleAssoc.
 // GLOBAL-LABEL: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWp" = internal constant [2 x i8*]

--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-stdlib %s -module-name main -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+
+import Swift
+import StdlibUnittest
+
+protocol P {
+  associatedtype A
+}
+
+fileprivate struct Foo {
+  fileprivate struct Inner: P {
+    fileprivate struct Innermost { }
+    typealias A = Innermost
+  }
+}
+
+func getP_A<T: P>(_: T.Type) -> Any.Type {
+  return T.A.self
+}
+
+let AssociatedTypeDemangleTests = TestSuite("AssociatedTypeDemangle")
+
+
+AssociatedTypeDemangleTests.test("private types") {
+  expectEqual(Foo.Inner.Innermost.self, getP_A(Foo.Inner.self))
+}
+
+runAllTests()


### PR DESCRIPTION
(file)private entities are always available in the current file, so use
symbolic references to refer to them within mangled names (always). This
also eliminates problems stemming from our inability to demangle names
referring to private entities, because we (intentionally) don't allow
lookup for them.

Should fix rdar://problem/44977236.
