### PR TITLE
Remove references to SWIFT3 from benchmark Cmake files.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -170,16 +170,13 @@ set(SWIFT_BENCH_MODULES
     single-source/XorLoop
 )
 
-set(SWIFT_MULTISOURCE_SWIFT3_BENCHES
+set(SWIFT_MULTISOURCE_SWIFT_BENCHES
   multi-source/PrimsSplit
 )
 
 set(PrimsSplit_sources
     multi-source/PrimsSplit/Prims.swift
     multi-source/PrimsSplit/Prims_main.swift)
-
-set(SWIFT_MULTISOURCE_SWIFT4_BENCHES
-)
 
 set(BENCH_DRIVER_LIBRARY_FLAGS)
 if (SWIFT_RUNTIME_ENABLE_LEAK_CHECKER)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -154,7 +154,7 @@ To add a new multiple file test:
     instance of BenchmarkInfo (specified in the template below).
 
 2.  In `CMakeLists.txt` add the new directory name to
-    `SWIFT_MULTISOURCE_SWIFT3_BENCHES`, and set `YourTestName_sources` to the
+    `SWIFT_MULTISOURCE_SWIFT_BENCHES`, and set `YourTestName_sources` to the
     list of source file paths.
 
 3.  Edit `main.swift`. Import and register your new Swift module.

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -468,43 +468,7 @@ function (swift_benchmark_compile_archopts)
     endif()
   endforeach()
 
-  foreach(module_name_path ${SWIFT_MULTISOURCE_SWIFT3_BENCHES})
-    get_filename_component(module_name "${module_name_path}" NAME)
-
-    if ("${bench_flags}" MATCHES "-whole-module.*" AND
-        NOT "${bench_flags}" MATCHES "-num-threads.*")
-      set(objfile_out)
-      add_swift_multisource_wmo_benchmark_library(objfile_out
-        MODULE_PATH "${module_name_path}"
-        SOURCE_DIR "${srcdir}"
-        OBJECT_DIR "${objdir}"
-        SOURCES ${${module_name}_sources}
-        LIBRARY_FLAGS ${common_swift4_options} ${bench_flags} ${SWIFT_BENCHMARK_EXTRA_FLAGS}
-        DEPENDS ${bench_library_objects} ${stdlib_dependencies})
-      precondition(objfile_out)
-      list(APPEND SWIFT_BENCH_OBJFILES "${objfile_out}")
-
-      if(opt_view_main_dir)
-        set(opt_view_dir)
-        add_opt_view(${opt_view_main_dir}, ${module_name}, opt_view_dir)
-        precondition(opt_view_dir)
-        list(APPEND opt_view_dirs ${opt_view_dir})
-      endif()
-    else()
-      set(objfiles_out)
-      add_swift_multisource_nonwmo_benchmark_library(objfiles_out
-        MODULE_PATH "${module_name_path}"
-        SOURCE_DIR "${srcdir}"
-        OBJECT_DIR "${objdir}"
-        SOURCES ${${module_name}_sources}
-        LIBRARY_FLAGS ${common_swift4_options} ${bench_flags} ${SWIFT_BENCHMARK_EXTRA_FLAGS}
-        DEPENDS ${bench_library_objects} ${stdlib_dependencies})
-      precondition(objfiles_out)
-      list(APPEND SWIFT_BENCH_OBJFILES ${objfiles_out})
-    endif()
-  endforeach()
-
-  foreach(module_name_path ${SWIFT_MULTISOURCE_SWIFT4_BENCHES})
+  foreach(module_name_path ${SWIFT_MULTISOURCE_SWIFT_BENCHES})
     get_filename_component(module_name "${module_name_path}" NAME)
 
     if ("${bench_flags}" MATCHES "-whole-module.*" AND


### PR DESCRIPTION
Swift 3 support is going away.
