### PR TITLE
[CSBindings] Cache already computed type variable bindings

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1561,7 +1561,6 @@ ConstraintSystem::matchTypesBindTypeVar(
   }
 
   assignFixedType(typeVar, type);
-
   return getTypeMatchSuccess();
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -232,6 +232,10 @@ void ConstraintSystem::addTypeVariableConstraintsToWorkList(
                              constraint);
     constraint->setActive(true);
   }
+
+  // Invalidate pre-computed bindings associated
+  // with this type variable (if any).
+  invalidateBindings(typeVar);
 }
 
 /// Retrieve a dynamic result signature for the given declaration.

--- a/validation-test/Sema/type_checker_perf/fast/rdar30596744_3.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30596744_3.swift.gyb
@@ -1,0 +1,15 @@
+// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+% array_elements = 20
+
+let _ = [
+%for i in range(0, N):
+  ${i} : [
+    %for j in range(array_elements):
+      "e${j}",
+    %end
+  ],
+%end
+]

--- a/validation-test/Sema/type_checker_perf/slow/rdar30596744_2.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar30596744_2.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select NumLeafScopes %s --expected-exit-code 1
+// RUN: %scale-test --invert-result --begin 1 --end 4 --step 1 --select NumLeafScopes %s --expected-exit-code 1
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
To avoid re-computing same bindings over and over again,
let's try to keep a cache of active bindings and invalidate
them as needed.

Invalidate bindings conservatively when new constraints are
introduced (even if such constraints are not going to result
in new type bindings), and when type variables are assigned
fixed types or merged together.

Invalidation also makes sure to erase bindings of all adjacent
type variables related to equivalence class of the variables
in question.

This significantly speeds up use-cases which have a lot of type
variables such as collection literals with arbitrary nesting.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
