### PR TITLE
SILOptimizer: fix a phase ordering problem, which prevented array optimizations to work in some cases

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -154,6 +154,8 @@ PASS(ARCSequenceOpts, "arc-sequence-opts",
      "ARC Sequence Optimization")
 PASS(ARCLoopOpts, "arc-loop-opts",
      "ARC Loop Optimization")
+PASS(EarlyRedundantLoadElimination, "early-redundant-load-elim",
+     "Early Redundant Load Elimination")
 PASS(RedundantLoadElimination, "redundant-load-elim",
      "Redundant Load Elimination")
 PASS(DeadStoreElimination, "dead-store-elim",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -305,7 +305,14 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
   P.addSimplifyCFG();
 
   P.addCSE();
-  P.addRedundantLoadElimination();
+  if (OpLevel == OptimizationLevelKind::HighLevel) {
+    // Early RLE does not touch loads from Arrays. This is important because
+    // later array optimizations, like ABCOpt, get confused if an array load in
+    // a loop is converted to a pattern with a phi argument.
+    P.addEarlyRedundantLoadElimination();
+  } else {
+    P.addRedundantLoadElimination();
+  }
 
   P.addPerformanceConstantPropagation();
   P.addCSE();

--- a/test/SILOptimizer/early-rle.sil
+++ b/test/SILOptimizer/early-rle.sil
@@ -1,0 +1,36 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -early-redundant-load-elim | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+
+// Check that earlyl redundant load elimination ignores arrays.
+
+
+// CHECK-LABEL: test_array
+// CHECK: %1 = load
+// CHECK: %2 = load
+// CHECK: %3 = tuple (%1 {{.*}}, %2 {{.*}})
+sil @test_array : $@convention(thin) (@inout Array<Int>) -> (Array<Int>, Array<Int>) {
+bb0(%0 : $*Array<Int>):
+  %1 = load %0 : $*Array<Int>
+  %2 = load %0 : $*Array<Int>
+  %3 = tuple (%1: $Array<Int>, %2: $Array<Int>)
+  return %3 : $(Array<Int>, Array<Int>)
+}
+
+// CHECK-LABEL: test_non_array
+// CHECK: %1 = load
+// CHECK: %2 = tuple (%1 {{.*}}, %1 {{.*}})
+sil @test_non_array : $@convention(thin) (@inout Int) -> (Int, Int) {
+bb0(%0 : $*Int):
+  %1 = load %0 : $*Int
+  %2 = load %0 : $*Int
+  %3 = tuple (%1: $Int, %2: $Int)
+  return %3 : $(Int, Int)
+}
+
+


### PR DESCRIPTION
Introduce an "early redundant load elimination", which does not optimize loads from arrays.
Later array optimizations, like ABCOpt, get confused if an array load in a loop is converted to a pattern with a phi argument.

This problem was introduced with accessors.

rdar://problem/44184763
