### PR TITLE
Make _swift_dispatch_block_create_with_qos_class NS_RETURNS_RETAINED

### DIFF
--- a/stdlib/public/SwiftShims/DispatchOverlayShims.h
+++ b/stdlib/public/SwiftShims/DispatchOverlayShims.h
@@ -113,12 +113,10 @@ _swift_dispatch_source_create(
   return source;
 }
 
-static inline __swift_shims_dispatch_block_t
+static inline SWIFT_DISPATCH_RETURNS_RETAINED __swift_shims_dispatch_block_t
 _swift_dispatch_block_create_with_qos_class(
-    dispatch_block_flags_t flags,
-    dispatch_qos_class_t qos,
-    int relative_priority,
-    __swift_shims_dispatch_block_t _Nonnull block) {
+    dispatch_block_flags_t flags, dispatch_qos_class_t qos,
+    int relative_priority, __swift_shims_dispatch_block_t _Nonnull block) {
   return dispatch_block_create_with_qos_class(
       flags, qos, relative_priority, block);
 }

--- a/test/Interpreter/withoutActuallyEscapingBlocks.swift
+++ b/test/Interpreter/withoutActuallyEscapingBlocks.swift
@@ -41,4 +41,34 @@ WithoutEscapingSuite.test("ExpectNoCrash2") {
   }
 }
 
+if #available(OSX 10.10, iOS 8.0, *) {
+
+enum Result<T> {
+  case error
+  case t(T)
+}
+
+func foo<T>(block: () throws -> T) {
+  let q = DispatchQueue(label: "Test")
+  var result: Result<T>! = nil
+  withoutActuallyEscaping(block) { (block) -> () in
+    let item = DispatchWorkItem(qos: .unspecified, flags: []) {
+      do {
+        result = .t(try block())
+      }
+      catch {
+        result = .error
+      }
+    }
+    q.sync(execute: item)
+  }
+}
+
+WithoutEscapingSuite.test("ExpectNoCrash3") {
+  for _ in 1...10 {
+    foo(block: { return 10 })
+  }
+}
+
+}
 runAllTests()


### PR DESCRIPTION
Otherwise, we return in the autorelease pool and this can keep the block
alive longer than a surrounding withoutActuallyEscaping expression
causing verification failures.

rdar://45226617
SR-8955