### PR TITLE
build: workaround incorrectly cased import libraries in WinSDK

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -416,6 +416,11 @@ function(_add_variant_link_flags)
     endif()
     swift_windows_lib_for_arch(${LFLAGS_ARCH} ${LFLAGS_ARCH}_LIB)
     list(APPEND library_search_directories ${${LFLAGS_ARCH}_LIB})
+
+    # NOTE(compnerd) workaround incorrectly extensioned import libraries from
+    # the Windows SDK on case sensitive file systems.
+    list(APPEND library_search_directories
+         ${CMAKE_BINARY_DIR}/winsdk_lib_${LFLAGS_ARCH}_symlinks)
   elseif("${LFLAGS_SDK}" STREQUAL "HAIKU")
     list(APPEND result "-lbsd" "-latomic" "-Wl,-Bsymbolic")
   elseif("${LFLAGS_SDK}" STREQUAL "ANDROID")

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -282,6 +282,26 @@ macro(configure_sdk_windows name environment architectures)
     # to the driver -- rely on the `INCLUDE` AND `LIB` environment variables
     # instead.
     set(SWIFT_SDK_${prefix}_ARCH_${arch}_PATH "/")
+
+    # NOTE(compnerd) workaround incorrectly extensioned import libraries from
+    # the Windows SDK on case sensitive file systems.
+    swift_windows_arch_spelling(${arch} WinSDKArchitecture)
+    set(WinSDK${arch}UMDir "$ENV{UniversalCRTSdkDir}/Lib/$ENV{UCRTVersion}/um/${WinSDKArchitecture}")
+    set(OverlayDirectory "${CMAKE_BINARY_DIR}/winsdk_lib_${arch}_symlinks")
+
+    file(MAKE_DIRECTORY ${OverlayDirectory})
+
+    file(GLOB libraries RELATIVE "${WinSDK${arch}UMDir}" "${WinSDK${arch}UMDir}/*")
+    foreach(library ${libraries})
+      get_filename_component(name_we "${library}" NAME_WE)
+      get_filename_component(ext "${library}" EXT)
+      string(TOLOWER "${ext}" lowercase_ext)
+      set(lowercase_ext_symlink_name "${name_we}${lowercase_ext}")
+      if(NOT library STREQUAL lowercase_ext_symlink_name)
+        execute_process(COMMAND
+                        "${CMAKE_COMMAND}" -E create_symlink "${WinSDK${arch}UMDir}/${library}" "${OverlayDirectory}/${lowercase_ext_symlink_name}")
+      endif()
+    endforeach()
   endforeach()
 
   # Add this to the list of known SDKs.


### PR DESCRIPTION
The Windows SDK proides kernel32.Lib which on case sensitive file systems will
fail (due to the capital L in the extension).  Workaround that by creating
symbolic links to handle this.  This mirrors the technique used in LLVM.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
