### PR TITLE
[stdlib] Enable lgamma for Android.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -535,7 +535,7 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
     // using Glibc or a libc that respects that flag. This will cause some
     // source breakage however (specifically with strerror_r()) on Linux
     // without a workaround.
-    if (triple.isOSFuchsia()) {
+    if (triple.isOSFuchsia() || triple.isAndroid()) {
       // Many of the modern libc features are hidden behind feature macros like
       // _GNU_SOURCE or _XOPEN_SOURCE.
       invocationArgStrs.insert(invocationArgStrs.end(), {

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -292,8 +292,8 @@ public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
 %  if T == 'Float80':
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
 %  else:
-//  lgamma not avaialable on Windows, apparently?
-#if !os(Windows) && !os(Android)
+//  lgamma not available on Windows, apparently?
+#if !os(Windows)
 %  end
 @_transparent
 public func lgamma(_ x: ${T}) -> (${T}, Int) {


### PR DESCRIPTION
Android Bionic offers lgammaf_r and lgamma_r only if _GNU_SOURCE is
provided. It also offers lgammal_r in API levels 23 and above, but
that one will not be available until 128 bit floats are supported.

The patch modifies the importer to use _GNU_SOURCE while importing
Android headers and slighly modify a check that was avoding the
function from being created for Android.

This fixes the compilation of the tgmath test in Android.