### PR TITLE
Temporarily disable test IRGen/objc_globals.swift pending a test fix.

### DIFF
--- a/test/IRGen/objc_globals.swift
+++ b/test/IRGen/objc_globals.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir | %FileCheck %s
 //
 // REQUIRES: objc_interop
+// REQUIRES: temporarily_disabled
 
 import gadget
 import Foundation


### PR DESCRIPTION
Temporarily disable test IRGen/objc_globals.swift pending a test fix.

The test was broken by a clang change.