### PR TITLE
[ABI] Move the resilient witness table into the conformance descriptor.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -86,7 +86,7 @@ Globals
 
   global ::= protocol-conformance 'WG'   // generic protocol witness table
   global ::= protocol-conformance 'Wp'   // protocol witness table pattern
-  global ::= protocol-conformance 'Wr'   // resilient witness table
+  global ::= protocol-conformance 'Wr'   // resilient witness table (HISTORICAL)
   global ::= protocol-conformance 'WI'   // generic protocol witness table instantiation function
   global ::= type protocol-conformance 'WL'   // lazy protocol witness table cache variable
 

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2013,16 +2013,8 @@ struct TargetGenericWitnessTable {
   /// to require instantiation.
   uint16_t WitnessTablePrivateSizeInWordsAndRequiresInstantiation;
 
-  /// The protocol descriptor. Only used for resilient conformances.
-  RelativeIndirectablePointer<ProtocolDescriptor,
-                              /*nullable*/ true> Protocol;
-
   /// The pattern.
   RelativeDirectPointer<const TargetWitnessTable<Runtime>> Pattern;
-
-  /// The resilient witness table, if any.
-  RelativeDirectPointer<const TargetResilientWitnessTable<Runtime>,
-                        /*nullable*/ true> ResilientWitnesses;
 
   /// The instantiation function, which is called after the template is copied.
   RelativeDirectPointer<void(TargetWitnessTable<Runtime> *instantiatedTable,
@@ -2043,6 +2035,18 @@ struct TargetGenericWitnessTable {
   /// Whether the witness table is known to require instantiation.
   uint16_t requiresInstantiation() const {
     return WitnessTablePrivateSizeInWordsAndRequiresInstantiation & 0x01;
+  }
+
+  /// Retrieve the protocol conformance descriptor.
+  ConstTargetPointer<Runtime, TargetProtocolConformanceDescriptor<Runtime>>
+  getConformance() const {
+    return Pattern->Description;
+  }
+
+  /// Retrieve the protocol.
+  ConstTargetPointer<Runtime, TargetProtocolDescriptor<Runtime>>
+  getProtocol() const {
+    return Pattern->Description->getProtocol();
   }
 };
 using GenericWitnessTable = TargetGenericWitnessTable<InProcess>;
@@ -2222,6 +2226,14 @@ struct TargetTypeReference {
 };
 using TypeReference = TargetTypeReference<InProcess>;
 
+/// Header containing information about the resilient witnesses in a
+/// protocol conformance descriptor.
+template <typename Runtime>
+struct TargetResilientWitnessesHeader {
+  uint32_t NumWitnesses;
+};
+using ResilientWitnessesHeader = TargetResilientWitnessesHeader<InProcess>;
+
 /// The structure of a protocol conformance.
 ///
 /// This contains enough static information to recover the witness table for a
@@ -2231,12 +2243,16 @@ struct TargetProtocolConformanceDescriptor final
   : public swift::ABI::TrailingObjects<
              TargetProtocolConformanceDescriptor<Runtime>,
              RelativeContextPointer<Runtime>,
-             TargetGenericRequirementDescriptor<Runtime>> {
+             TargetGenericRequirementDescriptor<Runtime>,
+             TargetResilientWitnessesHeader<Runtime>,
+             TargetResilientWitness<Runtime>> {
 
   using TrailingObjects = swift::ABI::TrailingObjects<
                              TargetProtocolConformanceDescriptor<Runtime>,
                              RelativeContextPointer<Runtime>,
-                             TargetGenericRequirementDescriptor<Runtime>>;
+                             TargetGenericRequirementDescriptor<Runtime>,
+                             TargetResilientWitnessesHeader<Runtime>,
+                             TargetResilientWitness<Runtime>>;
   friend TrailingObjects;
 
   template<typename T>
@@ -2249,6 +2265,9 @@ public:
 
   using GenericRequirementDescriptor =
     TargetGenericRequirementDescriptor<Runtime>;
+
+  using ResilientWitnessesHeader = TargetResilientWitnessesHeader<Runtime>;
+  using ResilientWitness = TargetResilientWitness<Runtime>;
 
 private:
   /// The protocol being conformed to.
@@ -2271,7 +2290,8 @@ private:
   ConformanceFlags Flags;
 
 public:
-  const ProtocolDescriptor *getProtocol() const {
+  ConstTargetPointer<Runtime, TargetProtocolDescriptor<Runtime>>
+  getProtocol() const {
     return Protocol;
   }
 
@@ -2345,6 +2365,16 @@ public:
   const swift::TargetWitnessTable<Runtime> *
   getWitnessTable(const TargetMetadata<Runtime> *type) const;
 
+  /// Retrieve the resilient witnesses.
+  ArrayRef<ResilientWitness> getResilientWitnesses() const{
+    if (!Flags.hasResilientWitnesses())
+      return { };
+
+    return ArrayRef<ResilientWitness>(
+             this->template getTrailingObjects<ResilientWitness>(),
+             numTrailingObjects(OverloadToken<ResilientWitness>()));
+  }
+
 #if !defined(NDEBUG) && SWIFT_OBJC_INTEROP
   void dump() const;
 #endif
@@ -2367,6 +2397,17 @@ private:
 
   size_t numTrailingObjects(OverloadToken<GenericRequirementDescriptor>) const {
     return Flags.getNumConditionalRequirements();
+  }
+
+  size_t numTrailingObjects(OverloadToken<ResilientWitnessesHeader>) const {
+    return Flags.hasResilientWitnesses() ? 1 : 0;
+  }
+
+  size_t numTrailingObjects(OverloadToken<ResilientWitness>) const {
+    return Flags.hasResilientWitnesses()
+      ? this->template getTrailingObjects<ResilientWitnessesHeader>()
+          ->NumWitnesses
+      : 0;
   }
 };
 using ProtocolConformanceDescriptor

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -627,6 +627,8 @@ private:
 
     NumConditionalRequirementsMask = 0xFF << 8,
     NumConditionalRequirementsShift = 8,
+
+    HasResilientWitnessesMask = 0x01 << 16,
   };
 
   int_type Value;
@@ -658,6 +660,12 @@ public:
   ConformanceFlags withNumConditionalRequirements(unsigned n) const {
     return ConformanceFlags((Value & ~NumConditionalRequirementsMask)
                             | (n << NumConditionalRequirementsShift));
+  }
+
+  ConformanceFlags withHasResilientWitnesses(bool hasResilientWitnesses) const {
+    return ConformanceFlags((Value & ~HasResilientWitnessesMask)
+                            | (hasResilientWitnesses? HasResilientWitnessesMask
+                                                    : 0));
   }
 
   /// Retrieve the conformance kind.
@@ -694,6 +702,11 @@ public:
   unsigned getNumConditionalRequirements() const {
     return (Value & NumConditionalRequirementsMask)
               >> NumConditionalRequirementsShift;
+  }
+
+  /// Whether this conformance has any resilient witnesses.
+  bool hasResilientWitnesses() const {
+    return Value & HasResilientWitnessesMask;
   }
 
   int_type getIntValue() const { return Value; }

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -255,9 +255,6 @@ class LinkEntity {
     /// The secondary pointer is a ProtocolConformance*.
     GenericProtocolWitnessTableInstantiationFunction,
 
-    /// A list of key/value pairs that resiliently specify a witness table.
-    ResilientProtocolWitnessTable,
-
     /// A function which returns the witness table for a protocol-constrained
     /// associated type of a protocol.  The secondary pointer is a
     /// ProtocolConformance*.  The index of the associated conformance
@@ -745,13 +742,6 @@ public:
   forGenericProtocolWitnessTableCache(const ProtocolConformance *C) {
     LinkEntity entity;
     entity.setForProtocolConformance(Kind::GenericProtocolWitnessTableCache, C);
-    return entity;
-  }
-
-  static LinkEntity
-  forResilientProtocolWitnessTable(const ProtocolConformance *C) {
-    LinkEntity entity;
-    entity.setForProtocolConformance(Kind::ResilientProtocolWitnessTable, C);
     return entity;
   }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3650,14 +3650,6 @@ getAddrOfGenericWitnessTableCache(const NormalProtocolConformance *conf,
                                expectedTy, DebugTypeInfo());
 }
 
-llvm::Constant *IRGenModule::
-getAddrOfResilientWitnessTable(const NormalProtocolConformance *conf,
-                               ConstantInit definition) {
-  auto entity = LinkEntity::forResilientProtocolWitnessTable(conf);
-  return getAddrOfLLVMVariable(entity, getPointerAlignment(), definition,
-                               definition.getType(), DebugTypeInfo());
-}
-
 llvm::Function *
 IRGenModule::getAddrOfGenericWitnessTableInstantiationFunction(
                                       const NormalProtocolConformance *conf) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1926,10 +1926,6 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
   //    /// The pattern.
   //    RelativeDirectPointer<WitnessTable> WitnessTable;
   //
-  //    /// The resilient witness table, if any.
-  //    RelativeDirectPointer<const TargetResilientWitnessTable<Runtime>,
-  //                          /*nullable*/ true> ResilientWitnesses;
-  //
   //    /// The instantiation function, which is called after the template is copied.
   //    RelativeDirectPointer<void(WitnessTable *, const Metadata *, void * const *)>
   //                               Instantiator;

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1244,9 +1244,9 @@ llvm::Value *uniqueForeignWitnessTableRef(IRGenFunction &IGF,
                            SILWT->getConformance()->getType())
                          ->getCanonicalType()),
           Conformance(*SILWT->getConformance()),
-          ConformanceInContext(mapConformanceIntoContext(IGM,
-                                                         Conformance,
-                                                         Conformance.getDeclContext())),
+          ConformanceInContext(
+            mapConformanceIntoContext(IGM, Conformance,
+                                      Conformance.getDeclContext())),
           SILEntries(SILWT->getEntries()),
           SILConditionalConformances(SILWT->getConditionalConformances()),
           ResilientConformance(isResilientConformance(&Conformance)),
@@ -1493,7 +1493,11 @@ llvm::Value *uniqueForeignWitnessTableRef(IRGenFunction &IGF,
       return *Fulfillments;
     }
 
-    llvm::Constant *emitResilientWitnessTable();
+  public:
+    /// Collect the set of resilient witnesses, which will become part of the
+    /// protocol conformance descriptor.
+    void collectResilientWitnesses(
+                        SmallVectorImpl<llvm::Constant *> &resilientWitnesses);
   };
 } // end anonymous namespace
 
@@ -1798,60 +1802,29 @@ emitReturnOfCheckedLoadFromCache(IRGenFunction &IGF, Address destTable,
     resultState->addIncoming(completedState, cachingBB);
 }
 
-llvm::Constant *WitnessTableBuilder::emitResilientWitnessTable() {
-  unsigned count = 0;
+void WitnessTableBuilder::collectResilientWitnesses(
+                      SmallVectorImpl<llvm::Constant *> &resilientWitnesses) {
+  if (!ResilientConformance)
+    return;
+
+  assert(resilientWitnesses.empty());
   for (auto &entry : SILWT->getEntries()) {
-    if (entry.getKind() != SILWitnessTable::Method &&
-        entry.getKind() != SILWitnessTable::AssociatedType &&
-        entry.getKind() != SILWitnessTable::AssociatedTypeProtocol)
-      continue;
-
-    count++;
-  }
-
-  if (count == 0)
-    return nullptr;
-
-  ConstantInitBuilder B(IGM);
-
-  auto table = B.beginStruct();
-
-  table.addInt(IGM.Int32Ty, count);
-
-  for (auto &entry : SILWT->getEntries()) {
-    // Associated type witness access function.
+    // Associated type witness.
     if (entry.getKind() == SILWitnessTable::AssociatedType) {
-      // Associated type descriptor.
+      // Associated type witness.
       auto assocType = entry.getAssociatedTypeWitness().Requirement;
-      auto assocTypeDescriptor =
-        IGM.getAddrOfLLVMVariableOrGOTEquivalent(
-          LinkEntity::forAssociatedTypeDescriptor(assocType),
-          Alignment(4), IGM.ProtocolRequirementStructTy);
-      table.addRelativeAddress(assocTypeDescriptor);
-
-      // Associated type metadata access function.
       auto associate = Conformance.getTypeWitness(assocType, nullptr)
           ->getCanonicalType();
 
       llvm::Constant *witness =
           IGM.getAssociatedTypeWitness(associate, /*inProtocolContext=*/false);
-      table.addRelativeAddress(witness);
+      resilientWitnesses.push_back(witness);
       continue;
     }
 
     // Associated conformance access function.
     if (entry.getKind() == SILWitnessTable::AssociatedTypeProtocol) {
       const auto &witness = entry.getAssociatedTypeProtocolWitness();
-
-      // Associated type descriptor.
-      AssociatedConformance requirement(SILWT->getConformance()->getProtocol(),
-                                        witness.Requirement,
-                                        witness.Protocol);
-      auto assocConformanceDescriptor =
-        IGM.getAddrOfLLVMVariableOrGOTEquivalent(
-          LinkEntity::forAssociatedConformanceDescriptor(requirement),
-          Alignment(4), IGM.ProtocolRequirementStructTy);
-      table.addRelativeAddress(assocConformanceDescriptor);
 
       auto associate =
         ConformanceInContext.getAssociatedType(
@@ -1860,24 +1833,20 @@ llvm::Constant *WitnessTableBuilder::emitResilientWitnessTable() {
       ProtocolConformanceRef associatedConformance =
         ConformanceInContext.getAssociatedConformance(witness.Requirement,
                                                       witness.Protocol);
+      AssociatedConformance requirement(SILWT->getConformance()->getProtocol(),
+                                        witness.Requirement,
+                                        witness.Protocol);
 
       llvm::Constant *wtableAccessFunction =
         getAssociatedTypeWitnessTableAccessFunction(requirement,
                                                     associate,
                                                     associatedConformance);
-      table.addRelativeAddress(wtableAccessFunction);
+      resilientWitnesses.push_back(wtableAccessFunction);
       continue;
     }
 
     if (entry.getKind() != SILWitnessTable::Method)
       continue;
-
-    auto declRef = entry.getMethodWitness().Requirement;
-    auto requirement =
-      IGM.getAddrOfLLVMVariableOrGOTEquivalent(
-        LinkEntity::forMethodDescriptor(declRef),
-        Alignment(4), IGM.ProtocolRequirementStructTy);
-    table.addRelativeAddress(requirement);
 
     SILFunction *Func = entry.getMethodWitness().Witness;
     llvm::Constant *witness;
@@ -1888,17 +1857,8 @@ llvm::Constant *WitnessTableBuilder::emitResilientWitnessTable() {
       // It should be never called. We add a null pointer.
       witness = nullptr;
     }
-    table.addRelativeAddress(witness);
+    resilientWitnesses.push_back(witness);
   }
-
-  auto *result =
-    cast<llvm::GlobalVariable>(
-      IGM.getAddrOfResilientWitnessTable(SILWT->getConformance(),
-                                         table.finishAndCreateFuture()));
-  result->setConstant(true);
-  IGM.setTrueConstGlobal(result);
-
-  return result;
 }
 
 /// Emit the access function for this witness table.
@@ -1963,9 +1923,6 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
   //    /// to require instantiation.
   //    uint16_t WitnessTablePrivateSizeInWordsAndRequiresInstantiation;
   //
-  //    /// The protocol.
-  //    RelativeIndirectablePointer<ProtocolDescriptor> Protocol;
-  //
   //    /// The pattern.
   //    RelativeDirectPointer<WitnessTable> WitnessTable;
   //
@@ -1997,14 +1954,6 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
     instantiationFn = buildInstantiationFunction();
   }
 
-  auto descriptorRef = IGM.getAddrOfLLVMVariableOrGOTEquivalent(
-                LinkEntity::forProtocolDescriptor(Conformance.getProtocol()),
-                IGM.getPointerAlignment(), IGM.ProtocolDescriptorStructTy);
-
-  llvm::Constant *resilientWitnessTable = nullptr;
-  if (ResilientConformance)
-    resilientWitnessTable = emitResilientWitnessTable();
-
   // Fill in the global.
   auto cacheTy = cast<llvm::StructType>(cache->getValueType());
   ConstantInitBuilder cacheInitBuilder(IGM);
@@ -2014,12 +1963,8 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
   // WitnessTablePrivateSizeInWordsAndRequiresInstantiation
   cacheData.addInt(IGM.Int16Ty,
                    (NextPrivateDataIndex << 1) | RequiresSpecialization);
-  // RelativeIndirectablePointer<ProtocolDescriptor>
-  cacheData.addRelativeAddress(descriptorRef);
   // RelativePointer<WitnessTable>
   cacheData.addRelativeAddress(wtable);
-  // RelativePointer<ResilientWitnesses>
-  cacheData.addRelativeAddressOrNull(resilientWitnessTable);
   // Instantiation function
   cacheData.addRelativeAddressOrNull(instantiationFn);
   // Private data
@@ -2120,14 +2065,19 @@ namespace {
     IRGenModule &IGM;
     ConstantStructBuilder &B;
     const NormalProtocolConformance *Conformance;
+    SILWitnessTable *SILWT;
+    ArrayRef<llvm::Constant *> ResilientWitnesses;
     ConformanceFlags Flags;
 
   public:
     ProtocolConformanceDescriptorBuilder(
                                  IRGenModule &IGM,
                                  ConstantStructBuilder &B,
-                                 const NormalProtocolConformance *conformance)
-    : IGM(IGM), B(B), Conformance(conformance) { }
+                                 const NormalProtocolConformance *conformance,
+                                 SILWitnessTable *SILWT,
+                                 ArrayRef<llvm::Constant *> resilientWitnesses)
+      : IGM(IGM), B(B), Conformance(conformance), SILWT(SILWT),
+        ResilientWitnesses(resilientWitnesses) { }
 
     void layout() {
       addProtocol();
@@ -2136,6 +2086,7 @@ namespace {
       addFlags();
       addContext();
       addConditionalRequirements();
+      addResilientWitnesses();
 
       B.suggestType(IGM.ProtocolConformanceDescriptorTy);
     }
@@ -2197,6 +2148,7 @@ namespace {
       Flags = Flags.withIsRetroactive(Conformance->isRetroactive());
       Flags =
         Flags.withIsSynthesizedNonUnique(Conformance->isSynthesizedNonUnique());
+      Flags = Flags.withHasResilientWitnesses(!ResilientWitnesses.empty());
 
       // Add the flags.
       B.addInt32(Flags.getIntValue());
@@ -2222,18 +2174,72 @@ namespace {
         nominal->getGenericSignatureOfContext(),
         Conformance->getConditionalRequirements());
     }
+
+    void addResilientWitnesses() {
+      if (ResilientWitnesses.empty())
+        return;
+
+      // TargetResilientWitnessesHeader
+      auto witnesses = ResilientWitnesses;
+      B.addInt32(witnesses.size());
+      for (const auto &entry : SILWT->getEntries()) {
+        // Add the requirement descriptor.
+        if (entry.getKind() == SILWitnessTable::AssociatedType) {
+          // Associated type descriptor.
+          auto assocType = entry.getAssociatedTypeWitness().Requirement;
+          auto assocTypeDescriptor =
+            IGM.getAddrOfLLVMVariableOrGOTEquivalent(
+              LinkEntity::forAssociatedTypeDescriptor(assocType),
+              Alignment(4), IGM.ProtocolRequirementStructTy);
+          B.addRelativeAddress(assocTypeDescriptor);
+        } else if (entry.getKind() == SILWitnessTable::AssociatedTypeProtocol) {
+          // Associated conformance descriptor.
+          const auto &witness = entry.getAssociatedTypeProtocolWitness();
+
+          AssociatedConformance requirement(
+                                  SILWT->getConformance()->getProtocol(),
+                                  witness.Requirement,
+                                  witness.Protocol);
+          auto assocConformanceDescriptor =
+            IGM.getAddrOfLLVMVariableOrGOTEquivalent(
+              LinkEntity::forAssociatedConformanceDescriptor(requirement),
+              Alignment(4), IGM.ProtocolRequirementStructTy);
+          B.addRelativeAddress(assocConformanceDescriptor);
+        } else if (entry.getKind() == SILWitnessTable::Method) {
+          // Method descriptor.
+          auto declRef = entry.getMethodWitness().Requirement;
+          auto requirement =
+            IGM.getAddrOfLLVMVariableOrGOTEquivalent(
+              LinkEntity::forMethodDescriptor(declRef),
+              Alignment(4), IGM.ProtocolRequirementStructTy);
+          B.addRelativeAddress(requirement);
+        } else {
+          // Not part of the resilient witness table.
+          continue;
+        }
+
+        // Add the witness.
+        B.addRelativeAddress(witnesses.front());
+        witnesses = witnesses.drop_front();
+      }
+      assert(witnesses.empty() && "Wrong # of resilient witnesses");
+    }
   };
 }
 
 void IRGenModule::emitProtocolConformance(
-                                const NormalProtocolConformance *conformance) {
+                                const ConformanceDescription &record) {
+  auto conformance = record.conformance;
+
   // Emit additional metadata to be used by reflection.
   emitAssociatedTypeMetadataRecord(conformance);
 
   // Form the protocol conformance descriptor.
   ConstantInitBuilder initBuilder(*this);
   auto init = initBuilder.beginStruct();
-  ProtocolConformanceDescriptorBuilder builder(*this, init, conformance);
+  ProtocolConformanceDescriptorBuilder builder(*this, init, conformance,
+                                               record.wtable,
+                                               record.resilientWitnesses);
   builder.layout();
 
   auto var =
@@ -2410,6 +2416,12 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   WitnessTableBuilder wtableBuilder(*this, wtableContents, wt);
   wtableBuilder.build();
 
+  // Collect the resilient witnesses, which will end up in the protocol
+  // conformance descriptor.
+  ConformanceDescription description(conf, wt);
+  wtableBuilder.collectResilientWitnesses(description.resilientWitnesses);
+  addProtocolConformance(std::move(description));
+
   // Produce the initializer value.
   auto initializer = wtableContents.finishAndCreateFuture();
 
@@ -2423,8 +2435,6 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
 
   // Always emit an accessor function.
   wtableBuilder.buildAccessFunction(global);
-
-  addProtocolConformance(conf);
 
   // Behavior conformances can't be reflected.
   if (conf->isBehaviorConformance())

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -259,11 +259,6 @@ public:
     return mangleConformanceSymbol(Type(), C, "WI");
   }
 
-  std::string mangleResilientProtocolWitnessTable(
-                                                const ProtocolConformance *C) {
-    return mangleConformanceSymbol(Type(), C, "Wr");
-  }
-
   std::string mangleProtocolWitnessTableAccessFunction(
                                                 const ProtocolConformance *C) {
     return mangleConformanceSymbol(Type(), C, "Wa");

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1304,9 +1304,6 @@ public:
   llvm::Constant *
   getAddrOfGenericWitnessTableCache(const NormalProtocolConformance *C,
                                     ForDefinition_t forDefinition);
-  llvm::Constant *
-  getAddrOfResilientWitnessTable(const NormalProtocolConformance *C,
-                                 ConstantInit definition);
   llvm::Function *
   getAddrOfGenericWitnessTableInstantiationFunction(
                                     const NormalProtocolConformance *C);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -447,6 +447,24 @@ enum class MangledTypeRefRole {
   DefaultAssociatedTypeWitness,
 };
 
+/// The description of a protocol conformance, including its witness table
+/// and any additional information needed to produce the protocol conformance
+/// descriptor.
+struct ConformanceDescription {
+  /// The conformance itself.
+  const NormalProtocolConformance *conformance;
+
+  /// The witness table.
+  SILWitnessTable *wtable;
+
+  /// The resilient witnesses, if any.
+  SmallVector<llvm::Constant *, 4> resilientWitnesses;
+
+  ConformanceDescription(const NormalProtocolConformance *conformance,
+                         SILWitnessTable *wtable)
+    : conformance(conformance), wtable(wtable) { }
+};
+
 /// IRGenModule - Primary class for emitting IR for global declarations.
 /// 
 class IRGenModule {
@@ -819,7 +837,7 @@ public:
   void addCompilerUsedGlobal(llvm::GlobalValue *global);
   void addObjCClass(llvm::Constant *addr, bool nonlazy);
   void addFieldTypes(ArrayRef<CanType> fieldTypes);
-  void addProtocolConformance(const NormalProtocolConformance *conformance);
+  void addProtocolConformance(ConformanceDescription conformance);
 
   llvm::Constant *emitSwiftProtocols();
   llvm::Constant *emitProtocolConformances();
@@ -916,8 +934,8 @@ private:
   SmallVector<llvm::WeakTrackingVH, 4> ObjCCategories;
   /// List of non-ObjC protocols described by this module.
   SmallVector<ProtocolDecl *, 4> SwiftProtocols;
-  /// List of protocol conformances to generate records for.
-  SmallVector<const NormalProtocolConformance *, 4> ProtocolConformances;
+  /// List of protocol conformances to generate descriptors for.
+  SmallVector<ConformanceDescription, 4> ProtocolConformances;
   /// List of nominal types to generate type metadata records for.
   SmallVector<NominalTypeDecl *, 4> RuntimeResolvableTypes;
   /// List of ExtensionDecls corresponding to the generated
@@ -1130,7 +1148,7 @@ public:
   void emitSILProperty(SILProperty *prop);
   void emitSILStaticInitializers();
   llvm::Constant *emitFixedTypeLayout(CanType t, const FixedTypeInfo &ti);
-  void emitProtocolConformance(const NormalProtocolConformance *conformance);
+  void emitProtocolConformance(const ConformanceDescription &record);
   void emitNestedTypeDecls(DeclRange members);
   void emitClangDecl(const clang::Decl *decl);
   void finalizeClangCodeGen();

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -216,9 +216,6 @@ std::string LinkEntity::mangleAsString() const {
     return mangler.mangleGenericProtocolWitnessTableInstantiationFunction(
                                                     getProtocolConformance());
 
-  case Kind::ResilientProtocolWitnessTable:
-    return mangler.mangleResilientProtocolWitnessTable(getProtocolConformance());
-
   case Kind::ProtocolWitnessTableAccessFunction:
     return mangler.mangleProtocolWitnessTableAccessFunction(
                                                     getProtocolConformance());
@@ -478,7 +475,6 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     return getLinkageAsConformance();
 
   case Kind::ProtocolWitnessTablePattern:
-  case Kind::ResilientProtocolWitnessTable:
     if (getLinkageAsConformance() == SILLinkage::Shared)
       return SILLinkage::Shared;
     return SILLinkage::Private;
@@ -617,7 +613,6 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
     return ::isAvailableExternally(IGM, getProtocolConformance()->getDeclContext());
 
   case Kind::ProtocolWitnessTablePattern:
-  case Kind::ResilientProtocolWitnessTable:
   case Kind::ObjCClassRef:
   case Kind::ModuleDescriptor:
   case Kind::ExtensionDescriptor:

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -99,18 +99,12 @@ struct Pair<T, U> : P, Q {}
 // GLOBAL-SAME:    i16 4,
 // GLOBAL-SAME:    i16 1,
 
-//    Relative reference to protocol
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ({{.*}} @"$s23associated_type_witness8AssockedMp" to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWG", i32 0, i32 2) to i64)) to i32
-
 //    Relative reference to witness table template
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([4 x i8*]* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWp" to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWG", i32 0, i32 3) to i64)) to i32
-
-//    Relative reference to resilient witnesses
-// GLOBAL-SAME:    i32 0,
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([4 x i8*]* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWp" to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWG", i32 0, i32 2) to i64)) to i32
 
 //    No instantiator function
 // GLOBAL-SAME:    i32 0,
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* [[PRIVATE:@.*]] to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWG", i32 0, i32 6) to i64)) to i32)
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* [[PRIVATE:@.*]] to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWG", i32 0, i32 4) to i64)) to i32)
 // GLOBAL-SAME:  }
 // GLOBAL:       [[PRIVATE]] = internal global [16 x i8*] zeroinitializer
 
@@ -141,17 +135,11 @@ protocol DerivedFromSimpleAssoc : HasSimpleAssoc {}
 // GLOBAL-SAME:    i16 2,
 // GLOBAL-SAME:    i16 1,
 
-//   Relative reference to protocol
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ({{.*}} @"$s23associated_type_witness22DerivedFromSimpleAssocMp" to i64
-
 //   Relative reference to witness table template
 // GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([2 x i8*]* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWp" to i64
 
-//   Relative reference to resilient witnesses
-// GLOBAL-SAME:    i32 0,
-
 //   Relative reference to instantiator function
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint (void (i8**, %swift.type*, i8**)* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI" to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", i32 0, i32 5) to i64)) to i32)
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint (void (i8**, %swift.type*, i8**)* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI" to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", i32 0, i32 3) to i64)) to i32)
 
 //   Relative reference to private data
 struct GenericComputed<T: P> : DerivedFromSimpleAssoc {

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -11,7 +11,7 @@ import gizmo
 // CHECK: @"$sSo16NSRuncingOptionsVMn" = linkonce_odr hidden constant
 // CHECK: @"$sSo16NSRuncingOptionsVN" = linkonce_odr hidden constant
 //   CHECK-SAME: @"$sBi{{[0-9]+}}_WV"
-// CHECK: @"$sSo16NSRuncingOptionsVSQSCMc" = linkonce_odr hidden constant %swift.protocol_conformance_descriptor { {{.*}}@"$sSo16NSRuncingOptionsVSQSCWa
+// CHECK: @"$sSo16NSRuncingOptionsVSQSCMc" = linkonce_odr hidden constant{{.*}}@"$sSo16NSRuncingOptionsVSQSCWa
 // CHECK-NOT: @"$sSo28NeverActuallyMentionedByNameVSQSCWp" = linkonce_odr hidden constant
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i32 @main

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -24,14 +24,8 @@ import resilient_protocol
 // -- size of private area + 'needs instantiation' bit
 // CHECK-SAME:   i16 1,
 
-// -- the protocol descriptor
-// CHECK-SAME:   @"{{got.|__imp_}}$s18resilient_protocol22OtherResilientProtocolMp"
-
 // -- the template
 // CHECK-SAME:   @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWp"
-
-// -- resilient witnesses
-// CHECK-SAME:   i32 0,
 
 // -- instantiator function
 // CHECK-SAME:   i32 0
@@ -126,24 +120,29 @@ protocol InternalProtocol {
 // -- size of private area + 'needs instantiation' bit
 // CHECK-SAME:   i16 1,
 
-// -- the protocol descriptor
-// CHECK-SAME:   @"{{got.|__imp_}}$s18resilient_protocol24ProtocolWithRequirementsMp"
-
 // -- the template
 // CHECK-SAME:   @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWp"
-
-// -- resilient witnesses
-// CHECK-SAME:   @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWr"
 
 // -- instantiator function
 // CHECK-SAME:   i32 0
 
 // CHECK-SAME: }
 
+// Witness table for conformance with resilient associated type
 
-// CHECK: @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWr"
+// CHECK: @"$s19protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWP" = {{(protected )?}}hidden global [3 x i8*] [
+// CHECK-SAME:   i8* bitcast (i8** ()* @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa" to i8*)
+// CHECK-SAME:   @"symbolic 19protocol_resilience23ResilientConformingTypeV"
+// CHECK-SAME: ]
 
-// CHECK-SAME: internal constant {
+// ConformsWithRequirements protocol conformance descriptor
+
+// CHECK: "$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAMc" = hidden constant {
+
+// -- flags
+// CHECK-SAME: i32 65537,
+
+// CHECK-SAME: i32 3,
 
 // -- type metadata for associated type
 // CHECK-SAME: @"{{got.|__imp_}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl"
@@ -157,14 +156,6 @@ protocol InternalProtocol {
 
 // CHECK-SAME: }
 
-
-// Witness table for conformance with resilient associated type
-
-// CHECK: @"$s19protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWP" = {{(protected )?}}hidden global [3 x i8*] [
-// CHECK-SAME:   i8* bitcast (i8** ()* @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa" to i8*)
-// CHECK-SAME:   @"symbolic 19protocol_resilience23ResilientConformingTypeV"
-// CHECK-SAME: ]
-
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultC(%swift.opaque* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 sil @defaultC : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> () {
@@ -175,7 +166,6 @@ bb0(%0 : $*Self):
   %result = tuple ()
   return %result : $()
 }
-
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultD(%swift.opaque* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK-NEXT:  entry:

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -42,7 +42,7 @@ import resilient_protocol
 // ----------------------------------------------------------------------------
 // Resilient witness tables
 // ----------------------------------------------------------------------------
-// CHECK-USAGE-LABEL: $s31protocol_resilience_descriptors34ConformsToProtocolWithRequirementsVyxG010resilient_A00fgH0AAWr" = internal
+// CHECK-USAGE-LABEL: $s31protocol_resilience_descriptors34ConformsToProtocolWithRequirementsVyxG010resilient_A00fgH0AAMc" = constant
 // CHECK-USAGE-SAME: {{got.|__imp_}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl
 // CHECK-USAGE-SAME: @"symbolic x"
 public struct ConformsToProtocolWithRequirements<Element>
@@ -56,7 +56,7 @@ public protocol P { }
 public struct ConditionallyConforms<Element> { }
 public struct Y { }
 
-// CHECK-USAGE: @"$s31protocol_resilience_descriptors29ConformsWithAssocRequirementsV010resilient_A008ProtocoleF12TypeDefaultsAAWr" = internal
+// CHECK-USAGE: @"$s31protocol_resilience_descriptors29ConformsWithAssocRequirementsV010resilient_A008ProtocoleF12TypeDefaultsAAMc" = constant
 // CHECK-USAGE-SAME: $s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0Tn
 // CHECK-USAGE-SAME: $s31protocol_resilience_descriptors29ConformsWithAssocRequirementsV010resilient_A008ProtocoleF12TypeDefaultsAA2T2AdEP_AD014OtherResilientI0PWT
 public struct ConformsWithAssocRequirements : ProtocolWithAssocTypeDefaults {

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -42,7 +42,7 @@ import resilient_protocol
 // ----------------------------------------------------------------------------
 // Resilient witness tables
 // ----------------------------------------------------------------------------
-// CHECK-USAGE-LABEL: $s31protocol_resilience_descriptors34ConformsToProtocolWithRequirementsVyxG010resilient_A00fgH0AAMc" = constant
+// CHECK-USAGE-LABEL: $s31protocol_resilience_descriptors34ConformsToProtocolWithRequirementsVyxG010resilient_A00fgH0AAMc" =
 // CHECK-USAGE-SAME: {{got.|__imp_}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl
 // CHECK-USAGE-SAME: @"symbolic x"
 public struct ConformsToProtocolWithRequirements<Element>
@@ -56,7 +56,7 @@ public protocol P { }
 public struct ConditionallyConforms<Element> { }
 public struct Y { }
 
-// CHECK-USAGE: @"$s31protocol_resilience_descriptors29ConformsWithAssocRequirementsV010resilient_A008ProtocoleF12TypeDefaultsAAMc" = constant
+// CHECK-USAGE: @"$s31protocol_resilience_descriptors29ConformsWithAssocRequirementsV010resilient_A008ProtocoleF12TypeDefaultsAAMc" =
 // CHECK-USAGE-SAME: $s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0Tn
 // CHECK-USAGE-SAME: $s31protocol_resilience_descriptors29ConformsWithAssocRequirementsV010resilient_A008ProtocoleF12TypeDefaultsAA2T2AdEP_AD014OtherResilientI0PWT
 public struct ConformsWithAssocRequirements : ProtocolWithAssocTypeDefaults {

--- a/test/multifile/resilient-witness.swift
+++ b/test/multifile/resilient-witness.swift
@@ -39,7 +39,7 @@ public func inlineThis(_ char: Character) {
 
 // The witness table and witness definition need to be in the same file.
 
-// CHECK: @"$s4test7ContextC8SomeEnumOSQAAWr" = {{.*}}sub {{.*}} @"$s4test7ContextC8SomeEnumOSQAASQ2eeoiySbx_xtFZTW" {{.*}} @"$s4test7ContextC8SomeEnumOSQAAWr"
+// CHECK: @"$s4test7ContextC8SomeEnumOSQAAMc" = {{.*}}sub {{.*}} @"$s4test7ContextC8SomeEnumOSQAASQ2eeoiySbx_xtFZTW" {{.*}} @"$s4test7ContextC8SomeEnumOSQAAMc"
 
 
 // CHECK: define{{.*}}@"$s4test7ContextC8SomeEnumOSQAASQ2eeoiySbx_xtFZTW"({{.*}}){{.*}} {


### PR DESCRIPTION
Place resilient witnesses in the protocol conformance descriptor,
tail-allocated after the conditional requirements, so they can be found by
reflection. Drop the resilient witness table and protocol descriptor from
the generic witness table.

Addresses rdar://problem/45228582.