### PR TITLE
test: update IRGen test for aarch64 (AAPCS64)

### DIFF
--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -51,3 +51,12 @@ public func use_global() -> Int {
 // arm64:        str [[REG2]], [sp]
 // arm64:        bl _swift_endAccess
 // arm64:        ldr x0, [sp]
+
+// aarch64-LABEL: $s4main10use_globalSiyF:
+// aarch64:        adrp [[REG1:x[0-9]+]], ($s4main6globalSivp@PAGE)
+// aarch64:        add [[REG1]], [[REG1]], :lo12:($s4main6globalSivp)
+// aarch64:        bl swift_beginAccess
+// aarch64:        ldr [[REG2:x[0-9]+]], {{\[}}[[REG1]]{{\]}}
+// aarch64:        str [[REG2]], [sp]
+// aarch64:        bl swift_endAccess
+// aarch64:        ldr x0, [sp]


### PR DESCRIPTION
Update the syntax/codegen verification to account for differences with
the aarch64 target.  This makes it pass on Linux-aarch64 (and should
also suffice for android-aarch64).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
