### PR TITLE
Unqualified lookup fixes

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1452,6 +1452,11 @@ public:
   /// Whether this is an explicitly-stated requirement.
   bool isExplicit() const;
 
+  /// Whether this is a top-level requirement written in source.
+  /// FIXME: This is a hack because expandConformanceRequirement()
+  /// is too eager; we should remove this once we fix it properly.
+  bool isTopLevel() const { return kind == Explicit; }
+
   /// Return the "inferred" version of this source, if it isn't already
   /// inferred.
   FloatingRequirementSource asInferred(const TypeRepr *typeRepr) const;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -254,6 +254,12 @@ bool TypeResolution::areSameType(Type type1, Type type2) const {
 
   // If we have a generic signature, canonicalize using it.
   if (auto genericSig = getGenericSignature()) {
+    // If both are type parameters, we can use a cheaper check
+    // that avoids transforming the type and computing anchors.
+    if (type1->isTypeParameter() &&
+        type2->isTypeParameter()) {
+      return genericSig->areSameTypeParameterInContext(type1, type2);
+    }
     return genericSig->getCanonicalTypeInContext(type1)
       == genericSig->getCanonicalTypeInContext(type2);
   }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -351,6 +351,11 @@ public:
                                   SourceRange baseRange,
                                   ComponentIdentTypeRepr *ref) const;
 
+  /// Resolve an unqualified reference to an associated type or type alias
+  /// in a protocol.
+  Type resolveSelfAssociatedType(Type baseTy, DeclContext *DC,
+                                 Identifier name) const;
+
   /// Determine whether the given two types are equivalent within this
   /// type resolution context.
   bool areSameType(Type type1, Type type2) const;

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -240,6 +240,7 @@ func structuralSameType3<T, U, V, W>(_: T, _: U, _: V, _: W)
   where X1<T, U> == X1<V, W> { }
 // expected-error@-1{{same-type requirement makes generic parameters 'T' and 'V' equivalent}}
 // expected-error@-2{{same-type requirement makes generic parameters 'U' and 'W' equivalent}}
+// expected-warning@-3{{neither type in same-type constraint ('X1<T, U>' or 'X1<V, W>') refers to a generic parameter or associated type}}
 
 protocol P2 {
   associatedtype Assoc1
@@ -285,6 +286,7 @@ func test9<T: P6, U: P6>(_ t: T, u: U)
 func testMetatypeSameType<T, U>(_ t: T, _ u: U)
   where T.Type == U.Type { }
 // expected-error@-1{{same-type requirement makes generic parameters 'T' and 'U' equivalent}}
+// expected-warning@-2{{neither type in same-type constraint ('T.Type' or 'U.Type') refers to a generic parameter or associated type}}
 
 func testSameTypeCommutativity1<U, T>(_ t: T, _ u: U)
   where T.Type == U { } // Equivalent to U == T.Type

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -38,13 +38,13 @@ protocol P {
 
 func f12<T : P>(x: T) -> T.A<Int> {} // expected-error {{cannot specialize non-generic type 'T.A'}}{{29-34=}}
 
-func f13<T : P>(x: T) -> T.B<Int> {} // expected-error {{cannot specialize non-generic type 'P.B' (aka 'Int')}}{{29-34=}}
+func f13<T : P>(x: T) -> T.B<Int> {} // expected-error {{cannot specialize non-generic type 'T.B' (aka 'Int')}}{{29-34=}}
 
 func f14<T : P>(x: T) -> T.C<Int> {}
 
 func f15<T : P>(x: T) -> T.D<Int> {}
 
-func f16<T : P>(x: T) -> T.D {} // expected-error {{reference to generic type 'P.D' (aka 'G') requires arguments in <...>}}
+func f16<T : P>(x: T) -> T.D {} // expected-error {{reference to generic type 'T.D' (aka 'G') requires arguments in <...>}}
 
 func f17<T : P>(x: T) -> T.E<Int> {}
 

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -35,6 +35,7 @@ func requirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, T.C == T.B.X {}
 // CHECK-LABEL: .concreteRequirementOnConcreteNestedTypeAlias@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == τ_0_0.B.A>
 func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> == T.B.X {}
+// expected-warning@-1 {{neither type in same-type constraint ('S<T.C>' or 'S<T.B.A>') refers to a generic parameter or associated type}}
 
 
 // Incompatible concrete typealias types are flagged as such

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -376,8 +376,7 @@ func resultTypeSuppress<T: P1>() -> StructTakingP1<T> {
 typealias NotAnInt = Double
 
 extension X11 where NotAnInt == Int { }
-// expected-warning@-1{{neither type in same-type constraint ('NotAnInt' (aka 'Double') or 'Int') refers to a generic parameter or associated type}}
-// expected-error@-2{{generic signature requires types 'NotAnInt' (aka 'Double') and 'Int' to be the same}}
+// expected-error@-1{{generic signature requires types 'NotAnInt' (aka 'Double') and 'Int' to be the same}}
 
 
 struct X12<T> { }

--- a/test/decl/protocol/req/associated_type_ambiguity.swift
+++ b/test/decl/protocol/req/associated_type_ambiguity.swift
@@ -38,3 +38,21 @@ extension P1 where Self : P2 {
 protocol P3 {
   associatedtype T
 }
+
+// FIXME: This extension's generic signature is still minimized differently from
+// the next one. We need to decide if 'T == Int' is a redundant requirement or
+// not.
+extension P2 where Self : P3, T == Int {
+  func takeT1(_: T) {}
+  func takeT2(_: Self.T) {}
+}
+
+extension P2 where Self : P3 {
+  func takeT1(_: T) {}
+  func takeT2(_: Self.T) {}
+}
+
+protocol P4 : P2, P3 {
+  func takeT1(_: T)
+  func takeT2(_: Self.T)
+}

--- a/test/decl/protocol/req/associated_type_ambiguity.swift
+++ b/test/decl/protocol/req/associated_type_ambiguity.swift
@@ -1,0 +1,40 @@
+// RUN: %target-typecheck-verify-swift
+
+// Reference to associated type from 'where' clause should not be
+// ambiguous when there's a typealias with the same name in another
+// protocol.
+//
+// FIXME: The semantics here are still really iffy. There's also a
+// case to be made that type aliases in protocol extensions should
+// only act as defaults and not as same-type constraints. However,
+// if we decide to go down that route, it's important that *both*
+// the unqualified (T) and qualified (Self.T) lookups behave the
+// same.
+protocol P1 {
+  typealias T = Int // expected-note {{found this candidate}}
+}
+
+protocol P2 {
+  associatedtype T // expected-note {{found this candidate}}
+}
+
+// FIXME: This extension's generic signature is still minimized differently from
+// the next one. We need to decide if 'T == Int' is a redundant requirement or
+// not.
+extension P1 where Self : P2, T == Int {
+  func takeT1(_: T) {}
+  func takeT2(_: Self.T) {}
+}
+
+extension P1 where Self : P2 {
+  // FIXME: This doesn't make sense -- either both should
+  // succeed, or both should be ambiguous.
+  func takeT1(_: T) {} // expected-error {{'T' is ambiguous for type lookup in this context}}
+  func takeT2(_: Self.T) {}
+}
+
+// Same as above, but now we have two visible associated types with the same
+// name.
+protocol P3 {
+  associatedtype T
+}


### PR DESCRIPTION
This part of the language is not very well specified and there are some deeper issues that need to be addressed, as you can see from the several FIXMEs I added here. However, this should be an improvement overall and it fixes a long-standing regression from 4.0 to 4.1. More cleanups need to happen here though.

Fixes <rdar://problem/35756206>.