### PR TITLE
[master-next] Fix some test failures

### DIFF
--- a/test/ClangImporter/CoreGraphics_test.swift
+++ b/test/ClangImporter/CoreGraphics_test.swift
@@ -100,9 +100,9 @@ public func testRenames(transform: CGAffineTransform, context: CGContext,
   let _ = point.applying(transform)
   var rect = rect.applying(transform)
   let _ = size.applying(transform)
-// CHECK:   %{{.*}} = call { double, double } @CGPointApplyAffineTransform(double %{{.*}}, double %{{.*}}, %struct.CGAffineTransform* {{.*}})
+// CHECK:   %{{.*}} = {{(tail )?}}call { double, double } @CGPointApplyAffineTransform(double %{{.*}}, double %{{.*}}, %struct.CGAffineTransform* {{.*}})
 // CHECK:   call void @CGRectApplyAffineTransform(%struct.CGRect* {{.*}}, %struct.CGRect* {{.*}}, %struct.CGAffineTransform* {{.*}})
-// CHECK:   %{{.*}} = call { double, double } @CGSizeApplyAffineTransform(double %{{.*}}, double %{{.*}}, %struct.CGAffineTransform* {{.*}})
+// CHECK:   %{{.*}} = {{(tail )?}}call { double, double } @CGSizeApplyAffineTransform(double %{{.*}}, double %{{.*}}, %struct.CGAffineTransform* {{.*}})
 
   context.concatenate(transform)
   context.rotate(by: CGFloat.pi)

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -375,6 +375,6 @@ void TestOptions::printHelp(bool ShowHidden) const {
 
   TestOptTable Table;
 
-  Table.PrintHelp(llvm::outs(), "sourcekitd-test", "SourceKit Testing Tool",
-                      ShowHidden);
+  Table.PrintHelp(llvm::outs(), "sourcekitd-test [options] <inputs>",
+                  "SourceKit Testing Tool", ShowHidden);
 }


### PR DESCRIPTION
There are 2 small fixes here to get the master-next bots passing again:
- Adjust sourcekitd-test PrintHelp call for LLVM r344097
- Update test/ClangImporter/CoreGraphics_test.swift to accept tail calls in 2 places
