### PR TITLE
[Sema][CS] Re-try failedConstraint during salvage

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -82,9 +82,14 @@ Type RequirementFailure::getOwnerType() const {
   return getType(getAnchor())->getInOutObjectType()->getMetatypeInstanceType();
 }
 
+const GenericContext *RequirementFailure::getGenericContext() const {
+  if (auto *genericCtx = AffectedDecl->getAsGenericContext())
+    return genericCtx;
+  return AffectedDecl->getDeclContext()->getAsDecl()->getAsGenericContext();
+}
+
 const Requirement &RequirementFailure::getRequirement() const {
-  auto *genericCtx = AffectedDecl->getAsGenericContext();
-  return genericCtx->getGenericRequirements()[getRequirementIndex()];
+  return getGenericContext()->getGenericRequirements()[getRequirementIndex()];
 }
 
 ValueDecl *RequirementFailure::getDeclRef() const {
@@ -139,7 +144,7 @@ bool RequirementFailure::diagnoseAsError() {
 
   auto *anchor = getAnchor();
   const auto *reqDC = getRequirementDC();
-  auto *genericCtx = AffectedDecl->getAsGenericContext();
+  auto *genericCtx = getGenericContext();
 
   if (reqDC != genericCtx) {
     auto *NTD = reqDC->getSelfNominalTypeDecl();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -186,6 +186,9 @@ public:
   /// The generic base type where failing requirement comes from.
   Type getOwnerType() const;
 
+  /// Generic context associated with the failure.
+  const GenericContext *getGenericContext() const;
+
   /// Generic requirement associated with the failure.
   const Requirement &getRequirement() const;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2045,8 +2045,14 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
     SolverState state(expr, *this, FreeTypeVariableBinding::Disallow);
     state.recordFixes = true;
 
-    if (failedConstraint && simplifyConstraint(*failedConstraint) == SolutionKind::Solved)
+    // Retry all inactive and failed constraints
+    if (failedConstraint) {
+      addUnsolvedConstraint(failedConstraint);
       failedConstraint = nullptr;
+    }
+    ActiveConstraints.splice(ActiveConstraints.end(), InactiveConstraints);
+    for (auto &constraint : ActiveConstraints)
+      constraint.setActive(true);
 
     // Solve the system.
     solve(viable);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2045,6 +2045,9 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
     SolverState state(expr, *this, FreeTypeVariableBinding::Disallow);
     state.recordFixes = true;
 
+    if (failedConstraint && simplifyConstraint(*failedConstraint) == SolutionKind::Solved)
+      failedConstraint = nullptr;
+
     // Solve the system.
     solve(viable);
 

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -563,7 +563,7 @@ do {
 }
 
 func rdar35890334(_ arr: inout [Int]) {
-  _ = arr.popFirst() // expected-error {{value of type '[Int]' has no member 'popFirst'}}
+  _ = arr.popFirst() // expected-error {{referencing instance method 'popFirst()' on 'Collection' requires the types '[Int]' and 'ArraySlice<Int>' be equivalent}}
 }
 
 // rdar://problem/39616039
@@ -621,3 +621,11 @@ func rdar40537858() {
   let _: E = .foo(s)   // expected-error {{generic enum 'E' requires that 'S' conform to 'P'}}
   let _: E = .bar([s]) // expected-error {{generic enum 'E' requires that 'S' conform to 'P'}}
 }
+
+// SR-8934
+struct BottleLayout {
+    let count : Int
+}
+let arr = [BottleLayout]()
+let layout = BottleLayout(count:1)
+let ix = arr.firstIndex(of:layout) // expected-error {{argument type 'BottleLayout' does not conform to expected type 'Equatable'}}

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -97,7 +97,7 @@ extension GenericOverloads where T : P1, U : P2 {
   subscript (i: Int) -> Int { return i }
 }
 
-extension Array where Element : Hashable {
+extension Array where Element : Hashable { // expected-note {{where 'Element' = 'T'}}
   var worseHashEver: Int {
     var result = 0
     for elt in self {
@@ -108,7 +108,7 @@ extension Array where Element : Hashable {
 }
 
 func notHashableArray<T>(_ x: [T]) {
-  x.worseHashEver // expected-error{{type 'T' does not conform to protocol 'Hashable'}}
+  x.worseHashEver // expected-error{{property 'worseHashEver' requires that 'T' conform to 'Hashable'}}
 }
 
 func hashableArray<T : Hashable>(_ x: [T]) {
@@ -132,7 +132,7 @@ func genericClassEquatable<T : Equatable>(_ gc: GenericClass<T>, x: T, y: T) {
 }
 
 func genericClassNotEquatable<T>(_ gc: GenericClass<T>, x: T, y: T) {
-  gc.foo(x, y: y) // expected-error{{type 'T' does not conform to protocol 'Equatable'}}
+  gc.foo(x, y: y) // expected-error{{argument type 'T' does not conform to expected type 'Equatable'}}
 }
 
 

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -208,8 +208,8 @@ struct S4d : P4 {
   func reqP4a() -> Bool { return false }
 }
 
-extension P4 where Self.AssocP4 == Int {
-  func extP4Int() { } // expected-note {{candidate requires that the types 'Bool' and 'Int' be equivalent (requirement specified as 'Self.AssocP4' == 'Int')}}
+extension P4 where Self.AssocP4 == Int { // expected-note {{where 'Self.AssocP4' = 'Bool'}}
+  func extP4Int() { }
 }
 
 extension P4 where Self.AssocP4 == Bool {
@@ -229,7 +229,7 @@ func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above
-  s4d.extP4Int() // expected-error{{value of type 'S4d' has no member 'extP4Int'}}
+  s4d.extP4Int() // expected-error{{referencing instance method 'extP4Int()' on 'P4' requires the types 'Bool' and 'Int' be equivalent}}
   _ = b1
 }
 

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -377,7 +377,7 @@ protocol ExpressibleByDogLiteral {}
 struct Kitten : ExpressibleByCatLiteral {}
 struct Puppy : ExpressibleByDogLiteral {}
 
-struct Claws<A: ExpressibleByCatLiteral> {
+struct Claws<A: ExpressibleByCatLiteral> { // expected-note {{'A' declared as parameter to type 'Claws'}}
   struct Fangs<B: ExpressibleByDogLiteral> { }
 }
 
@@ -402,7 +402,8 @@ func test() {
   let _: Claws.Fangs<NotADog> = something()
   // expected-error@-1 {{generic parameter 'T' could not be inferred}} // FIXME: bad diagnostic
   _ = Claws.Fangs<NotADog>()
-  // expected-error@-1 {{type 'NotADog' does not conform to protocol 'ExpressibleByDogLiteral'}}
+  // expected-error@-1 {{generic parameter 'A' could not be inferred}}
+  // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
 }
 
 // https://bugs.swift.org/browse/SR-4379

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
@@ -21,7 +21,7 @@ class Conditional<T> {
   }
 }
 
-extension Conditional: Codable where T: Codable {
+extension Conditional: Codable where T: Codable { // expected-note 2 {{where 'T' = 'Nonconforming'}}
     // expected-error@-1 2 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}
 }
 
@@ -32,7 +32,8 @@ let _ = Conditional<Int>.encode(to:)
 // but only for Codable parameters.
 struct Nonconforming {}
 let _ = Conditional<Nonconforming>.init(from:) // expected-error {{type 'Conditional<Nonconforming>' has no member 'init(from:)'}}
-let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{referencing instance method 'encode(to:)' on 'Conditional' requires that 'Nonconforming' conform to 'Decodable'}}
+// expected-error@-1 {{referencing instance method 'encode(to:)' on 'Conditional' requires that 'Nonconforming' conform to 'Encodable'}}
 
 // The synthesized CodingKeys type should not be accessible from outside the
 // struct.

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
@@ -20,7 +20,7 @@ final class Conditional<T> {
   }
 }
 
-extension Conditional: Codable where T: Codable {}
+extension Conditional: Codable where T: Codable {} // expected-note 4 {{where 'T' = 'Nonconforming'}}
 
 // They should receive synthesized init(from:) and an encode(to:).
 let _ = Conditional<Int>.init(from:)
@@ -28,8 +28,10 @@ let _ = Conditional<Int>.encode(to:)
 
 // but only for Codable parameters.
 struct Nonconforming {}
-let _ = Conditional<Nonconforming>.init(from:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
-let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+let _ = Conditional<Nonconforming>.init(from:) // expected-error {{referencing initializer 'init(from:)' on 'Conditional' requires that 'Nonconforming' conform to 'Encodable'}}
+//expected-error@-1 {{referencing initializer 'init(from:)' on 'Conditional' requires that 'Nonconforming' conform to 'Decodable'}}
+let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{referencing instance method 'encode(to:)' on 'Conditional' requires that 'Nonconforming' conform to 'Decodable'}}
+//expected-error@-1 {{referencing instance method 'encode(to:)' on 'Conditional' requires that 'Nonconforming' conform to 'Encodable'}}
 
 // The synthesized CodingKeys type should not be accessible from outside the
 // struct.

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
@@ -20,10 +20,10 @@ final class Conditional<T> {
   }
 }
 
-extension Conditional: Encodable where T: Encodable {
+extension Conditional: Encodable where T: Encodable { // expected-note {{where 'T' = 'OnlyDec'}}
 }
 
-extension Conditional: Decodable where T: Decodable {
+extension Conditional: Decodable where T: Decodable { // expected-note {{where 'T' = 'OnlyEnc'}}
 }
 
 struct OnlyEnc: Encodable {}
@@ -34,8 +34,8 @@ let _ = Conditional<OnlyDec>.init(from:)
 let _ = Conditional<OnlyEnc>.encode(to:)
 
 // but only for the appropriately *codable parameters.
-let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{type 'OnlyEnc' does not conform to protocol 'Decodable'}}
-let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{type 'OnlyDec' does not conform to protocol 'Encodable'}}
+let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{referencing initializer 'init(from:)' on 'Conditional' requires that 'OnlyEnc' conform to 'Decodable'}}
+let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{referencing instance method 'encode(to:)' on 'Conditional' requires that 'OnlyDec' conform to 'Encodable'}}
 
 // The synthesized CodingKeys type should not be accessible from outside the
 // struct.

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
@@ -21,7 +21,7 @@ class Conditional<T> {
   }
 }
 
-extension Conditional: Encodable where T: Encodable {
+extension Conditional: Encodable where T: Encodable { // expected-note {{where 'T' = 'OnlyDec'}}
 }
 
 extension Conditional: Decodable where T: Decodable {
@@ -37,7 +37,7 @@ let _ = Conditional<OnlyEnc>.encode(to:)
 
 // but only for the appropriately *codable parameters.
 let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{type 'Conditional<OnlyEnc>' has no member 'init(from:)'}}
-let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{type 'OnlyDec' does not conform to protocol 'Encodable'}}
+let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{referencing instance method 'encode(to:)' on 'Conditional' requires that 'OnlyDec' conform to 'Encodable'}}
 
 // The synthesized CodingKeys type should not be accessible from outside the
 // struct.

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
@@ -16,7 +16,7 @@ struct Conditional<T> {
   }
 }
 
-extension Conditional: Codable where T: Codable {
+extension Conditional: Codable where T: Codable { // expected-note 4{{where 'T' = 'Nonconforming'}}
 }
 
 // They should receive synthesized init(from:) and an encode(to:).
@@ -25,8 +25,10 @@ let _ = Conditional<Int>.encode(to:)
 
 // but only for Codable parameters.
 struct Nonconforming {}
-let _ = Conditional<Nonconforming>.init(from:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
-let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+let _ = Conditional<Nonconforming>.init(from:) // expected-error {{referencing initializer 'init(from:)' on 'Conditional' requires that 'Nonconforming' conform to 'Encodable'}}
+// expected-error@-1 {{referencing initializer 'init(from:)' on 'Conditional' requires that 'Nonconforming' conform to 'Decodable'}}
+let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{referencing instance method 'encode(to:)' on 'Conditional' requires that 'Nonconforming' conform to 'Encodable'}}
+// expected-error@-1 {{referencing instance method 'encode(to:)' on 'Conditional' requires that 'Nonconforming' conform to 'Decodable'}}
 
 // The synthesized CodingKeys type should not be accessible from outside the
 // struct.

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
@@ -16,9 +16,9 @@ struct Conditional<T> {
   }
 }
 
-extension Conditional: Encodable where T: Encodable {
+extension Conditional: Encodable where T: Encodable { // expected-note {{where 'T' = 'OnlyDec'}}
 }
-extension Conditional: Decodable where T: Decodable {
+extension Conditional: Decodable where T: Decodable { // expected-note {{where 'T' = 'OnlyEnc'}}
 }
 
 struct OnlyEnc: Encodable {}
@@ -29,8 +29,8 @@ let _ = Conditional<OnlyDec>.init(from:)
 let _ = Conditional<OnlyEnc>.encode(to:)
 
 // but only for the appropriately *codable parameters.
-let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{type 'OnlyEnc' does not conform to protocol 'Decodable'}}
-let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{type 'OnlyDec' does not conform to protocol 'Encodable'}}
+let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{referencing initializer 'init(from:)' on 'Conditional' requires that 'OnlyEnc' conform to 'Decodable'}}
+let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{referencing instance method 'encode(to:)' on 'Conditional' requires that 'OnlyDec' conform to 'Encodable'}}
 
 // The synthesized CodingKeys type should not be accessible from outside the
 // struct.


### PR DESCRIPTION
...now that attemptFixes is turned on. This enables the better RequirementFailure diagnoses in more cases. Also revealed an example where the AffectedDecl is a computed var, and so the GenericContext for the RequirementFailure needs to be the var's extension context.

Resolves [SR-8934](https://bugs.swift.org/browse/SR-8934).
