### PR TITLE
Change Default Linker to Gold for x86

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -111,6 +111,7 @@ std::string toolchains::GenericUnix::getDefaultLinker() const {
     // final executables, as such, unless specified, we default to gold
     // linker.
     return "gold";
+  case llvm::Triple::x86:
   case llvm::Triple::x86_64:
   case llvm::Triple::ppc64:
   case llvm::Triple::ppc64le:


### PR DESCRIPTION
For the same reasons that most platforms rely on the gold linker to be the default, x86/i686 needs it to be the default to avoid issues when using swift/swiftc to build/link modules. 