### PR TITLE
Force AttributeBase Alignment to 8-byte

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -135,7 +135,7 @@ public:
   static const char *getAttrName(TypeAttrKind kind);
 };
 
-class AttributeBase {
+class alignas(1 << AttrAlignInBits) AttributeBase {
 public:
   /// The location of the '@'.
   const SourceLoc AtLoc;

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -30,6 +30,7 @@ namespace swift {
   class ArchetypeType;
   class AssociatedTypeDecl;
   class ASTContext;
+  class AttributeBase;
   class BraceStmt;
   class Decl;
   class DeclContext;
@@ -51,6 +52,7 @@ namespace swift {
   class ValueDecl;
 
   /// We frequently use three tag bits on all of these types.
+  constexpr size_t AttrAlignInBits = 3;
   constexpr size_t DeclAlignInBits = 3;
   constexpr size_t DeclContextAlignInBits = 3;
   constexpr size_t ExprAlignInBits = 3;
@@ -113,6 +115,8 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::Pattern,
                             swift::PatternAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::SILFunction,
                             swift::SILFunctionAlignInBits)
+
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::AttributeBase, swift::AttrAlignInBits)
 
 static_assert(alignof(void*) >= 2, "pointer alignment is too small");
 


### PR DESCRIPTION
On 32-bit ARM, if an AvailableAttr was getting 4-byte aligned, it would trigger a LLVM assert that the PointerIntPair wasn't aligned enough. Forcing 8-byte alignment for AttributeBase addresses the problem. However, the assert is mentioning it wants 2 bits (ParserResult also only asks for 2), so it's a bit more complicated here than simply too many bits being asked for.

If you are using the custom new operator on a child class of AttributeBase, you get the implementation on AttributeBase, which appears to force alignment to be that of AttributeBase. This is problematic if any child class requires more strict alignment than AttributeBase in general. It looks like PointerIntPair uses NumLowBitsAvailable to mask the pointer, and LLVM was catching that AvailableAttr was getting aligned less strictly than its type requires due to the behavior in new. 

It's probably better to fix the underlying issue in the new operator to be able to allocate on the alignment of the type, but as an unblocking measure, it is simpler to ensure that AttributeBase has an alignment at least as strict as its child classes.