### PR TITLE
[silgen] Fix the ownership of enum element pattern initialization.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -971,3 +971,9 @@ void SILGenBuilder::emitDestructureValueOperation(
         return func(index, cloner.clone(subValue));
       });
 }
+
+ManagedValue SILGenBuilder::createProjectBox(SILLocation loc, ManagedValue mv,
+                                             unsigned index) {
+  auto *pbi = SILBuilder::createProjectBox(loc, mv.getValue(), index);
+  return ManagedValue::forUnmanaged(pbi);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -417,6 +417,10 @@ public:
   void emitDestructureValueOperation(
       SILLocation loc, ManagedValue value,
       function_ref<void(unsigned, ManagedValue)> func);
+
+  using SILBuilder::createProjectBox;
+  ManagedValue createProjectBox(SILLocation loc, ManagedValue mv,
+                                unsigned index);
 };
 
 } // namespace Lowering

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name indirect_enum -Xllvm -sil-print-debuginfo %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-sil-ownership -module-name indirect_enum -Xllvm -sil-print-debuginfo %s | %FileCheck %s
 
 indirect enum TreeA<T> {
   case Nil
@@ -151,7 +151,9 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $TreeA<T>):
   // --           x +2
   // CHECK:       [[ARG_COPY:%.*]] = copy_value [[ARG]]
-  // CHECK:       switch_enum [[ARG_COPY]] : $TreeA<T>,
+  // CHECK:       [[BORROWED_ARG_COPY:%.*]] = begin_borrow [[ARG_COPY]]
+  // CHECK:       [[ARG_COPY_2:%.*]] = copy_value [[BORROWED_ARG_COPY]]
+  // CHECK:       switch_enum [[ARG_COPY_2]] : $TreeA<T>,
   // CHECK:          case #TreeA.Nil!enumelt: [[NIL_CASE:bb1]],
   // CHECK:          case #TreeA.Leaf!enumelt.1: [[LEAF_CASE:bb2]],
   // CHECK:          case #TreeA.Branch!enumelt.1: [[BRANCH_CASE:bb3]],
@@ -177,13 +179,15 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK:       [[TUPLE_ADDR:%.*]] = project_box [[NODE_BOX]]
   // CHECK:       [[TUPLE:%.*]] = load_borrow [[TUPLE_ADDR]]
   // CHECK:       ([[LEFT:%.*]], [[RIGHT:%.*]]) = destructure_tuple [[TUPLE]]
-  // CHECK:       switch_enum [[LEFT]] : $TreeA<T>,
+  // CHECK:       [[LEFT_COPY:%.*]] = copy_value [[LEFT]]
+  // CHECK:       switch_enum [[LEFT_COPY]] : $TreeA<T>,
   // CHECK:          case #TreeA.Leaf!enumelt.1: [[LEAF_CASE_LEFT:bb[0-9]+]],
   // CHECK:          default [[FAIL_LEFT:bb[0-9]+]]
 
   // CHECK:     [[LEAF_CASE_LEFT]]([[LEFT_LEAF_BOX:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <T>):
   // CHECK:       [[LEFT_LEAF_VALUE:%.*]] = project_box [[LEFT_LEAF_BOX]]
-  // CHECK:       switch_enum [[RIGHT]] : $TreeA<T>,
+  // CHECK:       [[RIGHT_COPY:%.*]] = copy_value [[RIGHT]]
+  // CHECK:       switch_enum [[RIGHT_COPY]] : $TreeA<T>,
   // CHECK:          case #TreeA.Leaf!enumelt.1: [[LEAF_CASE_RIGHT:bb[0-9]+]],
   // CHECK:          default [[FAIL_RIGHT:bb[0-9]+]]
 
@@ -195,10 +199,12 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK:       destroy_value [[NODE_BOX]]
   // CHECK:       br [[OUTER_CONT]]
 
-  // CHECK:     [[FAIL_RIGHT]]:
+  // CHECK:     [[FAIL_RIGHT]]([[DEFAULT_VAL:%.*]] :
+  // CHECK:       destroy_value [[DEFAULT_VAL]]
   // CHECK:       br [[DEFAULT:bb[0-9]+]]
 
-  // CHECK:     [[FAIL_LEFT]]:
+  // CHECK:     [[FAIL_LEFT]]([[DEFAULT_VAL:%.*]] :
+  // CHECK:       destroy_value [[DEFAULT_VAL]]
   // CHECK:       br [[DEFAULT]]
 
   case .Branch(.Leaf(let x), .Leaf(let y)):
@@ -310,6 +316,27 @@ func switchTreeB<T>(_ x: TreeB<T>) {
   // CHECK:       return
 }
 
+// Make sure that switchTreeInt obeys ownership invariants.
+//
+// CHECK-LABEL: sil hidden @$s13indirect_enum13switchTreeInt{{[_0-9a-zA-Z]*}}F
+func switchTreeInt(_ x: TreeInt) {
+  switch x {
+
+  case .Nil:
+    a()
+
+  case .Leaf(let x):
+    b(x)
+
+  case .Branch(.Leaf(let x), .Leaf(let y)):
+    c(x, y)
+
+  default:
+    d()
+  }
+}
+// CHECK: } // end sil function '$s13indirect_enum13switchTreeInt{{[_0-9a-zA-Z]*}}F'
+
 // CHECK-LABEL: sil hidden @$s13indirect_enum10guardTreeA{{[_0-9a-zA-Z]*}}F
 func guardTreeA<T>(_ tree: TreeA<T>) {
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $TreeA<T>):
@@ -340,8 +367,9 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK: [[YES]]([[BOX:%.*]] : @owned $<τ_0_0> { var (left: TreeA<τ_0_0>, right: TreeA<τ_0_0>) } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
-    // CHECK:   [[TUPLE:%.*]] = load [take] [[VALUE_ADDR]]
+    // CHECK:   [[TUPLE:%.*]] = load_borrow [[VALUE_ADDR]]
     // CHECK:   [[TUPLE_COPY:%.*]] = copy_value [[TUPLE]]
+    // CHECK:   end_borrow [[TUPLE]]
     // CHECK:   ([[L:%.*]], [[R:%.*]]) = destructure_tuple [[TUPLE_COPY]]
     // CHECK:   destroy_value [[BOX]]
     guard case .Branch(left: let l, right: let r) = tree else { return }
@@ -381,8 +409,9 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK: [[YES]]([[BOX:%.*]] : @owned $<τ_0_0> { var (left: TreeA<τ_0_0>, right: TreeA<τ_0_0>) } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
-    // CHECK:   [[TUPLE:%.*]] = load [take] [[VALUE_ADDR]]
+    // CHECK:   [[TUPLE:%.*]] = load_borrow [[VALUE_ADDR]]
     // CHECK:   [[TUPLE_COPY:%.*]] = copy_value [[TUPLE]]
+    // CHECK:   end_borrow [[TUPLE]]
     // CHECK:   ([[L:%.*]], [[R:%.*]]) = destructure_tuple [[TUPLE_COPY]]
     // CHECK:   destroy_value [[BOX]]
     // CHECK:   destroy_value [[R]]
@@ -390,7 +419,6 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     if case .Branch(left: let l, right: let r) = tree { }
   }
 }
-
 // CHECK-LABEL: sil hidden @$s13indirect_enum10guardTreeB{{[_0-9a-zA-Z]*}}F
 func guardTreeB<T>(_ tree: TreeB<T>) {
   do {
@@ -475,6 +503,25 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
     // CHECK:   destroy_value [[BOX]]
     // CHECK:   destroy_addr [[R]]
     // CHECK:   destroy_addr [[L]]
+    if case .Branch(left: let l, right: let r) = tree { }
+  }
+}
+
+// Just run guardTreeInt through the ownership verifier
+//
+// CHECK-LABEL: sil hidden @$s13indirect_enum12guardTreeInt{{[_0-9a-zA-Z]*}}F
+func guardTreeInt(_ tree: TreeInt) {
+  do {
+    guard case .Nil = tree else { return }
+
+    guard case .Leaf(let x) = tree else { return }
+
+    guard case .Branch(left: let l, right: let r) = tree else { return }
+  }
+
+  do {
+    if case .Nil = tree { }
+    if case .Leaf(let x) = tree { }
     if case .Branch(left: let l, right: let r) = tree { }
   }
 }


### PR DESCRIPTION
The problem here is that we were taking advantage of swift not-trashing the
original memory location after performing a load [take] to use load [take] as a
+0 load. This breaks the ownership verifier since the load [take] is never
actually destroyed. Instead this commit changes this code to use a load_borrow.

I found this when trying to enable ownership verification on
test/SILGen/indirect_enum.swift using some out of tree work that should have
fixed all of the ownership issues with SILGenPattern. Turns out I can just
enable ownership verification with just this change... so I did that as well in
this PR.

rdar://29791263
