### PR TITLE
[Sema] Omit protocol match diagnosis for constructors with differing names.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1963,11 +1963,12 @@ static void
 diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
               ValueDecl *req, const RequirementMatch &match) {
 
-  // If we are matching a constructor and the name doesn't match,
+  // If the name doesn't match and that's not the only problem,
   // it is likely this witness wasn't intended to be a match at all, so omit
   // diagnosis.
-  if (req->getKind() == DeclKind::Constructor && match.Kind != MatchKind::RenamedMatch
-      && !match.Witness->getAttrs().hasAttribute<ImplementsAttr>() &&
+  if (match.Kind != MatchKind::RenamedMatch &&
+      !match.Witness->getAttrs().hasAttribute<ImplementsAttr>() &&
+      match.Witness->getFullName() &&
       req->getFullName() != match.Witness->getFullName())
     return;
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1961,7 +1961,16 @@ static void addOptionalityFixIts(
 /// \brief Diagnose a requirement match, describing what went wrong (or not).
 static void
 diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
-              ValueDecl *req, const RequirementMatch &match){
+              ValueDecl *req, const RequirementMatch &match) {
+
+  // If we are matching a constructor and the name doesn't match,
+  // it is likely this witness wasn't intended to be a match at all, so omit
+  // diagnosis.
+  if (req->getKind() == DeclKind::Constructor && match.Kind != MatchKind::RenamedMatch
+      && !match.Witness->getAttrs().hasAttribute<ImplementsAttr>() &&
+      req->getFullName() != match.Witness->getFullName())
+    return;
+
   // Form a string describing the associated type deductions.
   // FIXME: Determine which associated types matter, and only print those.
   llvm::SmallString<128> withAssocTypes;

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -270,7 +270,7 @@ func classAnyObject(_ obj: NSObject) {
 }
 
 // Protocol conformances
-class Wobbler : NSWobbling { // expected-note{{candidate has non-matching type '()'}}
+class Wobbler : NSWobbling {
   @objc func wobble() { }
 
   func returnMyself() -> Self { return self } // expected-error{{non-'@objc' method 'returnMyself()' does not satisfy requirement of '@objc' protocol 'NSWobbling'}}{{none}}
@@ -280,7 +280,7 @@ class Wobbler : NSWobbling { // expected-note{{candidate has non-matching type '
 extension Wobbler : NSMaybeInitWobble { // expected-error{{type 'Wobbler' does not conform to protocol 'NSMaybeInitWobble'}}
 }
 
-@objc class Wobbler2 : NSObject, NSWobbling { // expected-note{{candidate has non-matching type '()'}}
+@objc class Wobbler2 : NSObject, NSWobbling {
   func wobble() { }
   func returnMyself() -> Self { return self }
 }

--- a/test/Compatibility/special_func_name.swift
+++ b/test/Compatibility/special_func_name.swift
@@ -18,7 +18,6 @@ protocol P2 {
 }
 
 struct S21 : P2 { // expected-error {{type 'S21' does not conform to protocol 'P2'}}
-  // expected-note@-1 {{candidate has non-matching type '()'}}
   static func `init`(_: Int) {}
 }
 

--- a/test/Constraints/generic_protocol_witness.swift
+++ b/test/Constraints/generic_protocol_witness.swift
@@ -42,7 +42,7 @@ class TooTightConstraints : NeedsGenericMethods { // expected-error{{type 'TooTi
   func oneArgWithConstraint<U : Fungible>(x: U) {} // expected-note{{candidate has non-matching type '<U> (x: U) -> ()'}}
   func oneArgWithConstraints<U : Runcible & Fungible & Ansible>(x: U) {} // expected-note{{candidate has non-matching type '<U> (x: U) -> ()'}}
 
-  func twoArgsOneVar<U : Runcible>(x: U) {} // expected-note{{candidate has non-matching type '<U> (x: U) -> ()'}}
+  func twoArgsOneVar<U : Runcible>(x: U) {}
   func twoArgsTwoVars<U>(x: U, y: U) {} // expected-note{{candidate has non-matching type '<U> (x: U, y: U) -> ()'}}
 }
 func •(_ x: TooTightConstraints, y: Int) {} // expected-note {{candidate has non-matching type '(TooTightConstraints, Int) -> ()'}}

--- a/test/decl/func/special_func_name.swift
+++ b/test/decl/func/special_func_name.swift
@@ -18,7 +18,6 @@ protocol P2 {
 }
 
 struct S21 : P2 { // expected-error {{type 'S21' does not conform to protocol 'P2'}}
-  // expected-note@-1 {{candidate has non-matching type '()'}}
   static func `init`(_: Int) {}
 }
 

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -97,7 +97,7 @@ struct P6Conformer : P6 { // expected-error 2 {{does not conform}}
 // expected-error@+1{{type 'A' does not conform to protocol 'RawRepresentable'}}
 struct A: OptionSet {
   let rawValue = 0
-  init() { } // expected-note 2{{candidate has non-matching type '()'}}
+  init() { }
 }
 
 // Type witness cannot have its own generic parameters

--- a/test/decl/protocol/conforms/fixit_stub.swift
+++ b/test/decl/protocol/conforms/fixit_stub.swift
@@ -11,7 +11,7 @@ protocol Protocol1 {
   subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; do you want to add a stub?}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
 }
 
-class Adopter: Protocol1 { // expected-error{{type 'Adopter' does not conform to protocol 'Protocol1'}} expected-note{{candidate has non-matching type '()'}}
+class Adopter: Protocol1 { // expected-error{{type 'Adopter' does not conform to protocol 'Protocol1'}}
 }
 
 
@@ -26,7 +26,7 @@ protocol Protocol2 {
   subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; do you want to add a stub?}} {{32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
 }
 
-class Adopter2 {} //  expected-note{{candidate has non-matching type '()'}}
+class Adopter2 {}
 
 extension Adopter2: Protocol2 { // expected-error{{ype 'Adopter2' does not conform to protocol 'Protocol2'}}
 }
@@ -131,19 +131,19 @@ public class Adopter11: ProtocolWithPrivateAccess3, ProtocolWithPrivateAccess4 {
 protocol ProtocolRequiresInit1 {
   init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{48-48=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
 }
-final class Adopter12 : ProtocolRequiresInit1 {} //expected-error {{type 'Adopter12' does not conform to protocol 'ProtocolRequiresInit1'}} // expected-note{{candidate}}
+final class Adopter12 : ProtocolRequiresInit1 {} //expected-error {{type 'Adopter12' does not conform to protocol 'ProtocolRequiresInit1'}}
 
 protocol ProtocolRequiresInit2 {
   init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{46-46=\n    convenience init(arg: Int) {\n        <#code#>\n    \}\n}}
 }
-final class Adopter13 {} // expected-note{{candidate}}
+final class Adopter13 {}
 extension Adopter13 : ProtocolRequiresInit2 {} //expected-error {{type 'Adopter13' does not conform to protocol 'ProtocolRequiresInit2'}}
 
 protocol ProtocolRequiresInit3 {
   init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{46-46=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
 }
 
-struct Adopter14 {} // expected-note{{candidate}}
+struct Adopter14 {}
 extension Adopter14 : ProtocolRequiresInit3 {} //expected-error {{type 'Adopter14' does not conform to protocol 'ProtocolRequiresInit3'}}
 
 protocol ProtocolChain1 {

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -77,7 +77,7 @@ class NotPrintableC : CustomStringConvertible, Any {} // expected-error{{type 'N
 enum NotPrintableO : Any, CustomStringConvertible {} // expected-error{{type 'NotPrintableO' does not conform to protocol 'CustomStringConvertible'}}
 
 struct NotFormattedPrintable : FormattedPrintable { // expected-error{{type 'NotFormattedPrintable' does not conform to protocol 'CustomStringConvertible'}}
-  func print(format: TestFormat) {} // expected-note{{candidate has non-matching type '(TestFormat) -> ()'}}
+  func print(format: TestFormat) {} 
 }
 
 // Protocol compositions in inheritance clauses

--- a/test/decl/protocol/req/func.swift
+++ b/test/decl/protocol/req/func.swift
@@ -74,7 +74,7 @@ struct X2x : P2 { // expected-error{{type 'X2x' does not conform to protocol 'P2
 // Mismatch in parameter types
 struct X2y : P2 { // expected-error{{type 'X2y' does not conform to protocol 'P2'}}
   typealias Assoc = X1a
-  func f1(x: X1b) { } // expected-note{{candidate has non-matching type '(X1b) -> ()'}}
+  func f1(x: X1b) { }
 }
 
 // Ambiguous deduction
@@ -192,7 +192,7 @@ protocol P6 {
 }
 struct X6 : P6 { // expected-error{{type 'X6' does not conform to protocol 'P6'}}
   func foo(_ x: Missing) { } // expected-error{{use of undeclared type 'Missing'}}
-  func bar() { } // expected-note{{candidate has non-matching type '() -> ()'}}
+  func bar() { }
 }
 
 protocol P6Ownership {

--- a/test/decl/protocol/special/coding/enum_coding_key.swift
+++ b/test/decl/protocol/special/coding/enum_coding_key.swift
@@ -41,14 +41,10 @@ enum Int8Key : Int8, CodingKey { // expected-error {{type 'Int8Key' does not con
 
 // Structs conforming to CodingKey should not get implicit derived conformance.
 struct StructKey : CodingKey { // expected-error {{type 'StructKey' does not conform to protocol 'CodingKey'}}
-  // expected-note@-1 {{candidate has non-matching type '()'}}
-  // expected-note@-2 {{candidate has non-matching type '()'}}
 }
 
 // Classes conforming to CodingKey should not get implict derived conformance.
 class ClassKey : CodingKey { //expected-error {{type 'ClassKey' does not conform to protocol 'CodingKey'}}
-  // expected-note@-1 {{candidate has non-matching type '()'}}
-  // expected-note@-2 {{candidate has non-matching type '()'}}
 }
 
 // Types which are valid for CodingKey derived conformance should not get that

--- a/validation-test/compiler_crashers_2_fixed/0160-rdar41141944.swift
+++ b/validation-test/compiler_crashers_2_fixed/0160-rdar41141944.swift
@@ -11,8 +11,6 @@ class C : P {
 // expected-error@-1 {{type 'C' does not conform to protocol 'P'}}
   var foo: Float = 0.75
   // expected-note@-1 {{'foo' previously declared here}}
-  // expected-note@-2 {{candidate is not a function}}
   func foo() {}
   // expected-error@-1 {{invalid redeclaration of 'foo()'}}
-  // expected-note@-2 {{candidate has non-matching type '() -> ()'}}
 }


### PR DESCRIPTION
When matching potential witnesses, we look at and diagnose all possible matches with the same short name that could possibly apply, even with differing parameter counts or names. This is especially bad for constructors, where we diagnose every `init`.

E.g. because OptionSet has a `init(rawValue:)` requirement, the line `struct X: OptionSet {}` resulted in:
```
../a.swift:1:8: note: candidate has non-matching type '()' [with Element = X]
struct X : OptionSet {}
       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.RawRepresentable:2:24: note: candidate throws, but protocol does not allow it
    public convenience init(from decoder: Decoder) throws
                       ^
Swift.SetAlgebra:2:24: note: candidate has non-matching type 'S' [with Element = X]
    public convenience init<S>(_ sequence: S) where S : Sequence, Self.Element == S.Element
                       ^
Swift.SetAlgebra:2:24: note: candidate has non-matching type '(arrayLiteral: Self.Element...)' [with Element = X]
    public convenience init(arrayLiteral: Self.Element...)
                       ^
Swift.OptionSet:2:24: note: candidate has non-matching type '()' [with Element = X]
    public convenience init()
                       ^
```

Change this so that unless the full name of the witness is the same as the requirement, constructor mismatches aren't diagnosed.

I also tested this with _any_ witness (not just constructors), so that a potential witness wouldn't be diagnosed unless full name matched OR everything except name (e.g. a Renamed mismatch), and I think that would be a reasonable thing to do also, but it's a little more arguable, so in this PR just doing the obvious good.  

Resolves [SR-8757](https://bugs.swift.org/browse/SR-8757).