### PR TITLE
[master-next] After LLVM r344359, Timer names with slashes do not work.

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -589,7 +589,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
   performNameBinding(SF, StartElem);
 
   {
-    SharedTimer timer("Type checking / Semantic analysis");
+    SharedTimer timer("Type checking and Semantic analysis");
 
     TC.setWarnLongFunctionBodies(WarnLongFunctionBodies);
     TC.setWarnLongExpressionTypeChecking(WarnLongExpressionTypeChecking);


### PR DESCRIPTION
The code in TimerGroup::printJSONValue asserts that the name does not need
to be quoted. Perhaps we can get this fixed, but for now at least, rename
a Timer that has a forward slash in its name.