### PR TITLE
Use target-swift-frontend

### DIFF
--- a/test/IRGen/ELF-objc-sections.swift
+++ b/test/IRGen/ELF-objc-sections.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target x86_64-unknown-linux-gnu -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -I %S/Inputs/usr/include -Xcc --sysroot=/var/empty -emit-ir %s -o - | %FileCheck %s -check-prefix CHECK-ELF
+// RUN: %target-swift-frontend -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -I %S/Inputs/usr/include -Xcc --sysroot=/var/empty -emit-ir %s -o - | %FileCheck %s -check-prefix CHECK-ELF
 
 // REQUIRES: OS=linux-gnu
 


### PR DESCRIPTION
```test/IRGen/ELF-objc-sections.swift``` hard codes  swift target to x86_64-unknown-linux-gnu.  This results in failure of test case on s390x architecture.

This PR uses ```%target-swift-frontend``` to make it generic across Linux platforms.