### PR TITLE
[update-checkout] Use swift-5.0-branch of Clang/LLVM with swift-5.0-branch

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -180,9 +180,9 @@
         "swift-5.0-branch" : {
             "aliases": ["swift-5.0-branch"],
             "repos": {
-                "llvm": "swift-4.2-branch",
-                "clang": "swift-4.2-branch",
-                "compiler-rt": "swift-4.2-branch",
+                "llvm": "swift-5.0-branch",
+                "clang": "swift-5.0-branch",
+                "compiler-rt": "swift-5.0-branch",
                 "swift": "swift-5.0-branch",
                 "lldb": "swift-5.0-branch",
                 "cmark": "master",


### PR DESCRIPTION
We have now rebranched swift-5.0 from master so it should build with the
swift-5.0-branch of Clang/LLVM.