### PR TITLE
test: add swift-test-depends target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -316,6 +316,11 @@ foreach(SDK ${SWIFT_SDKS})
             COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE}"
             USES_TERMINAL)
 
+        set(test_dependencies_target_name
+            "swift${test_subset_target_suffix}${test_mode_target_suffix}${VARIANT_SUFFIX}-test-depends")
+        add_custom_target("${test_dependencies_target_name}"
+            DEPENDS ${dependencies})
+
         add_custom_target("${test_target_name}-custom"
             ${command_upload_stdlib}
             ${command_upload_swift_reflection_test}
@@ -353,5 +358,8 @@ foreach(test_mode ${TEST_MODES})
         DEPENDS "${test_target_name}${SWIFT_PRIMARY_VARIANT_SUFFIX}")
     set_property(TARGET "${test_target_name}"
         PROPERTY FOLDER "Tests/check-swift")
+
+    add_custom_target("swift${test_subset_target_suffix}${test_mode_target_suffix}-test-depends"
+        DEPENDS "swift${test_subset_target_suffix}${test_mode_target_suffix}${SWIFT_PRIMARY_VARIANT_SUFFIX}-test-depends")
   endforeach()
 endforeach()


### PR DESCRIPTION
check-llvm and check-clang have llvm-test-depends and
clang-test-depends targets which build all dependencies but doesn't run
the tests. Add similar target for check-swift. This allows me to easily
cross-compile the tests on a different system and then run on a matching
machine later.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
