### PR TITLE
[ComponentStep] NFC: Remove redundant `numComponents` check for debug…

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -117,7 +117,7 @@ void SplitterStep::computeFollowupSteps(
         CS, i, /*single=*/false, &Components[i], PartialSolutions[i]));
   }
 
-  if (numComponents > 1 && isDebugMode()) {
+  if (isDebugMode()) {
     auto &log = getDebugLogger();
     // Verify that the constraint graph is valid.
     CG.verify();


### PR DESCRIPTION
… output

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
