### PR TITLE
[DNM] Conform float types to TextOutputStreamable

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -82,7 +82,11 @@ extension ${Self} : CustomStringConvertible {
   @inlinable // FIXME(sil-serialize-all)
   public var description: String {
     if isFinite {
-      return _float${bits}ToString(self, debug: false)
+      var (buffer, length) = _float${bits}ToString(self, debug: false)
+      return buffer.withBytes { (bufferPtr) in
+        String._fromASCII(
+          UnsafeBufferPointer(start: bufferPtr, count: length))
+      }
     } else if isNaN {
       return "nan"
     } else if sign == .minus {
@@ -97,11 +101,26 @@ extension ${Self} : CustomDebugStringConvertible {
   /// A textual representation of the value, suitable for debugging.
   public var debugDescription: String {
     if isFinite || isNaN {
-      return _float${bits}ToString(self, debug: true)
+      var (buffer, length) = _float${bits}ToString(self, debug: true)
+      return buffer.withBytes { (bufferPtr) in
+        String._fromASCII(
+          UnsafeBufferPointer(start: bufferPtr, count: length))
+      }
     } else if sign == .minus {
       return "-inf"
     } else {
       return "inf"
+    }
+  }
+}
+
+extension ${Self} : TextOutputStreamable {
+  @inlinable
+  public func write<Target>(to target: inout Target) where Target : TextOutputStream {
+    var (buffer, length) = _float${bits}ToString(self, debug: true)
+    buffer.withBytes { (bufferPtr) in
+      let bufPtr = UnsafeBufferPointer(start: bufferPtr, count: length)
+      target._writeASCII(bufPtr)
     }
   }
 }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -72,11 +72,18 @@ public protocol TextOutputStream {
 
   /// Appends the given string to the stream.
   mutating func write(_ string: String)
+
+  mutating func _writeASCII(_ buffer: UnsafeBufferPointer<UInt8>)
 }
 
 extension TextOutputStream {
   public mutating func _lock() {}
   public mutating func _unlock() {}
+
+  @inlinable // FIXME(sil-serialize-all)
+  public mutating func _writeASCII(_ buffer: UnsafeBufferPointer<UInt8>) {
+    write(String._fromASCII(buffer))
+  }
 }
 
 /// A source of text-streaming operations.
@@ -562,6 +569,10 @@ extension String : TextOutputStream {
   @inlinable // FIXME(sil-serialize-all)
   public mutating func write(_ other: String) {
     self += other
+  }
+  
+  public mutating func _writeASCII(_ buffer: UnsafeBufferPointer<UInt8>) {
+    self._guts.append(_UnmanagedString(buffer))
   }
 }
 

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -385,14 +385,13 @@ internal func _float${bits}ToStringImpl(
 @inlinable // FIXME(sil-serialize-all)
 internal func _float${bits}ToString(
   _ value: Float${bits}, debug: Bool
-) -> String {
+) -> (buffer: _Buffer32, length: Int) {
   _sanityCheck(MemoryLayout<_Buffer32>.size == 32)
   var buffer = _Buffer32()
-  return buffer.withBytes { (bufferPtr) in
-    let actualLength = _float${bits}ToStringImpl(bufferPtr, 32, value, debug)
-    return String._fromASCII(
-      UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+  let length = buffer.withBytes { (bufferPtr) in
+    Int(_float${bits}ToStringImpl(bufferPtr, 32, value, debug))
   }
+  return (buffer, length)
 }
 
 % if bits == 80:


### PR DESCRIPTION
This is a change included in [SE-0228](https://github.com/apple/swift-evolution/blob/master/proposals/0228-fix-expressiblebystringinterpolation.md) which allows floating-point types to write themselves into strings without generating a temporary `String`. It may not be a win for all floating-point types, so I'm pulling it into a separate branch to benchmark it separately. (OTOH, it might not look like a win at all here because of how the old string interpolation design works—we'll see.)