### PR TITLE
[ConstraintSystem] Make sure that system is returned into its original

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2045,15 +2045,6 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
     SolverState state(expr, *this, FreeTypeVariableBinding::Disallow);
     state.recordFixes = true;
 
-    // Retry all inactive and failed constraints
-    if (failedConstraint) {
-      addUnsolvedConstraint(failedConstraint);
-      failedConstraint = nullptr;
-    }
-    ActiveConstraints.splice(ActiveConstraints.end(), InactiveConstraints);
-    for (auto &constraint : ActiveConstraints)
-      constraint.setActive(true);
-
     // Solve the system.
     solve(viable);
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1308,6 +1308,10 @@ private:
     /// are added back to the circulation.
     ConstraintList retiredConstraints;
 
+    /// The set of constraints which were active at the time of this state
+    /// creating, it's used to re-activate them on destruction.
+    SmallVector<Constraint *, 4> activeConstraints;
+
     /// The current set of generated constraints.
     SmallVector<Constraint *, 4> generatedConstraints;
 

--- a/validation-test/Sema/type_checker_perf/fast/more_specialized_generic_func.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/more_specialized_generic_func.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 10 --step 1 --select incrementScopeCounter %s --expected-exit-code 0
+// RUN: %scale-test --begin 8 --end 40 --step 2 --select incrementScopeCounter %s --expected-exit-code 0
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
… state after solving

Currently (with or w/o failures) constraint system is not returned
back to its original state after solving, because constraints from
initial "active" list are not returned to the system. To fix that
let's allocate "initial" scope which captures state right before
solving begins, and add "active" list to the solver state to capture
information about "active" constraints at the time of its creation.

This is follow-up to https://github.com/apple/swift/pull/19873

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
