### PR TITLE
Fix typo correction crash

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -731,6 +731,7 @@ GenericSignature *GenericContext::getGenericSignature() const {
   // The signature of a Protocol is trivial (Self: TheProtocol) so let's compute
   // it.
   if (auto PD = dyn_cast<ProtocolDecl>(this)) {
+    const_cast<ProtocolDecl *>(PD)->createGenericParamsIfMissing();
     auto self = PD->getSelfInterfaceType()->castTo<GenericTypeParamType>();
     auto req =
         Requirement(RequirementKind::Conformance, self, PD->getDeclaredType());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4771,8 +4771,12 @@ Type DeclContext::getSelfTypeInContext() const {
   assert(isTypeContext());
 
   // For a protocol or extension thereof, the type is 'Self'.
-  if (getSelfProtocolDecl())
-    return mapTypeIntoContext(getProtocolSelfType());
+  if (getSelfProtocolDecl()) {
+    auto selfType = getProtocolSelfType();
+    if (!selfType)
+      return ErrorType::get(getASTContext());
+    return mapTypeIntoContext(selfType);
+  }
   return getDeclaredTypeInContext();
 }
 
@@ -4781,8 +4785,12 @@ Type DeclContext::getSelfInterfaceType() const {
   assert(isTypeContext());
 
   // For a protocol or extension thereof, the type is 'Self'.
-  if (getSelfProtocolDecl())
-    return getProtocolSelfType();
+  if (getSelfProtocolDecl()) {
+    auto selfType = getProtocolSelfType();
+    if (!selfType)
+      return ErrorType::get(getASTContext());
+    return selfType;
+  }
   return getDeclaredInterfaceType();
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3884,13 +3884,13 @@ findProtocolSelfReferences(const ProtocolDecl *proto, Type type,
   }
 
   // A direct reference to 'Self' is covariant.
-  if (proto->getProtocolSelfType()->isEqual(type))
+  if (proto->getSelfInterfaceType()->isEqual(type))
     return SelfReferenceKind::Result();
 
   // Special handling for associated types.
   if (!skipAssocTypes && type->is<DependentMemberType>()) {
     type = type->getRootGenericParam();
-    if (proto->getProtocolSelfType()->isEqual(type))
+    if (proto->getSelfInterfaceType()->isEqual(type))
       return SelfReferenceKind::Other();
   }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -88,11 +88,13 @@ ProtocolDecl *DeclContext::getExtendedProtocolDecl() const {
 GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   assert(getSelfProtocolDecl() && "not a protocol");
 
+  GenericParamList *genericParams;
   if (auto proto = dyn_cast<ProtocolDecl>(this)) {
-    const_cast<ProtocolDecl *>(proto)->createGenericParamsIfMissing();
+    genericParams = proto->getGenericParams();
+  } else {
+    genericParams = cast<ExtensionDecl>(this)->getGenericParams();
   }
 
-  auto *genericParams = getGenericParamsOfContext();
   if (genericParams == nullptr)
     return nullptr;
 

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -1014,11 +1014,11 @@ void swift::lookupVisibleDecls(VisibleDeclConsumer &Consumer,
         }
       }
     } else if (auto ED = dyn_cast<ExtensionDecl>(DC)) {
-      ExtendedType = ED->getDeclaredTypeInContext();
+      ExtendedType = ED->getSelfTypeInContext();
       if (ExtendedType)
         BaseDecl = ExtendedType->getNominalOrBoundGenericNominal();
     } else if (auto ND = dyn_cast<NominalTypeDecl>(DC)) {
-      ExtendedType = ND->getDeclaredTypeInContext();
+      ExtendedType = ND->getSelfTypeInContext();
       BaseDecl = ND;
     }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -415,13 +415,13 @@ ProtocolConformanceRef::getInheritedConformanceRef(ProtocolDecl *base) const {
   auto proto = concrete->getProtocol();
   auto path =
     proto->getGenericSignature()->getConformanceAccessPath(
-                                            proto->getProtocolSelfType(), base);
+                                            proto->getSelfInterfaceType(), base);
   ProtocolConformanceRef result = *this;
   Type resultType = concrete->getType();
   bool first = true;
   for (const auto &step : path) {
     if (first) {
-      assert(step.first->isEqual(proto->getProtocolSelfType()));
+      assert(step.first->isEqual(proto->getSelfInterfaceType()));
       assert(step.second == proto);
       first = false;
       continue;
@@ -774,7 +774,7 @@ Type ProtocolConformanceRef::getAssociatedType(Type conformingType,
 
   // Fast path for dependent member types on 'Self' of our associated types.
   auto memberType = cast<DependentMemberType>(type);
-  if (memberType.getBase()->isEqual(proto->getProtocolSelfType()) &&
+  if (memberType.getBase()->isEqual(proto->getSelfInterfaceType()) &&
       memberType->getAssocType()->getProtocol() == proto &&
       isConcrete())
     return getConcrete()->getTypeWitness(memberType->getAssocType(), resolver);

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -525,7 +525,7 @@ SubstitutionMap::getOverrideSubstitutions(
   // For overrides within a protocol hierarchy, substitute the Self type.
   if (auto baseProto = baseDecl->getDeclContext()->getSelfProtocolDecl()) {
     if (auto derivedProtoSelf =
-          derivedDecl->getDeclContext()->getProtocolSelfType()) {
+          derivedDecl->getDeclContext()->getSelfInterfaceType()) {
       return SubstitutionMap::getProtocolSubstitutions(
                                              baseProto,
                                              derivedProtoSelf,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -817,9 +817,7 @@ namespace {
         conformance.getConcrete()->getType()->hasArchetype();
       if (hasArchetype) {
         // Bind local Self type data from the metadata argument.
-        CanType selfInContext =
-            Proto->mapTypeIntoContext(Proto->getProtocolSelfType())
-              ->getCanonicalType();
+        auto selfInContext = Proto->getSelfTypeInContext()->getCanonicalType();
         IGF.bindLocalTypeDataFromTypeMetadata(selfInContext, IsExact, self,
                                               MetadataState::Abstract);
         IGF.setUnscopedLocalTypeData(

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -972,7 +972,7 @@ bool irgen::isDependentConformance(const NormalProtocolConformance *conformance)
   auto proto = conformance->getProtocol();
   for (const auto &req : proto->getRequirementSignature()) {
     if (req.getKind() != RequirementKind::Conformance ||
-        !req.getFirstType()->isEqual(proto->getProtocolSelfType()))
+        !req.getFirstType()->isEqual(proto->getSelfInterfaceType()))
       continue;
 
     auto inherited = req.getSecondType()->castTo<ProtocolType>()->getDecl();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -50,7 +50,7 @@ SubstitutionMap SILGenModule::mapSubstitutionsForWitnessOverride(
                                               SubstitutionMap subs) {
   // Substitute the 'Self' type of the base protocol.
   auto origProto = cast<ProtocolDecl>(original->getDeclContext());
-  Type origProtoSelfType = origProto->getProtocolSelfType();
+  Type origProtoSelfType = origProto->getSelfInterfaceType();
   auto baseProto = cast<ProtocolDecl>(overridden->getDeclContext());
   return SubstitutionMap::getProtocolSubstitutions(
            baseProto,

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -622,7 +622,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
   // looking for the conformance of 'Self'.
   if (reqtSubMap) {
     auto requirement = conformance.getRequirement();
-    auto self = requirement->getProtocolSelfType()->getCanonicalType();
+    auto self = requirement->getSelfInterfaceType()->getCanonicalType();
 
     conformance = *reqtSubMap.lookupConformance(self, requirement);
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2308,7 +2308,7 @@ static void checkProtocolSelfRequirements(ProtocolDecl *proto,
         case RequirementKind::Layout:
         case RequirementKind::Superclass:
           if (reqRepr &&
-              req.getFirstType()->isEqual(proto->getProtocolSelfType())) {
+              req.getFirstType()->isEqual(proto->getSelfInterfaceType())) {
             auto &diags = proto->getASTContext().Diags;
             diags.diagnose(reqRepr->getSubjectLoc().getLoc(),
                            diag::protocol_where_clause_self_requirement);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3441,7 +3441,7 @@ void ConformanceChecker::ensureRequirementsAreSatisfied(
       DC, Loc, Loc,
       // FIXME: maybe this should be the conformance's type
       proto->getDeclaredInterfaceType(),
-      { Type(proto->getProtocolSelfType()) },
+      { proto->getSelfInterfaceType() },
       proto->getRequirementSignature(),
       QuerySubstitutionMap{substitutions},
       TypeChecker::LookUpConformance(DC),
@@ -3966,7 +3966,7 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
 
     auto conditionalCheckResult = checkGenericArguments(
         DC, ComplainLoc, noteLoc, T,
-        {Type(lookupResult->getRequirement()->getProtocolSelfType())},
+        {lookupResult->getRequirement()->getSelfInterfaceType()},
         *condReqs,
         [](SubstitutableType *dependentType) { return Type(dependentType); },
         LookUpConformance(DC), options);
@@ -5328,7 +5328,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
   for (const auto &req : proto->getRequirementSignature()) {
     if (req.getKind() != RequirementKind::Conformance)
       continue;
-    if (req.getFirstType()->isEqual(proto->getProtocolSelfType()))
+    if (req.getFirstType()->isEqual(proto->getSelfInterfaceType()))
       continue;
 
     // Find the innermost dependent member type (e.g., Self.AssocType), so
@@ -5341,7 +5341,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
              depMemTy->getBase()->getAs<DependentMemberType>())
       depMemTy = innerDepMemTy;
 
-    if (!depMemTy->getBase()->isEqual(proto->getProtocolSelfType()))
+    if (!depMemTy->getBase()->isEqual(proto->getSelfInterfaceType()))
       continue;
 
     auto assocType = depMemTy->getAssocType();

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1121,7 +1121,7 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
   auto result =
     tc.checkGenericArguments(dc, SourceLoc(), SourceLoc(),
                              typeInContext,
-                             { Type(proto->getProtocolSelfType()) },
+                             { proto->getSelfInterfaceType() },
                              sanitizedRequirements,
                              QuerySubstitutionMap{substitutions},
                              TypeChecker::LookUpConformance(dc),

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -420,7 +420,7 @@ void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
         continue;
 
       // Skip inherited requirements.
-      if (req.getFirstType()->isEqual(PD->getProtocolSelfType()))
+      if (req.getFirstType()->isEqual(PD->getSelfInterfaceType()))
         continue;
 
       AssociatedConformance conformance(

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -127,9 +127,9 @@ protocol P2 {
 }
 
 // P2: Begin completions
-// P2-DAG: Decl[GenericTypeParam]/CurrNominal: Self[#Self#];
-// P2-DAG: Decl[AssociatedType]/CurrNominal:   T;
-// P2-DAG: Decl[AssociatedType]/CurrNominal:   U;
+// P2-DAG: Decl[GenericTypeParam]/Super: Self[#Self#];
+// P2-DAG: Decl[AssociatedType]/Super:   T;
+// P2-DAG: Decl[AssociatedType]/Super:   U;
 // P2: End completions
 
 // U_DOT: Begin completions

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -166,3 +166,14 @@ class CircularValidationWithTypo {
     didSet { }
   }
 }
+
+// Crash with invalid extension that has not been bound -- https://bugs.swift.org/browse/SR-8984
+protocol PP {}
+
+func boo() { // expected-note {{did you mean 'boo'?}}
+  extension PP { // expected-error {{declaration is only valid at file scope}}
+    func g() {
+      booo() // expected-error {{use of unresolved identifier 'booo'}}
+    }
+  }
+}


### PR DESCRIPTION
Also a couple of related cleanups.

Fixes <rdar://problem/45242943> / <https://bugs.swift.org/browse/SR-8984>.