### PR TITLE
uniquify graph fn names across expressions in the lldb repl

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -455,7 +455,8 @@ private: // Helpers to create TensorFlow graph nodes.
   bool addTopLevelTPUConfigLogic(TF_Operation **metadataNode);
 
 public: // Lowering functionality.
-  std::string getUniqueName(SILDebugLocation loc, const char *baseName);
+  std::string getUniqueName(SILDebugLocation loc, const SILFunction *fn,
+                            const char *baseName);
 
   TF_DataType getTensorFlowDataType(SILType type, SILLocation loc);
 
@@ -671,6 +672,7 @@ static std::string escapeDeclName(DeclName name) {
 /// Produce a "stack trace" for the specified location, producing it in a form
 /// that we can use as a unique op name.
 std::string TFGraphFunctionLowering::getUniqueName(SILDebugLocation loc,
+                                                   const SILFunction *fn,
                                                    const char *baseName) {
   std::string name = baseName;
 
@@ -740,6 +742,12 @@ std::string TFGraphFunctionLowering::getUniqueName(SILDebugLocation loc,
   // Append device type to ensure the name is unique across all devices.
   name += ':';
   name += thisDeviceTypeStr;
+
+  // Append module name to ensure the name is unique across all modules.
+  // (Duplicate names happen across execution units in the lldb repl).
+  auto module = fn->getModule().getAssociatedContext()->getParentModule();
+  name += ':';
+  name += *module->getReverseFullModuleName();
 
   // Escape op name.
   escapeOpName(name);
@@ -1656,7 +1664,8 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
 
   // The name label we put on the op is summarized from the "stack trace" of
   // the operation's source location.
-  auto opLocString = getUniqueName(inst->getDebugLocation(), "op");
+  auto opLocString = getUniqueName(inst->getDebugLocation(),
+                                   inst->getFunction(), "op");
 
   auto *op = TF_NewOperation(graphFn.getGraph(), opName.str().c_str(),
                              opLocString.c_str());
@@ -2129,8 +2138,9 @@ static TF_Output getCondition(CondBranchInst *condBr,
 // Given a boolean value, create a 'not' operation to invert it, returning the
 // inverted result.
 static TF_Output createNotOp(TF_Output input, SILDebugLocation loc,
+                             const SILFunction *fn,
                              TFGraphFunctionLowering &lowering) {
-  auto opLocString = lowering.getUniqueName(loc, "not");
+  auto opLocString = lowering.getUniqueName(loc, fn, "not");
   auto &graphFn = lowering.getCurrentGraphFunction();
   auto *op =
       TF_NewOperation(graphFn.getGraph(), "LogicalNot", opLocString.c_str());
@@ -2147,8 +2157,9 @@ static TF_Output createNotOp(TF_Output input, SILDebugLocation loc,
 
 /// Given a boolean value, create a 'cast' operation to convert it to int32.
 static TF_Output castBoolToInt32(TF_Output input, SILDebugLocation loc,
+                                 const SILFunction *fn,
                                  TFGraphFunctionLowering &lowering) {
-  auto opLocString = lowering.getUniqueName(loc, "cast");
+  auto opLocString = lowering.getUniqueName(loc, fn, "cast");
   auto &graphFn = lowering.getCurrentGraphFunction();
   auto *op = TF_NewOperation(graphFn.getGraph(), "Cast", opLocString.c_str());
   TF_AddInput(op, input);
@@ -2312,7 +2323,8 @@ GLStatus TFGraphFunctionLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
     // condition.
     // TODO: add a unit test to cover this case.
     if (headerBr->getTrueBB() == r->getExit()) {
-      condValue = createNotOp(condValue, headerBr->getDebugLocation(), *this);
+      condValue = createNotOp(condValue, headerBr->getDebugLocation(),
+                              headerBr->getFunction(), *this);
       if (!condValue.oper) {
         S = GLStatus::Error;
         return;
@@ -2325,7 +2337,8 @@ GLStatus TFGraphFunctionLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
       // FIXME: this added cast may not work for XlaWhile. Revisit whether/how
       // to support loops in XLA GPU.
       condValue =
-          castBoolToInt32(condValue, headerBr->getDebugLocation(), *this);
+          castBoolToInt32(condValue, headerBr->getDebugLocation(),
+                          headerBr->getFunction(), *this);
       if (!condValue.oper) {
         S = GLStatus::Error;
         return;
@@ -2347,13 +2360,14 @@ GLStatus TFGraphFunctionLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
 
   // Create TF_Function's for our condition and body.
   auto loc = headerBr->getDebugLocation();
-  auto loopBodyFnName = getUniqueName(loc, "whilebody");
+  const auto *fn = headerBr->getFunction();
+  auto loopBodyFnName = getUniqueName(loc, fn, "whilebody");
   SmallVector<TF_DataType, 4> inputTypes, outputTypes;
   bool bodyHasSideEffects = false;
   if (buildGraphFunction(loopBodyFn, loopBodyFnName, bodyHasSideEffects,
                          &inputTypes, &outputTypes))
     return GLStatus::Error;
-  auto condFnName = getUniqueName(loc, "whilecond");
+  auto condFnName = getUniqueName(loc, fn, "whilecond");
   bool condHasSideEffects = false;
   if (buildGraphFunction(condFn, condFnName, condHasSideEffects,
                          /*inputTypes*/ nullptr, /*outputTypes*/ nullptr))
@@ -2373,7 +2387,7 @@ GLStatus TFGraphFunctionLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
   //   .Attr("T: list(type) >= 0")
   //   .Attr("cond: func")
   //   .Attr("body: func")
-  auto opLocString = getUniqueName(loc, "op");
+  auto opLocString = getUniqueName(loc, fn, "op");
   auto *op = TF_NewOperation(graphFn.getGraph(),
                              bodyHasSideEffects ? "While" : "StatelessWhile",
                              opLocString.c_str());
@@ -2416,6 +2430,7 @@ TFGraphFunctionLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
   // invocation.
   auto condBr = cast<CondBranchInst>(r->getBranchBB()->getTerminator());
   auto loc = condBr->getDebugLocation();
+  const auto *fn = condBr->getFunction();
 
   auto condValue = getCondition(condBr, *this);
   if (!condValue.oper)
@@ -2547,14 +2562,14 @@ TFGraphFunctionLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
   }
 
   // Create the graph functions for the true/false code.
-  auto trueFnName = getUniqueName(loc, "true");
+  auto trueFnName = getUniqueName(loc, fn, "true");
   bool trueFnHasSideEffects = false;
   SmallVector<TF_DataType, 4> inputTypes, outputTypes;
   if (buildGraphFunction(trueCodeFn, trueFnName, trueFnHasSideEffects,
                          &inputTypes, &outputTypes))
     return GLStatus::Error;
   bool falseFnHasSideEffects = false;
-  auto falseFnName = getUniqueName(loc, "false");
+  auto falseFnName = getUniqueName(loc, fn, "false");
   if (buildGraphFunction(falseCodeFn, falseFnName, falseFnHasSideEffects,
                          /*inputTypes*/ nullptr, /*outputTypes*/ nullptr))
     return GLStatus::Error;
@@ -2572,7 +2587,7 @@ TFGraphFunctionLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
   //   .Attr("else_branch: func")
   //   .Attr("Tin: list(type) >= 0")
   //   .Attr("Tout: list(type) >= 0")
-  auto opLocString = getUniqueName(loc, "op");
+  auto opLocString = getUniqueName(loc, fn, "op");
   bool useSideEffectingIf = trueFnHasSideEffects || falseFnHasSideEffects;
   auto *op = TF_NewOperation(graphFn.getGraph(),
                              useSideEffectingIf ? "If" : "StatelessIf",
@@ -3012,12 +3027,19 @@ bool TFGraphLowering::serializeGraphProtoBuf(ASTContext &ctx,
 
 #endif // SWIFT_ENABLE_TENSORFLOW
 
-/// Gets a function name that can be used as a TF op name.
-StringRef getTFCompatibleFuncName(SILFunction *fn) {
+/// Gets a function name that can be used as a TF op name. This name is based on
+/// fn's name, with
+/// - disallowed characters removed, and
+/// - fn's module name added, so that identically-named functions in different
+///   modules do not clash (this happens for the "main" function in the lldb
+///   repl)
+std::string getTFCompatibleFuncName(SILFunction *fn) {
   auto fnName = fn->getName();
   if (fnName.startswith("$"))
     fnName = fnName.substr(1);
-  return fnName;
+
+  auto module = fn->getModule().getAssociatedContext()->getParentModule();
+  return (*module->getReverseFullModuleName() + "_" + fnName).str();
 }
 
 bool TFGraphLowering::lowerTFGraphOrFunction(
@@ -3098,7 +3120,7 @@ bool TFGraphLowering::lowerTFGraphOrFunction(
 
     std::string graphFnName =
         isAcceleratorOnly ? graphFnNameForCaller
-                          : std::string(getTFCompatibleFuncName(perDeviceFn));
+                          : getTFCompatibleFuncName(perDeviceFn);
     assert(!graphFunctions.count(graphFnName));
 
     bool funcHasSideEffects = false;

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -49,14 +49,14 @@ public func test1SendWithParam(x: Float) {
 // The _Send node should be hooked up as a control dependency on the return
  // node, so that Sends gets run before the function returns.
 // CHECK:        function {
-// CHECK:          name: "{{.*}}test1SendWithParam{{.*}}.tf_CPU.device_partition"
-// CHECK:        function {
 // CHECK:          name: "{{.*}}test1SendWithParam{{.*}}.tf_GPU.device_partition"
 // CHECK:          node_def {
 // CHECK:            name: "RunControlDependency"
 // CHECK:            op: "Identity"
 // CHECK-NEXT:       input: "op/test1SendWithParam.x_
 // CHECK-NEXT:       input: "^tf_send_0"
+// CHECK:        function {
+// CHECK:          name: "{{.*}}test1SendWithParam{{.*}}.tf_CPU.device_partition"
 
 public func test2Sends() {
   var a = Tensor<Float>(1.0)

--- a/test/TensorFlowRuntime/Inputs/ConflictingModule1.swift
+++ b/test/TensorFlowRuntime/Inputs/ConflictingModule1.swift
@@ -1,0 +1,11 @@
+import TensorFlow
+
+public func conflictingFunction(_ n: Int) -> Tensor<Double> {
+  var i = 0
+  var t = Tensor(0)
+  while i < n {
+    t += 1
+    i += 1
+  }
+  return t
+}

--- a/test/TensorFlowRuntime/Inputs/ConflictingModule2.swift
+++ b/test/TensorFlowRuntime/Inputs/ConflictingModule2.swift
@@ -1,0 +1,11 @@
+import TensorFlow
+
+public func conflictingFunction(_ n: Int) -> Tensor<Double> {
+  var i = 0
+  var t = Tensor(0)
+  while i < n {
+    t += 2
+    i += 1
+  }
+  return t
+}

--- a/test/TensorFlowRuntime/conflicting_module.swift
+++ b/test/TensorFlowRuntime/conflicting_module.swift
@@ -1,0 +1,25 @@
+// Compiles two modules with identically-named tensor functions, then calls
+// those functions. This reproduces a former bug where the associated
+// "whilecond" and "whilebody" functions get identical names, which causes a
+// crash at runtime when adding the functions to the eager context.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/Inputs/ConflictingModule1.swift -emit-module -emit-library -module-name ConflictingModule1 -o %t/libConflictingModule1.%target-dylib-extension -emit-module-path %t/ConflictingModule1.swiftmodule
+// RUN: %target-build-swift %S/Inputs/ConflictingModule2.swift -emit-module -emit-library -module-name ConflictingModule2 -o %t/libConflictingModule2.%target-dylib-extension -emit-module-path %t/ConflictingModule2.swiftmodule
+// RUN: %target-build-swift %s -I %t -L %t -lConflictingModule1 -lConflictingModule2 -Xlinker -rpath -Xlinker %t -o %t/a.out
+// RUN: %target-run %t/a.out
+
+import StdlibUnittest
+import TensorFlowUnittest
+
+import ConflictingModule1
+import ConflictingModule2
+
+var ConflictingModuleTests = TestSuite("ConflictingModule")
+
+ConflictingModuleTests.testAllBackends("call functions") {
+  expectEqual(5, ConflictingModule1.conflictingFunction(5).scalar!)
+  expectEqual(10, ConflictingModule2.conflictingFunction(5).scalar!)
+}
+
+runAllTests()


### PR DESCRIPTION
If you try to execute tensor code (like `Tensor(1)`) twice in the lldb repl, you'll get an error: "Fatal error: Cannot add function 'main.tf_CPU.device_partition' because a different function with the same name already exists.: file /usr/local/google/home/marcrasi/swift-base/swift/stdlib/public/TensorFlow/CompilerRuntime.swift, line 414".

You can get a similar error with "whilecond" by executing the iris tutorial.

This PR fixes the problem by uniquifying graph function names by adding the module name to them. This works because each lldb repl expression gets a new module name.

Includes a test that reproduces the issue with a "whilecond". I think it's only possible to test the issue with "main" in lldb, so I don't have a test for that.

A different approach that I discussed with @mhong was to modify the TFE API so that you can replace existing functions. This turned out to be harder than it sounds, because TFE caches the function in the ["kernel"](https://github.com/tensorflow/tensorflow/blob/b75a555c3c930d8e15b3c7928f30f1941a48f43f/tensorflow/core/common_runtime/eager/execute.cc#L259) the first time you execute it.