### PR TITLE
[Tests] Enable SILGen tests that were xfailed since the time when the

### DIFF
--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -215,16 +215,16 @@ func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return [[ANON_CLOSURE_APP]]
 }
-// FIXME(integers): the following checks should be updated for the new way +
-// gets invoked. <rdar://problem/29939484>
-// XCHECK: sil private @[[CLOSURE_NAME]] : $@convention(thin) (Int, @guaranteed { var Int }) -> Int
-// XCHECK: bb0([[DOLLAR0:%[0-9]+]] : $Int, [[XBOX:%[0-9]+]] : ${ var Int }):
-// XCHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
-// XCHECK: [[PLUS:%[0-9]+]] = function_ref @$ss1poiS2i_SitF{{.*}}
-// XCHECK: [[LHS:%[0-9]+]] = load [trivial] [[XADDR]]
-// XCHECK: [[RET:%[0-9]+]] = apply [[PLUS]]([[LHS]], [[DOLLAR0]])
-// XCHECK: destroy_value [[XBOX]]
-// XCHECK: return [[RET]]
+// CHECK: sil private @[[CLOSURE_NAME]] : $@convention(thin) (Int, @guaranteed { var Int }) -> Int
+// CHECK: bb0([[DOLLAR0:%[0-9]+]] : @trivial $Int, [[XBOX:%[0-9]+]] : @guaranteed ${ var Int }):
+// CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
+// CHECK: [[INTTYPE:%[0-9]+]] = metatype $@thin Int.Type
+// CHECK: [[XACCESS:%[0-9]+]] = begin_access [read] [unknown] [[XADDR]] : $*Int
+// CHECK: [[LHS:%[0-9]+]] = load [trivial] [[XACCESS]]
+// CHECK: end_access [[XACCESS]] : $*Int
+// CHECK: [[PLUS:%[0-9]+]] = function_ref @$sSi1poiyS2i_SitFZ{{.*}}
+// CHECK: [[RET:%[0-9]+]] = apply [[PLUS]]([[LHS]], [[DOLLAR0]], [[INTTYPE]])
+// CHECK: return [[RET]]
 
 // CHECK-LABEL: sil hidden @$s8closures24small_closure_no_capture{{[_0-9a-zA-Z]*}}F
 func small_closure_no_capture() -> (_ y: Int) -> Int {

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -43,13 +43,14 @@ class E {
   var i = Int64()
 }
 
-// FIXME(integers): the following checks should be updated for the new way +
-// gets invoked. <rdar://problem/29939484>
-// XCHECK-LABEL: sil hidden [transparent] @$s19default_constructor1EC1is5Int64Vvfi : $@convention(thin) () -> Int64
-// XCHECK:      [[FN:%.*]] = function_ref @$ss5Int64VABycfC : $@convention(method) (@thin Int64.Type) -> Int64
-// XCHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin Int64.Type
-// XCHECK-NEXT: [[VALUE:%.*]] = apply [[FN]]([[METATYPE]]) : $@convention(method) (@thin Int64.Type) -> Int64
-// XCHECK-NEXT: return [[VALUE]] : $Int64
+// CHECK-LABEL: sil hidden [transparent] @$s19default_constructor1EC1is5Int64Vvpfi : $@convention(thin) () -> Int64
+// CHECK:      [[IADDR:%[0-9]+]] = alloc_stack $Int64
+// CHECK:      [[INTTYPE:%[0-9]+]] = metatype $@thick Int64.Type
+// CHECK:      [[INIT:%[0-9]+]] = function_ref @$sSzsExycfC : $@convention(method)
+// CHECK-NEXT: apply [[INIT]]<Int64>([[IADDR]], [[INTTYPE]])
+// CHECK-NEXT: [[VALUE:%[0-9]+]] = load [trivial] [[IADDR]]
+// CHECK-NEXT: dealloc_stack [[IADDR]]
+// CHECK-NEXT: return [[VALUE]] : $Int64
 
 // CHECK-LABEL: sil hidden @$s19default_constructor1EC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned E) -> @owned E
 // CHECK: bb0([[SELFIN:%[0-9]+]] : @owned $E)

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -8,10 +8,6 @@ func takeClosure(_ a : () -> Int) {}
 // CHECK-LABEL: sil hidden @{{.*}}test1
 func test1(_ a : Int) -> Int {
   // CHECK-NOT: alloc_box
-  // FIXME(integers): the following check should be updated for the new way +
-  // gets invoked. <rdar://problem/29939484>
-  // XCHECK-NOT: alloc_stack
-
   let (b,c) = (a, 32)
 
   return b+c

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -566,37 +566,34 @@ func getFridge(_ home: APPHouse) -> Refrigerator {
   return home.fridge
 }
 
-// FIXME(integers): the following checks should be updated for the new integer
-// protocols. <rdar://problem/29939484>
-// XCHECK-LABEL: sil hidden @$s13objc_bridging16updateFridgeTemp{{.*}}F
-// XCHECK: bb0([[HOME:%[0-9]+]] : $APPHouse, [[DELTA:%[0-9]+]] : $Double):
+// CHECK-LABEL: sil hidden @$s13objc_bridging16updateFridgeTemp{{.*}}F
+// CHECK: bb0([[HOME:%[0-9]+]] : @guaranteed $APPHouse, [[DELTA:%[0-9]+]] : @trivial $Double):
 func updateFridgeTemp(_ home: APPHouse, delta: Double) {
-  // +=
-  // XCHECK: [[PLUS_EQ:%[0-9]+]] = function_ref @$ss2peoiyySdz_SdtF
-
   // Temporary fridge
-  // XCHECK: [[TEMP_FRIDGE:%[0-9]+]]  = alloc_stack $Refrigerator
+  // CHECK: [[TEMP_FRIDGE:%[0-9]+]]  = alloc_stack $Refrigerator
 
   // Get operation
-  // CHECK: [[GETTER:%[0-9]+]] = objc_method [[HOME]] : $APPHouse, #APPHouse.fridge!getter.1.foreign
-  // CHECK: [[OBJC_FRIDGE:%[0-9]+]] = apply [[GETTER]]([[HOME]])
+  // CHECK-NEXT: [[GETTER:%[0-9]+]] = objc_method [[HOME]] : $APPHouse, #APPHouse.fridge!getter.1.foreign
+  // CHECK-NEXT: [[OBJC_FRIDGE:%[0-9]+]] = apply [[GETTER]]([[HOME]])
   // CHECK: [[BRIDGE_FROM_FN:%[0-9]+]] = function_ref @$s10Appliances12RefrigeratorV36_unconditionallyBridgeFromObjectiveCyACSo15APPRefrigeratorCSgFZ
-  // CHECK: [[REFRIGERATOR_META:%[0-9]+]] = metatype $@thin Refrigerator.Type
-  // CHECK: [[FRIDGE:%[0-9]+]] = apply [[BRIDGE_FROM_FN]]([[OBJC_FRIDGE]], [[REFRIGERATOR_META]])
+  // CHECK-NEXT: [[REFRIGERATOR_META:%[0-9]+]] = metatype $@thin Refrigerator.Type
+  // CHECK-NEXT: [[FRIDGE:%[0-9]+]] = apply [[BRIDGE_FROM_FN]]([[OBJC_FRIDGE]], [[REFRIGERATOR_META]])
+  // CHECK-NEXT: store [[FRIDGE]] to [trivial] [[TEMP_FRIDGE]]
 
   // Addition
-  // XCHECK: [[TEMP:%[0-9]+]] = struct_element_addr [[TEMP_FRIDGE]] : $*Refrigerator, #Refrigerator.temperature
-  // XCHECK: apply [[PLUS_EQ]]([[TEMP]], [[DELTA]])
+  // CHECK-NEXT: [[TEMP:%[0-9]+]] = struct_element_addr [[TEMP_FRIDGE]] : $*Refrigerator, #Refrigerator.temperature
+  // CHECK: [[PLUS_EQ:%[0-9]+]] = function_ref @$sSd2peoiyySdz_SdtFZ
+  // CHECK-NEXT: apply [[PLUS_EQ]]([[TEMP]], [[DELTA]], [[METATYPE:%[0-9]+]])
 
   // Setter
-  // XCHECK: [[FRIDGE:%[0-9]+]] = load [trivial] [[TEMP_FRIDGE]] : $*Refrigerator
-  // XCHECK: [[SETTER:%[0-9]+]] = objc_method [[BORROWED_HOME]] : $APPHouse, #APPHouse.fridge!setter.1.foreign
-  // XCHECK: [[BRIDGE_TO_FN:%[0-9]+]] = function_ref @$s10Appliances12RefrigeratorV19_bridgeToObjectiveCSo15APPRefrigeratorCyF
-  // XCHECK: [[OBJC_ARG:%[0-9]+]] = apply [[BRIDGE_TO_FN]]([[FRIDGE]])
-  // XCHECK: apply [[SETTER]]([[OBJC_ARG]], [[BORROWED_HOME]]) : $@convention(objc_method) (APPRefrigerator, APPHouse) -> ()
-  // XCHECK: destroy_value [[OBJC_ARG]]
-  // XCHECK: end_borrow [[BORROWED_HOME]]
-  // XCHECK: destroy_value [[HOME]]
+  // CHECK: [[FRIDGE:%[0-9]+]] = load [trivial] [[TEMP_FRIDGE]] : $*Refrigerator
+  // CHECK: [[BRIDGE_TO_FN:%[0-9]+]] = function_ref @$s10Appliances12RefrigeratorV19_bridgeToObjectiveCSo15APPRefrigeratorCyF
+  // CHECK-NEXT: [[OBJC_ARG:%[0-9]+]] = apply [[BRIDGE_TO_FN]]([[FRIDGE]])
+  // CHECK-NEXT: [[SETTER:%[0-9]+]] = objc_method [[HOME]] : $APPHouse, #APPHouse.fridge!setter.1.foreign
+  // CHECK-NEXT: apply [[SETTER]]([[OBJC_ARG]], [[HOME]]) : $@convention(objc_method) (APPRefrigerator, APPHouse) -> ()
+  // CHECK-NEXT: destroy_value [[OBJC_ARG]]
+  // CHECK-NEXT: destroy_value [[OBJC_FRIDGE]]
+  // CHECK-NEXT: dealloc_stack [[TEMP_FRIDGE]]
   home.fridge.temperature += delta
 }
 

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -572,36 +572,32 @@ func test_multiple_patterns1() {
   }
 }
 
-// FIXME(integers): the following checks should be updated for the new integer
-// protocols. <rdar://problem/29939484>
-// XCHECK-LABEL: sil hidden @$s10switch_var23test_multiple_patterns2yyF : $@convention(thin) () -> () {
+// CHECK-LABEL: sil hidden @$s10switch_var23test_multiple_patterns2yyF : $@convention(thin) () -> () {
 func test_multiple_patterns2() {
   let t1 = 2
   let t2 = 4
-  // XCHECK:   debug_value [[T1:%.*]] :
-  // XCHECK:   debug_value [[T2:%.*]] :
+  // CHECK:   debug_value [[T1:%.+]] :
+  // CHECK:   debug_value [[T2:%.+]] :
   switch (0,0) {
-    // XCHECK-NOT: br bb
+    // CHECK-NOT: br bb
   case (_, let x) where x > t1, (let x, _) where x > t2:
-    // XCHECK:   [[FIRST_X:%.*]] = tuple_extract {{%.*}} : $(Int, Int), 1
-    // XCHECK:   debug_value [[FIRST_X]] :
-    // XCHECK:   apply {{%.*}}([[FIRST_X]], [[T1]])
-    // XCHECK:   cond_br {{%.*}}, [[FIRST_MATCH_CASE:bb[0-9]+]], [[FIRST_FAIL:bb[0-9]+]]
-    // XCHECK:   [[FIRST_MATCH_CASE]]:
-    // XCHECK:     br [[CASE_BODY:bb[0-9]+]]([[FIRST_X]] : $Int)
-    // XCHECK:   [[FIRST_FAIL]]:
-    // XCHECK:     debug_value [[SECOND_X:%.*]] :
-    // XCHECK:     apply {{%.*}}([[SECOND_X]], [[T2]])
-    // XCHECK:     cond_br {{%.*}}, [[SECOND_MATCH_CASE:bb[0-9]+]], [[SECOND_FAIL:bb[0-9]+]]
-    // XCHECK:   [[SECOND_MATCH_CASE]]:
-    // XCHECK:     br [[CASE_BODY]]([[SECOND_X]] : $Int)
-    // XCHECK:   [[CASE_BODY]]([[BODY_VAR:%.*]] : $Int):
-    // XCHECK:     [[A:%.*]] = function_ref @$s10switch_var1aySi1x_tF
-    // XCHECK:     apply [[A]]([[BODY_VAR]])
+    // CHECK:   ([[FIRST:%[0-9]+]], [[SECOND:%[0-9]+]]) = destructure_tuple {{%.+}} : $(Int, Int)
+    // CHECK:   apply {{%.+}}([[SECOND]], [[T1]], {{%.+}})
+    // CHECK:   cond_br {{%.*}}, [[FIRST_MATCH_CASE:bb[0-9]+]], [[FIRST_FAIL:bb[0-9]+]]
+    // CHECK:   [[FIRST_MATCH_CASE]]:
+    // CHECK:     br [[CASE_BODY:bb[0-9]+]]([[SECOND]] : $Int)
+    // CHECK:   [[FIRST_FAIL]]:
+    // CHECK:     apply {{%.*}}([[FIRST]], [[T2]], {{%.+}})
+    // CHECK:     cond_br {{%.*}}, [[SECOND_MATCH_CASE:bb[0-9]+]], [[SECOND_FAIL:bb[0-9]+]]
+    // CHECK:   [[SECOND_MATCH_CASE]]:
+    // CHECK:     br [[CASE_BODY]]([[FIRST]] : $Int)
+    // CHECK:   [[CASE_BODY]]([[BODY_VAR:%.*]] : @trivial $Int):
+    // CHECK:     [[A:%.*]] = function_ref @$s10switch_var1a1xySi_tF
+    // CHECK:     apply [[A]]([[BODY_VAR]])
     a(x: x)
   default:
-    // XCHECK:   [[SECOND_FAIL]]:
-    // XCHECK:     function_ref @$s10switch_var1byyF
+    // CHECK:   [[SECOND_FAIL]]:
+    // CHECK:     function_ref @$s10switch_var1byyF
     b()
   }
 }

--- a/test/SILOptimizer/diagnostic_constant_propagation.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation.swift
@@ -5,8 +5,8 @@
 // tests here that must fail don't currently. Such tests have comments
 // describing the desirable behavior. They are false negatives now but have
 // to be addressed in the future.
-// References: <rdar://problem/29937936>, <rdar://problem/29939484>,
-// <https://bugs.swift.org/browse/SR-5964>, <rdar://problem/39120081>
+// References: <rdar://problem/29937936>,
+// <https://bugs.swift.org/browse/SR-5964>
 
 import StdlibUnittest
 


### PR DESCRIPTION
integer protocols changed the way basic arithmetic operations were
called.

This commit re-enables those tests and updates the SIL that was checked
in the tests to be consistent with the one generated by the current
compiler.

<rdar://29939484> has more information.
