### PR TITLE
[ConstraintSystem] Extend solver support for designated types for ope…

### DIFF
--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -422,15 +422,15 @@ infix operator &>> : BitwiseShiftPrecedence, FixedWidthInteger
 
 infix operator   * : MultiplicationPrecedence, Numeric
 infix operator  &* : MultiplicationPrecedence, FixedWidthInteger
-infix operator   / : MultiplicationPrecedence, BinaryInteger
+infix operator   / : MultiplicationPrecedence, BinaryInteger, FloatingPoint
 infix operator   % : MultiplicationPrecedence, BinaryInteger
 infix operator   & : MultiplicationPrecedence, BinaryInteger
 
 // "Additive"
 
-infix operator   + : AdditionPrecedence, Numeric
+infix operator   + : AdditionPrecedence, Numeric, String, Strideable
 infix operator  &+ : AdditionPrecedence, FixedWidthInteger
-infix operator   - : AdditionPrecedence, Numeric
+infix operator   - : AdditionPrecedence, Numeric, Strideable
 infix operator  &- : AdditionPrecedence, FixedWidthInteger
 infix operator   | : AdditionPrecedence, BinaryInteger
 infix operator   ^ : AdditionPrecedence, BinaryInteger
@@ -482,9 +482,9 @@ infix operator   *= : AssignmentPrecedence, Numeric
 infix operator  &*= : AssignmentPrecedence, FixedWidthInteger
 infix operator   /= : AssignmentPrecedence, BinaryInteger
 infix operator   %= : AssignmentPrecedence, BinaryInteger
-infix operator   += : AssignmentPrecedence, Numeric
+infix operator   += : AssignmentPrecedence, Numeric, String, Strideable
 infix operator  &+= : AssignmentPrecedence, FixedWidthInteger
-infix operator   -= : AssignmentPrecedence, Numeric
+infix operator   -= : AssignmentPrecedence, Numeric, Strideable
 infix operator  &-= : AssignmentPrecedence, FixedWidthInteger
 infix operator  <<= : AssignmentPrecedence, BinaryInteger
 infix operator &<<= : AssignmentPrecedence, FixedWidthInteger

--- a/validation-test/Sema/type_checker_perf/fast/rdar17170728.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17170728.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let i: Int? = 1
@@ -6,6 +6,5 @@ let j: Int?
 let k: Int? = 2
 
 let _ = [i, j, k].reduce(0 as Int?) {
-  // expected-error@-1 {{reasonable time}}
   $0 != nil && $1 != nil ? $0! + $1! : ($0 != nil ? $0! : ($1 != nil ? $1! : nil))
 }


### PR DESCRIPTION
…rators.

Have the constraint solver consider multiple designated types for an
operator. We currently consider the overloads from each in turn,
stopping as soon as we have a solution. As a result, we can still end
up with exponential type checking in some cases if an operator has
more than a single designated type. This still allows us to reduce the
base of that exponent, though, which makes it possible to increase the
number of expressions we can type check successfully in practice.
