### PR TITLE
Fix cmake flag: SWIFT_ENABLE_STDLIBCORE_EXCLUSIVITY_CHECKING

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -245,6 +245,10 @@ function(_compile_swift_files
     list(APPEND swift_flags "-Xfrontend" "-enable-sil-ownership")
   endif()
 
+  if(SWIFT_ENABLE_STDLIBCORE_EXCLUSIVITY_CHECKING AND SWIFTFILE_IS_STDLIB)
+    list(APPEND swift_flags "-Xfrontend" "-enforce-exclusivity=checked")
+  endif()
+
   if(SWIFT_EMIT_SORTED_SIL_OUTPUT)
     list(APPEND swift_flags "-Xfrontend" "-emit-sorted-sil")
   endif()


### PR DESCRIPTION
A cmake fix.