### PR TITLE
remove unnecessary "fn" argument

### DIFF
--- a/test/TensorFlowRuntime/conflicting_module.swift
+++ b/test/TensorFlowRuntime/conflicting_module.swift
@@ -8,6 +8,7 @@
 // RUN: %target-build-swift %S/Inputs/ConflictingModule2.swift -emit-module -emit-library -module-name ConflictingModule2 -o %t/libConflictingModule2.%target-dylib-extension -emit-module-path %t/ConflictingModule2.swiftmodule
 // RUN: %target-build-swift %s -I %t -L %t -lConflictingModule1 -lConflictingModule2 -Xlinker -rpath -Xlinker %t -o %t/a.out
 // RUN: %target-run %t/a.out
+// REQUIRES: executable_test
 
 import StdlibUnittest
 import TensorFlowUnittest


### PR DESCRIPTION
Addresses @mhong's comment from https://github.com/apple/swift/pull/19906.

Also while rerunning the test I realize that it should have a `REQUIRES: executable_test` because it runs an executable.