### PR TITLE
Add `(rhs: Self, lhs: Self)` function to `==` and `<` operators.

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1764,6 +1764,11 @@ extension BinaryInteger {
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)
   }
+  
+  @_transparent
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs == rhs
+  }
 
   @_transparent
   public static func <= (lhs: Self, rhs: Self) -> Bool {

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1787,7 +1787,7 @@ extension BinaryInteger {
   
   @_transparent
   public static func < (lhs: Self, rhs: Self) -> Bool {
-    reutrn lhs < rhs 
+    return lhs < rhs 
   }
 }
 

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1779,6 +1779,11 @@ extension BinaryInteger {
   public static func > (lhs: Self, rhs: Self) -> Bool {
     return rhs < lhs
   }
+  
+  @_transparent
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    reutrn lhs < rhs 
+  }
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
<!-- What's in this pull request? -->
While conforming a custom type to `BinaryInteger`, I found in the docs that for all binary comparison operators except for `==` and `<`, there are 2 functions, one with arguments `(lhs: Self, rhs: Self)` and one with arguments `(lhs: Self, rhs: Other)` with `Other being a generic parameter that conforms to `BinaryInteger` (see the docs [here](https://developer.apple.com/documentation/swift/binaryinteger/2884492) and [here](https://developer.apple.com/documentation/swift/binaryinteger/2886190) for both versions of the `>` operator).

For consistency reasons, I felt like both methods should be there for all operators, not excluding two at (seemingly) random.