### PR TITLE
[Sema][QoI] Call out missing conformances in protocol witness candidates.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1782,8 +1782,8 @@ NOTE(bad_associated_type_deduction,none,
      "unable to infer associated type %0 for protocol %1",
      (DeclName, DeclName))
 NOTE(associated_type_deduction_witness_failed,none,
-     "inferred type %1 (by matching requirement %0) is invalid: "
-     "does not %select{inherit from|conform to}3 %2",
+     "candidate would match and infer %0=%1 if %1 "
+     "%select{inherited from|conformed to}3 %2",
      (DeclName, Type, Type, bool))
 NOTE(ambiguous_associated_type_deduction,none,
      "ambiguous inference of associated type %0: %1 vs. %2",
@@ -1805,6 +1805,8 @@ NOTE(protocol_witness_kind_conflict,none,
      "a subscript}0", (RequirementKind))
 NOTE(protocol_witness_type_conflict,none,
      "candidate has non-matching type %0%1", (Type, StringRef))
+NOTE(protocol_witness_missing_conformance,none,
+     "candidate would match if %0 conformed to %1", (Type, Type))
 
 NOTE(protocol_witness_optionality_conflict,none,
      "candidate %select{type has|result type has|parameter type has|"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1782,9 +1782,18 @@ NOTE(bad_associated_type_deduction,none,
      "unable to infer associated type %0 for protocol %1",
      (DeclName, DeclName))
 NOTE(associated_type_deduction_witness_failed,none,
-     "candidate would match and infer %0=%1 if %1 "
+     "candidate would match and infer %0 = %1 if %1 "
      "%select{inherited from|conformed to}3 %2",
      (DeclName, Type, Type, bool))
+NOTE(associated_type_witness_conform_impossible,none,
+     "candidate can not infer %0 = %1 because %1 "
+     "is not a nominal type and so can't conform to %2",
+     (DeclName, Type, Type))
+NOTE(associated_type_witness_inherit_impossible,none,
+     "candidate can not infer %0 = %1 because %1 "
+     "is not a class type and so can't inherit from %2",
+     (DeclName, Type, Type))
+
 NOTE(ambiguous_associated_type_deduction,none,
      "ambiguous inference of associated type %0: %1 vs. %2",
      (DeclName, Type, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1814,8 +1814,9 @@ NOTE(protocol_witness_kind_conflict,none,
      "a subscript}0", (RequirementKind))
 NOTE(protocol_witness_type_conflict,none,
      "candidate has non-matching type %0%1", (Type, StringRef))
-NOTE(protocol_witness_missing_conformance,none,
-     "candidate would match if %0 conformed to %1", (Type, Type))
+NOTE(protocol_witness_missing_requirement,none,
+     "candidate would match if %0 %select{conformed to|subclassed|"
+     "was the same type as}2 %1", (Type, Type, unsigned))
 
 NOTE(protocol_witness_optionality_conflict,none,
      "candidate %select{type has|result type has|parameter type has|"

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -288,6 +288,10 @@ public:
   static MissingConformance *create(ConstraintSystem &cs, Type type,
                                     ProtocolDecl *protocol,
                                     ConstraintLocator *locator);
+
+  Type getNonConformingType() { return NonConformingType; }
+
+  ProtocolDecl *getProtocol() { return Protocol; }
 };
 
 /// Skip same-type generic requirement constraint,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -75,6 +75,11 @@ enum class FixKind : uint8_t {
   /// Skip same-type generic requirement constraint,
   /// and assume that types are equal.
   SkipSameTypeRequirement,
+
+  /// Skip superclass generic requirement constraint,
+  /// and assume that types are related.
+  SkipSuperclassRequirement,
+
 };
 
 class ConstraintFix {
@@ -311,6 +316,9 @@ public:
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
+  Type lhsType() { return LHS; }
+  Type rhsType() { return RHS; }
+
   static SkipSameTypeRequirement *create(ConstraintSystem &cs, Type lhs,
                                          Type rhs, ConstraintLocator *locator);
 };
@@ -322,8 +330,8 @@ class SkipSuperclassRequirement final : public ConstraintFix {
 
   SkipSuperclassRequirement(ConstraintSystem &cs, Type lhs, Type rhs,
                             ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::SkipSameTypeRequirement, locator), LHS(lhs),
-        RHS(rhs) {}
+      : ConstraintFix(cs, FixKind::SkipSuperclassRequirement, locator),
+        LHS(lhs), RHS(rhs) {}
 
 public:
   std::string getName() const override {
@@ -331,6 +339,9 @@ public:
   }
 
   bool diagnose(Expr *root, bool asNote = false) const override;
+
+  Type subclassType() { return LHS; }
+  Type superclassType() { return RHS; }
 
   static SkipSuperclassRequirement *
   create(ConstraintSystem &cs, Type lhs, Type rhs, ConstraintLocator *locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5038,7 +5038,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     return result;
   }
 
-  case FixKind::SkipSameTypeRequirement: {
+  case FixKind::SkipSameTypeRequirement:
+  case FixKind::SkipSuperclassRequirement: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -524,10 +524,17 @@ ConstraintSystem::SolverScope::~SolverScope() {
 /// \returns a solution if a single unambiguous one could be found, or None if
 /// ambiguous or unsolvable.
 Optional<Solution>
-ConstraintSystem::solveSingle(FreeTypeVariableBinding allowFreeTypeVariables) {
+ConstraintSystem::solveSingle(FreeTypeVariableBinding allowFreeTypeVariables,
+                              bool allowFixes) {
+
+  SolverState state(nullptr, *this, allowFreeTypeVariables);
+  state.recordFixes = allowFixes;
+
   SmallVector<Solution, 4> solutions;
-  if (solve(nullptr, solutions, allowFreeTypeVariables) ||
-      solutions.size() != 1)
+  solve(solutions);
+  filterSolutions(solutions, state.ExprWeights);
+
+  if (solutions.size() != 1)
     return Optional<Solution>();
 
   return std::move(solutions[0]);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3054,10 +3054,13 @@ public:
   /// \param allowFreeTypeVariables How to bind free type variables in
   /// the solution.
   ///
+  /// \param allowFixes Whether to allow fixes in the solution.
+  ///
   /// \returns a solution if a single unambiguous one could be found, or None if
   /// ambiguous or unsolvable.
   Optional<Solution> solveSingle(FreeTypeVariableBinding allowFreeTypeVariables
-                                    = FreeTypeVariableBinding::Disallow);
+                                 = FreeTypeVariableBinding::Disallow,
+                                 bool allowFixes = false);
 
 private:
   /// \brief Solve the system of constraints.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -861,8 +861,8 @@ swift::matchWitness(TypeChecker &tc,
             return RequirementMatch(witness, MatchKind::MissingConformance,
                                     assocType, protocolType);
       if (type->isEqual(conformance->getType())) {
-        if (auto bgt = type->getAs<BoundGenericType>())
-          type = bgt->getDecl()->getDeclaredType();
+        if (auto agt = type->getAs<AnyGenericType>())
+          type = agt->getDecl()->getDeclaredInterfaceType();
         return RequirementMatch(witness, MatchKind::MissingConformance, type,
                                 protocolType);
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -885,9 +885,9 @@ swift::matchWitness(TypeChecker &tc,
         return missingRequirementMatch(type);
 
       type = type->mapTypeOutOfContext();
-      if (auto typeParamTy = type->getAs<GenericTypeParamType>())
+      if (type->hasTypeParameter())
         if (auto env = conformance->getGenericEnvironment())
-          if (auto assocType = env->mapTypeIntoContext(typeParamTy))
+          if (auto assocType = env->mapTypeIntoContext(type))
             return missingRequirementMatch(assocType);
 
       auto reqSubMap = reqEnvironment.getRequirementToSyntheticMap();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -678,6 +678,69 @@ static const RequirementEnvironment &getOrCreateRequirementEnvironment(
   return cacheIter->getSecond();
 }
 
+static Optional<RequirementMatch> findMissingGenericRequirementForSolutionFix(
+    constraints::ConstraintFix *fix, ValueDecl *witness,
+    ProtocolConformance *conformance,
+    const RequirementEnvironment &reqEnvironment) {
+  Type type, missingType;
+  RequirementKind requirementKind;
+
+  using namespace constraints;
+
+  switch (fix->getKind()) {
+  case FixKind::AddConformance: {
+    auto missingConform = (MissingConformance *)fix;
+    requirementKind = RequirementKind::Conformance;
+    type = missingConform->getNonConformingType();
+    missingType = missingConform->getProtocol()->getDeclaredType();
+    break;
+  }
+  case FixKind::SkipSameTypeRequirement: {
+    requirementKind = RequirementKind::SameType;
+    auto requirementFix = (SkipSameTypeRequirement *)fix;
+    type = requirementFix->lhsType();
+    missingType = requirementFix->rhsType();
+    break;
+  }
+  case FixKind::SkipSuperclassRequirement: {
+    requirementKind = RequirementKind::Superclass;
+    auto requirementFix = (SkipSuperclassRequirement *)fix;
+    type = requirementFix->subclassType();
+    missingType = requirementFix->superclassType();
+    break;
+  }
+  default:
+    return Optional<RequirementMatch>();
+  }
+
+  auto missingRequirementMatch = [&](Type type) -> RequirementMatch {
+    Requirement requirement(requirementKind, type, missingType);
+    return RequirementMatch(witness, MatchKind::MissingRequirement,
+                            requirement);
+  };
+
+  if (auto memberTy = type->getAs<DependentMemberType>())
+    return missingRequirementMatch(type);
+
+  type = type->mapTypeOutOfContext();
+  if (type->hasTypeParameter())
+    if (auto env = conformance->getGenericEnvironment())
+      if (auto assocType = env->mapTypeIntoContext(type))
+        return missingRequirementMatch(assocType);
+
+  auto reqSubMap = reqEnvironment.getRequirementToSyntheticMap();
+  auto proto = conformance->getProtocol();
+  Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
+  if (type->isEqual(selfTy)) {
+    type = conformance->getType();
+    if (auto agt = type->getAs<AnyGenericType>())
+      type = agt->getDecl()->getDeclaredInterfaceType();
+    return missingRequirementMatch(type);
+  }
+
+  return Optional<RequirementMatch>();
+}
+
 RequirementMatch
 swift::matchWitness(TypeChecker &tc,
                     WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
@@ -845,61 +908,13 @@ swift::matchWitness(TypeChecker &tc,
 
     // If the types would match but for some other missing conformance, find and
     // call that out.
-    if (solution && conformance && solution->Fixes.size() == 1) {
-      auto fix = solution->Fixes.front();
-      Type type, missingType;
-      RequirementKind requirementKind;
-      switch (fix->getKind()) {
-      case FixKind::AddConformance: {
-        auto missingConform = (MissingConformance *)fix;
-        requirementKind = RequirementKind::Conformance;
-        type = missingConform->getNonConformingType();
-        missingType = missingConform->getProtocol()->getDeclaredType();
-        break;
-      }
-      case FixKind::SkipSameTypeRequirement: {
-        requirementKind = RequirementKind::SameType;
-        auto requirementFix = (SkipSameTypeRequirement *)fix;
-        type = requirementFix->lhsType();
-        missingType = requirementFix->rhsType();
-        break;
-      }
-      case FixKind::SkipSuperclassRequirement: {
-        requirementKind = RequirementKind::Superclass;
-        auto requirementFix = (SkipSuperclassRequirement *)fix;
-        type = requirementFix->subclassType();
-        missingType = requirementFix->superclassType();
-        break;
-      }
-      default:
-        return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
-      }
-
-      auto missingRequirementMatch = [&](Type type) -> RequirementMatch {
-        Requirement requirement(requirementKind, type, missingType);
-        return RequirementMatch(witness, MatchKind::MissingRequirement,
-                                requirement);
-      };
-
-      if (auto memberTy = type->getAs<DependentMemberType>())
-        return missingRequirementMatch(type);
-
-      type = type->mapTypeOutOfContext();
-      if (type->hasTypeParameter())
-        if (auto env = conformance->getGenericEnvironment())
-          if (auto assocType = env->mapTypeIntoContext(type))
-            return missingRequirementMatch(assocType);
-
-      auto reqSubMap = reqEnvironment.getRequirementToSyntheticMap();
-      Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
-      if (type->isEqual(selfTy)) {
-        type = conformance->getType();
-        if (auto agt = type->getAs<AnyGenericType>())
-          type = agt->getDecl()->getDeclaredInterfaceType();
-        return missingRequirementMatch(type);
+    if (solution && conformance && solution->Fixes.size()) {
+      for (auto fix : solution->Fixes) {
+        if (auto result = findMissingGenericRequirementForSolutionFix(
+                fix, witness, conformance, reqEnvironment))
+          return *result;
       }
     }
-
     if (!solution || solution->Fixes.size())
       return RequirementMatch(witness, MatchKind::TypeConflict,
                               witnessType);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -845,26 +845,58 @@ swift::matchWitness(TypeChecker &tc,
 
     // If the types would match but for some other missing conformance, find and
     // call that out.
-    if (solution && conformance && solution->Fixes.size() == 1 &&
-        solution->Fixes.front()->getKind() == FixKind::AddConformance) {
-      auto fix = (MissingConformance *)solution->Fixes.front();
-      auto type = fix->getNonConformingType();
-      auto protocolType = fix->getProtocol()->getDeclaredType();
+    if (solution && conformance && solution->Fixes.size() == 1) {
+      auto fix = solution->Fixes.front();
+      Type type, missingType;
+      RequirementKind requirementKind;
+      switch (fix->getKind()) {
+      case FixKind::AddConformance: {
+        auto missingConform = (MissingConformance *)fix;
+        requirementKind = RequirementKind::Conformance;
+        type = missingConform->getNonConformingType();
+        missingType = missingConform->getProtocol()->getDeclaredType();
+        break;
+      }
+      case FixKind::SkipSameTypeRequirement: {
+        requirementKind = RequirementKind::SameType;
+        auto requirementFix = (SkipSameTypeRequirement *)fix;
+        type = requirementFix->lhsType();
+        missingType = requirementFix->rhsType();
+        break;
+      }
+      case FixKind::SkipSuperclassRequirement: {
+        requirementKind = RequirementKind::Superclass;
+        auto requirementFix = (SkipSuperclassRequirement *)fix;
+        type = requirementFix->subclassType();
+        missingType = requirementFix->superclassType();
+        break;
+      }
+      default:
+        return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
+      }
+
+      auto missingRequirementMatch = [&](Type type) -> RequirementMatch {
+        Requirement requirement(requirementKind, type, missingType);
+        return RequirementMatch(witness, MatchKind::MissingRequirement,
+                                requirement);
+      };
+
       if (auto memberTy = type->getAs<DependentMemberType>())
-        return RequirementMatch(witness, MatchKind::MissingConformance, type,
-                                protocolType);
+        return missingRequirementMatch(type);
 
       type = type->mapTypeOutOfContext();
       if (auto typeParamTy = type->getAs<GenericTypeParamType>())
         if (auto env = conformance->getGenericEnvironment())
           if (auto assocType = env->mapTypeIntoContext(typeParamTy))
-            return RequirementMatch(witness, MatchKind::MissingConformance,
-                                    assocType, protocolType);
-      if (type->isEqual(conformance->getType())) {
+            return missingRequirementMatch(assocType);
+
+      auto reqSubMap = reqEnvironment.getRequirementToSyntheticMap();
+      Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
+      if (type->isEqual(selfTy) /*type->isEqual(conformance->getType())*/) {
+        type = conformance->getType();
         if (auto agt = type->getAs<AnyGenericType>())
           type = agt->getDecl()->getDeclaredInterfaceType();
-        return RequirementMatch(witness, MatchKind::MissingConformance, type,
-                                protocolType);
+        return missingRequirementMatch(type);
       }
     }
 
@@ -2051,9 +2083,10 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     break;
   }
 
-  case MatchKind::MissingConformance:
-    diags.diagnose(match.Witness, diag::protocol_witness_missing_conformance,
-                   match.WitnessType, match.SecondType);
+  case MatchKind::MissingRequirement:
+    diags.diagnose(match.Witness, diag::protocol_witness_missing_requirement,
+                   match.WitnessType, match.MissingRequirement->getSecondType(),
+                   (unsigned)match.MissingRequirement->getKind());
     break;
 
   case MatchKind::ThrowsConflict:

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -892,7 +892,7 @@ swift::matchWitness(TypeChecker &tc,
 
       auto reqSubMap = reqEnvironment.getRequirementToSyntheticMap();
       Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
-      if (type->isEqual(selfTy) /*type->isEqual(conformance->getType())*/) {
+      if (type->isEqual(selfTy)) {
         type = conformance->getType();
         if (auto agt = type->getAs<AnyGenericType>())
           type = agt->getDecl()->getDeclaredInterfaceType();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -758,7 +758,7 @@ swift::matchWitness(TypeChecker &tc,
   auto setup = [&]() -> std::tuple<Optional<RequirementMatch>, Type, Type> {
     // Construct a constraint system to use to solve the equality between
     // the required type and the witness type.
-    cs.emplace(tc, dc, ConstraintSystemOptions());
+    cs.emplace(tc, dc, ConstraintSystemFlags::AllowFixes);
 
     auto reqGenericEnv = reqEnvironment.getSyntheticEnvironment();
     auto reqSubMap = reqEnvironment.getRequirementToSyntheticMap();
@@ -840,8 +840,34 @@ swift::matchWitness(TypeChecker &tc,
     // Try to solve the system disallowing free type variables, because
     // that would resolve in incorrect substitution matching when witness
     // type has free type variables present as well.
-    auto solution = cs->solveSingle(FreeTypeVariableBinding::Disallow);
-    if (!solution)
+    auto solution = cs->solveSingle(FreeTypeVariableBinding::Disallow,
+                                    /* allowFixes */ true);
+
+    // If the types would match but for some other missing conformance, find and
+    // call that out.
+    if (solution && solution->Fixes.size() == 1 &&
+        solution->Fixes.front()->getKind() == FixKind::AddConformance) {
+      auto fix = (MissingConformance *)solution->Fixes.front();
+      auto type = fix->getNonConformingType()->mapTypeOutOfContext();
+      auto protocolType = fix->getProtocol()->getDeclaredType();
+      if (auto memberTy = type->getAs<DependentMemberType>())
+        if (memberTy->getBase()->isEqual(conformance->getType()))
+          return RequirementMatch(witness, MatchKind::MissingConformance, type,
+                                  protocolType);
+      if (auto typeParamTy = type->getAs<GenericTypeParamType>())
+        if (auto assocType =
+            conformance->getGenericEnvironment()->mapTypeIntoContext(typeParamTy))
+          return RequirementMatch(witness, MatchKind::MissingConformance,
+                                  assocType, protocolType);
+      if (type->isEqual(conformance->getType())) {
+        if (auto bgt = type->getAs<BoundGenericType>())
+          type = bgt->getDecl()->getDeclaredType();
+        return RequirementMatch(witness, MatchKind::MissingConformance, type,
+                                protocolType);
+      }
+    }
+
+    if (!solution || solution->Fixes.size())
       return RequirementMatch(witness, MatchKind::TypeConflict,
                               witnessType);
 
@@ -2023,6 +2049,11 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
       fixItOverrideDeclarationTypes(diag, match.Witness, req);
     break;
   }
+
+  case MatchKind::MissingConformance:
+    diags.diagnose(match.Witness, diag::protocol_witness_missing_conformance,
+                   match.WitnessType, match.SecondType);
+    break;
 
   case MatchKind::ThrowsConflict:
     diags.diagnose(match.Witness, diag::protocol_witness_throws_conflict);

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -79,6 +79,9 @@ public:
   bool isConformanceRequirement() const {
     return Requirement->isExistentialType();
   }
+  bool isSuperclassRequirement() const {
+    return !isConformanceRequirement();
+  }
   bool isError() const {
     return Requirement->is<ErrorType>();
   }

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1747,7 +1747,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
           if (failed.Result.isError())
             continue;
 
-          if (!failed.TypeWitness->is<NominalType>() &&
+          if (!failed.TypeWitness->getAnyNominal() &&
               failed.Result.isConformanceRequirement()) {
             diags.diagnose(failed.Witness,
                            diag::associated_type_witness_conform_impossible,
@@ -1755,8 +1755,8 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
                            failed.Result.getRequirement());
             continue;
           }
-          if (!failed.TypeWitness->is<ClassType>() &&
-              !failed.Result.isConformanceRequirement()) {
+          if (!failed.TypeWitness->getClassOrBoundGenericClass() &&
+              failed.Result.isSuperclassRequirement()) {
             diags.diagnose(failed.Witness,
                            diag::associated_type_witness_inherit_impossible,
                            assocType->getName(), failed.TypeWitness,

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1749,7 +1749,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
 
           diags.diagnose(failed.Witness,
                          diag::associated_type_deduction_witness_failed,
-                         failed.Requirement->getFullName(),
+                         assocType->getName(),
                          failed.TypeWitness,
                          failed.Result.getRequirement(),
                          failed.Result.isConformanceRequirement());

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1747,7 +1747,8 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
           if (failed.Result.isError())
             continue;
 
-          if (!failed.TypeWitness->getAnyNominal() &&
+          if ((!failed.TypeWitness->getAnyNominal() ||
+               failed.TypeWitness->isExistentialType()) &&
               failed.Result.isConformanceRequirement()) {
             diags.diagnose(failed.Witness,
                            diag::associated_type_witness_conform_impossible,

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1747,6 +1747,23 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
           if (failed.Result.isError())
             continue;
 
+          if (!failed.TypeWitness->is<NominalType>() &&
+              failed.Result.isConformanceRequirement()) {
+            diags.diagnose(failed.Witness,
+                           diag::associated_type_witness_conform_impossible,
+                           assocType->getName(), failed.TypeWitness,
+                           failed.Result.getRequirement());
+            continue;
+          }
+          if (!failed.TypeWitness->is<ClassType>() &&
+              !failed.Result.isConformanceRequirement()) {
+            diags.diagnose(failed.Witness,
+                           diag::associated_type_witness_inherit_impossible,
+                           assocType->getName(), failed.TypeWitness,
+                           failed.Result.getRequirement());
+            continue;
+          }
+
           diags.diagnose(failed.Witness,
                          diag::associated_type_deduction_witness_failed,
                          assocType->getName(),

--- a/test/Generics/associated_types_inherit.swift
+++ b/test/Generics/associated_types_inherit.swift
@@ -19,7 +19,7 @@ struct X1 : P {
 }
 
 struct X2 : P { // expected-error{{type 'X2' does not conform to protocol 'P'}}
-  func getAssoc() -> E { return E() } // expected-note{{candidate would match and infer 'Assoc'='E' if 'E' inherited from 'C'}}
+  func getAssoc() -> E { return E() } // expected-note{{candidate would match and infer 'Assoc' = 'E' if 'E' inherited from 'C'}}
 }
 
 func testP<T:P>(_ t: T) {

--- a/test/Generics/associated_types_inherit.swift
+++ b/test/Generics/associated_types_inherit.swift
@@ -19,7 +19,7 @@ struct X1 : P {
 }
 
 struct X2 : P { // expected-error{{type 'X2' does not conform to protocol 'P'}}
-  func getAssoc() -> E { return E() } // expected-note{{inferred type 'E' (by matching requirement 'getAssoc()') is invalid: does not inherit from 'C'}}
+  func getAssoc() -> E { return E() } // expected-note{{candidate would match and infer 'Assoc'='E' if 'E' inherited from 'C'}}
 }
 
 func testP<T:P>(_ t: T) {

--- a/test/decl/ext/protocol_as_witness.swift
+++ b/test/decl/ext/protocol_as_witness.swift
@@ -8,8 +8,7 @@ protocol P1 {
 protocol Q1 {}
 
 extension P1 where Self : Q1 {
-  // FIXME: Poor QoI
-  func f() {} // expected-note{{candidate has non-matching type '<Self> () -> ()'}}
+  func f() {} // expected-note{{candidate would match if 'X1' conformed to 'Q1'}}
 }
 
 struct X1 : P1 {} // expected-error{{type 'X1' does not conform to protocol 'P1'}}
@@ -33,7 +32,7 @@ protocol P3 {
 }
 
 extension P3 where Self : Equatable {
-  func f() {} // expected-note{{candidate has non-matching type '<Self> () -> ()'}}
+  func f() {} // expected-note{{candidate would match if 'X3' conformed to 'Equatable'}}
 }
 
 struct X3 : P3 {} // expected-error{{type 'X3' does not conform to protocol 'P3'}}

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -61,12 +61,7 @@ class SeriousClass {}
 
 extension HasDefault where Self : SeriousClass {
   func foo() {}
-  // expected-note@-1 {{candidate has non-matching type '<Self> () -> ()'}}
-
-  // FIXME: the above diangostic is from trying to check conformance for
-  // 'SillyClass' and not 'SeriousClass'. Evidently name lookup finds members
-  // from all constrained extensions, and then if any don't have a matching
-  // generic signature, diagnostics doesn't really know what to do about it.
+  // expected-note@-1 {{candidate would match if 'SillyClass' subclassed 'SeriousClass'}}
 }
 
 extension SeriousClass : HasDefault {}

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -50,8 +50,8 @@ struct X0f : P0 { // okay: Assoc1 = Int because Float doesn't conform to PSimple
 }
 
 struct X0g : P0 { // expected-error{{type 'X0g' does not conform to protocol 'P0'}}
-  func f0(_: Float) { } // expected-note{{candidate would match and infer 'Assoc1'='Float' if 'Float' conformed to 'PSimple'}}
-  func g0(_: Float) { } // expected-note{{candidate would match and infer 'Assoc1'='Float' if 'Float' conformed to 'PSimple'}}
+  func f0(_: Float) { } // expected-note{{candidate would match and infer 'Assoc1' = 'Float' if 'Float' conformed to 'PSimple'}}
+  func g0(_: Float) { } // expected-note{{candidate would match and infer 'Assoc1' = 'Float' if 'Float' conformed to 'PSimple'}}
 }
 
 struct X0h<T : PSimple> : P0 {
@@ -93,8 +93,8 @@ protocol P2 {
 }
 
 extension P2 where Self.P2Assoc : PSimple {
-  func f0(_ x: P2Assoc) { } // expected-note{{candidate would match and infer 'Assoc1'='Float' if 'Float' conformed to 'PSimple'}}
-  func g0(_ x: P2Assoc) { } // expected-note{{candidate would match and infer 'Assoc1'='Float' if 'Float' conformed to 'PSimple'}}
+  func f0(_ x: P2Assoc) { } // expected-note{{candidate would match and infer 'Assoc1' = 'Float' if 'Float' conformed to 'PSimple'}}
+  func g0(_ x: P2Assoc) { } // expected-note{{candidate would match and infer 'Assoc1' = 'Float' if 'Float' conformed to 'PSimple'}}
 }
 
 struct X0k : P0, P2 {
@@ -123,7 +123,7 @@ struct XProp0a : PropertyP0 { // okay PropType = Int
 }
 
 struct XProp0b : PropertyP0 { // expected-error{{type 'XProp0b' does not conform to protocol 'PropertyP0'}}
-  var property: Float // expected-note{{candidate would match and infer 'Prop'='Float' if 'Float' conformed to 'PSimple'}}
+  var property: Float // expected-note{{candidate would match and infer 'Prop' = 'Float' if 'Float' conformed to 'PSimple'}}
 }
 
 // Inference from subscripts
@@ -144,7 +144,7 @@ struct XSubP0a : SubscriptP0 {
 
 struct XSubP0b : SubscriptP0 {
 // expected-error@-1{{type 'XSubP0b' does not conform to protocol 'SubscriptP0'}}
-  subscript (i: Int) -> Float { get { return Float(i) } } // expected-note{{candidate would match and infer 'Element'='Float' if 'Float' conformed to 'PSimple'}}
+  subscript (i: Int) -> Float { get { return Float(i) } } // expected-note{{candidate would match and infer 'Element' = 'Float' if 'Float' conformed to 'PSimple'}}
 }
 
 struct XSubP0c : SubscriptP0 {

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -50,8 +50,8 @@ struct X0f : P0 { // okay: Assoc1 = Int because Float doesn't conform to PSimple
 }
 
 struct X0g : P0 { // expected-error{{type 'X0g' does not conform to protocol 'P0'}}
-  func f0(_: Float) { } // expected-note{{inferred type 'Float' (by matching requirement 'f0') is invalid: does not conform to 'PSimple'}}
-  func g0(_: Float) { } // expected-note{{inferred type 'Float' (by matching requirement 'g0') is invalid: does not conform to 'PSimple'}}
+  func f0(_: Float) { } // expected-note{{candidate would match and infer 'Assoc1'='Float' if 'Float' conformed to 'PSimple'}}
+  func g0(_: Float) { } // expected-note{{candidate would match and infer 'Assoc1'='Float' if 'Float' conformed to 'PSimple'}}
 }
 
 struct X0h<T : PSimple> : P0 {
@@ -93,8 +93,8 @@ protocol P2 {
 }
 
 extension P2 where Self.P2Assoc : PSimple {
-  func f0(_ x: P2Assoc) { } // expected-note{{inferred type 'Float' (by matching requirement 'f0') is invalid: does not conform to 'PSimple'}}
-  func g0(_ x: P2Assoc) { } // expected-note{{inferred type 'Float' (by matching requirement 'g0') is invalid: does not conform to 'PSimple'}}
+  func f0(_ x: P2Assoc) { } // expected-note{{candidate would match and infer 'Assoc1'='Float' if 'Float' conformed to 'PSimple'}}
+  func g0(_ x: P2Assoc) { } // expected-note{{candidate would match and infer 'Assoc1'='Float' if 'Float' conformed to 'PSimple'}}
 }
 
 struct X0k : P0, P2 {
@@ -123,7 +123,7 @@ struct XProp0a : PropertyP0 { // okay PropType = Int
 }
 
 struct XProp0b : PropertyP0 { // expected-error{{type 'XProp0b' does not conform to protocol 'PropertyP0'}}
-  var property: Float // expected-note{{inferred type 'Float' (by matching requirement 'property') is invalid: does not conform to 'PSimple'}}
+  var property: Float // expected-note{{candidate would match and infer 'Prop'='Float' if 'Float' conformed to 'PSimple'}}
 }
 
 // Inference from subscripts
@@ -144,7 +144,7 @@ struct XSubP0a : SubscriptP0 {
 
 struct XSubP0b : SubscriptP0 {
 // expected-error@-1{{type 'XSubP0b' does not conform to protocol 'SubscriptP0'}}
-  subscript (i: Int) -> Float { get { return Float(i) } } // expected-note{{inferred type 'Float' (by matching requirement 'subscript(_:)') is invalid: does not conform to 'PSimple'}}
+  subscript (i: Int) -> Float { get { return Float(i) } } // expected-note{{candidate would match and infer 'Element'='Float' if 'Float' conformed to 'PSimple'}}
 }
 
 struct XSubP0c : SubscriptP0 {

--- a/test/decl/protocol/req/func.swift
+++ b/test/decl/protocol/req/func.swift
@@ -266,7 +266,7 @@ protocol P12 {
 struct XIndexType : P11 { }
 
 struct X12 : P12 { // expected-error{{type 'X12' does not conform to protocol 'P12'}}
-  func getIndex() -> XIndexType { return XIndexType() } // expected-note{{candidate would match and infer 'Index'='XIndexType' if 'XIndexType' conformed to 'P1'}}
+  func getIndex() -> XIndexType { return XIndexType() } // expected-note{{candidate would match and infer 'Index' = 'XIndexType' if 'XIndexType' conformed to 'P1'}}
 }
 
 func ==(x: X12.Index, y: X12.Index) -> Bool { return true }

--- a/test/decl/protocol/req/func.swift
+++ b/test/decl/protocol/req/func.swift
@@ -266,7 +266,7 @@ protocol P12 {
 struct XIndexType : P11 { }
 
 struct X12 : P12 { // expected-error{{type 'X12' does not conform to protocol 'P12'}}
-  func getIndex() -> XIndexType { return XIndexType() } // expected-note{{inferred type 'XIndexType' (by matching requirement 'getIndex()') is invalid: does not conform to 'P1'}}
+  func getIndex() -> XIndexType { return XIndexType() } // expected-note{{candidate would match and infer 'Index'='XIndexType' if 'XIndexType' conformed to 'P1'}}
 }
 
 func ==(x: X12.Index, y: X12.Index) -> Bool { return true }

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -98,3 +98,15 @@ extension P10 where A == Int {
     func bar() {} // expected-note {{candidate would match if 'A' was the same type as 'Int'}}
 }
 struct S2<A> : P10 {} // expected-error {{type 'S2<A>' does not conform to protocol 'P10'}}
+
+protocol P11 {}
+protocol P12 {
+    associatedtype A : P11 // expected-note {{unable to infer associated type 'A' for protocol 'P12'}}
+    func bar() -> A
+}
+extension Int : P11 {}
+struct S3 : P12 { // expected-error {{type 'S3' does not conform to protocol 'P12'}}
+    func bar() -> P11 { return 0 }
+    // expected-note@-1 {{candidate can not infer 'A' = 'P11' because 'P11' is not a nominal type and so can't conform to 'P11'}}
+}
+

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -1,0 +1,57 @@
+// RUN: %target-typecheck-verify-swift
+
+// Test candidates for witnesses that are missing conformances
+// in various ways.
+
+protocol LikeSetAlgebra {
+    func onion(_ other: Self) -> Self // expected-note {{protocol requires function 'onion' with type '(X) -> X'; do you want to add a stub?}}
+    func indifference(_ other: Self) -> Self // expected-note {{protocol requires function 'indifference' with type '(X) -> X'; do you want to add a stub?}}
+
+}
+protocol LikeOptionSet : LikeSetAlgebra, RawRepresentable {}
+extension LikeOptionSet where RawValue : FixedWidthInteger {
+    func onion(_ other: Self) -> Self { return self } // expected-note {{candidate would match if 'X.RawValue' conformed to 'FixedWidthInteger'}}
+    func indifference(_ other: Self) -> Self { return self } // expected-note {{candidate would match if 'X.RawValue' conformed to 'FixedWidthInteger'}}
+}
+
+struct X : LikeOptionSet {}
+// expected-error@-1 {{type 'X' does not conform to protocol 'LikeSetAlgebra'}}
+// expected-error@-2 {{type 'X' does not conform to protocol 'RawRepresentable'}}
+
+protocol IterProtocol {}
+protocol LikeSequence {
+    associatedtype Iter : IterProtocol // expected-note {{unable to infer associated type 'Iter' for protocol 'LikeSequence'}}
+    func makeIter() -> Iter
+}
+extension LikeSequence where Self == Self.Iter {
+    func makeIter() -> Self { return self } // expected-note {{candidate would match and infer 'Iter'='Y' if 'Y' conformed to 'IterProtocol'}}
+}
+
+struct Y : LikeSequence {} // expected-error {{type 'Y' does not conform to protocol 'LikeSequence'}}
+
+protocol P1 {
+    associatedtype Result
+    func get() -> Result // expected-note {{protocol requires function 'get()' with type '() -> Result'; do you want to add a stub?}}
+    func got() // expected-note {{protocol requires function 'got()' with type '() -> ()'; do you want to add a stub?}}
+}
+protocol P2 {
+    static var singularThing: Self { get }
+}
+extension P1 where Result : P2 {
+    func get() -> Result { return Result.singularThing } // expected-note {{candidate would match if 'Result' conformed to 'P2'}}
+}
+protocol P3 {}
+extension P1 where Self : P3 {
+    func got() {} // expected-note {{candidate would match if 'Z' conformed to 'P3'}}
+}
+
+struct Z<T1, T2, T3, Result, T4> : P1 {} // expected-error {{type 'Z<T1, T2, T3, Result, T4>' does not conform to protocol 'P1'}}
+
+protocol P4 {
+    func this() // expected-note {{protocol requires function 'this()' with type '() -> ()'; do you want to add a stub?}}
+}
+protocol P5 {}
+extension P4 where Self : P5 {
+    func this() {} // expected-note {{candidate would match if 'W' conformed to 'P5'}}
+}
+struct W : P4 {} // expected-error {{type 'W' does not conform to protocol 'P4'}}

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -80,3 +80,21 @@ protocol P8 {
 struct B : P8 { // expected-error {{type 'B' does not conform to protocol 'P8'}}
     func g(t: (Int, String)) {} // expected-note {{candidate can not infer 'T' = '(Int, String)' because '(Int, String)' is not a nominal type and so can't conform to 'P7'}}
 }
+
+protocol P9 {
+    func foo() // expected-note {{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}}
+}
+class C2 {}
+extension P9 where Self : C2 {
+    func foo() {} // expected-note {{candidate would match if 'C3' subclassed 'C2'}}
+}
+class C3 : P9 {} // expected-error {{type 'C3' does not conform to protocol 'P9'}}
+
+protocol P10 {
+    associatedtype A
+    func bar() // expected-note {{protocol requires function 'bar()' with type '() -> ()'; do you want to add a stub?}}
+}
+extension P10 where A == Int {
+    func bar() {} // expected-note {{candidate would match if 'A' was the same type as 'Int'}}
+}
+struct S2<A> : P10 {} // expected-error {{type 'S2<A>' does not conform to protocol 'P10'}}

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -24,7 +24,7 @@ protocol LikeSequence {
     func makeIter() -> Iter
 }
 extension LikeSequence where Self == Self.Iter {
-    func makeIter() -> Self { return self } // expected-note {{candidate would match and infer 'Iter'='Y' if 'Y' conformed to 'IterProtocol'}}
+    func makeIter() -> Self { return self } // expected-note {{candidate would match and infer 'Iter' = 'Y' if 'Y' conformed to 'IterProtocol'}}
 }
 
 struct Y : LikeSequence {} // expected-error {{type 'Y' does not conform to protocol 'LikeSequence'}}
@@ -42,16 +42,41 @@ extension P1 where Result : P2 {
 }
 protocol P3 {}
 extension P1 where Self : P3 {
-    func got() {} // expected-note {{candidate would match if 'Z' conformed to 'P3'}}
+    func got() {} // expected-note {{candidate would match if 'Z<T1, T2, T3, Result, T4>' conformed to 'P3'}}
 }
 
 struct Z<T1, T2, T3, Result, T4> : P1 {} // expected-error {{type 'Z<T1, T2, T3, Result, T4>' does not conform to protocol 'P1'}}
 
 protocol P4 {
-    func this() // expected-note {{protocol requires function 'this()' with type '() -> ()'; do you want to add a stub?}}
+    func this() // expected-note 2 {{protocol requires function 'this()' with type '() -> ()'; do you want to add a stub?}}
 }
 protocol P5 {}
 extension P4 where Self : P5 {
     func this() {} // expected-note {{candidate would match if 'W' conformed to 'P5'}}
+    //// expected-note@-1 {{candidate would match if 'S<T>.SS' conformed to 'P5'}}
 }
 struct W : P4 {} // expected-error {{type 'W' does not conform to protocol 'P4'}}
+
+struct S<T> {
+    struct SS : P4 {} // expected-error {{type 'S<T>.SS' does not conform to protocol 'P4'}}
+}
+
+class C {}
+protocol P6 {
+    associatedtype T : C // expected-note {{unable to infer associated type 'T' for protocol 'P6'}}
+    func f(t: T)
+}
+
+struct A : P6 { // expected-error {{type 'A' does not conform to protocol 'P6'}}
+    func f(t: Int) {} // expected-note {{candidate can not infer 'T' = 'Int' because 'Int' is not a class type and so can't inherit from 'C'}}
+}
+
+protocol P7 {}
+protocol P8 {
+    associatedtype T : P7 // expected-note {{unable to infer associated type 'T' for protocol 'P8'}}
+    func g(t: T)
+}
+
+struct B : P8 { // expected-error {{type 'B' does not conform to protocol 'P8'}}
+    func g(t: (Int, String)) {} // expected-note {{candidate can not infer 'T' = '(Int, String)' because '(Int, String)' is not a nominal type and so can't conform to 'P7'}}
+}

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -10,7 +10,7 @@ protocol P {
 
 extension P {
   func f<T: P>(_: T) where T.A == Self.A, T.A == Self.B { }
-  // expected-note@-1 {{candidate has non-matching type '<Self, T> (T) -> ()'}}
+  // expected-note@-1 {{candidate would match if 'X' was the same type as 'X.B' (aka 'Int')}}
 }
 
 struct X : P { // expected-error {{type 'X' does not conform to protocol 'P'}}

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -17,7 +17,7 @@ func bad_containers_2(bc: BadContainer2) {
 }
 
 struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does not conform to protocol 'Sequence'}}
-  func makeIterator() { } // expected-note{{candidate would match and infer 'Iterator'='()' if '()' conformed to 'IteratorProtocol'}}
+  func makeIterator() { } // expected-note{{candidate can not infer 'Iterator' = '()' because '()' is not a nominal type and so can't conform to 'IteratorProtocol'}}
 }
 
 func bad_containers_3(bc: BadContainer3) {

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -17,7 +17,7 @@ func bad_containers_2(bc: BadContainer2) {
 }
 
 struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does not conform to protocol 'Sequence'}}
-  func makeIterator() { } // expected-note{{inferred type '()' (by matching requirement 'makeIterator()') is invalid: does not conform to 'IteratorProtocol'}}
+  func makeIterator() { } // expected-note{{candidate would match and infer 'Iterator'='()' if '()' conformed to 'IteratorProtocol'}}
 }
 
 func bad_containers_3(bc: BadContainer3) {


### PR DESCRIPTION
Continuing on to try to further improve inference QoI: Let CS::solveSingle() optionally allow fixes in the solution. Use this in protocol inference to look for fixes due to missing conformances and give better candidate failure notes. (Which were previously types-didn't-match notes that didn't really say anything about the actual problem.) Also changed the diagnosis text for the existing associated type inference failure due to missing requirement so that it is phrased similarly. 

Thus, new candidate notes like:
```
a.swift:1:8: error: type 'X' does not conform to protocol 'SetAlgebra'
struct X : OptionSet {}
       ^
Swift.OptionSet:3:37: note: candidate would match if 'X.RawValue' conformed to 'FixedWidthInteger'
    @inlinable public mutating func formUnion(_ other: Self)
```

```
a.swift:2:8: error: type 'Y' does not conform to protocol 'Sequence'
struct Y : Sequence {}
       ^
Swift.Sequence:3:20: note: unable to infer associated type 'Iterator' for protocol 'Sequence'
    associatedtype Iterator : IteratorProtocol
                   ^
Swift.Sequence:2:40: note: candidate would match and infer 'Iterator'='Y' if 'Y' conformed to 'IteratorProtocol'
    @inlinable public __consuming func makeIterator() -> Self
```