### PR TITLE
SourceKit: always install the header

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -103,7 +103,7 @@ macro(add_sourcekit_library name)
   cmake_parse_arguments(SOURCEKITLIB
       "SHARED"
       "INSTALL_IN_COMPONENT"
-      "LINK_LIBS;DEPENDS;LLVM_COMPONENT_DEPENDS"
+      "HEADERS;LINK_LIBS;DEPENDS;LLVM_COMPONENT_DEPENDS"
       ${ARGN})
   set(srcs ${SOURCEKITLIB_UNPARSED_ARGUMENTS})
 
@@ -199,6 +199,9 @@ macro(add_sourcekit_library name)
       LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
       ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
       RUNTIME DESTINATION "bin")
+  swift_install_in_component("${SOURCEKITLIB_INSTALL_IN_COMPONENT}"
+    FILES ${SOURCEKITLIB_HEADERS}
+    DESTINATION "include/SourceKit")
   set_target_properties(${name} PROPERTIES FOLDER "SourceKit libraries")
   add_sourcekit_default_compiler_flags("${name}")
 endmacro()

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
@@ -21,6 +21,8 @@ if (SOURCEKIT_INSTALLING_INPROC)
   else()
     add_sourcekit_library(sourcekitdInProc
       ${sourcekitdInProc_args}
+      HEADERS
+        ${SOURCEKITD_SOURCE_DIR}/include/sourcekitd/sourcekitd.h
       INSTALL_IN_COMPONENT sourcekit-inproc
       SHARED
     )
@@ -28,6 +30,8 @@ if (SOURCEKIT_INSTALLING_INPROC)
 else()
   add_sourcekit_library(sourcekitdInProc
     ${sourcekitdInProc_args}
+    HEADERS
+      ${SOURCEKITD_SOURCE_DIR}/include/sourcekitd/sourcekitd.h
     INSTALL_IN_COMPONENT sourcekit-inproc
     SHARED
   )
@@ -38,6 +42,8 @@ endif()
 # that is in the same directory as the swift library directory.
 if (SOURCEKITD_BUILD_STATIC_INPROC)
   add_sourcekit_library(sourcekitdInProc_Static
+    HEADERS
+      ${SOURCEKITD_SOURCE_DIR}/include/sourcekitd/sourcekitd.h
     ${sourcekitdInProc_args}
   )
 endif()


### PR DESCRIPTION
Ensure that we install the client header for the InProc sourcekitd.  This is
needed to actually make it usable.  With this, it is now possible to develop
against SourceKit on Linux and Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
