### PR TITLE
GSB: When merging two equivalence classes, don't forget to re-process delayed requirements

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4926,8 +4926,11 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenTypeParameters(
   if (equivClass2)
     equivClass->modified(*this);
 
-  // Same-type requirements.
+  // Same-type requirements, delayed requirements.
   if (equivClass2) {
+    Impl->DelayedRequirements.append(equivClass2->delayedRequirements.begin(),
+                                     equivClass2->delayedRequirements.end());
+
     equivClass->sameTypeConstraints.insert(
                                    equivClass->sameTypeConstraints.end(),
                                    equivClass2->sameTypeConstraints.begin(),


### PR DESCRIPTION
Fixes <rdar://problem/45307061>.