### PR TITLE
[android] Disable LLD when cross-compiling Android in CI.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -787,6 +787,7 @@ mixin-preset=buildbot_linux
 
 release
 assertions
+extra-cmake-options=-DSWIFT_ENABLE_LLD_LINKER:BOOL=OFF
 
 dash-dash
 


### PR DESCRIPTION
Ubuntu 16.04 doesn't include LLD, and the included gold doesn't
link Android correctly.

Because of the change in e7ba154d59d73c5bfa04090c0d32f187cc6ad873
the -B option was not passed during compiling, and the Ubuntu gold
was being used in the CI (the default value for
SWIFT_ENABLE_LLD_LINKER is ON, even if LLD is not present).

This change sets the value to OFF in the preset, so LLD will not
try to be used in CI. All other builds should be unchanged, so in
other developers setups the compiling machine LLD will try to be
used (which works on more recent Ubuntu versions).

/cc @compnerd: This is what I was talking about. The changes in the above commit applies even if the compiler will not be able to find LLD (like it happens in the CI machine). This change is the “minimal” change that I can think of that makes the CI work, and keeps everyone else setups untouched (like yours and mine). Ideally the settings will be “per SDK”, or LLD should be found in a better way, but those changes are more complicated to get right.

However, even if this change allows the CI machine to go further into the compilation, it is going to fail eventually trying to generate the ARM code (broken between 10/12 and 10/15, but I haven’t found the reason yet).