### PR TITLE
[Runtime/IRGen] Various fixes for demangled name round-tripping

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -924,9 +924,17 @@ namespace {
       auto params = type.getParams();
       auto numParams = params.size();
 
+      // Retrieve the ABI parameter flags from the type-level parameter
+      // flags.
+      auto getABIParameterFlags = [](ParameterTypeFlags flags) {
+        return ParameterFlags()
+                 .withValueOwnership(flags.getValueOwnership())
+                 .withVariadic(flags.isVariadic());
+      };
+
       bool hasFlags = false;
       for (auto param : params) {
-        if (!param.getParameterFlags().isNone()) {
+        if (!getABIParameterFlags(param.getParameterFlags()).isNone()) {
           hasFlags = true;
           break;
         }
@@ -969,11 +977,7 @@ namespace {
               auto param = params[index];
               auto flags = param.getParameterFlags();
 
-              auto parameterFlags =
-                  ParameterFlags()
-                      .withValueOwnership(flags.getValueOwnership())
-                      .withVariadic(flags.isVariadic());
-
+              auto parameterFlags = getABIParameterFlags(flags);
               processor(index, getFunctionParameterRef(param), parameterFlags);
             }
           };

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -3085,9 +3085,17 @@ bool _swift_isClassOrObjCExistentialType(const Metadata *value,
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 const Metadata *swift::_swift_class_getSuperclass(const Metadata *theClass) {
-  if (const ClassMetadata *classType = theClass->getClassObject())
+  if (const ClassMetadata *classType = theClass->getClassObject()) {
     if (classHasSuperclass(classType))
       return getMetadataForClass(classType->Superclass);
+  }
+
+  if (const ForeignClassMetadata *foreignClassType
+        = dyn_cast<ForeignClassMetadata>(theClass)) {
+    if (const Metadata *superclass = foreignClassType->Superclass)
+      return superclass;
+  }
+
   return nullptr;
 }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4688,6 +4688,8 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
   if (!verificationEnabled) return;
   
   Demangle::Demangler Dem;
+  Dem.setSymbolicReferenceResolver(ResolveToDemanglingForContext(Dem));
+
   auto node = _swift_buildDemanglingForMetadata(metadata, Dem);
   // If the mangled node involves types in an AnonymousContext, then by design,
   // it cannot be looked up by name.

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -463,12 +463,10 @@ recur:
     }
   }
 
-  // If the type is a class, try its superclass.
-  if (const ClassMetadata *classType = type->getClassObject()) {
-    if (classHasSuperclass(classType)) {
-      type = getMetadataForClass(classType->Superclass);
-      goto recur;
-    }
+  // If there is a superclass, look there.
+  if (auto superclass = _swift_class_getSuperclass(type)) {
+    type = superclass;
+    goto recur;
   }
 
   // We did not find an up-to-date cache entry.
@@ -506,12 +504,10 @@ bool isRelatedType(const Metadata *type, const void *candidate,
         return true;
     }
 
-    // If the type is a class, try its superclass.
-    if (const ClassMetadata *classType = type->getClassObject()) {
-      if (classHasSuperclass(classType)) {
-        type = getMetadataForClass(classType->Superclass);
-        continue;
-      }
+    // If there is a superclass, look there.
+    if (auto superclass = _swift_class_getSuperclass(type)) {
+      type = superclass;
+      continue;
     }
 
     break;

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -51,4 +51,8 @@ func test_arch() {
   // CHECK: store %swift.type* @"$ss4Int8VN", %swift.type** [[T:%.*]], align [[ALIGN:(4|8)]]
   // CHECK: call %swift.type* @swift_getFunctionTypeMetadata([[WORD]] 100663300, %swift.type** {{%.*}}, i32* getelementptr inbounds ([4 x i32], [4 x i32]* @parameter-flags.{{.*}}, i32 0, i32 0), %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @"$sytN", i32 0, i32 1))
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })
+
+  // CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden swiftcc %swift.metadata_response @"$syyyccMa"
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1(i64 67108865
+  arch({(x: @escaping () -> ()) -> () in })
 }

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -91,5 +91,10 @@ DemangleToMetadataTests.test("members of runtime-only Objective-C classes") {
     _typeByMangledName("So17OS_dispatch_queueC8DispatchE10AttributesV")!)
 }
 
+DemangleToMetadataTests.test("runtime conformance lookup via foreign superclasses") {
+  expectEqual(Set<CFMutableString>.self,
+    _typeByMangledName("ShySo18CFMutableStringRefaG")!)
+}
+
 runAllTests()
 


### PR DESCRIPTION
Three fixes to get us a bit closer to enabling the mangled name <-> metadata roundtrip verification in the Swift runtime:

* Resolve symbolic references to complete mangling in the roundtrip verification (no effect in non-asserts runtimes)
* Follow CF superclass metadata when looking for (e.g.) protocol conformances declared on superclasses of CF types
* Fix mismatch between IRGen's notion of when `swift_getFunctionTypeMetadata` needs parameter flags vs. the runtime's notion.