### PR TITLE
[CSDiag] Don't increase candidate curry level if base is ignored

### DIFF
--- a/test/Constraints/rdar45242032.swift
+++ b/test/Constraints/rdar45242032.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -module-name M
+
+protocol P {
+  var v: String { get }
+}
+
+func foo(bar: [P], baz: [P]) {
+// expected-note@-1 {{'foo(bar:baz:)' declared here}}
+}
+
+struct S {
+  static func bar(fiz: [P], baz: [P]) {}
+// expected-note@-1 {{'bar(fiz:baz:)' declared here}}
+}
+
+do {
+  let _ = M.foo(bar & // expected-error {{missing argument for parameter 'bar' in call}}
+} // expected-error {{expected expression after operator}}
+
+do {
+  let _ = S.bar(fiz & // expected-error {{missing argument for parameter 'fiz' in call}}
+} // expected-error {{expected expression after operator}}


### PR DESCRIPTION
When `CandidateCalleeInfo` tries to create a candidate for expression
in form of `<base>.<func>` it shouldn't assume that function type of
'<func>' would always be at curry level 1, because base could be ignored
when it is a module or 'b' refers to a static function.

Resolves: rdar://problem/45242032
Resolves: [SR-8987](https://bugs.swift.org/browse/SR-8987)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
