### PR TITLE
[ModuleInterface] Improvements to caching

### DIFF
--- a/include/swift/AST/FileSystem.h
+++ b/include/swift/AST/FileSystem.h
@@ -1,0 +1,44 @@
+//===--- FileSystem.h - File helpers that interact with Diags ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_FILESYSTEM_H
+#define SWIFT_AST_FILESYSTEM_H
+
+#include "swift/Basic/FileSystem.h"
+#include "swift/AST/DiagnosticEngine.h"
+
+namespace swift {
+
+/// A wrapper around swift::atomicallyWritingToFile that handles diagnosing any
+/// filesystem errors and asserts the output path is nonempty.
+///
+/// \returns true if there were any errors, either from the filesystem
+/// operations or from \p action returning true.
+inline bool
+withOutputFile(DiagnosticEngine &diags, StringRef outputPath,
+               llvm::function_ref<bool(llvm::raw_pwrite_stream &)> action) {
+  assert(!outputPath.empty());
+
+  bool actionFailed = false;
+  std::error_code EC = swift::atomicallyWritingToFile(
+      outputPath,
+      [&](llvm::raw_pwrite_stream &out) { actionFailed = action(out); });
+  if (EC) {
+    diags.diagnose(SourceLoc(), diag::error_opening_output, outputPath,
+                   EC.message());
+    return true;
+  }
+  return actionFailed;
+}
+} // end namespace swift
+
+#endif // SWIFT_AST_FILESYSTEM_H

--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -50,6 +50,8 @@ TYPE("swiftmodule",         SwiftModuleFile,           "swiftmodule",     "")
 TYPE("swiftdoc",            SwiftModuleDocFile,        "swiftdoc",        "")
 TYPE("swiftinterface",      SwiftParseableInterfaceFile, \
                                                        "swiftinterface",  "")
+TYPE("swiftinterfacedeps",  SwiftParseableInterfaceDeps, \
+                                                       "sid",             "")
 TYPE("assembly",            Assembly,                  "s",               "")
 TYPE("raw-sil",             RawSIL,                    "sil",             "")
 TYPE("raw-sib",             RawSIB,                    "sib",             "")

--- a/include/swift/Frontend/ParseableInterfaceSupport.h
+++ b/include/swift/Frontend/ParseableInterfaceSupport.h
@@ -64,9 +64,10 @@ class ParseableInterfaceModuleLoader : public SerializedModuleLoaderBase {
   std::string CacheDir;
 
   void
-  configureSubInvocationAndOutputPath(CompilerInvocation &SubInvocation,
-                                      StringRef InPath,
-                                      llvm::SmallString<128> &OutPath);
+  configureSubInvocationAndOutputPaths(CompilerInvocation &SubInvocation,
+                                       StringRef InPath,
+                                       llvm::SmallString<128> &OutPath,
+                                       llvm::SmallString<128> &DepPath);
 
   std::error_code
   openModuleFiles(StringRef DirName, StringRef ModuleFilename,

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -79,6 +79,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_ModuleTrace:
   case file_types::TY_OptRecord:
   case file_types::TY_SwiftParseableInterfaceFile:
+  case file_types::TY_SwiftParseableInterfaceDeps:
     return true;
   case file_types::TY_Image:
   case file_types::TY_Object:
@@ -135,6 +136,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_ModuleTrace:
   case file_types::TY_OptRecord:
   case file_types::TY_SwiftParseableInterfaceFile:
+  case file_types::TY_SwiftParseableInterfaceDeps:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -167,6 +169,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_SwiftModuleFile:
   case file_types::TY_SwiftModuleDocFile:
   case file_types::TY_SwiftParseableInterfaceFile:
+  case file_types::TY_SwiftParseableInterfaceDeps:
   case file_types::TY_SerializedDiagnostics:
   case file_types::TY_ClangModuleFile:
   case file_types::TY_SwiftDeps:

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1780,6 +1780,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_ModuleTrace:
       case file_types::TY_OptRecord:
       case file_types::TY_SwiftParseableInterfaceFile:
+      case file_types::TY_SwiftParseableInterfaceDeps:
         // We could in theory handle assembly or LLVM input, but let's not.
         // FIXME: What about LTO?
         Diags.diagnose(SourceLoc(), diag::error_unexpected_input_file,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -438,6 +438,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_TBD:
   case file_types::TY_OptRecord:
   case file_types::TY_SwiftParseableInterfaceFile:
+  case file_types::TY_SwiftParseableInterfaceDeps:
     llvm_unreachable("Output type can never be primary output.");
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID");
@@ -670,6 +671,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_ModuleTrace:
     case file_types::TY_OptRecord:
     case file_types::TY_SwiftParseableInterfaceFile:
+    case file_types::TY_SwiftParseableInterfaceDeps:
       llvm_unreachable("Output type can never be primary output.");
     case file_types::TY_INVALID:
       llvm_unreachable("Invalid type ID");

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/ASTScope.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/FileSystem.h"
 #include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/ASTMangler.h"
@@ -312,30 +313,6 @@ static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
                   PSPs.OutputFilename, opts.EmitSortedSIL);
 }
 
-/// A wrapper around swift::atomicallyWritingToFile that handles diagnosing any
-/// filesystem errors and ignores empty output paths.
-///
-/// \returns true if there were any errors, either from the filesystem
-/// operations or from \p action returning true.
-static bool atomicallyWritingToTextFile(
-    StringRef outputPath, DiagnosticEngine &diags,
-    llvm::function_ref<bool(llvm::raw_pwrite_stream &)> action) {
-  assert(!outputPath.empty());
-
-  bool actionFailed = false;
-  std::error_code EC =
-      swift::atomicallyWritingToFile(outputPath,
-                                     [&](llvm::raw_pwrite_stream &out) {
-    actionFailed = action(out);
-  });
-  if (EC) {
-    diags.diagnose(SourceLoc(), diag::error_opening_output,
-                   outputPath, EC.message());
-    return true;
-  }
-  return actionFailed;
-}
-
 /// Prints the Objective-C "generated header" interface for \p M to \p
 /// outputPath.
 ///
@@ -348,8 +325,8 @@ static bool printAsObjCIfNeeded(StringRef outputPath, ModuleDecl *M,
                                 StringRef bridgingHeader, bool moduleIsPublic) {
   if (outputPath.empty())
     return false;
-  return atomicallyWritingToTextFile(outputPath, M->getDiags(),
-                                     [&](raw_ostream &out) -> bool {
+  return withOutputFile(M->getDiags(), outputPath,
+                        [&](raw_ostream &out) -> bool {
     auto requiredAccess = moduleIsPublic ? AccessLevel::Public
                                          : AccessLevel::Internal;
     return printAsObjC(out, M, bridgingHeader, requiredAccess);
@@ -368,8 +345,8 @@ static bool printParseableInterfaceIfNeeded(StringRef outputPath,
                                             ModuleDecl *M) {
   if (outputPath.empty())
     return false;
-  return atomicallyWritingToTextFile(outputPath, M->getDiags(),
-                                     [M, Opts](raw_ostream &out) -> bool {
+  return withOutputFile(M->getDiags(), outputPath,
+                        [M, Opts](raw_ostream &out) -> bool {
     return swift::emitParseableInterface(out, Opts, M);
   });
 }

--- a/test/ParseableInterface/client.swift
+++ b/test/ParseableInterface/client.swift
@@ -3,11 +3,32 @@
 // RUN: %target-swift-frontend -enable-resilience -emit-parseable-module-interface-path %t/TestModule.swiftinterface -module-name TestModule %S/Inputs/other.swift -emit-module -o /dev/null
 // RUN: test -f %t/TestModule.swiftinterface
 // RUN: %target-swift-frontend -typecheck -enable-parseable-module-interface -module-cache-path %t/modulecache -I %t %s
+
+// RUN: test ! %t/modulecache/TestModule-*.swiftmodule -ot %t/TestModule.swiftinterface
 // RUN: llvm-bcanalyzer -dump %t/modulecache/TestModule-*.swiftmodule | %FileCheck %s -check-prefix=CHECK-SWIFTMODULE
+// RUN: %FileCheck %s -check-prefix=CHECK-SID <%t/modulecache/TestModule-*.sid
+
+// Now add a "dependency" to the .sid file but set it to be quite old
+// RUN: echo %t/fake-dep >>%t/modulecache/TestModule-*.sid
+// RUN: touch -t 201401240005 %t/fake-dep
+// RUN: %FileCheck %s -check-prefix=CHECK-SID2 <%t/modulecache/TestModule-*.sid
+
+// Check that the cache does not rebuild
+// RUN: %target-swift-frontend -typecheck -enable-parseable-module-interface -module-cache-path %t/modulecache -I %t %s
+// RUN: %FileCheck %s -check-prefix=CHECK-SID2 <%t/modulecache/TestModule-*.sid
+
+// Now touch the dependency a ways into the future, and check that the cache _does_ rebuild
+// (Sorry, this test will need refreshing in the year 2035)
+// RUN: touch -t 203501240005 %t/fake-dep
+// RUN: %target-swift-frontend -typecheck -enable-parseable-module-interface -module-cache-path %t/modulecache -I %t %s
+// RUN: %FileCheck %s -check-prefix=CHECK-SID3 <%t/modulecache/TestModule-*.sid
 
 // CHECK-SWIFTMODULE: {{MODULE_NAME.*blob data = 'TestModule'}}
 // CHECK-SWIFTMODULE: FUNC_DECL
 // CHECK-SWIFTMODULE: RESILIENCE_STRATEGY
+// CHECK-SID: Swift.swiftmodule
+// CHECK-SID2: fake-dep
+// CHECK-SID3-NOT: fake-dep
 
 import TestModule
 func foo() {


### PR DESCRIPTION
This picks up where https://github.com/apple/swift/pull/19518 left off, adding a new (very simple) dependency file type (called `.sid` since it's private anyways, and `.swiftinterfacedeps` seemed like it was getting a bit long) and improving the cache-key formation to match what @jrose-apple described over in https://forums.swift.org/t/thoughts-on-caching-compiled-parseable-interfaces/16746

Also factored out a common helper along the way that I was going to wind up adding another copy of if I didn't.