### PR TITLE
[android] Pass test environment variables to Android device.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -932,7 +932,8 @@ SIMULATOR_ENV_PREFIX = 'SIMCTL_CHILD_'
 ENV_VAR_PREFIXES = {
     'iphonesimulator': SIMULATOR_ENV_PREFIX,
     'watchsimulator': SIMULATOR_ENV_PREFIX,
-    'appletvsimulator': SIMULATOR_ENV_PREFIX
+    'appletvsimulator': SIMULATOR_ENV_PREFIX,
+    'android': 'ANDROID_CHILD_'
 }
 TARGET_ENV_PREFIX = ENV_VAR_PREFIXES.get(config.target_sdk_name, "")
 


### PR DESCRIPTION
When running tests in an Android device, the environment variables
were not passed to the device, which make some test fail, like
stdlib/HashingRandomization that test with and without the
environment variable SWIFT_DETERMINISTIC_HASHING.

The changes implement a process similar to what the iOS simulator
already seem to do: a variable prefix which is pick up by the
adb_test_runner.py and send to the device for the test.

Besides that, to make the test pass, the test runner will not print the standard out with an extra newline at the end (from the Python `print`). This should make the output match the rest of the platforms more closely.