### PR TITLE
[ModuleInterface] Use 2-arg form of basename(1) in overlay validation tests.

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.swift
+++ b/validation-test/ParseableInterface/verify_all_overlays.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: for x in %platform-sdk-overlay-dir/*.swiftinterface; do [[ $(basename "$x") = Swift.swiftinterface || $(basename "$x") = simd.swiftinterface || $(basename "$x") = SwiftLang.swiftinterface ]] && continue; %target-swift-frontend "$x" -emit-module -o %t/$(basename "${x/.*}").swiftmodule -disable-objc-attr-requires-foundation-module -enable-resilience -Fsystem %sdk/System/Library/PrivateFrameworks/ -swift-version 4 || echo '%target-os:' $(basename "$x") >> %t/failures.txt; done
+// RUN: for x in %platform-sdk-overlay-dir/*.swiftinterface; do [[ $(basename "$x") = Swift.swiftinterface || $(basename "$x") = simd.swiftinterface || $(basename "$x") = SwiftLang.swiftinterface ]] && continue; %target-swift-frontend "$x" -emit-module -o %t/$(basename "$x" .swiftinterface).swiftmodule -disable-objc-attr-requires-foundation-module -enable-resilience -Fsystem %sdk/System/Library/PrivateFrameworks/ -swift-version 4 || echo '%target-os:' $(basename "$x") >> %t/failures.txt; done
 // RUN: diff <(grep '%target-os:' %s) <(sort -f %t/failures.txt)
 
 // REQUIRES: nonexecutable_test

--- a/validation-test/ParseableInterface/verify_all_overlays_O.swift
+++ b/validation-test/ParseableInterface/verify_all_overlays_O.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: for x in %platform-sdk-overlay-dir/*.swiftinterface; do [[ $(basename "$x") = Swift.swiftinterface || $(basename "$x") = simd.swiftinterface || $(basename "$x") = SwiftLang.swiftinterface ]] && continue; %target-swift-frontend "$x" -emit-module -o %t/$(basename "${x/.*}").swiftmodule -disable-objc-attr-requires-foundation-module -enable-resilience -Fsystem %sdk/System/Library/PrivateFrameworks/ -swift-version 4 -O || echo '%target-os:' $(basename "$x") >> %t/failures.txt; done
+// RUN: for x in %platform-sdk-overlay-dir/*.swiftinterface; do [[ $(basename "$x") = Swift.swiftinterface || $(basename "$x") = simd.swiftinterface || $(basename "$x") = SwiftLang.swiftinterface ]] && continue; %target-swift-frontend "$x" -emit-module -o %t/$(basename "$x" .swiftinterface).swiftmodule -disable-objc-attr-requires-foundation-module -enable-resilience -Fsystem %sdk/System/Library/PrivateFrameworks/ -swift-version 4 -O || echo '%target-os:' $(basename "$x") >> %t/failures.txt; done
 // RUN: diff <(grep '%target-os:' %s) <(sort -f %t/failures.txt)
 
 // REQUIRES: nonexecutable_test


### PR DESCRIPTION
(Chery-pick of 9a3b2322575561c15534ae26010d87f335afa137 from swift-5.0-branch)

A bunch of .swiftinterface files fail to build into their respective .swiftmodules
if you pass -module-name <foo> for some foo that is not the correct module name.

The two tests in this change were using a shell expansion that incorrectly picked
the first path component with a period in the name as the module name; this caused
the failures.

Rather than using a shell expansion, this change uses the 2-argument form of
basename(1) (which is POSIX) that also removes a suffix from the basename.

rdar://45347391
