### PR TITLE
[ConstraintSystem] Replace curry level with a boolean flag

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3078,7 +3078,7 @@ END_CAN_TYPE_WRAPPER(FunctionType, AnyFunctionType)
 /// it.
 SmallBitVector
 computeDefaultMap(ArrayRef<AnyFunctionType::Param> params,
-                  const ValueDecl *paramOwner, unsigned level);
+                  const ValueDecl *paramOwner, bool skipCurriedSelf);
 
 /// Turn a param list into a symbolic and printable representation that does not
 /// include the types, something like (: , b:, c:)

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -749,7 +749,7 @@ Type TypeBase::replaceCovariantResultType(Type newResultType,
 
 SmallBitVector
 swift::computeDefaultMap(ArrayRef<AnyFunctionType::Param> params,
-                         const ValueDecl *paramOwner, unsigned level) {
+                         const ValueDecl *paramOwner, bool skipCurriedSelf) {
   SmallBitVector resultVector(params.size());
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -762,15 +762,15 @@ swift::computeDefaultMap(ArrayRef<AnyFunctionType::Param> params,
   const ParameterList *paramList = nullptr;
   if (auto *func = dyn_cast<AbstractFunctionDecl>(paramOwner)) {
     if (func->hasImplicitSelfDecl()) {
-      if (level == 1)
+      if (skipCurriedSelf)
         paramList = func->getParameters();
-    } else if (level == 0)
+    } else if (!skipCurriedSelf)
       paramList = func->getParameters();
   } else if (auto *subscript = dyn_cast<SubscriptDecl>(paramOwner)) {
-    if (level == 1)
+    if (skipCurriedSelf)
       paramList = subscript->getIndices();
   } else if (auto *enumElement = dyn_cast<EnumElementDecl>(paramOwner)) {
-    if (level == 1)
+    if (skipCurriedSelf)
       paramList = enumElement->getParameterList();
   }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2856,10 +2856,10 @@ static bool candidatesHaveAnyDefaultValues(
     if (!function) continue;
 
     if (function->hasImplicitSelfDecl()) {
-      if (cand.level != 1)
+      if (!cand.skipCurriedSelf)
         return false;
     } else {
-      if (cand.level != 0)
+      if (cand.skipCurriedSelf)
         return false;
     }
 
@@ -2910,10 +2910,10 @@ static Optional<unsigned> getElementForScalarInitOfArg(
   if (!function) return getElementForScalarInitSimple(tupleTy);
 
   if (function->hasImplicitSelfDecl()) {
-    if (cand.level != 1)
+    if (!cand.skipCurriedSelf)
       return getElementForScalarInitSimple(tupleTy);
   } else {
-    if (cand.level != 0)
+    if (cand.skipCurriedSelf)
       return getElementForScalarInitSimple(tupleTy);
   }
 
@@ -2987,7 +2987,7 @@ typeCheckArgumentChildIndependently(Expr *argExpr, Type argType,
   // diagnostics when we don't force the self type down.
   if (argType && !candidates.empty())
     if (auto decl = candidates[0].getDecl())
-      if (decl->isInstanceMember() && candidates[0].level == 0 &&
+      if (decl->isInstanceMember() && !candidates[0].skipCurriedSelf &&
           !isa<SubscriptDecl>(decl))
         argType = Type();
 
@@ -3052,7 +3052,7 @@ typeCheckArgumentChildIndependently(Expr *argExpr, Type argType,
     SmallBitVector defaultMap(params.size());
     if (!candidates.empty()) {
       defaultMap = computeDefaultMap(params, candidates[0].getDecl(),
-                                     candidates[0].level);
+                                     candidates[0].skipCurriedSelf);
     }
 
     // Form a set of call arguments, using a dummy type (Void), because the
@@ -3461,14 +3461,15 @@ diagnoseInstanceMethodAsCurriedMemberOnType(CalleeCandidateInfo &CCI,
     // it might be worth while to check if it's instance method as curried
     // member of type problem.
     if (CCI.closeness == CC_ExactMatch &&
-        (decl->isInstanceMember() && candidate.level == 1))
+        (decl->isInstanceMember() && candidate.skipCurriedSelf))
       continue;
 
     auto params = candidate.getParameters();
     // If one of the candidates is an instance method with a single parameter
     // at the level 0, this might be viable situation for calling instance
     // method as curried member of type problem.
-    if (params.size() != 1 || !decl->isInstanceMember() || candidate.level > 0)
+    if (params.size() != 1 || !decl->isInstanceMember() ||
+        candidate.skipCurriedSelf)
       return false;
   }
 
@@ -4020,7 +4021,7 @@ diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI, Expr *fnExpr,
   auto params = candidate.getParameters();
 
   SmallBitVector defaultMap =
-    computeDefaultMap(params, candidate.getDecl(), candidate.level);
+    computeDefaultMap(params, candidate.getDecl(), candidate.skipCurriedSelf);
   auto args = decomposeArgType(CCI.CS.getType(argExpr), argLabels);
 
   // Check the case where a raw-representable type is constructed from an
@@ -4034,7 +4035,7 @@ diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI, Expr *fnExpr,
   //    MyEnumType.foo
   //
   if (params.size() == 1 && args.size() == 1 && candidate.getDecl() &&
-      isa<ConstructorDecl>(candidate.getDecl()) && candidate.level == 1) {
+      isa<ConstructorDecl>(candidate.getDecl()) && candidate.skipCurriedSelf) {
     AnyFunctionType::Param &arg = args[0];
     auto resTy =
         candidate.getResultType()->lookThroughAllOptionalTypes();
@@ -4320,7 +4321,7 @@ bool FailureDiagnosis::diagnoseSubscriptErrors(SubscriptExpr *SE,
     // We're about to typecheck the index list, which needs to be processed with
     // self already applied.
     for (unsigned i = 0, e = calleeInfo.size(); i != e; ++i)
-      ++calleeInfo.candidates[i].level;
+      calleeInfo.candidates[i].skipCurriedSelf = true;
 
     auto indexExpr =
         typeCheckArgumentChildIndependently(SE->getIndex(), Type(), calleeInfo);
@@ -4329,7 +4330,7 @@ bool FailureDiagnosis::diagnoseSubscriptErrors(SubscriptExpr *SE,
 
     // Back to analyzing the candidate list with self applied.
     for (unsigned i = 0, e = calleeInfo.size(); i != e; ++i)
-      --calleeInfo.candidates[i].level;
+      calleeInfo.candidates[i].skipCurriedSelf = false;
 
     ArrayRef<Identifier> argLabels = SE->getArgumentLabels();
     if (diagnoseParameterErrors(calleeInfo, SE, indexExpr, argLabels))
@@ -4353,9 +4354,8 @@ bool FailureDiagnosis::diagnoseSubscriptErrors(SubscriptExpr *SE,
               CC_ExactMatch)
             selfConstraint = CC_SelfMismatch;
 
-          // Increase the uncurry level to look past the self argument to the
-          // indices.
-          cand.level++;
+          // Set a flag to look past the self argument to the indices.
+          cand.skipCurriedSelf = true;
 
           // Explode out multi-index subscripts to find the best match.
           auto indexResult =
@@ -4378,7 +4378,7 @@ bool FailureDiagnosis::diagnoseSubscriptErrors(SubscriptExpr *SE,
 
     // Any other failures relate to the index list.
     for (unsigned i = 0, e = calleeInfo.size(); i != e; ++i)
-      ++calleeInfo.candidates[i].level;
+      calleeInfo.candidates[i].skipCurriedSelf = true;
 
     // TODO: Is there any reason to check for CC_NonLValueInOut here?
 
@@ -4668,7 +4668,7 @@ bool FailureDiagnosis::diagnoseArgumentGenericRequirements(
 
   auto params = candidate.getParameters();
   SmallBitVector defaultMap =
-    computeDefaultMap(params, candidate.getDecl(), candidate.level);
+    computeDefaultMap(params, candidate.getDecl(), candidate.skipCurriedSelf);
   auto args = decomposeArgType(CS.getType(argExpr), argLabels);
 
   SmallVector<ParamBinding, 4> bindings;
@@ -5232,7 +5232,7 @@ static bool isViableOverloadSet(const CalleeCandidateInfo &CCI,
       return true;
     };
 
-    auto defaultMap = computeDefaultMap(params, funcDecl, cand.level);
+    auto defaultMap = computeDefaultMap(params, funcDecl, cand.skipCurriedSelf);
     InputMatcher IM(params, defaultMap);
     auto result = IM.match(numArgs, pairMatcher);
     if (result == InputMatcher::IM_Succeeded)
@@ -5413,7 +5413,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
     if (!calleeInfo.empty()) {
       auto &&cand = calleeInfo[0];
       auto decl = cand.getDecl();
-      if (decl && decl->isInstanceMember() && cand.level == 0 &&
+      if (decl && decl->isInstanceMember() && !cand.skipCurriedSelf &&
           cand.getParameters().size() == 1)
         isInstanceMethodAsCurriedMemberOnType = true;
     }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5126,7 +5126,7 @@ bool FailureDiagnosis::diagnoseSubscriptMisuse(ApplyExpr *callExpr) {
   using ClosenessPair = CalleeCandidateInfo::ClosenessResultTy;
 
   candidateInfo.filterList([&](OverloadCandidate cand) -> ClosenessPair {
-    auto candFuncType = cand.getUncurriedFunctionType();
+    auto candFuncType = cand.getFunctionType();
     if (!candFuncType)
       return {CC_GeneralMismatch, {}};
 
@@ -5679,7 +5679,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
           return false;
 
         auto candidate = calleeInfo[0];
-        auto *fnType = candidate.getUncurriedFunctionType();
+        auto *fnType = candidate.getFunctionType();
         if (!fnType)
           return false;
 
@@ -7228,7 +7228,7 @@ bool FailureDiagnosis::visitUnresolvedMemberExpr(UnresolvedMemberExpr *E) {
       // expected result type.
       auto resultTy = candidateInfo[0].getResultType();
       if (!resultTy)
-        resultTy = candidateInfo[0].getUncurriedType();
+        resultTy = candidateInfo[0].getType();
 
       if (resultTy && !CS.getContextualType()->is<UnboundGenericType>() &&
           !CS.TC.isConvertibleTo(resultTy, CS.getContextualType(), CS.DC)) {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4146,7 +4146,7 @@ static bool diagnoseRawRepresentableMismatch(CalleeCandidateInfo &CCI,
   auto arguments = decomposeArgType(argType, argLabels);
 
   auto bestMatchKind = RawRepresentableMismatch::NotApplicable;
-  const UncurriedCandidate *bestMatchCandidate = nullptr;
+  const OverloadCandidate *bestMatchCandidate = nullptr;
   KnownProtocolKind bestMatchProtocol;
   size_t bestMatchIndex;
 
@@ -4341,7 +4341,7 @@ bool FailureDiagnosis::diagnoseSubscriptErrors(SubscriptExpr *SE,
     auto decomposedBaseType = decomposeArgType(baseType, {Identifier()});
     auto decomposedIndexType = decomposeArgType(indexType, argLabels);
     calleeInfo.filterList(
-        [&](UncurriedCandidate cand) -> CalleeCandidateInfo::ClosenessResultTy {
+        [&](OverloadCandidate cand) -> CalleeCandidateInfo::ClosenessResultTy {
           // Classify how close this match is.  Non-subscript decls don't match.
           auto subscriptDecl = dyn_cast_or_null<SubscriptDecl>(cand.getDecl());
           if (!subscriptDecl ||
@@ -4402,7 +4402,7 @@ bool FailureDiagnosis::diagnoseSubscriptErrors(SubscriptExpr *SE,
         // and more concrete expected type for this subscript decl, in order
         // to diagnose a better error.
         if (baseType && indexType->hasUnresolvedType()) {
-          UncurriedCandidate cand = calleeInfo.candidates[0];
+          auto cand = calleeInfo.candidates[0];
           auto candType = baseType->getTypeOfMember(CS.DC->getParentModule(),
                                                     cand.getDecl(), nullptr);
           if (auto *candFunc = candType->getAs<FunctionType>()) {
@@ -5125,7 +5125,7 @@ bool FailureDiagnosis::diagnoseSubscriptMisuse(ApplyExpr *callExpr) {
   auto params = decomposeArgType(CS.getType(argExpr), argLabels);
   using ClosenessPair = CalleeCandidateInfo::ClosenessResultTy;
 
-  candidateInfo.filterList([&](UncurriedCandidate cand) -> ClosenessPair {
+  candidateInfo.filterList([&](OverloadCandidate cand) -> ClosenessPair {
     auto candFuncType = cand.getUncurriedFunctionType();
     if (!candFuncType)
       return {CC_GeneralMismatch, {}};
@@ -5443,7 +5443,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   if (auto fn = fnType->getAs<AnyFunctionType>()) {
     using Closeness = CalleeCandidateInfo::ClosenessResultTy;
 
-    calleeInfo.filterList([&](UncurriedCandidate candidate) -> Closeness {
+    calleeInfo.filterList([&](OverloadCandidate candidate) -> Closeness {
       auto resultType = candidate.getResultType();
       if (!resultType)
         return {CC_GeneralMismatch, {}};

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -143,8 +143,8 @@ void OverloadCandidate::dump() const {
     llvm::errs() << "<<EXPR>>";
   llvm::errs() << " - ignore curried self = " << (skipCurriedSelf ? "yes"
                                                                   : "no");
-  
-  if (auto FT = getUncurriedFunctionType())
+
+  if (auto FT = getFunctionType())
     llvm::errs() << " - type: " << Type(FT) << "\n";
   else
     llvm::errs() << " - type <<NONFUNCTION>>: " << entityType << "\n";

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -56,8 +56,8 @@ static bool isSubstitutableFor(Type type, ArchetypeType *archetype,
   return true;
 }
 
-UncurriedCandidate::UncurriedCandidate(ValueDecl *decl, unsigned level)
-: declOrExpr(decl), level(level), substituted(false) {
+UncurriedCandidate::UncurriedCandidate(ValueDecl *decl, bool skipCurriedSelf)
+: declOrExpr(decl), skipCurriedSelf(skipCurriedSelf), substituted(false) {
 
   if (auto *PD = dyn_cast<ParamDecl>(decl)) {
     if (PD->hasValidSignature())
@@ -95,15 +95,15 @@ ArrayRef<Identifier> UncurriedCandidate::getArgumentLabels(
   if (auto decl = getDecl()) {
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
       if (func->hasImplicitSelfDecl()) {
-        if (level == 0) {
+        if (!skipCurriedSelf) {
           scratch.push_back(Identifier());
           return scratch;
         }
 
-        --level;
+        skipCurriedSelf = false;
       }
 
-      if (level == 0) {
+      if (!skipCurriedSelf) {
         // Retrieve the argument labels of the corresponding parameter list.
         for (auto param : *func->getParameters()) {
           scratch.push_back(param->getArgumentName());
@@ -112,20 +112,18 @@ ArrayRef<Identifier> UncurriedCandidate::getArgumentLabels(
       }
     } else if (auto enumElt = dyn_cast<EnumElementDecl>(decl)) {
       // 'self'
-      if (level == 0) {
+      if (!skipCurriedSelf) {
         scratch.push_back(Identifier());
         return scratch;
       }
       
       // The associated data of the case.
-      if (level == 1) {
-        auto *paramList = enumElt->getParameterList();
-        if (!paramList) return { };
-        for (auto param : *paramList) {
-          scratch.push_back(param->getArgumentName());
-        }
-        return scratch;
+      auto *paramList = enumElt->getParameterList();
+      if (!paramList) return { };
+      for (auto param : *paramList) {
+        scratch.push_back(param->getArgumentName());
       }
+      return scratch;
     }
   }
 
@@ -143,7 +141,8 @@ void UncurriedCandidate::dump() const {
     decl->dumpRef(llvm::errs());
   else
     llvm::errs() << "<<EXPR>>";
-  llvm::errs() << " - uncurry level " << level;
+  llvm::errs() << " - ignore curried self = " << (skipCurriedSelf ? "yes"
+                                                                  : "no");
   
   if (auto FT = getUncurriedFunctionType())
     llvm::errs() << " - type: " << Type(FT) << "\n";
@@ -322,7 +321,7 @@ CalleeCandidateInfo::evaluateCloseness(UncurriedCandidate candidate,
 
   auto candArgs = candidate.getParameters();
   SmallBitVector candDefaultMap =
-    computeDefaultMap(candArgs, candidate.getDecl(), candidate.level);
+    computeDefaultMap(candArgs, candidate.getDecl(), candidate.skipCurriedSelf);
   
   struct OurListener : public MatchCallArgumentListener {
     CandidateCloseness result = CC_ExactMatch;
@@ -589,28 +588,27 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
                                      /*implicitDotSyntax=*/false);
   }
   
-  // Determine the callee level for a "bare" reference to the given
-  // declaration.
-  auto getCalleeLevel = [implicitDotSyntax](ValueDecl *decl) -> unsigned {
+  // Determine if we need to skip "self" to get to a "bare" reference.
+  auto skipCurriedSelf = [implicitDotSyntax](ValueDecl *decl) -> bool {
     if (auto func = dyn_cast<FuncDecl>(decl)) {
       if (func->isOperator() && func->getDeclContext()->isTypeContext() &&
           !implicitDotSyntax)
-        return 1;
+        return true;
     }
     
-    return 0;
+    return false;
   };
   
   if (auto declRefExpr = dyn_cast<DeclRefExpr>(fn)) {
     auto decl = declRefExpr->getDecl();
-    candidates.push_back({ decl, getCalleeLevel(decl) });
+    candidates.push_back({ decl, skipCurriedSelf(decl) });
     declName = decl->getBaseName().userFacingName();
     return;
   }
   
   if (auto declRefExpr = dyn_cast<OtherConstructorDeclRefExpr>(fn)) {
     auto decl = declRefExpr->getDecl();
-    candidates.push_back({ decl, getCalleeLevel(decl) });
+    candidates.push_back({ decl, skipCurriedSelf(decl) });
     
     if (auto selfTy = decl->getDeclContext()->getSelfInterfaceType())
       declName = selfTy.getString() + ".init";
@@ -621,7 +619,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
   
   if (auto overloadedDRE = dyn_cast<OverloadedDeclRefExpr>(fn)) {
     for (auto cand : overloadedDRE->getDecls()) {
-      candidates.push_back({ cand, getCalleeLevel(cand) });
+      candidates.push_back({ cand, skipCurriedSelf(cand) });
     }
     
     if (!candidates.empty())
@@ -671,12 +669,13 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
         baseType = CS.getType(AE->getArg())->getWithoutSpecifierType();
 
       for (auto &C : candidates) {
-        C.level += 1;
+        bool hadCurriedSelf = C.skipCurriedSelf;
 
+        C.skipCurriedSelf = true;
         baseType = replaceTypeVariablesWithUnresolved(baseType);
 
         // Compute a new substituted type if we have a base type to apply.
-        if (baseType && C.level == 1 && C.getDecl()) {
+        if (baseType && !hadCurriedSelf && C.getDecl()) {
           baseType = baseType
             ->getWithoutSpecifierType()
             ->getMetatypeInstanceType();
@@ -691,7 +690,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
           }
         }
       }
-      
+
       return;
     }
   }
@@ -709,28 +708,27 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
   
   // Otherwise, we couldn't tell structurally what is going on here, so try to
   // dig something out of the constraint system.
-  unsigned uncurryLevel = 0;
+  bool hasCurriedSelf = false;
   
   // The candidate list of an unresolved_dot_expr is the candidate list of the
   // base uncurried by one level, and we refer to the name of the member, not to
   // the name of any base.
   if (auto UDE = dyn_cast<UnresolvedDotExpr>(fn)) {
     declName = UDE->getName().getBaseName().userFacingName();
-    uncurryLevel = 1;
+    hasCurriedSelf = true;
 
     // If base is a module or metatype, this is just a simple
     // reference so its curry level should be 0.
     if (auto *DRE = dyn_cast<DeclRefExpr>(UDE->getBase())) {
       if (auto baseType = DRE->getType())
-        uncurryLevel =
-            (baseType->is<ModuleType>() || baseType->is<AnyMetatypeType>()) ? 0
-                                                                            : 1;
+        hasCurriedSelf = !(baseType->is<ModuleType>() ||
+                           baseType->is<AnyMetatypeType>());
     }
 
     // If we actually resolved the member to use, return it.
     auto loc = CS.getConstraintLocator(UDE, ConstraintLocator::Member);
     if (auto *member = CS.findResolvedMemberRef(loc)) {
-      candidates.push_back({ member, uncurryLevel });
+      candidates.push_back({ member, hasCurriedSelf });
       return;
     }
     
@@ -738,7 +736,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
     auto ctorLoc =
     CS.getConstraintLocator(UDE, ConstraintLocator::ConstructorMember);
     if (auto *member = CS.findResolvedMemberRef(ctorLoc)) {
-      candidates.push_back({ member, uncurryLevel });
+      candidates.push_back({ member, hasCurriedSelf });
       return;
     }
     
@@ -754,7 +752,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
   }
   
   if (isa<MemberRefExpr>(fn))
-    uncurryLevel = 1;
+    hasCurriedSelf = true;
   
   // Scan to see if we have a disjunction constraint for this callee.
   for (auto &constraint : CS.getConstraints()) {
@@ -768,7 +766,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
         continue;
       auto c = bindOverload->getOverloadChoice();
       if (c.isDecl())
-        candidates.push_back({ c.getDecl(), uncurryLevel });
+        candidates.push_back({ c.getDecl(), hasCurriedSelf });
     }
     
     // If we found some candidates, then we're done.
@@ -865,13 +863,13 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
     auto decl = cand.getDecl();
     
     // If this is a method or enum case member (not a var or subscript), then
-    // the uncurry level is 1 if self has already been applied.
-    unsigned uncurryLevel = 0;
+    // we need to skip `self` if it has already been applied.
+    bool hasCurriedSelf = false;
     if (decl->getDeclContext()->isTypeContext() &&
         selfAlreadyApplied && !isa<SubscriptDecl>(decl))
-      uncurryLevel = 1;
+      hasCurriedSelf = true;
     
-    candidates.push_back({ decl, uncurryLevel });
+    candidates.push_back({ decl, hasCurriedSelf });
     
     // If we have a base type for this member, try to perform substitutions into
     // it to get a simpler and more concrete type.

--- a/lib/Sema/CalleeCandidateInfo.h
+++ b/lib/Sema/CalleeCandidateInfo.h
@@ -81,8 +81,8 @@ namespace swift {
     Expr *getExpr() const {
       return declOrExpr.dyn_cast<Expr*>();
     }
-    
-    Type getUncurriedType() const {
+
+    Type getType() const {
       // Start with the known type of the decl.
       auto type = entityType;
       if (skipCurriedSelf) {
@@ -92,13 +92,13 @@ namespace swift {
       }
       return type;
     }
-    
-    AnyFunctionType *getUncurriedFunctionType() const {
-      if (auto type = getUncurriedType())
+
+    AnyFunctionType *getFunctionType() const {
+      if (auto type = getType())
         return type->getAs<AnyFunctionType>();
       return nullptr;
     }
-    
+
     /// Given a function candidate with an uncurry level, return the parameter
     /// type at the specified uncurry level.  If there is an error getting to
     /// the specified input, this returns a null Type.
@@ -110,20 +110,18 @@ namespace swift {
       return FunctionType::composeInput(ctx, params, false);
     }
 
-    bool hasParameters() const {
-      return getUncurriedFunctionType();
-    }
+    bool hasParameters() const { return getFunctionType(); }
 
     ArrayRef<AnyFunctionType::Param> getParameters() const {
       assert(hasParameters());
-      return getUncurriedFunctionType()->getParams();
+      return getFunctionType()->getParams();
     }
     
     /// Given a function candidate with an uncurry level, return the parameter
     /// type at the specified uncurry level.  If there is an error getting to
     /// the specified input, this returns a null Type.
     Type getResultType() const {
-      if (auto *funcTy = getUncurriedFunctionType())
+      if (auto *funcTy = getFunctionType())
         return funcTy->getResult();
       return Type();
     }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3370,7 +3370,7 @@ matchCallArguments(ConstraintSystem &cs,
 /// given parameter depth cannot be used with the given value.
 /// If this cannot be proven, conservatively returns true.
 bool areConservativelyCompatibleArgumentLabels(ValueDecl *decl,
-                                               unsigned parameterDepth,
+                                               bool hasCurriedSelf,
                                                ArrayRef<Identifier> labels,
                                                bool hasTrailingClosure);
 


### PR DESCRIPTION
Arbitrary currying is no longer allowed so level could be switched
to a boolean flag for methods like `computeDefaultMap` to identify
 if they need to look through curried self type or not.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
