### PR TITLE
[Runtime] Demangle @autoclosure function types to metadata.

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -246,10 +246,13 @@ class TypeDecoder {
     case NodeKind::CFunctionPointer:
     case NodeKind::ThinFunctionType:
     case NodeKind::NoEscapeFunctionType:
+    case NodeKind::AutoClosureType:
+    case NodeKind::EscapingAutoClosureType:
     case NodeKind::FunctionType: {
       if (Node->getNumChildren() < 2)
         return BuiltType();
 
+      // FIXME: autoclosure is not represented in function metadata
       FunctionTypeFlags flags;
       if (Node->getKind() == NodeKind::ObjCBlock) {
         flags = flags.withConvention(FunctionMetadataConvention::Block);
@@ -275,7 +278,9 @@ class TypeDecoder {
       flags =
           flags.withNumParameters(parameters.size())
               .withParameterFlags(hasParamFlags)
-              .withEscaping(Node->getKind() == NodeKind::FunctionType);
+              .withEscaping(
+                          Node->getKind() == NodeKind::FunctionType ||
+                          Node->getKind() == NodeKind::EscapingAutoClosureType);
 
       auto result = decodeMangledType(Node->getChild(isThrow ? 2 : 1));
       if (!result) return BuiltType();

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -53,6 +53,6 @@ func test_arch() {
   arch({(x: inout Int, y: Double, z: String, w: Int8) -> () in })
 
   // CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden swiftcc %swift.metadata_response @"$syyyccMa"
-  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1(i64 67108865
+  // CHECK: call %swift.type* @swift_getFunctionTypeMetadata1({{i(32|64)}} 67108865
   arch({(x: @escaping () -> ()) -> () in })
 }

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -45,6 +45,10 @@ func f1_owned(x: __owned AnyObject) { }
 
 func f2_variadic_inout(x: ()..., y: inout ()) { }
 
+func f1_escaping(_: @escaping (Int) -> Float) { }
+func f1_autoclosure(_: @autoclosure () -> Float) { }
+func f1_escaping_autoclosure(_: @autoclosure @escaping () -> Float) { }
+
 DemangleToMetadataTests.test("function types") {
   // Conventions
   expectEqual(type(of: f0), _typeByMangledName("yyc")!)
@@ -77,6 +81,13 @@ DemangleToMetadataTests.test("function types") {
   // A function type that hasn't been built before.
   expectEqual("(Int, Float, Double, String, Character, UInt, Bool) -> ()",
     String(describing: _typeByMangledName("yySi_SfSdSSs9CharacterVSuSbtc")!))
+
+  // Escaping
+  expectEqual(type(of: f1_escaping), _typeByMangledName("ySfSicc")!)
+
+  // Autoclosure
+  expectEqual(type(of: f1_autoclosure), _typeByMangledName("ySfyXKc")!)
+  expectEqual(type(of: f1_escaping_autoclosure), _typeByMangledName("ySfyXAc")!)
 }
 
 DemangleToMetadataTests.test("metatype types") {


### PR DESCRIPTION
`@autoclosure` is currently represented in mangled names, but the
demangle-to-metadata path did not handle it. Add basic support for it
so we can round-trip.

The IRGen fix is for rdar://problem/45338589