### PR TITLE
[android] adb_test_runner.py pushes file arguments.

### DIFF
--- a/utils/android/adb/commands.py
+++ b/utils/android/adb/commands.py
@@ -99,6 +99,22 @@ def execute_on_device(executable_path, executable_arguments):
                          for (k, v) in os.environ.items()
                          if k.startswith(ENV_PREFIX)]
 
+    # The executables are sometimes passed arguments, and sometimes those
+    # arguments are files that have to be pushed, but also the argument values
+    # have to be changed to the new path in the Android device.
+    translated_executable_arguments = []
+    for executable_argument in executable_arguments:
+        # Currently we only support arguments that are file paths themselves.
+        # Things like `--foo=/path/to/file` or directories are not supported.
+        # Relative paths from the executable to the arguments are not kept.
+        if os.path.isfile(executable_argument):
+            final_path = '{}/{}'.format(uuid_dir,
+                                        os.path.basename(executable_argument))
+            push(executable_argument, final_path)
+            translated_executable_arguments.append(final_path)
+        else:
+            translated_executable_arguments.append(executable_argument)
+
     # When running the executable on the device, we need to pass it the same
     # arguments, as well as specify the correct LD_LIBRARY_PATH. Save these
     # to a file we can easily call multiple times.
@@ -111,7 +127,7 @@ def execute_on_device(executable_path, executable_arguments):
             tmp_dir=DEVICE_TEMP_DIR,
             child_environment=' '.join(child_environment),
             executable=executable,
-            executable_arguments=' '.join(executable_arguments)))
+            executable_arguments=' '.join(translated_executable_arguments)))
 
     # Write the output from the test executable to a file named '__stdout', and
     # if the test executable succeeds, write 'SUCCEEDED' to a file


### PR DESCRIPTION
Some tests need more than just the executable to be pushed. For
example the resilience tests need the executable and the linked
library to be pushed. adb_test_runner.py only pushed the
executable.

The changes look into the arguments passed to the executable
and figure out which ones refer to files. Those files are pushed
to the device and transformed to refer to the path on the device
instead (the resilience test do not actually use the argument
values themselves, but maybe others do).

This PR might conflict with #19940, since both touch the same parts of the file, but both of them are complementary and should work at the same time.