### PR TITLE
[CodeCompletion] Implement completion for 'get', 'set', 'willSet', 'didSet'

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -495,6 +495,7 @@ enum class CompletionKind {
   CaseStmtBeginning,
   CaseStmtDotPrefix,
   NominalMemberBeginning,
+  AccessorBeginning,
   AttributeBegin,
   AttributeDeclParen,
   PoundAvailablePlatform,

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -176,6 +176,9 @@ public:
   virtual void completeNominalMemberBeginning(
       SmallVectorImpl<StringRef> &Keywords) = 0;
 
+  /// Complete at the beginning of accessor in a accessor block.
+  virtual void completeAccessorBeginning() = 0;
+
   /// Complete the keyword in attribute, for instance, @available.
   virtual void completeDeclAttrKeyword(Decl *D, bool Sil, bool Param) = 0;
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -894,30 +894,23 @@ public:
   void consumeGetSetBody(AbstractFunctionDecl *AFD, SourceLoc LBLoc);
 
   struct ParsedAccessors;
-  bool parseGetSetImpl(ParseDeclOptions Flags,
-                       GenericParamList *GenericParams,
-                       ParameterList *Indices,
-                       TypeLoc ElementTy,
-                       ParsedAccessors &accessors,
-                       AbstractStorageDecl *storage,
-                       SourceLoc &LastValidLoc,
-                       SourceLoc StaticLoc, SourceLoc VarLBLoc);
-  bool parseGetSet(ParseDeclOptions Flags,
-                   GenericParamList *GenericParams,
-                   ParameterList *Indices,
-                   TypeLoc ElementTy,
-                   ParsedAccessors &accessors,
-                   AbstractStorageDecl *storage,
-                   SourceLoc StaticLoc);
+  ParserStatus parseGetSet(ParseDeclOptions Flags,
+                           GenericParamList *GenericParams,
+                           ParameterList *Indices,
+                           TypeLoc ElementTy,
+                           ParsedAccessors &accessors,
+                           AbstractStorageDecl *storage,
+                           SourceLoc StaticLoc);
   void recordAccessors(AbstractStorageDecl *storage, ParseDeclOptions flags,
                        TypeLoc elementTy, const DeclAttributes &attrs,
                        SourceLoc staticLoc, ParsedAccessors &accessors);
-  void parseAccessorBodyDelayed(AbstractFunctionDecl *AFD);
-  VarDecl *parseDeclVarGetSet(Pattern *pattern, ParseDeclOptions Flags,
-                              SourceLoc StaticLoc, SourceLoc VarLoc,
-                              bool hasInitializer,
-                              const DeclAttributes &Attributes,
-                              SmallVectorImpl<Decl *> &Decls);
+  ParserResult<VarDecl> parseDeclVarGetSet(Pattern *pattern,
+                                           ParseDeclOptions Flags,
+                                           SourceLoc StaticLoc,
+                                           SourceLoc VarLoc,
+                                           bool hasInitializer,
+                                           const DeclAttributes &Attributes,
+                                           SmallVectorImpl<Decl *> &Decls);
   
   void consumeAbstractFunctionBody(AbstractFunctionDecl *AFD,
                                    const DeclAttributes &Attrs);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1461,6 +1461,7 @@ public:
   void completeInPrecedenceGroup(SyntaxKind SK) override;
   void completeNominalMemberBeginning(
       SmallVectorImpl<StringRef> &Keywords) override;
+  void completeAccessorBeginning() override;
 
   void completePoundAvailablePlatform() override;
   void completeImportDecl(std::vector<std::pair<Identifier, SourceLoc>> &Path) override;
@@ -4819,6 +4820,11 @@ void CodeCompletionCallbacksImpl::completeNominalMemberBeginning(
   CurDeclContext = P.CurDeclContext;
 }
 
+void CodeCompletionCallbacksImpl::completeAccessorBeginning() {
+  Kind = CompletionKind::AccessorBeginning;
+  CurDeclContext = P.CurDeclContext;
+}
+
 static bool isDynamicLookup(Type T) {
   return T->getRValueType()->isAnyObject();
 }
@@ -4887,6 +4893,16 @@ static void addLetVarKeywords(CodeCompletionResultSink &Sink) {
   addKeyword(Sink, "var", CodeCompletionKeywordKind::kw_var);
 }
 
+static void addAccessorKeywords(CodeCompletionResultSink &Sink) {
+  addKeyword(Sink, "get", CodeCompletionKeywordKind::None);
+  addKeyword(Sink, "set", CodeCompletionKeywordKind::None);
+}
+
+static void addObserverKeywords(CodeCompletionResultSink &Sink) {
+  addKeyword(Sink, "willSet", CodeCompletionKeywordKind::None);
+  addKeyword(Sink, "didSet", CodeCompletionKeywordKind::None);
+}
+
 static void addExprKeywords(CodeCompletionResultSink &Sink) {
   // Expr keywords.
   addKeyword(Sink, "try", CodeCompletionKeywordKind::kw_try);
@@ -4927,6 +4943,25 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
   case CompletionKind::PrecedenceGroup:
     break;
 
+  case CompletionKind::AccessorBeginning: {
+    // TODO: Omit already declared or mutally exclusive accessors.
+    //       E.g. If 'get' is already declared, emit 'set' only.
+    addAccessorKeywords(Sink);
+
+    // Only 'var' for non-protocol context can have 'willSet' and 'didSet'.
+    assert(ParsedDecl);
+    VarDecl *var = dyn_cast<VarDecl>(ParsedDecl);
+    if (auto accessor = dyn_cast<AccessorDecl>(ParsedDecl))
+      var = dyn_cast<VarDecl>(accessor->getStorage());
+    if (var && !var->getDeclContext()->getSelfProtocolDecl())
+      addObserverKeywords(Sink);
+
+    if (!isa<AccessorDecl>(ParsedDecl))
+      break;
+
+    MaybeFuncBody = true;
+    LLVM_FALLTHROUGH;
+  }
   case CompletionKind::StmtOrExpr:
     addDeclKeywords(Sink);
     addStmtKeywords(Sink, MaybeFuncBody);
@@ -5667,6 +5702,13 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     OverrideLookup.getOverrideCompletions(SourceLoc());
     break;
   }
+
+  case CompletionKind::AccessorBeginning: {
+    if (isa<AccessorDecl>(ParsedDecl))
+      DoPostfixExprBeginning();
+    break;
+  }
+
   case CompletionKind::AttributeBegin: {
     Lookup.getAttributeDeclCompletions(IsInSil, AttTargetDK);
     break;

--- a/test/IDE/complete_accessor.swift
+++ b/test/IDE/complete_accessor.swift
@@ -1,0 +1,250 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GLOBAL_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GLOBAL_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=LOCAL_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=LOCAL_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_PROPERTY_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_PROPERTY_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_SUBSCRIPT_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_SUBSCRIPT_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_EXT_PROPERTY_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_EXT_PROPERTY_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_EXT_SUBSCRIPT_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_EXT_SUBSCRIPT_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONCRETE_PROPERTY_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONCRETE_PROPERTY_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONCRETE_SUBSCRIPT_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONCRETE_SUBSCRIPT_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONCRETE_EXT_PROPERTY_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONCRETE_EXT_PROPERTY_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONCRETE_EXT_SUBSCRIPT_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONCRETE_EXT_SUBSCRIPT_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNKNOWN_EXT_PROPERTY_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNKNOWN_EXT_PROPERTY_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNKNOWN_EXT_SUBSCRIPT_FIRST > %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNKNOWN_EXT_SUBSCRIPT_SECOND > %t.result
+// RUN: %FileCheck %s -check-prefix=NO_GLOBAL < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_SELF < %t.result
+// RUN: %FileCheck %s -check-prefix=WITH_GETSET < %t.result
+// RUN: %FileCheck %s -check-prefix=NO_OBSERVER < %t.result
+
+// WITH_GETSET: Keyword/None:                       get; name=get
+// WITH_GETSET: Keyword/None:                       set; name=set
+// NO_GETSET-NOT: get
+// NO_GETSET-NOT: set
+
+// WITH_OBSERVER: Keyword/None:                       willSet; name=willSet
+// WITH_OBSERVER: Keyword/None:                       didSet; name=didSet
+// NO_OBSERVER-NOT: willSet
+// NO_OBSERVER-NOT: didSet
+
+// WITH_GLOBAL: Decl[GlobalVar]/CurrModule:         globalValue[#String#];
+// NO_GLOBAL-NOT: globalValue;
+
+// WITH_SELF: Decl[LocalVar]/Local:               self[#{{.+}}#]; name=self
+// NO_SELF-NOT: self
+
+var globalValue: String
+
+var something1: String = 1 {
+  #^GLOBAL_FIRST^#
+  willSet {}
+}
+
+var something2: String {
+  get {}
+  #^GLOBAL_SECOND^#
+}
+
+func testLocal() {
+  var something3: String = 1 {
+    #^LOCAL_FIRST^#
+    willSet {}
+  }
+
+  var something4: String {
+    get {}
+    #^LOCAL_SECOND^#
+  }
+}
+
+protocol SomeProto {
+  var prop1: Int {
+    #^PROTOCOL_PROPERTY_FIRST^#
+  }
+  var prop2: Int {
+    get #^PROTOCOL_PROPERTY_SECOND^#
+  }
+  subscript(_1 index:Int) -> Int {
+    #^PROTOCOL_SUBSCRIPT_FIRST^#
+  }
+  subscript(_2 index:Int) -> String {
+    get
+    #^PROTOCOL_SUBSCRIPT_SECOND^#
+  }
+}
+
+extension SomeProto {
+  var prop1: Int {
+    #^PROTOCOL_EXT_PROPERTY_FIRST^#
+  }
+  var prop2: Int {
+    set {} #^PROTOCOL_EXT_PROPERTY_SECOND^#
+  }
+  subscript(_1 index:Int) -> Int {
+    #^PROTOCOL_EXT_SUBSCRIPT_FIRST^#
+  }
+  subscript(_2 index:Int) -> String {
+    get { }
+    #^PROTOCOL_EXT_SUBSCRIPT_SECOND^#
+  }
+}
+
+struct SomeStruct {
+  var prop1: Int {
+    #^CONCRETE_PROPERTY_FIRST^#
+  }
+  var prop2: Int {
+    get {}
+    @available(*, unavailable)
+    #^CONCRETE_PROPERTY_SECOND^#
+  }
+  subscript<T>(_1 index: T) -> Int {
+    #^CONCRETE_SUBSCRIPT_FIRST^#
+  }
+  subscript(_2 index: Int) -> String {
+    get { }
+    #^CONCRETE_SUBSCRIPT_SECOND^#
+  }
+}
+
+extension SomeStruct {
+  var prop3: Int {
+    #^CONCRETE_EXT_PROPERTY_FIRST^#
+  }
+  var prop4: Int {
+    get {}
+    #^CONCRETE_EXT_PROPERTY_SECOND^#
+  }
+  subscript(_3 index:Int) -> Int {
+    #^CONCRETE_EXT_SUBSCRIPT_FIRST^#
+  }
+  subscript<U>(_4 index: Int) -> U {
+    get { }
+    #^CONCRETE_EXT_SUBSCRIPT_SECOND^#
+  }
+}
+
+extension UNKNOWN_TYPE {
+  var prop1: Int {
+    #^UNKNOWN_EXT_PROPERTY_FIRST^#
+  }
+  var prop2: Int {
+    get {}
+    #^UNKNOWN_EXT_PROPERTY_SECOND^#
+  }
+  subscript<T>(_1 index: T) -> T where T: ANOTHER_UNKNWON_TYPE {
+    #^UNKNOWN_EXT_SUBSCRIPT_FIRST^#
+  }
+  subscript(_2 index: Int) -> String {
+    get { }
+    #^UNKNOWN_EXT_SUBSCRIPT_SECOND^#
+  }
+}


### PR DESCRIPTION
Implement 'get', 'set', 'willSet', 'didSet' completion at the beginning
of accessor position.

Support implicit getter.
```swift
  var value: Ty {
    <HERE> // 'get', 'set', 'willSet' and 'didSet' along with normal completion.
  }

  var value: Ty {
    get { return ... }
    <HERE> // 'get', 'set', 'willSet' and 'didSet' only.
  }

  var value: Ty {
    something()
    <HERE> // Normal completion without 'get', 'set', et al.
  }
```

rdar://problem/20957182