### PR TITLE
[incrParse] Skip missing node in SyntaxData::getNextNode()

### DIFF
--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -133,15 +133,16 @@ class SyntaxData final
   }
 
 public:
-  /// Get the node immediately before this current node. Return 0 if we cannot
-  /// find such node.
+  /// Get the node immediately before this current node that does contain a
+  /// non-missing token. Return nullptr if we cannot find such node.
   RC<SyntaxData> getPreviousNode() const;
 
-  /// Get the node immediately after this current node. Return 0 if we cannot
-  /// find such node.
+  /// Get the node immediately after this current node that does contain a
+  /// non-missing token. Return nullptr if we cannot find such node.
   RC<SyntaxData> getNextNode() const;
 
-  /// Get the first token node in this tree
+  /// Get the first non-missing token node in this tree. Return nullptr if this
+  /// node does not contain non-missing tokens.
   RC<SyntaxData> getFirstToken() const;
 
   ~SyntaxData() {

--- a/lib/Parse/SyntaxParsingCache.cpp
+++ b/lib/Parse/SyntaxParsingCache.cpp
@@ -37,6 +37,7 @@ bool SyntaxParsingCache::nodeCanBeReused(const Syntax &Node, size_t NodeStart,
   if (auto NextNode = Node.getData().getNextNode()) {
     auto NextLeafNode = NextNode->getFirstToken();
     auto NextRawNode = NextLeafNode->getRaw();
+    assert(NextRawNode->isPresent());
     NextLeafNodeLength += NextRawNode->getTokenText().size();
     for (auto TriviaPiece : NextRawNode->getLeadingTrivia()) {
       NextLeafNodeLength += TriviaPiece.getTextLength();
@@ -66,7 +67,7 @@ llvm::Optional<Syntax> SyntaxParsingCache::lookUpFrom(const Syntax &Node,
   size_t ChildStart = NodeStart;
   for (size_t I = 0, E = Node.getNumChildren(); I < E; ++I) {
     llvm::Optional<Syntax> Child = Node.getChild(I);
-    if (!Child.hasValue()) {
+    if (!Child.hasValue() || Child->isMissing()) {
       continue;
     }
     auto ChildEnd = ChildStart + Child->getTextLength();

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -59,7 +59,8 @@ RC<SyntaxData> SyntaxData::getPreviousNode() const {
     if (hasParent()) {
       for (size_t I = N - 1; ; I--) {
         if (auto C = getParent()->getChild(I)) {
-          return C;
+          if (C->getRaw()->isPresent() && C->getFirstToken())
+            return C;
         }
         if (I == 0)
           break;
@@ -73,8 +74,10 @@ RC<SyntaxData> SyntaxData::getNextNode() const {
   if (hasParent()) {
     for (size_t I = getIndexInParent() + 1, N = Parent->getNumChildren();
          I != N; I++) {
-      if (auto C = getParent()->getChild(I))
-        return C;
+      if (auto C = getParent()->getChild(I)) {
+        if (C->getRaw()->isPresent() && C->getFirstToken())
+          return C;
+      }
     }
     return Parent->getNextNode();
   }
@@ -82,18 +85,24 @@ RC<SyntaxData> SyntaxData::getNextNode() const {
 }
 
 RC<SyntaxData> SyntaxData::getFirstToken() const {
+  if (getRaw()->isToken()) {
+    // Get a reference counted version of this
+    assert(hasParent() && "The syntax tree should not conisist only of the root");
+    return getParent()->getChild(getIndexInParent());
+  }
+
   for (size_t I = 0, E = getNumChildren(); I < E; ++I) {
     if (auto Child = getChild(I)) {
-      if (!Child->getRaw()->isMissing()) {
-        return Child->getFirstToken();
+      if (Child->getRaw()->isMissing())
+        continue;
+      if (Child->getRaw()->isToken()) {
+        return Child;
+      } else if (auto Token = Child->getFirstToken()) {
+        return Token;
       }
     }
   }
-
-  // Get a reference counted version of this
-  assert(getRaw()->isToken() && "Leaf node that is no token?");
-  assert(hasParent() && "The syntax tree should not conisist only of the root");
-  return getParent()->getChild(getIndexInParent());
+  return nullptr;
 }
 
 AbsolutePosition SyntaxData::getAbsolutePositionBeforeLeadingTrivia() const {

--- a/test/incrParse/add-else-to-ifconfig.swift
+++ b/test/incrParse/add-else-to-ifconfig.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+// RUN: %validate-incrparse %s --test-case ADD_ELSE
+
+func container() {
+#if false
+  <<ADD_ELSE<|||#else>>>
+

--- a/test/incrParse/add-space-at-missing-brace.swift
+++ b/test/incrParse/add-space-at-missing-brace.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %validate-incrparse %s --test-case INSERT_SPACE
+
+class AnimationType {
+  func foo(x: Blah) {
+    switch x {
+    case (.
+
+extension AnimationType {
+  public<<INSERT_SPACE<||| >>> 


### PR DESCRIPTION
Parser complements missing `}` as missing token for code blocks.
Taking Missing node into account confuses reusability checking in incremental parsing.

rdar://problem/45215049 https://bugs.swift.org/browse/SR-8976
rdar://problem/45287031 https://bugs.swift.org/browse/SR-9006