### PR TITLE
[stdlib] CollectionOfOne.subscript: Replace setter with _modify

### DIFF
--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -131,9 +131,9 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
       _precondition(position == 0, "Index out of range")
       return _element
     }
-    set {
+    _modify {
       _precondition(position == 0, "Index out of range")
-      _element = newValue
+      yield &_element
     }
   }
 


### PR DESCRIPTION
`CollectionOfOne` is a `MutableCollection`; implementing `_modify` makes it provide direct access to its element, which can be of some benefit.