### PR TITLE
[CodeCompletion] Polish unresolved member completion

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3825,7 +3825,12 @@ public:
       // convertible to the contextual type.
       if (auto CD = dyn_cast<TypeDecl>(VD)) {
         declTy = declTy->getMetatypeInstanceType();
-        return declTy->isEqual(T) || swift::isConvertibleTo(declTy, T, *DC);
+
+        // Emit construction for the same type via typealias doesn't make sense
+        // because we are emitting all `.init()`s.
+        if (declTy->isEqual(T))
+          return false;
+        return swift::isConvertibleTo(declTy, T, *DC);
       }
 
       // Only static member can be referenced.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2637,6 +2637,10 @@ public:
       for (auto *init : initializers) {
         if (shouldHideDeclFromCompletionResults(init))
           continue;
+        if (IsUnresolvedMember &&
+            cast<ConstructorDecl>(init)->getFailability() == OTK_Optional) {
+          continue;
+        }
         addConstructorCall(cast<ConstructorDecl>(init), Reason, type, None,
                            /*IsOnType=*/true, name);
       }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3789,6 +3789,9 @@ public:
     // same result type) as the contextual type.
     FilteredDeclConsumer consumer(*this, [=](ValueDecl *VD,
                                              DeclVisibilityKind reason) {
+      if (VD->isOperator())
+        return false;
+
       if (!VD->hasInterfaceType()) {
         TypeResolver->resolveDeclSignature(VD);
         if (!VD->hasInterfaceType())
@@ -3822,7 +3825,7 @@ public:
       // convertible to the contextual type.
       if (auto CD = dyn_cast<TypeDecl>(VD)) {
         declTy = declTy->getMetatypeInstanceType();
-        return swift::isConvertibleTo(declTy, T, *DC);
+        return declTy->isEqual(T) || swift::isConvertibleTo(declTy, T, *DC);
       }
 
       // Only static member can be referenced.
@@ -3839,7 +3842,7 @@ public:
         // FIXME: This emits just 'factory'. We should emit 'factory()' instead.
         declTy = FT->getResult();
       }
-      return swift::isConvertibleTo(declTy, T, *DC);
+      return declTy->isEqual(T) || swift::isConvertibleTo(declTy, T, *DC);
     });
 
     auto baseType = MetatypeType::get(T);

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -443,12 +443,12 @@ struct AnotherTy: MyProtocol {}
 func testSubType() {
   var _: BaseClass = .#^SUBTYPE_1^#
 }
-// SUBTYPE_1: Begin completions, 4 items
+// SUBTYPE_1: Begin completions, 3 items
 // SUBTYPE_1-NOT: init(failable:
+// SUBTYPE_1-NOT: Concrete1(
 // SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#BaseClass#];
 // SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: SubClass()[#BaseClass.SubClass#];
 // SUBTYPE_1-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: subInstance[#BaseClass.SubClass#];
-// SUBTYPE_1-DAG: Decl[Constructor]/Super/TypeRelation[Identical]: Concrete1()[#BaseClass#];
 // SUBTYPE_1: End completions
 
 func testMemberTypealias() {

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -431,6 +431,8 @@ func testInStringInterpolation() {
 class BaseClass {
   class SubClass : BaseClass { init() {} }
   static var subInstance: SubClass = SubClass()
+  init() {}
+  init?(failable: Void) {}
 }
 protocol MyProtocol {
   typealias Concrete1 = BaseClass
@@ -442,6 +444,7 @@ func testSubType() {
   var _: BaseClass = .#^SUBTYPE_1^#
 }
 // SUBTYPE_1: Begin completions, 4 items
+// SUBTYPE_1-NOT: init(failable:
 // SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#BaseClass#];
 // SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: SubClass()[#BaseClass.SubClass#];
 // SUBTYPE_1-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: subInstance[#BaseClass.SubClass#];
@@ -452,6 +455,7 @@ func testMemberTypealias() {
   var _: MyProtocol = .#^SUBTYPE_2^#
 }
 // SUBTYPE_2: Begin completions, 2 items
+// SUBTYPE_1-NOT: Concrete1(failable:
 // SUBTYPE_2-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: Concrete1()[#BaseClass#];
 // SUBTYPE_2-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: Concrete2()[#AnotherTy#];
 // SUBTYPE_2: End completions


### PR DESCRIPTION
* Don't emit failable construction for member types:
  ```swift
  class Base {
    class Sub : Base {
      init?(arg: Int) { return nil }
    }
  }
  let _: Base = .<HERE> // This used to emit `.Sub(arg:)`
  ``` 
* Don't emit member type construction for the same type:
  ```swift
  struct Node {
    typealias Child = Node
    init(children: [Child]) {}
  }
  let node: Node = .<HERE>
  ```
  This used to emit `.init(children:)` and `.Child(children:)`. But emitting `.Child(children:)` is meaningless and may confuse users, especially if the type has many initializers.
  For example, `String` has several member types aliased to `String` such as `UnicodeScalarLiteralType`, `StringLiteralType`. Emitting `.StringLiteralType()` along with `.init()` doesn't make sense. 
* Tiny optimization by early return for operators.
  