### PR TITLE
lib: update for LLVM API change

### DIFF
--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -82,7 +82,7 @@ public:
   bool hasPostTerminatorIP() const {
     return GetInsertBlock() != nullptr &&
            !GetInsertBlock()->empty() &&
-           isa<llvm::TerminatorInst>(GetInsertBlock()->back());
+           GetInsertBlock()->back().isTerminator();
   }
 
   void ClearInsertionPoint() {

--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -718,7 +718,7 @@ static bool performStoreOnlyObjectElimination(CallInst &Allocation,
       // it is perfectly fine to delete this instruction if all uses of the
       // instruction are also eliminable.
 
-      if (I->mayHaveSideEffects() || isa<TerminatorInst>(I))
+      if (I->mayHaveSideEffects() || I->isTerminator())
         return false;
       break;
 

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -312,7 +312,7 @@ private:
     /// Advances the current instruction to the next instruction.
     void nextInst() {
       assert(CurrentInst);
-      if (isa<TerminatorInst>(CurrentInst)) {
+      if (CurrentInst->isTerminator()) {
         auto BlockIter = std::next(CurrentInst->getParent()->getIterator());
         if (BlockIter == F->end()) {
           CurrentInst = nullptr;


### PR DESCRIPTION
TerminatorInst has been removed and been made into a regular Instruction.  Use
the `isTerminator` function instead of the dyn_cast.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
