### PR TITLE
Fix type checker performance test to compile successfully.

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
@@ -1,8 +1,7 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asserts
 
-2...100.reversed().filter({ $0 % 11 == 0 }).map {
-  // expected-error@-1 {{value of type 'Int' has no member 'reversed'}}
+_ = (2...100).reversed().filter({ $0 % 11 == 0 }).map {
   "\($0) bottles of beer on the wall, \($0) bottles of beer;\n"
   + "  take eleven down, pass 'em around, \($0-11) bottles of beer on the wall!"
 }


### PR DESCRIPTION
At some point this test case was updated such that it no longer
compiled successfully. The originally reported test case did compile
successfully, just slowly.
