### PR TITLE
[android] Force parsing of literal as unsigned.

### DIFF
--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -560,7 +560,7 @@ Runtime.test("SwiftError layout constants for LLDB") {
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0)
 #elseif os(Android)
   #if arch(arm)
-    let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0xffffffff)
+    let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0xffffffff as UInt)
   #elseif arch(arm64)
     let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0)
   #else


### PR DESCRIPTION
0xffffffff do not fit into Int, and even if it doesn't, Swift
doesn't change the default to be UInt and fit, so we have to
be explicit.

/cc @compnerd fixes #19479 in 32 bits.