### PR TITLE
[IRGen] Fix issues impacting the mangled name <-> roundtrip verification

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -901,7 +901,7 @@ llvm::Constant *IRGenModule::getAddrOfAssociatedTypeGenericParamRef(
   // Otherwise, build the reference path.
   ConstantInitBuilder builder(*this);
   auto B = builder.beginStruct();
-  B.addInt32(ordinal << 1);
+  B.addInt32(ordinal);
 
   for (auto *assocType : reversed(assocTypePath)) {
     auto proto = getConstantReferenceForProtocolDescriptor(

--- a/test/IRGen/generic_types.swift
+++ b/test/IRGen/generic_types.swift
@@ -93,20 +93,6 @@
 // CHECK-SAME:   i32 {{3|2}},
 // CHECK-SAME: }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s13generic_types1ACMi"(%swift.type_descriptor*, i8**, i8*) {{.*}} {
-// CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
-// CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2)
-// CHECK-NEXT:   ret %swift.type* [[METADATA]]
-// CHECK: }
-
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s13generic_types1BCMi"(%swift.type_descriptor*, i8**, i8*) {{.*}} {
-// CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
-// CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2)
-// CHECK-NEXT: ret %swift.type* [[METADATA]]
-// CHECK: }
-
 class A<T> {
   var x = 0
 
@@ -149,3 +135,38 @@ func testFixed() {
   var a = F(value: ClassA()).value
   var b = F(value: ClassB()).value
 }
+
+// Checking generic requirement encoding
+protocol P1 { }
+protocol P2 {
+  associatedtype A
+}
+
+struct X1: P1 { }
+struct X2: P2 {
+  typealias A = X1
+}
+
+// Check for correct root generic parameters in the generic requirements of X3.
+// CHECK-LABEL: @"$sq_1A13generic_types2P2P_MXA" = linkonce_odr hidden constant
+
+// Root: generic parameter 1
+// CHECK-SAME: i32 1
+
+// Protocol P2
+// CHECK-SAME: $s13generic_types2P2Mp
+struct X3<T, U> where U: P2, U.A: P1 { }
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s13generic_types1ACMi"(%swift.type_descriptor*, i8**, i8*) {{.*}} {
+// CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
+// CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2)
+// CHECK-NEXT:   ret %swift.type* [[METADATA]]
+// CHECK: }
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s13generic_types1BCMi"(%swift.type_descriptor*, i8**, i8*) {{.*}} {
+// CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
+// CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2)
+// CHECK-NEXT: ret %swift.type* [[METADATA]]
+// CHECK: }

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -9,7 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: %target-run-stdlib-swift-swift3
+// RUN: %target-run-stdlib-swift
 // REQUIRES: executable_test
 
 // FIXME: This test runs very slowly on watchOS.
@@ -17,9 +17,9 @@
 
 public enum ApproximateCount {
   case Unknown
-  case Precise(IntMax)
-  case Underestimate(IntMax)
-  case Overestimate(IntMax)
+  case Precise(Int64)
+  case Underestimate(Int64)
+  case Overestimate(Int64)
 }
 
 public protocol ApproximateCountableSequence : Sequence {


### PR DESCRIPTION
Introduce two small fixes that address problems discovered by mangle name <-> metadata roundtrip verification in the runtime:

* IRGen for the JIT: register Objective-C classes/categories after other type metadata, because the registration might need to lookup type metadata

* IRGen for generic requirements: we were improperly encoding the root generic parameter for associated type requirements, meaning any requirement based on generic parameter with a flat index greater than 0 would be incorrectly interpreted. I suspect we have conditional-conformances failures due to this.