### PR TITLE
[silgenpattern] Fix pattern emission of tuples with address only and …

### DIFF
--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -1148,3 +1148,56 @@ func testUninhabitedSwitchScrutinee() {
     switch myFatalError() {}
   }
 }
+
+// Make sure that we properly can handle address only tuples with loadable
+// subtypes.
+class Klass {}
+
+enum TrivialSingleCaseEnum {
+case a
+}
+
+enum NonTrivialSingleCaseEnum {
+case a(Klass)
+}
+
+// CHECK-LABEL: sil hidden @$s6switch33address_only_with_trivial_subtypeyyAA21TrivialSingleCaseEnumO_yptF : $@convention(thin) (TrivialSingleCaseEnum, @in_guaranteed Any) -> () {
+// CHECK: [[MEM:%.*]] = alloc_stack $(TrivialSingleCaseEnum, Any)
+// CHECK: [[INIT_TUP_0:%.*]] = tuple_element_addr [[MEM]] : $*(TrivialSingleCaseEnum, Any), 0
+// CHECK: [[INIT_TUP_1:%.*]] = tuple_element_addr [[MEM]] : $*(TrivialSingleCaseEnum, Any), 1
+// CHECK: store {{%.*}} to [trivial] [[INIT_TUP_0]]
+// CHECK: copy_addr [take] {{%.*}} to [initialization] [[INIT_TUP_1]]
+// CHECK: [[TUP_0:%.*]] = tuple_element_addr [[MEM]] : $*(TrivialSingleCaseEnum, Any), 0
+// CHECK: [[TUP_0_VAL:%.*]] = load [trivial] [[TUP_0]]
+// CHECK: [[TUP_1:%.*]] = tuple_element_addr [[MEM]] : $*(TrivialSingleCaseEnum, Any), 1
+// CHECK: switch_enum [[TUP_0_VAL]]
+//
+// CHECK: } // end sil function '$s6switch33address_only_with_trivial_subtypeyyAA21TrivialSingleCaseEnumO_yptF'
+func address_only_with_trivial_subtype(_ a: TrivialSingleCaseEnum, _ value: Any) {
+  switch (a, value) {
+  case (.a, _):
+    break
+  default:
+    break
+  }
+}
+
+// CHECK-LABEL: sil hidden @$s6switch36address_only_with_nontrivial_subtypeyyAA24NonTrivialSingleCaseEnumO_yptF : $@convention(thin) (@guaranteed NonTrivialSingleCaseEnum, @in_guaranteed Any) -> () {
+// CHECK: [[MEM:%.*]] = alloc_stack $(NonTrivialSingleCaseEnum, Any)
+// CHECK: [[INIT_TUP_0:%.*]] = tuple_element_addr [[MEM]] : $*(NonTrivialSingleCaseEnum, Any), 0
+// CHECK: [[INIT_TUP_1:%.*]] = tuple_element_addr [[MEM]] : $*(NonTrivialSingleCaseEnum, Any), 1
+// CHECK: store {{%.*}} to [init] [[INIT_TUP_0]]
+// CHECK: copy_addr [take] {{%.*}} to [initialization] [[INIT_TUP_1]]
+// CHECK: [[TUP_0:%.*]] = tuple_element_addr [[MEM]] : $*(NonTrivialSingleCaseEnum, Any), 0
+// CHECK: [[TUP_0_VAL:%.*]] = load_borrow [[TUP_0]]
+// CHECK: [[TUP_1:%.*]] = tuple_element_addr [[MEM]] : $*(NonTrivialSingleCaseEnum, Any), 1
+// CHECK: switch_enum [[TUP_0_VAL]]
+// CHECK: } // end sil function '$s6switch36address_only_with_nontrivial_subtypeyyAA24NonTrivialSingleCaseEnumO_yptF'
+func address_only_with_nontrivial_subtype(_ a: NonTrivialSingleCaseEnum, _ value: Any) {
+  switch (a, value) {
+  case (.a, _):
+    break
+  default:
+    break
+  }
+}


### PR DESCRIPTION
…loadable components.

The problem here was that if we had a tuple with mixed address only and loadable
components and we used take on success during pattern matching, we would load
the loadable component with a load [take] and then pass it as take on success.
Instead we load the loadable components of the tuple using a load_borrow and
make the cast consumption kind BorrowAlways.

This can not happen with enum element emission since enum element emission does
not support take_on_success so the problem can not occur there.

SR-9029
rdar://45345844
