### PR TITLE
[android] Push test binaries w/o modifying executable name.

### DIFF
--- a/utils/android/adb/commands.py
+++ b/utils/android/adb/commands.py
@@ -17,6 +17,7 @@
 
 from __future__ import print_function
 
+import os
 import subprocess
 import tempfile
 import uuid
@@ -88,9 +89,12 @@ def execute_on_device(executable_path, executable_arguments):
     uuid_dir = '{}/{}'.format(DEVICE_TEMP_DIR, str(uuid.uuid4())[:10])
     shell(['mkdir', '-p', uuid_dir])
 
-    # `adb` can only handle commands under a certain length. No matter what the
-    # original executable's name, on device we call it `__executable`.
-    executable = '{}/__executable'.format(uuid_dir)
+    # `adb` can only handle commands under a certain length. That's why we
+    # hide the arguments and piping/status in executable files. However, at
+    # least one resilience test relies on checking the executable name, so we
+    # need to use the same name as the one provided.
+    executable_name = os.path.basename(executable_path)
+    executable = '{}/{}'.format(uuid_dir, executable_name)
     push(executable_path, executable)
 
     # When running the executable on the device, we need to pass it the same

--- a/utils/rth
+++ b/utils/rth
@@ -165,7 +165,8 @@ class ResilienceTest(object):
             config2_lower = config2.lower()
             output_obj = os.path.join(self.tmp_dir,
                                       config1_lower + '_' + config2_lower)
-            tmp_dir_contents = glob.glob(os.path.join(self.tmp_dir, '*', '*'))
+            tmp_dir_contents = glob.glob(
+                os.path.join(self.tmp_dir, self.config_dir_map[config1], '*'))
             command = self.target_run + [output_obj] + tmp_dir_contents
             verbose_print_command(command)
             returncode = subprocess.call(command)


### PR DESCRIPTION
At least test_rth.swift is checking the name of the executable
during the test, so renaming every executable to __executable in
Android will never work.

Also, during the rth tool execution, all the results from before
and after are pushed for every test. Since Android copies the
passed files without relative paths, the library files will
overwrite each other, making the test fail.

Depends on #19949 (more or less)

@modocache: I suppose that you might not remember why you renamed every binary to `__executable`, but I think that since the arguments end up in the text files, the length of the binary name should not be that important anymore. If you think it would be a problem, I might include an special case for the binaries pushed by the resilience tests (`before_before`, `before_after`, `after_before`, `after_after`).

@jrose-apple: I had to limit the glob from only one of the directories (`before` or `after`). I don’t think this would break the test, or invalidate the testing results. When testing `before`, the `after` directory would not be there, so trying to link against it would not find the library, failing the test. If you think this is not correct, I can try to modify #19949 to use relative paths, but it might get hairy.