### PR TITLE
implement dynamic attributes for most types

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -452,6 +452,10 @@ public:
   /// has been imported.  Otherwise, this returns null.
   StructDecl *getTensorShapeDecl() const;
 
+  /// Retrieve the decl for TensorFlow.TensorDataType iff the TensorFlow module
+  /// has been imported.  Otherwise, this returns null.
+  StructDecl *getTensorDataTypeDecl() const;
+
   /// Retrieve the type for Swift._AutoDiffTape.
   CanType getAutoDiffTapeType() const;
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1464,9 +1464,12 @@ FUNCTION(TFC_OpSetAttrOptionalTensorShapeArray,
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
+// The swift function signature is (CTFEOp, UnsafePointer<Int8>, String) -> ().
+// In LLVM IR, the String gets exploded to (BridgeObjectPtrTy, Int64Ty), so
+// IRGen passes those two values in place of the Swift String.
 FUNCTION(TFC_OpSetAttrString, _swift_tfc_OpSetAttrString, C_CC,
          RETURNS(),
-         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int64Ty),
+         ARGS(Int8PtrTy, Int8PtrTy, BridgeObjectPtrTy, Int64Ty),
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_CheckOk, _swift_tfc_CheckOk, C_CC,

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1423,6 +1423,52 @@ FUNCTION(TFC_CreateTensorHandleFromC, _swift_tfc_CreateTensorHandleFromC, C_CC,
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
 
+FUNCTION(TFC_OpSetAttrBoolArray, _swift_tfc_OpSetAttrBoolArray, C_CC,
+         RETURNS(),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
+         ATTRS(NoUnwind))
+
+FUNCTION(TFC_OpSetAttrInt32Array, _swift_tfc_OpSetAttrInt32Array, C_CC,
+         RETURNS(),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
+         ATTRS(NoUnwind))
+
+FUNCTION(TFC_OpSetAttrInt64Array, _swift_tfc_OpSetAttrInt64Array, C_CC,
+         RETURNS(),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
+         ATTRS(NoUnwind))
+
+FUNCTION(TFC_OpSetAttrDoubleArray, _swift_tfc_OpSetAttrDoubleArray, C_CC,
+         RETURNS(),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
+         ATTRS(NoUnwind))
+
+FUNCTION(TFC_OpSetAttrFloatArray, _swift_tfc_OpSetAttrFloatArray, C_CC,
+         RETURNS(),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
+         ATTRS(NoUnwind))
+
+FUNCTION(TFC_OpSetAttrTypeArray, _swift_tfc_OpSetAttrTypeArray, C_CC,
+         RETURNS(),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
+         ATTRS(NoUnwind))
+
+FUNCTION(TFC_OpSetAttrTensorShapeArray, _swift_tfc_OpSetAttrTensorShapeArray,
+         C_CC, RETURNS(),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy),
+         ATTRS(NoUnwind))
+
+FUNCTION(TFC_OpSetAttrOptionalTensorShapeArray,
+	 _swift_tfc_OpSetAttrOptionalTensorShapeArray,
+         C_CC, RETURNS(),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy),
+         ATTRS(NoUnwind))
+
+FUNCTION(TFC_OpSetAttrString, _swift_tfc_OpSetAttrString, C_CC,
+         RETURNS(),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int64Ty),
+         ATTRS(NoUnwind))
+
 FUNCTION(TFC_CheckOk, _swift_tfc_CheckOk, C_CC,
          RETURNS(),
          ARGS(Int8PtrTy),

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -151,6 +151,8 @@ struct ASTContext::Implementation {
   ClassDecl *TensorHandleDecl = nullptr;
   /// The declaration of TensorFlow.TensorShape.
   StructDecl *TensorShapeDecl = nullptr;
+  /// The declaration of TensorFlow.TensorDataType.
+  StructDecl *TensorDataTypeDecl = nullptr;
 
   /// The declaration of Swift._AutoDiffTape<T>.
   ClassDecl *AutoDiffTapeDecl = nullptr;
@@ -846,6 +848,27 @@ StructDecl *ASTContext::getTensorShapeDecl() const {
   for (auto result : results)
     if (auto CD = dyn_cast<StructDecl>(result))
       return getImpl().TensorShapeDecl = CD;
+  return nullptr;
+}
+
+/// Retrieve the decl for TensorFlow.TensorDataType iff the TensorFlow module has
+/// been imported.  Otherwise, this returns null.
+StructDecl *ASTContext::getTensorDataTypeDecl() const {
+  if (getImpl().TensorDataTypeDecl)
+    return getImpl().TensorDataTypeDecl;
+
+  // See if the TensorFlow module was imported.  If not, return null.
+  auto tfModule = getLoadedModule(Id_TensorFlow);
+  if (!tfModule)
+    return nullptr;
+
+  SmallVector<ValueDecl *, 1> results;
+  tfModule->lookupValue({}, getIdentifier("TensorDataType"),
+                        NLKind::UnqualifiedLookup, results);
+
+  for (auto result : results)
+    if (auto CD = dyn_cast<StructDecl>(result))
+      return getImpl().TensorDataTypeDecl = CD;
   return nullptr;
 }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1951,6 +1951,16 @@ static const char *inputListNumberAttr(StringRef opName) {
   return nullptr;
 }
 
+/// Returns the type Optional<`element`>.
+static Type getOptionalType(const ASTContext &ctx, Type element) {
+  return BoundGenericType::get(ctx.getOptionalDecl(), Type(), {element});
+}
+
+/// Returns the type Array<`element`>.
+static Type getArrayType(const ASTContext &ctx, Type element) {
+  return BoundGenericType::get(ctx.getArrayDecl(), Type(), {element});
+}
+
 // The code structure resembles
 // TFGraphFunctionLowering::visitGraphOperationInst().
 void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
@@ -2004,20 +2014,6 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
 
   auto *TFNewStatusFn = IGM.getTF_NewStatusFn();
   auto status = Builder.CreateCall(TFNewStatusFn, {});
-
-  // TODO: Remove these. They are a temporary way of testing that dynamic
-  // attributes make it here.
-  if (opInfo.getOperationName() == "_DynamicOp") {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Done with IRGen for dynamic graph_op; setting explosion.\n");
-    // The added explosion is incorrect, but is good enough for unit testing.
-    Explosion e;
-    e.add(TFNewStatusFn);
-
-    SILValue result = i->getResults()[0];
-    setLoweredExplosion(result, e);
-    return;
-  }
 
   // The true return type is TFE_Context*, which is an opaque pointer, so it
   // maps to void* in the Swift-C calling convention. `eagerContext` has type
@@ -2105,32 +2101,185 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
       }
       break;
     }
-    case GraphOperationInfo::ArgumentLowering::TFDataTypeAttribute: {
-      switch (structuredArgument.getKind()) {
-      case GraphOperationInfo::SAK_Single: {
-        auto silValue = structuredArgument.getSingleArgument();
-        auto silType = silValue->getType();
-        if (silType == SILType::getBuiltinIntegerType(32, astCtx)) {
-          // Deabstraction extracts the Builtin.Int32 that's inside the
-          // TensorDataType.
-          auto dtypeAttrValue = getLoweredSingletonExplosion(silValue);
-          auto *setAttrTypeFn = IGM.getTFE_OpSetAttrTypeFn();
-          auto attrNameValAddr = createStringValAddr(IGM, argumentName.c_str());
-          Builder.CreateCall(setAttrTypeFn,
-                             {op, attrNameValAddr, dtypeAttrValue});
-        } else {
-          // TODO: Implement dynamic type list attribute
-          assert(0 && "unknown TFDataTypeAttribute argument type");
-        }
+    case GraphOperationInfo::ArgumentLowering::NormalAttribute: {
+      assert(structuredArgument.getKind() == GraphOperationInfo::SAK_Single &&
+             "deabstraction should not generate NormalAttribute lists");
+      auto silValue = structuredArgument.getSingleArgument();
+      auto silType = silValue->getType();
+      auto astType = silType.getASTType();
+
+      LLVM_DEBUG(llvm::dbgs() << " Adding dynamic NormalAttribute of type "
+                 << astType << "\n");
+
+      auto *attrNameValAddr = createStringValAddr(IGM, argumentName.c_str());
+
+      // Deabstraction extracts builtin types out of stdlib types, so we match
+      // on builtin types. If we remove that part of deabstraction, we should
+      // change this to match on stdlib types.
+
+      if (astType->isBuiltinIntegerType(1)) {
+        auto *fn = IGM.getTFE_OpSetAttrBoolFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValue});
         break;
       }
-      case GraphOperationInfo::SAK_List:
-        assert(0 && "TODO: Implement dynamic type list attribute");
+
+      if (astType->isBuiltinIntegerType(64)) {
+        auto *fn = IGM.getTFE_OpSetAttrIntFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValue});
+        break;
       }
-      break;
+
+      if (auto floatType = dyn_cast<BuiltinFloatType>(astType)) {
+        auto *fn = IGM.getTFE_OpSetAttrFloatFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        if (floatType->getFPKind() == BuiltinFloatType::IEEE32) {
+          Builder.CreateCall(fn, {op, attrNameValAddr, attrValue});
+          break;
+        }
+        if (floatType->getFPKind() == BuiltinFloatType::IEEE64) {
+          auto *truncValue = Builder.CreateFPTrunc(attrValue, IGM.FloatTy);
+          Builder.CreateCall(fn, {op, attrNameValAddr, truncValue});
+          break;
+        }
+      }
+
+      if (astType->isEqual(
+          astCtx.getStringDecl()->getDeclaredInterfaceType())) {
+        auto *fn = IGM.getTFC_OpSetAttrStringFn();
+
+        // String values contain a ptr and an i64.
+        auto attrExplosion = getLoweredExplosion(silValue);
+        auto *untypedPtrValue = Builder.CreateBitCast(
+            attrExplosion.claimNext(), IGM.Int8PtrTy);
+        auto *i64Value = attrExplosion.claimNext();
+        Builder.CreateCall(fn,
+                           {op, attrNameValAddr, untypedPtrValue, i64Value});
+        break;
+      }
+
+      if (astType->isEqual(getArrayType(
+          astCtx, astCtx.getBoolDecl()->getDeclaredInterfaceType()))) {
+        auto *fn = IGM.getTFC_OpSetAttrBoolArrayFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        auto *attrValueUntyped = Builder.CreateBitCast(attrValue, IGM.Int8PtrTy);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValueUntyped});
+        break;
+      }
+
+      if (astType->isEqual(getArrayType(
+          astCtx, astCtx.getInt32Decl()->getDeclaredInterfaceType()))) {
+        auto *fn = IGM.getTFC_OpSetAttrInt32ArrayFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        auto *attrValueUntyped = Builder.CreateBitCast(attrValue, IGM.Int8PtrTy);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValueUntyped});
+        break;
+      }
+
+      if (astType->isEqual(getArrayType(
+          astCtx, astCtx.getInt64Decl()->getDeclaredInterfaceType()))) {
+        auto *fn = IGM.getTFC_OpSetAttrInt64ArrayFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        auto *attrValueUntyped = Builder.CreateBitCast(attrValue, IGM.Int8PtrTy);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValueUntyped});
+        break;
+      }
+
+      if (astType->isEqual(getArrayType(
+          astCtx, astCtx.getDoubleDecl()->getDeclaredInterfaceType()))) {
+        auto *fn = IGM.getTFC_OpSetAttrDoubleArrayFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        auto *attrValueUntyped = Builder.CreateBitCast(attrValue, IGM.Int8PtrTy);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValueUntyped});
+        break;
+      }
+
+      if (astType->isEqual(getArrayType(
+          astCtx, astCtx.getFloatDecl()->getDeclaredInterfaceType()))) {
+        auto *fn = IGM.getTFC_OpSetAttrFloatArrayFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        auto *attrValueUntyped = Builder.CreateBitCast(attrValue, IGM.Int8PtrTy);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValueUntyped});
+        break;
+      }
+
+      if (astType->isEqual(getArrayType(
+          astCtx, astCtx.getTensorShapeDecl()->getDeclaredInterfaceType()))) {
+        auto *fn = IGM.getTFC_OpSetAttrTensorShapeArrayFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        auto *attrValueUntyped = Builder.CreateBitCast(attrValue, IGM.Int8PtrTy);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValueUntyped, status});
+        checkOk(status);
+        break;
+      }
+
+      if (astType->isEqual(getArrayType(astCtx, getOptionalType(
+          astCtx, astCtx.getTensorShapeDecl()->getDeclaredInterfaceType())))) {
+        auto *fn = IGM.getTFC_OpSetAttrOptionalTensorShapeArrayFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        auto *attrValueUntyped = Builder.CreateBitCast(attrValue, IGM.Int8PtrTy);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValueUntyped, status});
+        checkOk(status);
+        break;
+      }
+
+      if (astType->isEqual(getArrayType(
+          astCtx, astCtx.getStringDecl()->getDeclaredInterfaceType()))) {
+        assert(0 && "TODO: dynamic string list attributes");
+      }
+
+      if (astType->is<AnyFunctionType>()) {
+        assert(0 && "TODO: dynamic function attributes");
+      }
+
+      assert(0 && "unknown NormalAttribute type");
     }
-    default:
-      assert(0 && "TODO: implement this dynamic attribute");
+    case GraphOperationInfo::ArgumentLowering::TFDataTypeAttribute: {
+      assert(structuredArgument.getKind() == GraphOperationInfo::SAK_Single &&
+             "deabstraction should not generate TFDataTypeAttribute lists");
+      auto silValue = structuredArgument.getSingleArgument();
+      auto silType = silValue->getType();
+      auto astType = silType.getASTType();
+
+      LLVM_DEBUG(llvm::dbgs() << " Adding dynamic TFDataTypeAttribute of type "
+                 << astType << "\n");
+
+      auto *attrNameValAddr = createStringValAddr(IGM, argumentName.c_str());
+
+      // Deabstraction extracts the Builtin.Int32 that's inside the
+      // TensorDataType.
+      if (astType->isBuiltinIntegerType(32)) {
+        auto *fn = IGM.getTFE_OpSetAttrTypeFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValue});
+        break;
+      }
+
+      if (astType->isEqual(getArrayType(
+          astCtx,
+          astCtx.getTensorDataTypeDecl()->getDeclaredInterfaceType()))) {
+        auto *fn = IGM.getTFC_OpSetAttrTypeArrayFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        auto *attrValueUntyped = Builder.CreateBitCast(attrValue, IGM.Int8PtrTy);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValueUntyped});
+        checkOk(status);
+        break;
+      }
+
+      assert(0 && "unknown TFDataTypeAttribute type");
+    }
+    case GraphOperationInfo::ArgumentLowering::ShapeAttribute:
+      assert(structuredArgument.getKind() == GraphOperationInfo::SAK_Single &&
+             "deabstraction should not generate ShapeAttribute lists");
+      auto silValue = structuredArgument.getSingleArgument();
+      auto silType = silValue->getType();
+      auto astType = silType.getASTType();
+
+      LLVM_DEBUG(llvm::dbgs() << " Adding dynamic ShapeAttribute of type "
+                 << astType << "\n");
+
+      assert(0 && "TODO: implement dynamic ShapeAttribute");
     }
   }
 
@@ -2223,7 +2372,7 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
 
         if (elementTypeString == "Float" || elementTypeString == "Double" ||
             elementTypeString == "Bool" || elementTypeString == "String") {
-          assert(0 && "TODO: implement type list typed attr");
+          assert(0 && "TODO: implement list(Float|Double|Bool|String) attr");
         }
         if (elementTypeString == "TensorShape" ||
             elementTypeString == "Optional<TensorShape>") {

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1254,8 +1254,8 @@ func _TFCOpSetAttrFloatArray(_ op: CTFEOp,
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrTypeArray")
 func _TFCOpSetAttrTypeArray(_ op: CTFEOp,
-                             _ attrName: UnsafePointer<Int8>,
-                             _ value: Array<TensorDataType>) {
+                            _ attrName: UnsafePointer<Int8>,
+                            _ value: Array<TensorDataType>) {
   value.withUnsafeBufferPointer { buffer in
     buffer.withMemoryRebound(to: TF_DataType.self) { reboundBuffer in
       TFE_OpSetAttrTypeList(op, attrName, reboundBuffer.baseAddress,
@@ -1267,9 +1267,9 @@ func _TFCOpSetAttrTypeArray(_ op: CTFEOp,
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrTensorShapeArray")
 func _TFCOpSetAttrTensorShapeArray(_ op: CTFEOp,
-                             _ attrName: UnsafePointer<Int8>,
-                             _ value: Array<TensorShape>,
-                             _ status: CTFStatus) {
+                                   _ attrName: UnsafePointer<Int8>,
+                                   _ value: Array<TensorShape>,
+                                   _ status: CTFStatus) {
   let flattenedDims = value.flatMap { $0.dimensions.map(Int64.init) }
   let ranks = value.map { $0.rank }
   setAttrShapeList(op: op, attrName: attrName, flattenedDims: flattenedDims,
@@ -1279,9 +1279,9 @@ func _TFCOpSetAttrTensorShapeArray(_ op: CTFEOp,
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrOptionalTensorShapeArray")
 func _TFCOpSetAttrOptionalTensorShapeArray(_ op: CTFEOp,
-                             _ attrName: UnsafePointer<Int8>,
-                             _ value: Array<TensorShape?>,
-                             _ status: CTFStatus) {
+                                           _ attrName: UnsafePointer<Int8>,
+                                           _ value: Array<TensorShape?>,
+                                           _ status: CTFStatus) {
   let flattenedDims = value.flatMap { (tensorShapeOpt) -> [Int64] in
     if let tensorShape = tensorShapeOpt {
       return tensorShape.dimensions.map(Int64.init)

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1197,6 +1197,150 @@ public func _TFCCreateTensorHandleFromC(
   }
 }
 
+// _TFCOpSetAttr*Array functions are wrappers around TFE_OpSetAttr*List
+// functions. The wrappers handle converting the Swift Stdlib Array<T> values
+// into buffers that TFE_OpSetAttr*List functions can read.
+
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrBoolArray")
+func _TFCOpSetAttrBoolArray(_ op: OpaquePointer,
+                            _ attrName: UnsafePointer<Int8>,
+                            _ value: Array<Bool>) {
+  value.map({ $0 ? UInt8(1) : UInt8(0) }).withUnsafeBufferPointer { buffer in
+    TFE_OpSetAttrBoolList(op, attrName, buffer.baseAddress, Int32(buffer.count))
+  }
+}
+
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrInt32Array")
+func _TFCOpSetAttrInt32Array(_ op: OpaquePointer,
+                             _ attrName: UnsafePointer<Int8>,
+                             _ value: Array<Int32>) {
+  value.map(Int64.init).withUnsafeBufferPointer { buffer in
+    TFE_OpSetAttrIntList(op, attrName, buffer.baseAddress, Int32(buffer.count))
+  }
+}
+
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrInt64Array")
+func _TFCOpSetAttrInt64Array(_ op: OpaquePointer,
+                             _ attrName: UnsafePointer<Int8>,
+                             _ value: Array<Int64>) {
+  value.withUnsafeBufferPointer { buffer in
+    TFE_OpSetAttrIntList(op, attrName, buffer.baseAddress, Int32(buffer.count))
+  }
+}
+
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrDoubleArray")
+func _TFCOpSetAttrDoubleArray(_ op: OpaquePointer,
+                              _ attrName: UnsafePointer<Int8>,
+                              _ value: Array<Double>) {
+  value.map(Float.init).withUnsafeBufferPointer { buffer in
+    TFE_OpSetAttrFloatList(op, attrName, buffer.baseAddress, Int32(buffer.count))
+  }
+}
+
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrFloatArray")
+func _TFCOpSetAttrFloatArray(_ op: OpaquePointer,
+                             _ attrName: UnsafePointer<Int8>,
+                             _ value: Array<Float>) {
+  value.withUnsafeBufferPointer { buffer in
+    TFE_OpSetAttrFloatList(op, attrName, buffer.baseAddress, Int32(buffer.count))
+  }
+}
+
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrTypeArray")
+func _TFCOpSetAttrTypeArray(_ op: OpaquePointer,
+                             _ attrName: UnsafePointer<Int8>,
+                             _ value: Array<TensorDataType>) {
+  value.withUnsafeBufferPointer { buffer in
+    buffer.withMemoryRebound(to: TF_DataType.self) { reboundBuffer in
+      TFE_OpSetAttrTypeList(op, attrName, reboundBuffer.baseAddress,
+                            Int32(reboundBuffer.count))
+    }
+  }
+}
+
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrTensorShapeArray")
+func _TFCOpSetAttrTensorShapeArray(_ op: OpaquePointer,
+                             _ attrName: UnsafePointer<Int8>,
+                             _ value: Array<TensorShape>,
+                             _ status: CTFStatus) {
+  let flattenedDims = value.flatMap { $0.dimensions.map(Int64.init) }
+  let ranks = value.map { $0.rank }
+  setAttrShapeList(op: op, attrName: attrName, flattenedDims: flattenedDims,
+                   ranks: ranks, status: status)
+}
+
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrOptionalTensorShapeArray")
+func _TFCOpSetAttrOptionalTensorShapeArray(_ op: OpaquePointer,
+                             _ attrName: UnsafePointer<Int8>,
+                             _ value: Array<TensorShape?>,
+                             _ status: CTFStatus) {
+  let flattenedDims = value.flatMap { (tensorShapeOpt) -> [Int64] in
+    if let tensorShape = tensorShapeOpt {
+      return tensorShape.dimensions.map(Int64.init)
+    }
+    return []
+  }
+  let ranks = value.map { tensorShapeOpt -> Int32 in
+    if let tensorShape = tensorShapeOpt {
+      return tensorShape.rank
+    }
+    return -1
+  }
+  setAttrShapeList(op: op, attrName: attrName, flattenedDims: flattenedDims,
+                   ranks: ranks, status: status)
+}
+
+/// Given dimensions and ranks in the form described below, makes the
+/// appropriate call to TFE_OpSetAttrShapeList(op, attrName, ..., status).
+///
+/// - Parameters
+///   - flattenedDims: all the shapes' dimensions concatenated together in
+///     order
+///   - ranks: all the shapes' ranks (-1 denotes unknown rank)
+func setAttrShapeList(op: OpaquePointer, attrName: UnsafePointer<Int8>,
+                      flattenedDims: Array<Int64>, ranks: Array<Int32>,
+                      status: CTFStatus) {
+  flattenedDims.withUnsafeBufferPointer { flattenedDimsBuffer in
+    var dimsPtr: UnsafePointer<Int64>? = flattenedDimsBuffer.baseAddress
+    var dims: [UnsafePointer<Int64>?] = []
+    for rank in ranks {
+      dims.append(dimsPtr)
+      if rank >= 0 {
+        dimsPtr = dimsPtr.map { $0.advanced(by: Int(rank)) }
+      }
+    }
+    dims.withUnsafeMutableBufferPointer { dimsBuffer in
+      ranks.withUnsafeBufferPointer { ranksBuffer in
+        TFE_OpSetAttrShapeList(op, attrName, dimsBuffer.baseAddress,
+                               ranksBuffer.baseAddress,
+                               Int32(ranksBuffer.count), status)
+      }
+    }
+  }
+}
+
+/// Wrapper around TFE_OpSetAttrString that handles converting the Swift Stdlib
+/// String into a buffer that TFE_OpSetAttrString can read.
+@usableFromInline
+@_silgen_name("_swift_tfc_OpSetAttrString")
+func _TFCOpSetAttrString(_ op: OpaquePointer,
+                         _ attrName: UnsafePointer<Int8>,
+                         _ value: String) {
+  value.utf8CString.withUnsafeBufferPointer { buffer in
+    // utf8CString is null-terminated; TFE_OpSetAttrString wants
+    // non-null-terminated.
+    TFE_OpSetAttrString(op, attrName, buffer.baseAddress, buffer.count - 1)
+  }
+}
+
 @usableFromInline
 @_cdecl("_swift_tfc_CheckOk")
 func _TFCCheckOk(_ s: CTFStatus) {

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1203,7 +1203,7 @@ public func _TFCCreateTensorHandleFromC(
 
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrBoolArray")
-func _TFCOpSetAttrBoolArray(_ op: OpaquePointer,
+func _TFCOpSetAttrBoolArray(_ op: CTFEOp,
                             _ attrName: UnsafePointer<Int8>,
                             _ value: Array<Bool>) {
   value.map({ $0 ? UInt8(1) : UInt8(0) }).withUnsafeBufferPointer { buffer in
@@ -1213,7 +1213,7 @@ func _TFCOpSetAttrBoolArray(_ op: OpaquePointer,
 
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrInt32Array")
-func _TFCOpSetAttrInt32Array(_ op: OpaquePointer,
+func _TFCOpSetAttrInt32Array(_ op: CTFEOp,
                              _ attrName: UnsafePointer<Int8>,
                              _ value: Array<Int32>) {
   value.map(Int64.init).withUnsafeBufferPointer { buffer in
@@ -1223,7 +1223,7 @@ func _TFCOpSetAttrInt32Array(_ op: OpaquePointer,
 
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrInt64Array")
-func _TFCOpSetAttrInt64Array(_ op: OpaquePointer,
+func _TFCOpSetAttrInt64Array(_ op: CTFEOp,
                              _ attrName: UnsafePointer<Int8>,
                              _ value: Array<Int64>) {
   value.withUnsafeBufferPointer { buffer in
@@ -1233,7 +1233,7 @@ func _TFCOpSetAttrInt64Array(_ op: OpaquePointer,
 
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrDoubleArray")
-func _TFCOpSetAttrDoubleArray(_ op: OpaquePointer,
+func _TFCOpSetAttrDoubleArray(_ op: CTFEOp,
                               _ attrName: UnsafePointer<Int8>,
                               _ value: Array<Double>) {
   value.map(Float.init).withUnsafeBufferPointer { buffer in
@@ -1243,7 +1243,7 @@ func _TFCOpSetAttrDoubleArray(_ op: OpaquePointer,
 
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrFloatArray")
-func _TFCOpSetAttrFloatArray(_ op: OpaquePointer,
+func _TFCOpSetAttrFloatArray(_ op: CTFEOp,
                              _ attrName: UnsafePointer<Int8>,
                              _ value: Array<Float>) {
   value.withUnsafeBufferPointer { buffer in
@@ -1253,7 +1253,7 @@ func _TFCOpSetAttrFloatArray(_ op: OpaquePointer,
 
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrTypeArray")
-func _TFCOpSetAttrTypeArray(_ op: OpaquePointer,
+func _TFCOpSetAttrTypeArray(_ op: CTFEOp,
                              _ attrName: UnsafePointer<Int8>,
                              _ value: Array<TensorDataType>) {
   value.withUnsafeBufferPointer { buffer in
@@ -1266,7 +1266,7 @@ func _TFCOpSetAttrTypeArray(_ op: OpaquePointer,
 
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrTensorShapeArray")
-func _TFCOpSetAttrTensorShapeArray(_ op: OpaquePointer,
+func _TFCOpSetAttrTensorShapeArray(_ op: CTFEOp,
                              _ attrName: UnsafePointer<Int8>,
                              _ value: Array<TensorShape>,
                              _ status: CTFStatus) {
@@ -1278,7 +1278,7 @@ func _TFCOpSetAttrTensorShapeArray(_ op: OpaquePointer,
 
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrOptionalTensorShapeArray")
-func _TFCOpSetAttrOptionalTensorShapeArray(_ op: OpaquePointer,
+func _TFCOpSetAttrOptionalTensorShapeArray(_ op: CTFEOp,
                              _ attrName: UnsafePointer<Int8>,
                              _ value: Array<TensorShape?>,
                              _ status: CTFStatus) {
@@ -1305,7 +1305,7 @@ func _TFCOpSetAttrOptionalTensorShapeArray(_ op: OpaquePointer,
 ///   - flattenedDims: all the shapes' dimensions concatenated together in
 ///     order
 ///   - ranks: all the shapes' ranks (-1 denotes unknown rank)
-func setAttrShapeList(op: OpaquePointer, attrName: UnsafePointer<Int8>,
+func setAttrShapeList(op: CTFEOp, attrName: UnsafePointer<Int8>,
                       flattenedDims: Array<Int64>, ranks: Array<Int32>,
                       status: CTFStatus) {
   flattenedDims.withUnsafeBufferPointer { flattenedDimsBuffer in
@@ -1331,7 +1331,7 @@ func setAttrShapeList(op: OpaquePointer, attrName: UnsafePointer<Int8>,
 /// String into a buffer that TFE_OpSetAttrString can read.
 @usableFromInline
 @_silgen_name("_swift_tfc_OpSetAttrString")
-func _TFCOpSetAttrString(_ op: OpaquePointer,
+func _TFCOpSetAttrString(_ op: CTFEOp,
                          _ attrName: UnsafePointer<Int8>,
                          _ value: String) {
   value.utf8CString.withUnsafeBufferPointer { buffer in

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -9,7 +9,7 @@ import StdlibUnittest
 
 var DynamicAttributeTests = TestSuite("DynamicAttribute")
 
-// ===== Dynamic Attribe Values ====
+// ===== Dynamic Attribute Values ====
 // These global vars with @inline(never) loaders ensure that the compiler
 // can't find the constant value of the attributes.
 

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-dynamic-compilation-swift --attributes-json %S/Inputs/attributes.json
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow
@@ -9,6 +9,7 @@ import StdlibUnittest
 
 var DynamicAttributeTests = TestSuite("DynamicAttribute")
 
+// ===== Dynamic Attribe Values ====
 // These global vars with @inline(never) loaders ensure that the compiler
 // can't find the constant value of the attributes.
 
@@ -24,7 +25,281 @@ func loadDtypeDouble() -> TensorDataType {
   return dtypeDouble
 }
 
-DynamicAttributeTests.test("single TFDataTypeAttribute") {
+var stridesInt32 = (Int32(1), Int32(1), Int32(1), Int32(1))
+@inline(never)
+func loadStridesInt32() -> (Int32, Int32, Int32, Int32) {
+  return stridesInt32
+}
+
+var stridesInt64 = [Int64(1), Int64(1), Int64(1), Int64(1)]
+@inline(never)
+func loadStridesInt64() -> [Int64] {
+  return stridesInt64
+}
+
+var trueBool = true
+@inline(never)
+func loadTrue() -> Bool {
+  return trueBool
+}
+
+var falseBool = false
+@inline(never)
+func loadFalse() -> Bool {
+  return falseBool
+}
+
+var int32_1: Int32 = 1
+@inline(never)
+func loadInt32_1() -> Int32 {
+  return int32_1
+}
+
+var int32_2: Int32 = 2
+@inline(never)
+func loadInt32_2() -> Int32 {
+  return int32_2
+}
+
+var int64_1: Int64 = 1
+@inline(never)
+func loadInt64_1() -> Int64 {
+  return int64_1
+}
+
+var int64_2: Int64 = 2
+@inline(never)
+func loadInt64_2() -> Int64 {
+  return int64_2
+}
+
+var double_1: Double = 1
+@inline(never)
+func loadDouble_1() -> Double {
+  return double_1
+}
+
+var double_0point1: Double = 0.1
+@inline(never)
+func loadDouble_0point1() -> Double {
+  return double_0point1
+}
+
+var float_1: Float = 1
+@inline(never)
+func loadFloat_1() -> Float {
+  return float_1
+}
+
+var float_0point1: Float = 0.1
+@inline(never)
+func loadFloat_0point1() -> Float {
+  return float_0point1
+}
+
+var boundariesDouble: [Double] = [0, 1, 2, 3]
+@inline(never)
+func loadBoundariesDouble() -> [Double] {
+  return boundariesDouble
+}
+
+var boundariesFloat: [Float] = [0, 1, 2, 3]
+@inline(never)
+func loadBoundariesFloat() -> [Float] {
+  return boundariesFloat
+}
+
+var tensorShapeArray = [TensorShape([1]), TensorShape([2])]
+@inline(never)
+func loadTensorShapeArray() -> [TensorShape] {
+  return tensorShapeArray
+}
+
+var optionalTensorShapeArray = [TensorShape([1]), nil]
+@inline(never)
+func loadOptionalTensorShapeArray() -> [TensorShape?] {
+  return optionalTensorShapeArray
+}
+
+var tensorDataTypeArray = [Int32.tensorFlowDataType, Int32.tensorFlowDataType]
+@inline(never)
+func loadTensorDataTypeArray() -> [TensorDataType] {
+  return tensorDataTypeArray
+}
+
+var VALIDString = "VALID"
+@inline(never)
+func loadVALIDString() -> String {
+  return VALIDString
+}
+
+// ==== Convolution Helper Values ====
+// Helper values for tests involving convolution ops.
+
+let convImage = Tensor<Float>([[
+  [[1], [0], [0]],
+  [[0], [1], [0]],
+  [[0], [0], [0]]
+]])
+let convFilter = Tensor<Float>([
+  [[[1]], [[1]]],
+  [[[1]], [[1]]]
+])
+let convExpectedResult = ShapedArray<Float>(
+    shape: [1, 2, 2, 1],
+    scalars: [2, 1,
+              1, 1]
+)
+
+// ==== Actual Tests ====
+
+DynamicAttributeTests.test("NormalAttribute Bool") {
+  let input = Tensor<Int32>([[1, 2], [2, 1]])
+  let reductionIndices = Tensor<Int32>(0)
+
+  let resultKeepDimsTrue = Raw.max(input, reductionIndices: reductionIndices,
+                                   keepDims: loadTrue())
+  let expectedResultKeepDimsTrue = ShapedArray<Int32>(shape: [1, 2],
+                                                      scalars: [2, 2])
+  expectEqual(expectedResultKeepDimsTrue, resultKeepDimsTrue.array)
+
+  let resultKeepDimsFalse = Raw.max(input, reductionIndices: reductionIndices,
+                                    keepDims: loadFalse())
+  let expectedResultKeepDimsFalse = ShapedArray<Int32>(shape: [2],
+                                                       scalars: [2, 2])
+  expectEqual(expectedResultKeepDimsFalse, resultKeepDimsFalse.array)
+}
+
+DynamicAttributeTests.test("NormalAttribute Int64") {
+  let input = Tensor<Int32>([1, 2, 3, 4, 5])
+
+  let shuffled1 = Raw.randomShuffle(value: input, seed: loadInt64_1(),
+                                    seed2: loadInt64_1())
+  let expectedResult1 = ShapedArray<Int32>([1, 4, 2, 3, 5])
+  expectEqual(expectedResult1, shuffled1.array)
+
+  let shuffled2 = Raw.randomShuffle(value: input, seed: loadInt64_2(),
+                                    seed2: loadInt64_2())
+  let expectedResult2 = ShapedArray<Int32>([1, 4, 2, 5, 3])
+  expectEqual(expectedResult2, shuffled2.array)
+}
+
+DynamicAttributeTests.test("NormalAttribute Double") {
+  let x = Tensor<Double>(1)
+  let y = Tensor<Double>(1.5)
+
+  let result1 = Raw.approximateEqual(x, y, tolerance: loadDouble_1())
+  expectEqual(true, result1.scalar!)
+
+  let result2 = Raw.approximateEqual(x, y, tolerance: loadDouble_0point1())
+  expectEqual(false, result2.scalar!)
+}
+
+DynamicAttributeTests.test("NormalAttribute Float") {
+  let x = Tensor<Float>(1)
+  let y = Tensor<Float>(1.5)
+
+  let result1: Tensor<Bool> = #tfop("ApproximateEqual", x, y,
+                                    T$dtype: Float.tensorFlowDataType,
+                                    tolerance: loadFloat_1())
+  expectEqual(true, result1.scalar!)
+
+  let result2: Tensor<Bool> = #tfop("ApproximateEqual", x, y,
+                                    T$dtype: Float.tensorFlowDataType,
+                                    tolerance: loadFloat_0point1())
+  expectEqual(false, result2.scalar!)
+}
+
+DynamicAttributeTests.test("NormalAttribute String") {
+  let result: Tensor<Float> = #tfop("Conv2D", convImage, convFilter,
+                                    T$dtype: Float.tensorFlowDataType,
+                                    strides: [1, 1, 1, 1],
+                                    padding: loadVALIDString())
+  expectEqual(convExpectedResult, result.array)
+}
+
+DynamicAttributeTests.test("NormalAttribute Array<Bool>") {
+  // There aren't any ops that take bool list attributes!
+}
+
+DynamicAttributeTests.test("NormalAttribute Array<Int32>") {
+  let result = convImage.convolved2D(withFilter: convFilter,
+                                     strides: loadStridesInt32(),
+                                     padding: .valid)
+  expectEqual(convExpectedResult, result.array)
+}
+
+DynamicAttributeTests.test("NormalAttribute Array<Int64>") {
+  let result: Tensor<Float> = #tfop("Conv2D", convImage, convFilter,
+                                    T$dtype: Float.tensorFlowDataType,
+                                    strides: loadStridesInt64(),
+                                    padding: "VALID")
+  expectEqual(convExpectedResult, result.array)
+}
+
+DynamicAttributeTests.test("NormalAttribute Array<Double>") {
+  let input = Tensor<Double>([-1, 0.1, 4.3, 1.2])
+  let result = Raw.bucketize(input, boundaries: loadBoundariesDouble())
+  let expectedResult = ShapedArray<Int32>([0, 1, 4, 2])
+  expectEqual(expectedResult, result.array)
+}
+
+DynamicAttributeTests.test("NormalAttribute Array<Float>") {
+  let input = Tensor<Float>([-1, 0.1, 4.3, 1.2])
+  let result: Tensor<Int32> = #tfop("Bucketize", input,
+                                    T$dtype: Float.tensorFlowDataType,
+                                    boundaries: loadBoundariesFloat())
+  let expectedResult = ShapedArray<Int32>([0, 1, 4, 2])
+  expectEqual(expectedResult, result.array)
+}
+
+/// Checks that `dataset` is a TensorSliceDataset of
+/// Tensor<Int32>([1, 2]) and Tensor<Int32>([[1, 1], [2, 2]])
+func check(dataset: VariantHandle) {
+  let outputTypes = [Int32.tensorFlowDataType, Int32.tensorFlowDataType]
+  let outputShapes = [nil, nil] as [TensorShape?]
+  let iterator: ResourceHandle = #tfop(
+    "IteratorV2", shared_name: "blah", container: "earth",
+    output_types$dtype: outputTypes, output_shapes: outputShapes
+  )
+  #tfop("MakeIterator", dataset, iterator) as Void
+  var next: (Tensor<Int32>, Tensor<Int32>) = #tfop(
+    "IteratorGetNext", iterator,
+    output_types$dtype: outputTypes, output_shapes: outputShapes
+  )
+  expectEqual(ShapedArray<Int32>([1]), next.0.array)
+  expectEqual(ShapedArray<Int32>([1, 1]), next.1.array)
+  next = #tfop(
+    "IteratorGetNext", iterator,
+    output_types$dtype: outputTypes, output_shapes: outputShapes
+  )
+  expectEqual(ShapedArray<Int32>([2]), next.0.array)
+  expectEqual(ShapedArray<Int32>([2, 2]), next.1.array)
+}
+
+DynamicAttributeTests.test("NormalAttribute Array<TensorShape>") {
+  let elements1 = Tensor<Int32>([[1], [2]])
+  let elements2 = Tensor<Int32>([[1, 1], [2, 2]])
+  let dataset: VariantHandle = #tfop(
+    "TensorSliceDataset", elements1, elements2,
+    Toutput_types$dtype: [Int32.tensorFlowDataType, Int32.tensorFlowDataType],
+    output_shapes: loadTensorShapeArray()
+  )
+  check(dataset: dataset)
+}
+
+DynamicAttributeTests.test("NormalAttribute Array<TensorShape?>") {
+  let elements1 = Tensor<Int32>([[1], [2]])
+  let elements2 = Tensor<Int32>([[1, 1], [2, 2]])
+  let dataset: VariantHandle = #tfop(
+    "TensorSliceDataset", [elements1, elements2],
+    Toutput_types$dtype: [Int32.tensorFlowDataType, Int32.tensorFlowDataType],
+    output_shapes: loadOptionalTensorShapeArray()
+  )
+  check(dataset: dataset)
+}
+
+DynamicAttributeTests.test("TFDataTypeAttribute TensorDataType") {
   let t1 = Tensor<Int32>(-1)
   let t1Result: Tensor<Int32> = #tfop("Abs", t1, T$dtype: loadDtypeInt32())
   expectEqual(1, t1Result.scalar!)
@@ -32,6 +307,17 @@ DynamicAttributeTests.test("single TFDataTypeAttribute") {
   let t2 = Tensor<Double>(-2)
   let t2Result: Tensor<Double> = #tfop("Abs", t2, T$dtype: loadDtypeDouble())
   expectEqual(2, t2Result.scalar!)
+}
+
+DynamicAttributeTests.test("TFDataTypeAttribute Array<TensorDataType>") {
+  let elements1 = Tensor<Int32>([[1], [2]])
+  let elements2 = Tensor<Int32>([[1, 1], [2, 2]])
+  let dataset: VariantHandle = #tfop(
+    "TensorSliceDataset", [elements1, elements2],
+    Toutput_types$dtype: loadTensorDataTypeArray(),
+    output_shapes: [nil, nil] as [TensorShape?]
+  )
+  check(dataset: dataset)
 }
 
 runAllTests()


### PR DESCRIPTION
I believe that this implements dynamic attributes for all possible types, except `shape`, `list(string)`, and `func`. There are TODO-assertions in the code for the three missing types.