### PR TITLE
type_traits: fix build with GCC

### DIFF
--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -33,7 +33,7 @@ struct IsTriviallyCopyable {
 #if _LIBCPP_VERSION || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_copyable.
   static const bool value = std::is_trivially_copyable<T>::value;
-#elif __has_feature(is_trivially_copyable)
+#elif __has_feature(is_trivially_copyable) || __GNUC__ >= 5
   static const bool value = __is_trivially_copyable(T);
 #else
 #  error "Not implemented"
@@ -45,7 +45,7 @@ struct IsTriviallyConstructible {
 #if _LIBCPP_VERSION || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_constructible.
   static const bool value = std::is_trivially_constructible<T>::value;
-#elif __has_feature(has_trivial_constructor)
+#elif __has_feature(has_trivial_constructor) || __GNUC__ >= 5
   static const bool value = __has_trivial_constructor(T);
 #else
 #  error "Not implemented"
@@ -57,7 +57,7 @@ struct IsTriviallyDestructible {
 #if _LIBCPP_VERSION || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_destructible.
   static const bool value = std::is_trivially_destructible<T>::value;
-#elif __has_feature(has_trivial_destructor)
+#elif __has_feature(has_trivial_destructor) || __GNUC__ >= 5
   static const bool value = __has_trivial_destructor(T);
 #else
 #  error "Not implemented"


### PR DESCRIPTION
GCC 5 introduced __is_trivially_copyable for implementing
std::is_trivially_copyable.  However, gcc does not report it through
__has_feature.  Perform a version check instead.  Repairs the build with
GCC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
