### PR TITLE
Update tests to enable -solver-enable-operator-designated-types when …

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/array_of_tuples.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/array_of_tuples.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/more_specialized_generic_func.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/more_specialized_generic_func.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 8 --end 40 --step 2 --select NumLeafScopes %s --expected-exit-code 0
+// RUN: %scale-test --begin 8 --end 40 --step 2 --select NumLeafScopes %s --expected-exit-code 0 -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func memoize<A: Hashable, R>(

--- a/validation-test/Sema/type_checker_perf/fast/rdar18699199.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18699199.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 public enum E

--- a/validation-test/Sema/type_checker_perf/fast/rdar18724501.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18724501.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19181998.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19181998.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19181998_nominals.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19181998_nominals.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19394804.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19394804.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 7 --end 12 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 7 --end 12 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 // REQUIRES: rdar42650365

--- a/validation-test/Sema/type_checker_perf/fast/rdar19777895.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19777895.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 7 --end 15 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 7 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 let a = [0]

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_any.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_any.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_explicit_overloads.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_explicit_overloads.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_named.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_named.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_typed.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_typed.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_weak.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_weak.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-verify
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-verify -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20875936.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20875936.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let _ = Array([0].lazy.reversed().filter { $0 % 2 == 0 }.map { $0 / 2 })

--- a/validation-test/Sema/type_checker_perf/fast/rdar21070413.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21070413.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar21328584.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21328584.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar21374729.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21374729.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 protocol P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar21398466.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21398466.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 4
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 // This problem is related to renaming,

--- a/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar21930551.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21930551.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar22249571.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22249571.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func rdar22249571() -> [UInt8] {

--- a/validation-test/Sema/type_checker_perf/fast/rdar22282851.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22282851.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 struct S {

--- a/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 _ = (1...10).map(String.init) + [": hi"]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22532650.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22532650.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 10 --end 15 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 10 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar22626740.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22626740.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar22810685.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22810685.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 8 --end 16 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 8 --end 16 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 // REQUIRES: rdar38378503
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar26939465.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar26939465.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar28018866.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar28018866.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 struct P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar29025667.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar29025667.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar30213053.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30213053.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar30389602.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30389602.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 15 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar31563957.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31563957.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar32999041.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32999041.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 3 --end 8 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 3 --end 8 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 // FIXME: https://bugs.swift.org/browse/SR-6997

--- a/validation-test/Sema/type_checker_perf/fast/rdar33688063.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33688063.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let _ = 1 | UInt32(0) << 0 | UInt32(1) << 1 | UInt32(2) << 2 | UInt32(3) << 3 | UInt32(4) << 4

--- a/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 class P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 struct T {

--- a/validation-test/Sema/type_checker_perf/fast/rdar40344044.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar40344044.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 3 --end 20  --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 3 --end 20  --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
…possible.

Add the following to all the expression type checker performance tests
that do not regress as a result:

- `-swift-version 5`
- `-solver-disable-shrink`
- `-disable-constraint-solver-performance-hacks`
- `-solver-enable-operator-designated-types`
