### PR TITLE
Syntax: correct implementation for `removing`

### DIFF
--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -15,6 +15,8 @@
 
 #include "swift/Syntax/Syntax.h"
 
+#include <iterator>
+
 namespace swift {
 namespace syntax {
 
@@ -173,8 +175,11 @@ public:
 
   /// Return a new collection with the element removed at index i.
   SyntaxCollection<CollectionKind, Element> removing(size_t i) const {
-    auto NewLayout = getRaw()->Layout;
-    NewLayout.erase(NewLayout.begin() + i);
+    assert(i <= size());
+    std::vector<RC<RawSyntax>> NewLayout = getRaw()->getLayout();
+    auto iterator = NewLayout.begin();
+    std::advance(iterator, i);
+    NewLayout.erase(iterator);
     auto Raw = RawSyntax::make(CollectionKind, NewLayout, getRaw()->getPresence());
     return Data->replaceSelf<SyntaxCollection<CollectionKind, Element>>(Raw);
   }

--- a/unittests/Syntax/SyntaxCollectionTests.cpp
+++ b/unittests/Syntax/SyntaxCollectionTests.cpp
@@ -257,3 +257,20 @@ TEST(SyntaxCollectionTests, Iteration) {
   List.print(OS);
   ASSERT_EQ(OS.str().str(), IteratedOS.str().str());
 }
+
+TEST(SyntaxCollectionTests, Removing) {
+  auto Arg = getCannedArgument();
+  auto List = SyntaxFactory::makeBlankFunctionCallArgumentList()
+    .appending(Arg)
+    .appending(Arg.withLabel(SyntaxFactory::makeIdentifier("first", {}, {})))
+    .appending(Arg)
+    .removing(1);
+
+  ASSERT_EQ(List.size(), static_cast<size_t>(2));
+
+  SmallString<48> Scratch;
+  llvm::raw_svector_ostream OS(Scratch);
+  List.print(OS);
+  ASSERT_EQ(OS.str().str(), "x: foo, x: foo, ");
+}
+


### PR DESCRIPTION
`llvm::ArrayRef<T>` does not define `erase`.  However, since the intent
here is to remove the last n elements, we can use `drop_back` instead.
Furthermore, replace the direct use of `Layout` with `getLayout()`.
This was identified by gcc 8.2.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
