### PR TITLE
[ConstraintSystem] Properly cache type for literal initialization coercions

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3599,6 +3599,7 @@ namespace {
 
         literalInit->setImplicit(false);
 
+        cs.setType(expr, toType);
         // Keep the coercion around, because it contains the source range
         // for the original constructor call.
         return expr;

--- a/test/Constraints/rdar45415874.swift
+++ b/test/Constraints/rdar45415874.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+final class A<T> {
+  init(_: T) {}
+}
+
+extension A: ExpressibleByNilLiteral where T: ExpressibleByNilLiteral {
+  convenience init(nilLiteral: ()) {
+    self.init(nil)
+  }
+}
+
+struct B {
+  var foo: A<B?> = A(nil)
+}


### PR DESCRIPTION
Since original implicit coercion expression is preserved in AST
it needs to have its simplified type cached in the constraint
system in order for AST to get the correct type when solution
is fully applied.

Resolves: rdar://problem/45415874

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
