### PR TITLE
Fix assertion from empty switch over uninhabited enum

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -983,6 +983,11 @@ chooseNecessaryColumn(const ClauseMatrix &matrix, unsigned firstRow) {
 /// Recursively emit a decision tree from the given pattern matrix.
 void PatternMatchEmission::emitDispatch(ClauseMatrix &clauses, ArgArray args,
                                         const FailureHandler &outerFailure) {
+  if (clauses.rows() == 0) {
+    SGF.B.createUnreachable(SILLocation(PatternMatchStmt));
+    return;
+  }
+
   unsigned firstRow = 0;
   while (true) {
     // If there are no rows remaining, then we fail.

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -360,6 +360,10 @@ enum MyNever {}
 func ~= (_ : MyNever, _ : MyNever) -> Bool { return true }
 func myFatalError() -> MyNever { fatalError() }
 
+@_frozen public enum UninhabitedT4<A> {
+  case x(A)
+}
+
 func checkUninhabited() {
   // Scrutinees of uninhabited type may match any number and kind of patterns
   // that Sema is willing to accept at will.  After all, it's quite a feat to
@@ -378,6 +382,10 @@ func checkUninhabited() {
     case myFatalError(): break
     case myFatalError(): break
     }
+  }
+
+  func test4(x: UninhabitedT4<Never>) {
+    switch x {} // No diagnostic.
   }
 }
 


### PR DESCRIPTION
Fixes [SR-8933](https://bugs.swift.org/browse/SR-8933) | rdar://problem/45216708.

Swift's uninhabited checking is conservative. An enum might not be found to be uninhabited, but all of its cases might. In that case, the switch can be empty even though the type isn't known to be uninhabited.

Fix an assertion that assumed there would always be at least one case for types that aren't known to be uninhabited.

This is the approach that was suggested by @jckarter in the ticket. (I hope I've done it correctly.)