### PR TITLE
build: clean up the shims installation

### DIFF
--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -5,42 +5,23 @@ set(datafiles
   watchos4.json
   overlay4.json
 )
-set(SWIFTLIB_DIR
-    "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/swift")
-set(output_dir "${SWIFTLIB_DIR}/migrator")
 
-add_custom_command(
-    OUTPUT "${output_dir}"
-    COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${output_dir}")
-
-set(outputs)
-
-foreach(input ${datafiles})
-  set(source "${CMAKE_CURRENT_SOURCE_DIR}/${input}")
-  set(dest "${output_dir}/${input}")
-  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    set(CMAKE_SYMLINK_COMMAND copy)
-  else()
-    set(CMAKE_SYMLINK_COMMAND create_symlink)
-  endif()
-
-  add_custom_command(OUTPUT
-                       "${output_dir}/${input}"
-                     DEPENDS
-                       "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
-                     COMMAND
-                       "${CMAKE_COMMAND}" "-E" "${CMAKE_SYMLINK_COMMAND}" "${source}" "${dest}")
-  list(APPEND outputs "${output_dir}/${input}")
-endforeach()
-list(APPEND outputs "${output_dir}")
-
-add_custom_target("symlink_migrator_data"
-    DEPENDS "${output_dir}" "${outputs}"
-    COMMENT "Symlinking migrator data to ${output_dir}")
+add_custom_target(swift-migrator-data ALL
+                  COMMAND
+                    ${CMAKE_COMMAND} -E make_directory ${SWIFTLIB_DIR}/migrator
+                  COMMAND
+                    ${CMAKE_COMMAND} -E copy_if_different ${datafiles} ${SWIFTLIB_DIR}/migrator/
+                  WORKING_DIRECTORY
+                    ${CMAKE_CURRENT_SOURCE_DIR}
+                  DEPENDS
+                    ${datafiles})
 
 swift_install_in_component(compiler
-  FILES ${datafiles}
-DESTINATION "lib/swift/migrator")
+                           FILES ${datafiles}
+                           DESTINATION "lib/swift/migrator"
+                           COMPONENT swift-migrator-data)
+add_llvm_install_targets(install-swift-migrator-data
+                         COMPONENT swift-migrator-data)
 
 add_swift_library(swiftMigrator STATIC
   APIDiffMigratorPass.cpp
@@ -50,6 +31,5 @@ add_swift_library(swiftMigrator STATIC
   MigrationState.cpp
   RewriteBufferEditsReceiver.cpp
   LINK_LIBRARIES swiftSyntax swiftIDE)
+add_dependencies(swiftMigrator swift-migrator-data)
 
-add_dependencies(swiftMigrator
-  "symlink_migrator_data")

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -51,28 +51,6 @@ set(sources
 
   module.modulemap
   )
-set(output_dir "${SWIFTLIB_DIR}/shims")
-
-add_custom_command(
-    OUTPUT "${output_dir}"
-    COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${output_dir}")
-set(outputs)
-foreach(input ${sources})
-  add_custom_command(
-      OUTPUT "${output_dir}/${input}"
-      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
-      COMMAND
-        "${CMAKE_COMMAND}" "-E" "copy_if_different"
-        "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
-        "${output_dir}/${input}")
-  list(APPEND outputs "${output_dir}/${input}")
-endforeach()
-# Put the output dir itself last so that it isn't considered the primary output.
-list(APPEND outputs "${output_dir}")
-
-add_custom_target("copy_shim_headers"
-    DEPENDS "${outputs}"
-    COMMENT "Copying SwiftShims module to ${output_dir}")
 
 if ("${LLVM_PACKAGE_VERSION}" STREQUAL "")
   message(FATAL_ERROR
@@ -106,34 +84,45 @@ function(find_llvm_clang_headers suffix description out_var)
 endfunction()
 
 if(SWIFT_BUILT_STANDALONE)
-  find_llvm_clang_headers("/clang/${CLANG_VERSION}" "Clang"
-    clang_headers_location)
+  find_llvm_clang_headers("/clang/${CLANG_VERSION}" "Clang" clang_headers_location)
 else() # NOT SWIFT_BUILT_STANDALONE
   set(clang_headers_location "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION}")
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set(cmake_symlink_option "copy_directory")
+  set(cmake_symlink_option copy_directory)
 else()
-  set(cmake_symlink_option "create_symlink")
+  set(cmake_symlink_option create_symlink)
 endif()
 
 add_custom_command_target(unused_var
-    COMMAND
-      "${CMAKE_COMMAND}" "-E" "make_directory" "${SWIFTLIB_DIR}"
-    COMMAND
-      "${CMAKE_COMMAND}" "-E" "${cmake_symlink_option}"
-      "${clang_headers_location}"
-      "${SWIFTLIB_DIR}/clang"
+                          OUTPUT
+                            ${SWIFT_LIBDIR}/clang
+                          CUSTOM_TARGET_NAME
+                            swift-clang-resource-dir-symlink
+                          COMMAND
+                            ${CMAKE_COMMAND} -E make_directory ${SWIFTLIB_DIR}
+                          COMMAND
+                            ${CMAKE_COMMAND} -E ${cmake_symlink_option} ${clang_headers_location} ${SWIFTLIB_DIR}/clang)
 
-    CUSTOM_TARGET_NAME "symlink_clang_headers"
-    OUTPUT "${SWIFTLIB_DIR}/clang"
-    COMMENT "Symlinking Clang resource headers into ${SWIFTLIB_DIR}/clang")
-add_dependencies(copy_shim_headers symlink_clang_headers)
+add_custom_command_target(unused_var
+                          OUTPUT
+                            ${SWIFT_LIBDIR}/shims
+                          CUSTOM_TARGET_NAME
+                            swift-shim-headers
+                          COMMAND
+                            ${CMAKE_COMMAND} -E make_directory ${SWIFTLIB_DIR}/shims
+                          COMMAND
+                            ${CMAKE_COMMAND} -E copy_if_different ${sources} ${SWIFTLIB_DIR}/shims/
+                          DEPENDS
+                            ${sources})
 
 swift_install_in_component(compiler
-    FILES ${sources}
-    DESTINATION "lib/swift/shims")
+                           FILES ${sources}
+                           DESTINATION "lib/swift/shims"
+                           COMPONENT swift-shim-headers)
+add_llvm_install_targets(install-swift-shim-headers
+                         COMPONENT swift-shim-headers)
 
 # Install Clang headers under the Swift library so that an installed Swift's
 # module importer can find the compiler headers corresponding to its Clang.

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -131,10 +131,9 @@ swift_install_in_component(clang-builtin-headers
     DESTINATION "lib/swift/clang"
     PATTERN "*.h")
 
-swift_install_symlink_component(clang-resource-dir-symlink
-  LINK_NAME clang
-  TARGET ../clang/${CLANG_VERSION}
-  DESTINATION "lib/swift")
+swift_install_symlink(clang ../clang/${CLANG_VERSION}
+                      DESTINATION "lib/swift"
+                      COMPONENT clang-resource-dir-symlink)
 
 # Possibly install Clang headers under Clang's resource directory in case we
 # need to use a different version of the headers than the installed Clang. This

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -278,13 +278,13 @@ endif()
 add_swift_library(swiftCore
                   ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
                     ${SWIFTLIB_SOURCES}
-                  # The copy_shim_headers target dependency is required to let the
+                  # The swift-shim-headers target dependency is required to let the
                   # build system know that there's a rule to produce the shims
                   # directory, but is not sufficient to cause the object file to be rebuilt
                   # when the shim header changes.  Therefore, we pass both the target
                   # and the generated directory as dependencies.
                   FILE_DEPENDS
-                    copy_shim_headers "${SWIFTLIB_DIR}/shims" ${GROUP_INFO_JSON_FILE}
+                    swift-shim-headers "${SWIFTLIB_DIR}/shims" ${GROUP_INFO_JSON_FILE}
                   SWIFT_COMPILE_FLAGS
                     ${swift_stdlib_compile_flags} -Xcc -DswiftCore_EXPORTS
                   LINK_FLAGS


### PR DESCRIPTION
This sets up the swift shims to be installed using the
LLVM_DISTRIBUTION_COMPONENTS mechanism.  Furthermore, it simplifies the
logic in SwiftShims since there is no need for all the manual handling
which CMake can handle.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
