### PR TITLE
[ParseableInterface] Print willSet/didSet for stored properties with observers

### DIFF
--- a/test/ParseableInterface/inlinable-function.swift
+++ b/test/ParseableInterface/inlinable-function.swift
@@ -26,9 +26,7 @@ public struct Foo: Hashable {
 
   // CHECK: public var hasDidSet: [[INT]] {
   public var hasDidSet: Int {
-    // CHECK-NEXT: @_transparent get{{$}}
-    // CHECK-NEXT: set[[NEWVALUE]]{{$}}
-    // CHECK-NOT: didSet
+    // CHECK-NEXT: didSet{{$}}
     didSet {
       print("b set to \(hasDidSet)")
     }

--- a/test/ParseableInterface/stored-property.swift
+++ b/test/ParseableInterface/stored-property.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t-resilient.swiftinterface -enable-resilience %s
+// RUN: %FileCheck %s < %t-resilient.swiftinterface
+
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-parseable-module-interface-path - | %FileCheck %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-resilience %t.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-resilience -emit-parseable-module-interface-path - | %FileCheck %s
+
+// CHECK: public struct Foo {
+public struct Foo {
+  // CHECK: public var computedReadOnly: [[INT:(Swift\.)?Int]] {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: }
+  public var computedReadOnly: Int { return 1 }
+
+  // CHECK: public var computedReadWrite: [[INT]] {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: set
+  // CHECK-NEXT: }
+  public var computedReadWrite: Int {
+    get { return 0 }
+    set { print("x") }
+  }
+
+  // CHECK: public var storedCustomSetter: [[INT]] {
+  // CHECK-NEXT: didSet{{$}}
+  // CHECK-NEXT: }
+  public var storedCustomSetter: Int {
+    didSet {}
+  }
+
+  // CHECK: public var storedTrivialSetter: [[INT]]{{$}}
+  public var storedTrivialSetter: Int
+
+  // CHECK: public private(set) var storedPrivateSet: [[INT]]{{$}}
+  public private(set) var storedPrivateSet: Int
+
+  // CHECK: public let storedImmutable: [[INT]]{{$}}
+  public let storedImmutable: Int
+
+  // FIXME: For some reason, only this VarDecl has no TypeRepr, so it always
+  //        prints module qualified.
+  // CHECK: @_hasInitialValue public var storedCustomSetterHasInitialValue: {{[a-zA-Z]*\.?}}Int {
+  // CHECK-NEXT: willSet
+  // CHECK-NEXT: didSet
+  // CHECK-NEXT: }
+  public var storedCustomSetterHasInitialValue: Int = 30 {
+    willSet {}
+    didSet {}
+  }
+
+  // CHECK: @_hasInitialValue public var storedTrivialSetterHasInitialValue: [[INT]]{{$}}
+  public var storedTrivialSetterHasInitialValue: Int = 30
+
+  // CHECK: @_hasInitialValue public var storedPrivateSetHasInitialValue: [[INT]]{{$}}
+  public var storedPrivateSetHasInitialValue: Int = 30
+
+  // CHECK: @_hasInitialValue public let storedImmutableHasInitialValue: [[INT]]{{$}}
+  public let storedImmutableHasInitialValue: Int = 30
+}


### PR DESCRIPTION
This is the proposed solution for handling properties with property
observers, which are distinct from properties that have a custom setter.
If a getter/setter are overwritten in a property, it is considered
computed, whereas properties with observers are stored and still
dispatch through a setter and an `@_transparent` getter.

rdar://43815861

---

@jrose-apple: This follows a proposed design I've outlined below, which avoids adding an extra attribute in favor of being consistent and closest to the original source as we can.

## Avoiding an attribute

### Computed Properties

| Semantics  | Syntax                 |
|------------|------------------------|
| Read-only  | `var x: T { get }`     |
| Read-write | `var x: T { get set }` |

### Stored Properties

| Semantics                | Syntax                          |
|--------------------------|---------------------------------|
| Immutable                | `let x: T`                      |
| Mutable (trivial setter) | `var x: T`                      |
| Mutable (custom setter)  | `var x: T { [willSet] didSet }` |
| Private(set)             | `private(set) var x: T`         |

## Allowing an attribute

If, instead, we want to add an attribute to decrease the kinds of keywords printed in interface files, I have a separate patch I can submit that adds an `@_hasStorage` attribute that we can use to distinguish stored properties with overridden getters/setters from computed properties. I could probably also assume that `@_hasInitialValue` implies `@_hasStorage` and elide printing `@_hasStorage` if we're going to print `@_hasInitialValue`.

### Computed Properties

| Semantics  | Syntax                 |
|------------|------------------------|
| Read-only  | `var x: T { get }`     |
| Read-write | `var x: T { get set }` |

### Stored Properties

| Semantics                | Syntax                              |
|--------------------------|-------------------------------------|
| Immutable                | `let x: T`                          |
| Mutable (trivial setter) | `var x: T`                          |
| Mutable (custom setter)  | `@_hasStorage var x: T { get set }` |
| Private(set)             | `@_hasStorage var x: T { get }`     |