### PR TITLE
[DoNotMerge] Add Arithmetic protocol and refactor Numeric protocol

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -28,7 +28,7 @@ extension ExpressibleByIntegerLiteral
 //===----------------------------------------------------------------------===//
 
 public protocol Arithmetic {
-  var zero: Self { get }
+  static var zero: Self { get }
 
   /// Adds two values and produces their sum.
   ///
@@ -121,7 +121,7 @@ public protocol Arithmetic {
 }
 
 public extension Arithmetic where Self : ExpressibleByIntegerLiteral {
-  var zero: Self {
+  static var zero: Self {
     return 0
   }
 }

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -24,10 +24,10 @@ extension ExpressibleByIntegerLiteral
 }
 
 //===----------------------------------------------------------------------===//
-//===--- Arithmetic -------------------------------------------------------===//
+//===--- AdditiveArithmetic -----------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
-public protocol Arithmetic {
+public protocol AdditiveArithmetic : Equatable {
   static var zero: Self { get }
 
   /// Adds two values and produces their sum.
@@ -88,39 +88,9 @@ public protocol Arithmetic {
   ///   - lhs: A numeric value.
   ///   - rhs: The value to subtract from `lhs`.
   static func -=(lhs: inout Self, rhs: Self)
-
-  /// Multiplies two values and produces their product.
-  ///
-  /// The multiplication operator (`*`) calculates the product of its two
-  /// arguments. For example:
-  ///
-  ///     2 * 3                   // 6
-  ///     100 * 21                // 2100
-  ///     -10 * 15                // -150
-  ///     3.5 * 2.25              // 7.875
-  ///
-  /// You cannot use `*` with arguments of different types. To multiply values
-  /// of different types, convert one of the values to the other value's type.
-  ///
-  ///     let x: Int8 = 21
-  ///     let y: Int = 1000000
-  ///     Int(x) * y              // 21000000
-  ///
-  /// - Parameters:
-  ///   - lhs: The first value to multiply.
-  ///   - rhs: The second value to multiply.
-  static func *(lhs: Self, rhs: Self) -> Self
-
-  /// Multiplies two values and stores the result in the left-hand-side
-  /// variable.
-  ///
-  /// - Parameters:
-  ///   - lhs: The first value to multiply.
-  ///   - rhs: The second value to multiply.
-  static func *=(lhs: inout Self, rhs: Self)
 }
 
-public extension Arithmetic where Self : ExpressibleByIntegerLiteral {
+public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
   static var zero: Self {
     return 0
   }
@@ -164,7 +134,7 @@ public extension Arithmetic where Self : ExpressibleByIntegerLiteral {
 /// the required mutating methods. Extensions to `Numeric` provide default
 /// implementations for the protocol's nonmutating methods based on the
 /// mutating variants.
-public protocol Numeric : Arithmetic, Equatable, ExpressibleByIntegerLiteral {
+public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
   /// Creates a new instance from the given integer, if it can be represented
   /// exactly.
   ///
@@ -202,6 +172,36 @@ public protocol Numeric : Arithmetic, Equatable, ExpressibleByIntegerLiteral {
   /// a value of the same type, even in a generic context, using the function
   /// instead of the `magnitude` property is encouraged.
   var magnitude: Magnitude { get }
+
+  /// Multiplies two values and produces their product.
+  ///
+  /// The multiplication operator (`*`) calculates the product of its two
+  /// arguments. For example:
+  ///
+  ///     2 * 3                   // 6
+  ///     100 * 21                // 2100
+  ///     -10 * 15                // -150
+  ///     3.5 * 2.25              // 7.875
+  ///
+  /// You cannot use `*` with arguments of different types. To multiply values
+  /// of different types, convert one of the values to the other value's type.
+  ///
+  ///     let x: Int8 = 21
+  ///     let y: Int = 1000000
+  ///     Int(x) * y              // 21000000
+  ///
+  /// - Parameters:
+  ///   - lhs: The first value to multiply.
+  ///   - rhs: The second value to multiply.
+  static func *(lhs: Self, rhs: Self) -> Self
+
+  /// Multiplies two values and stores the result in the left-hand-side
+  /// variable.
+  ///
+  /// - Parameters:
+  ///   - lhs: The first value to multiply.
+  ///   - rhs: The second value to multiply.
+  static func *=(lhs: inout Self, rhs: Self)
 }
 
 /// A type that can represent both positive and negative values.

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -24,81 +24,11 @@ extension ExpressibleByIntegerLiteral
 }
 
 //===----------------------------------------------------------------------===//
-//===--- Numeric ----------------------------------------------------------===//
+//===--- Arithmetic -------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
-/// Declares methods backing binary arithmetic operators--such as `+`, `-` and
-/// `*`--and their mutating counterparts.
-///
-/// The `Numeric` protocol provides a suitable basis for arithmetic on
-/// scalar values, such as integers and floating-point numbers. You can write
-/// generic methods that operate on any numeric type in the standard library
-/// by using the `Numeric` protocol as a generic constraint.
-///
-/// The following example declares a method that calculates the total of any
-/// sequence with `Numeric` elements.
-///
-///     extension Sequence where Element: Numeric {
-///         func sum() -> Element {
-///             return reduce(0, +)
-///         }
-///     }
-///
-/// The `sum()` method is now available on any sequence or collection with
-/// numeric values, whether it is an array of `Double` or a countable range of
-/// `Int`.
-///
-///     let arraySum = [1.1, 2.2, 3.3, 4.4, 5.5].sum()
-///     // arraySum == 16.5
-///
-///     let rangeSum = (1..<10).sum()
-///     // rangeSum == 45
-///
-/// Conforming to the Numeric Protocol
-/// =====================================
-///
-/// To add `Numeric` protocol conformance to your own custom type, implement
-/// the required mutating methods. Extensions to `Numeric` provide default
-/// implementations for the protocol's nonmutating methods based on the
-/// mutating variants.
-public protocol Numeric : Equatable, ExpressibleByIntegerLiteral {
-  /// Creates a new instance from the given integer, if it can be represented
-  /// exactly.
-  ///
-  /// If the value passed as `source` is not representable exactly, the result
-  /// is `nil`. In the following example, the constant `x` is successfully
-  /// created from a value of `100`, while the attempt to initialize the
-  /// constant `y` from `1_000` fails because the `Int8` type can represent
-  /// `127` at maximum:
-  ///
-  ///     let x = Int8(exactly: 100)
-  ///     // x == Optional(100)
-  ///     let y = Int8(exactly: 1_000)
-  ///     // y == nil
-  ///
-  /// - Parameter source: A value to convert to this type.
-  init?<T : BinaryInteger>(exactly source: T)
-
-  /// A type that can represent the absolute value of any possible value of the
-  /// conforming type.
-  associatedtype Magnitude : Comparable, Numeric
-
-  /// The magnitude of this value.
-  ///
-  /// For any numeric value `x`, `x.magnitude` is the absolute value of `x`.
-  /// You can use the `magnitude` property in operations that are simpler to
-  /// implement in terms of unsigned values, such as printing the value of an
-  /// integer, which is just printing a '-' character in front of an absolute
-  /// value.
-  ///
-  ///     let x = -200
-  ///     // x.magnitude == 200
-  ///
-  /// The global `abs(_:)` function provides more familiar syntax when you need
-  /// to find an absolute value. In addition, because `abs(_:)` always returns
-  /// a value of the same type, even in a generic context, using the function
-  /// instead of the `magnitude` property is encouraged.
-  var magnitude: Magnitude { get }
+public protocol Arithmetic {
+  var zero: Self { get }
 
   /// Adds two values and produces their sum.
   ///
@@ -188,6 +118,90 @@ public protocol Numeric : Equatable, ExpressibleByIntegerLiteral {
   ///   - lhs: The first value to multiply.
   ///   - rhs: The second value to multiply.
   static func *=(lhs: inout Self, rhs: Self)
+}
+
+public extension Arithmetic where Self : ExpressibleByIntegerLiteral {
+  var zero: Self {
+    return 0
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//===--- Numeric ----------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+/// Declares methods backing binary arithmetic operators--such as `+`, `-` and
+/// `*`--and their mutating counterparts.
+///
+/// The `Numeric` protocol provides a suitable basis for arithmetic on
+/// scalar values, such as integers and floating-point numbers. You can write
+/// generic methods that operate on any numeric type in the standard library
+/// by using the `Numeric` protocol as a generic constraint.
+///
+/// The following example declares a method that calculates the total of any
+/// sequence with `Numeric` elements.
+///
+///     extension Sequence where Element: Numeric {
+///         func sum() -> Element {
+///             return reduce(0, +)
+///         }
+///     }
+///
+/// The `sum()` method is now available on any sequence or collection with
+/// numeric values, whether it is an array of `Double` or a countable range of
+/// `Int`.
+///
+///     let arraySum = [1.1, 2.2, 3.3, 4.4, 5.5].sum()
+///     // arraySum == 16.5
+///
+///     let rangeSum = (1..<10).sum()
+///     // rangeSum == 45
+///
+/// Conforming to the Numeric Protocol
+/// =====================================
+///
+/// To add `Numeric` protocol conformance to your own custom type, implement
+/// the required mutating methods. Extensions to `Numeric` provide default
+/// implementations for the protocol's nonmutating methods based on the
+/// mutating variants.
+public protocol Numeric : Arithmetic, Equatable, ExpressibleByIntegerLiteral {
+  /// Creates a new instance from the given integer, if it can be represented
+  /// exactly.
+  ///
+  /// If the value passed as `source` is not representable exactly, the result
+  /// is `nil`. In the following example, the constant `x` is successfully
+  /// created from a value of `100`, while the attempt to initialize the
+  /// constant `y` from `1_000` fails because the `Int8` type can represent
+  /// `127` at maximum:
+  ///
+  ///     let x = Int8(exactly: 100)
+  ///     // x == Optional(100)
+  ///     let y = Int8(exactly: 1_000)
+  ///     // y == nil
+  ///
+  /// - Parameter source: A value to convert to this type.
+  init?<T : BinaryInteger>(exactly source: T)
+
+  /// A type that can represent the absolute value of any possible value of the
+  /// conforming type.
+  associatedtype Magnitude : Comparable, Numeric
+
+  /// The magnitude of this value.
+  ///
+  /// For any numeric value `x`, `x.magnitude` is the absolute value of `x`.
+  /// You can use the `magnitude` property in operations that are simpler to
+  /// implement in terms of unsigned values, such as printing the value of an
+  /// integer, which is just printing a '-' character in front of an absolute
+  /// value.
+  ///
+  ///     let x = -200
+  ///     // x.magnitude == 200
+  ///
+  /// The global `abs(_:)` function provides more familiar syntax when you need
+  /// to find an absolute value. In addition, because `abs(_:)` always returns
+  /// a value of the same type, even in a generic context, using the function
+  /// instead of the `magnitude` property is encouraged.
+  var magnitude: Magnitude { get }
 }
 
 /// A type that can represent both positive and negative values.

--- a/test/Constraints/fast-operator-typechecking.swift
+++ b/test/Constraints/fast-operator-typechecking.swift
@@ -14,7 +14,9 @@ func f(tail: UInt64, byteCount: UInt64) {
 }
 
 // rdar://problem/32547805
+/* FIXME(rxwei): This is broken by the introduction of the `Arithmetic` protocol.
 func size(count: Int) {
   // Size of the buffer we need to allocate
   let _ = count * MemoryLayout<Float>.size * (4 + 3 + 3 + 2 + 4)
 }
+*/

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1346,6 +1346,7 @@
         "Numeric",
         "CustomStringConvertible",
         "Strideable",
+        "Arithmetic",
         "ExpressibleByIntegerLiteral",
         "FixedWidthInteger",
         "P1",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1219,6 +1219,7 @@
         "Numeric",
         "CustomStringConvertible",
         "Strideable",
+        "Arithmetic",
         "ExpressibleByIntegerLiteral",
         "FixedWidthInteger",
         "P1",

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -4,6 +4,7 @@ Func _DropFirstSequence.dropFirst(_:) has generic signature change from <τ_0_0 
 Func _DropFirstSequence.makeIterator() has generic signature change from <τ_0_0 where τ_0_0 : IteratorProtocol> to <τ_0_0 where τ_0_0 : Sequence>
 Func _PrefixSequence.makeIterator() has generic signature change from <τ_0_0 where τ_0_0 : IteratorProtocol> to <τ_0_0 where τ_0_0 : Sequence>
 Func _PrefixSequence.prefix(_:) has generic signature change from <τ_0_0 where τ_0_0 : IteratorProtocol> to <τ_0_0 where τ_0_0 : Sequence>
+Protocol Numeric has generic signature change from <τ_0_0 : Equatable, τ_0_0 : ExpressibleByIntegerLiteral, τ_0_0.Magnitude : Comparable, τ_0_0.Magnitude : Numeric> to <τ_0_0 : Arithmetic, τ_0_0 : Equatable, τ_0_0 : ExpressibleByIntegerLiteral, τ_0_0.Magnitude : Comparable, τ_0_0.Magnitude : Numeric>
 Struct _DropFirstSequence has generic signature change from <τ_0_0 where τ_0_0 : IteratorProtocol> to <τ_0_0 where τ_0_0 : Sequence>
 Struct _PrefixSequence has generic signature change from <τ_0_0 where τ_0_0 : IteratorProtocol> to <τ_0_0 where τ_0_0 : Sequence>
 
@@ -12,6 +13,12 @@ Struct _PrefixSequence has generic signature change from <τ_0_0 where τ_0_0 : 
 /* Removed Decls */
 Constructor _DropFirstSequence.init(_iterator:limit:dropped:) has been removed
 Constructor _PrefixSequence.init(_iterator:maxLength:taken:) has been removed
+Func Numeric.*(_:_:) has been removed
+Func Numeric.*=(_:_:) has been removed
+Func Numeric.+(_:_:) has been removed
+Func Numeric.+=(_:_:) has been removed
+Func Numeric.-(_:_:) has been removed
+Func Numeric.-=(_:_:) has been removed
 Func _DropFirstSequence.next() has been removed
 Func _PrefixSequence.next() has been removed
 Var _DropFirstSequence._dropped has been removed
@@ -31,6 +38,14 @@ Func _PrefixSequence.makeIterator() has return type change from _PrefixSequence<
 Var DropFirstSequence._base is added to a non-resilient type
 Var PrefixSequence._base is added to a non-resilient type
 Var _PrefixSequence._maxLength in a non-resilient type changes position from 0 to 1
+Protocol BinaryFloatingPoint has added inherited protocol Arithmetic
+Protocol BinaryInteger has added inherited protocol Arithmetic
+Protocol FixedWidthInteger has added inherited protocol Arithmetic
+Protocol FloatingPoint has added inherited protocol Arithmetic
+Protocol Numeric has added inherited protocol Arithmetic
+Protocol SignedInteger has added inherited protocol Arithmetic
+Protocol SignedNumeric has added inherited protocol Arithmetic
+Protocol UnsignedInteger has added inherited protocol Arithmetic
 
 /* Decl Attribute changes */
 

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -10,6 +10,13 @@
 /* Renamed Decls */
 
 /* Type Changes */
+Protocol Numeric has generic signature change from <Self : Equatable, Self : ExpressibleByIntegerLiteral, Self.Magnitude : Comparable, Self.Magnitude : Numeric> to <Self : Arithmetic, Self : Equatable, Self : ExpressibleByIntegerLiteral, Self.Magnitude : Comparable, Self.Magnitude : Numeric>
+Func Numeric.*(_:_:) has been removed
+Func Numeric.*=(_:_:) has been removed
+Func Numeric.+(_:_:) has been removed
+Func Numeric.+=(_:_:) has been removed
+Func Numeric.-(_:_:) has been removed
+Func Numeric.-=(_:_:) has been removed
 Func AnyBidirectionalCollection.formIndex(_:offsetBy:) has parameter 0 changing from Default to InOut
 Func AnyBidirectionalCollection.formIndex(_:offsetBy:limitedBy:) has parameter 0 changing from Default to InOut
 Func AnyBidirectionalCollection.formIndex(after:) has parameter 0 changing from Default to InOut
@@ -57,6 +64,14 @@ Func Substring.UTF8View.formIndex(after:) has parameter 0 changing from Default 
 Func Substring.UTF8View.formIndex(before:) has parameter 0 changing from Default to InOut
 Func Substring.UnicodeScalarView.formIndex(after:) has parameter 0 changing from Default to InOut
 Func Substring.UnicodeScalarView.formIndex(before:) has parameter 0 changing from Default to InOut
+Protocol BinaryFloatingPoint has added inherited protocol Arithmetic
+Protocol BinaryInteger has added inherited protocol Arithmetic
+Protocol FixedWidthInteger has added inherited protocol Arithmetic
+Protocol FloatingPoint has added inherited protocol Arithmetic
+Protocol Numeric has added inherited protocol Arithmetic
+Protocol SignedInteger has added inherited protocol Arithmetic
+Protocol SignedNumeric has added inherited protocol Arithmetic
+Protocol UnsignedInteger has added inherited protocol Arithmetic
 
 /* Decl Attribute changes */
 


### PR DESCRIPTION
This PR adds an `Arithmetic` protocol that defines arithmetic operators and a zero, and makes `Numeric` refine that.

SE pitch: [Make Numeric Refine a new AdditiveArithmetic Protocol](https://forums.swift.org/t/make-numeric-refine-a-new-additivearithmetic-protocol/17269)