### PR TITLE
Removed the incorrect @_effects(readnone) label from the @__tf_to_accel() function definition.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -159,9 +159,9 @@ static PartitioningClass classifyInst(SILInstruction *inst) {
         return PartitioningClass::GetScalarOrDie;
       if (fn->getName().startswith("__tf_hoistable_"))
         return PartitioningClass::Hoistable;
-      if (fn->getName() == "__tf_send")
+      if (fn->getName() == "__tf_to_accel")
         return PartitioningClass::ExplicitToAccel;
-      if (fn->getName() == "__tf_receive")
+      if (fn->getName() == "__tf_to_host")
         return PartitioningClass::ExplicitToHost;
     }
   }
@@ -697,7 +697,7 @@ public:
   /// The set of values that must be sent to the accelerator.
   SmallPtrSet<SILValue, 8> valuesToSend;
 
-  /// Set of all of the __tf_send calls that silence copy-in warnings.
+  /// Set of all of the __tf_to_accel calls that silence copy-in warnings.
   SmallPtrSet<SILInstruction *, 8> explicitCopyMarkers;
 
   /// Set of source locations where we have issued copy-to-host warnings.

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1145,7 +1145,7 @@ public extension Tensor where Scalar : Numeric {
     }
     return Raw.padV2(
       self,
-      paddings: Tensor<Int32>(handle: _TFSend(paddings)),
+      paddings: Tensor<Int32>(handle: _TFToAcclerator(paddings)),
       constantValues: Tensor(value))
   }
 }

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -91,7 +91,6 @@ func _TFGetScalar<Scalar>(_ handle: TensorHandle<Scalar>) -> Scalar? {
 func _TFTensorFromScalars<Scalar>(
   _ scalars: [Scalar], shape: [Int32]
 ) -> TensorHandle<Scalar> {
-  debugLog("Calling @__tf_tensor_from_scalars() with scalars=\(scalars) and shape=\(shape).")
   let contiguousSize = shape.map(Int.init).reduce(1, *)
   precondition(scalars.count == contiguousSize,
                "The number of scalars does not match the shape.")

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -55,15 +55,14 @@ public struct Tensor<Scalar : AccelerableByTensorFlow> : TensorProtocol {
 // functions".
 
 @usableFromInline @inline(never)
-@_silgen_name("__tf_send")
-@_effects(readnone)
-func _TFSend<Scalar>(_ handle: TensorHandle<Scalar>) -> TensorHandle<Scalar> {
+@_silgen_name("__tf_to_accel")
+func _TFToAcclerator<Scalar>(_ handle: TensorHandle<Scalar>) -> TensorHandle<Scalar> {
   return handle
 }
 
 @usableFromInline @inline(never)
-@_silgen_name("__tf_receive")
-func _TFReceive<Scalar>(_ handle: TensorHandle<Scalar>)
+@_silgen_name("__tf_to_host")
+func _TFToHost<Scalar>(_ handle: TensorHandle<Scalar>)
   -> TensorHandle<Scalar> {
   return handle
 }
@@ -92,6 +91,7 @@ func _TFGetScalar<Scalar>(_ handle: TensorHandle<Scalar>) -> Scalar? {
 func _TFTensorFromScalars<Scalar>(
   _ scalars: [Scalar], shape: [Int32]
 ) -> TensorHandle<Scalar> {
+  debugLog("Calling @__tf_tensor_from_scalars() with scalars=\(scalars) and shape=\(shape).")
   let contiguousSize = shape.map(Int.init).reduce(1, *)
   precondition(scalars.count == contiguousSize,
                "The number of scalars does not match the shape.")
@@ -169,7 +169,7 @@ public extension Tensor {
   /// Mark memory transfer to accelerator.
   @inlinable @inline(__always)
   func toAccelerator() -> Tensor {
-    return Tensor(handle: _TFSend(handle))
+    return Tensor(handle: _TFToAcclerator(handle))
   }
 
   /// Mark memory transfer to host.
@@ -190,7 +190,7 @@ public extension Tensor {
   /// Mark memory transfer to host.
   @inlinable @inline(__always)
   func toHost() -> Tensor {
-    return Tensor(handle: _TFReceive(handle))
+    return Tensor(handle: _TFToHost(handle))
   }
 }
 

--- a/test/TensorFlow/retain_release.swift
+++ b/test/TensorFlow/retain_release.swift
@@ -96,12 +96,12 @@ public func testBalancedRetainReleases() {
 // CHECK: function_ref @_swift_tfc_FinishTensorComputation
 // CHECK: [[H:%.*]] = alloc_ref $TensorHandle<Float>
 //
-// __tf_receive is called here
-// CHECK: [[RECV:%.*]] = function_ref @__tf_receive
+// __tf_to_host is called here
+// CHECK: [[TOHOST:%.*]] = function_ref @__tf_to_host
 //
 // Currently we generate a retain for the use of apply below
 // CHECK: strong_retain [[H]] : $TensorHandle<Float>
-// CHECK: apply [[RECV]]<Float>([[H]])
+// CHECK: apply [[TOHOST]]<Float>([[H]])
 //
 // CHECK: strong_release [[H]] : $TensorHandle<Float>
 // CHECK: strong_release [[H]] : $TensorHandle<Float>


### PR DESCRIPTION


That function does read an input tensor handle.

Bug description: The randomUniform initializer of Tensor calls
toAccelerator() on some tensor handle TH, but the resulting @__tf_to_accel()
call got hoisted by the optimizer _below_ the last strong_release of TH, causing
the call of @__tf_to_accel() (or subsequent code) to crash.

See the incorrect SIL code generated by the optimizer, where %73 was hoisted
_below_ %28.

```
  %23 = function_ref @__tf_hoistable_Float : $@convention(method) (@noescape @callee_guaranteed () -> @owned TensorHandle<Float>, @thin Float.Type) -> @owned TensorHandle<Float> // user: %26
  %26 = apply %23(%21, %22) : $@convention(method) (@noescape @callee_guaranteed () -> @owned TensorHandle<Float>, @thin Float.Type) -> @owned TensorHandle<Float> // users: %28, %73
  strong_release %26 : $TensorHandle<Float>       // id: %28
...
  // function_ref __tf_to_accel
  %72 = function_ref @__tf_to_accel : $@convention(thin) <τ_0_0 where τ_0_0 : AccelerableByTensorFlow> (@guaranteed TensorHandle<τ_0_0>) -> @owned TensorHandle<τ_0_0> // user: %73
  %73 = apply %72<Float>(%26) : $@convention(thin) <τ_0_0 where τ_0_0 : AccelerableByTensorFlow> (@guaranteed TensorHandle<τ_0_0>) -> @owned TensorHandle<τ_0_0> // user: %74
```

Also, to avoid confusion, renamed the terms send/receive in the function names
respectively to "to accel" and "to host".

Resolves [SR-8862](https://bugs.swift.org/browse/SR-8862).
