### PR TITLE
[ABI] Collapse generic witness table into protocol conformance record.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -84,7 +84,7 @@ Globals
   global ::= protocol-conformance 'WP'   // protocol witness table
   global ::= protocol-conformance 'Wa'   // protocol witness table accessor
 
-  global ::= protocol-conformance 'WG'   // generic protocol witness table
+  global ::= protocol-conformance 'WG'   // generic protocol witness table (HISTORICAL)
   global ::= protocol-conformance 'Wp'   // protocol witness table pattern
   global ::= protocol-conformance 'Wr'   // resilient witness table (HISTORICAL)
   global ::= protocol-conformance 'WI'   // generic protocol witness table instantiation function

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -629,6 +629,7 @@ private:
     NumConditionalRequirementsShift = 8,
 
     HasResilientWitnessesMask = 0x01 << 16,
+    HasGenericWitnessTableMask = 0x01 << 17,
   };
 
   int_type Value;
@@ -666,6 +667,14 @@ public:
     return ConformanceFlags((Value & ~HasResilientWitnessesMask)
                             | (hasResilientWitnesses? HasResilientWitnessesMask
                                                     : 0));
+  }
+
+  ConformanceFlags withHasGenericWitnessTable(
+                                           bool hasGenericWitnessTable) const {
+    return ConformanceFlags((Value & ~HasGenericWitnessTableMask)
+                            | (hasGenericWitnessTable
+                                 ? HasGenericWitnessTableMask
+                                 : 0));
   }
 
   /// Retrieve the conformance kind.
@@ -707,6 +716,12 @@ public:
   /// Whether this conformance has any resilient witnesses.
   bool hasResilientWitnesses() const {
     return Value & HasResilientWitnessesMask;
+  }
+
+  /// Whether this conformance has a generic witness table that may need to
+  /// be instantiated.
+  bool hasGenericWitnessTable() const {
+    return Value & HasGenericWitnessTableMask;
   }
 
   int_type getIntValue() const { return Value; }

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -247,10 +247,6 @@ class LinkEntity {
     /// ProtocolConformance*.
     ProtocolWitnessTableAccessFunction,
 
-    /// A generic protocol witness table cache.  The secondary pointer is a
-    /// ProtocolConformance*.
-    GenericProtocolWitnessTableCache,
-
     /// The instantiation function for a generic protocol witness table.
     /// The secondary pointer is a ProtocolConformance*.
     GenericProtocolWitnessTableInstantiationFunction,
@@ -735,13 +731,6 @@ public:
     LinkEntity entity;
     entity.setForProtocolConformance(Kind::ProtocolWitnessTableAccessFunction,
                                      C);
-    return entity;
-  }
-
-  static LinkEntity
-  forGenericProtocolWitnessTableCache(const ProtocolConformance *C) {
-    LinkEntity entity;
-    entity.setForProtocolConformance(Kind::GenericProtocolWitnessTableCache, C);
     return entity;
   }
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -387,10 +387,10 @@ MetadataResponse swift_checkMetadataState(MetadataRequest request,
 
 /// Instantiate a resilient or generic protocol witness table.
 ///
-/// \param genericTable - The witness table template for the
-///   conformance. It may either have fields that require runtime
-///   initialization, or be missing requirements at the end for
-///   which default witnesses are available.
+/// \param conformance - The protocol conformance descriptor, which
+///   contains the generic witness table record. It may either have fields
+///   that require runtime initialization, or be missing requirements at the
+///   end for which default witnesses are available.
 ///
 /// \param type - The conforming type, used to form a uniquing key
 ///   for the conformance. If the witness table is not dependent on
@@ -406,9 +406,9 @@ MetadataResponse swift_checkMetadataState(MetadataRequest request,
 ///   conformances.
 SWIFT_RUNTIME_EXPORT
 const WitnessTable *
-swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
-                             const Metadata *type,
-                             void **const *instantiationArgs);
+swift_instantiateWitnessTable(ProtocolConformanceDescriptor *conformance,
+                              const Metadata *type,
+                              void **const *instantiationArgs);
 
 /// Retrieve an associated type witness from the given witness table.
 ///

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -635,12 +635,12 @@ FUNCTION(CheckMetadataState, swift_checkMetadataState, SwiftCC,
          ATTRS(NoUnwind, ReadOnly))
 
 // const ProtocolWitnessTable *
-// swift_getGenericWitnessTable(GenericProtocolWitnessTable *genericTable,
-//                              const Metadata *type,
-//                              void ** const *instantiationArgs);
-FUNCTION(GetGenericWitnessTable, swift_getGenericWitnessTable, C_CC,
+// swift_instantiateWitnessTable(const ProtocolConformanceDescriptor *conf,
+//                               const Metadata *type,
+//                               void ** const *instantiationArgs);
+FUNCTION(InstantiateWitnessTable, swift_instantiateWitnessTable, C_CC,
          RETURNS(WitnessTablePtrTy),
-         ARGS(getGenericWitnessTableCacheTy()->getPointerTo(),
+         ARGS(ProtocolConformanceDescriptorPtrTy,
               TypeMetadataPtrTy,
               WitnessTablePtrPtrTy),
          ATTRS(NoUnwind, ReadOnly))

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3644,15 +3644,6 @@ IRGenModule::getResilienceExpansionForLayout(SILGlobalVariable *global) {
   return ResilienceExpansion::Maximal;
 }
 
-llvm::Constant *IRGenModule::
-getAddrOfGenericWitnessTableCache(const NormalProtocolConformance *conf,
-                                  ForDefinition_t forDefinition) {
-  auto entity = LinkEntity::forGenericProtocolWitnessTableCache(conf);
-  auto expectedTy = getGenericWitnessTableCacheTy();
-  return getAddrOfLLVMVariable(entity, getPointerAlignment(), forDefinition,
-                               expectedTy, DebugTypeInfo());
-}
-
 llvm::Function *
 IRGenModule::getAddrOfGenericWitnessTableInstantiationFunction(
                                       const NormalProtocolConformance *conf) {
@@ -3673,25 +3664,6 @@ IRGenModule::getAddrOfGenericWitnessTableInstantiationFunction(
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
   entry = createFunction(*this, link, signature);
   return entry;
-}
-
-llvm::StructType *IRGenModule::getGenericWitnessTableCacheTy() {
-  if (auto ty = GenericWitnessTableCacheTy) return ty;
-
-  GenericWitnessTableCacheTy = llvm::StructType::create(getLLVMContext(),
-    {
-      // WitnessTableSizeInWords
-      Int16Ty,
-      // WitnessTablePrivateSizeInWords + RequiresInstantiation bit
-      Int16Ty,
-      // Pattern
-      RelativeAddressTy,
-      // Instantiator
-      RelativeAddressTy,
-      // PrivateData
-      RelativeAddressTy
-    }, "swift.generic_witness_table_cache");
-  return GenericWitnessTableCacheTy;
 }
 
 /// Fetch the witness table access function for a protocol conformance.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1259,6 +1259,15 @@ llvm::Value *uniqueForeignWitnessTableRef(IRGenFunction &IGF,
         RequiresSpecialization = true;
     }
 
+    /// The number of entries in the witness table.
+    unsigned getTableSize() const { return TableSize; }
+
+    /// The number of private entries in the witness table.
+    unsigned getTablePrivateSize() const { return NextPrivateDataIndex; }
+
+    /// Whether this witness table must be specialized at runtime.
+    bool requiresSpecialization() const { return RequiresSpecialization; }
+
     /// The top-level entry point.
     void build();
 
@@ -1421,6 +1430,10 @@ llvm::Value *uniqueForeignWitnessTableRef(IRGenFunction &IGF,
       Table.addBitCast(wtableAccessFunction, IGM.Int8PtrTy);
     }
 
+    /// Build the instantiation function that runs at the end of witness
+    /// table specialization.
+    llvm::Constant *buildInstantiationFunction();
+
   private:
     void addConditionalConformances() {
       for (auto conditional : SILConditionalConformances) {
@@ -1432,8 +1445,6 @@ llvm::Value *uniqueForeignWitnessTableRef(IRGenFunction &IGF,
         ConditionalRequirementPrivateDataIndices.push_back(reqtIndex);
       }
     }
-
-    llvm::Constant *buildInstantiationFunction();
 
     llvm::Constant *
     getAssociatedTypeWitnessTableAccessFunction(
@@ -1899,6 +1910,10 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
   assert(isDependentConformance(&Conformance) || needsUniquing);
 
   Explosion params = IGF.collectParameters();
+  llvm::Value *conformanceDescriptor =
+      IGF.Builder.CreateBitCast(
+        IGM.getAddrOfProtocolConformanceDescriptor(&Conformance),
+        IGM.ProtocolConformanceDescriptorPtrTy);
   llvm::Value *metadata;
   llvm::Value *instantiationArgs;
 
@@ -1911,75 +1926,10 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
         llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrPtrTy);
   }
 
-  // Okay, we need a cache.  Build the cache structure.
-  //  struct GenericWitnessTable {
-  //    /// The size of the witness table in words.
-  //    uint16_t WitnessTableSizeInWords;
-  //
-  //    /// The amount of private storage to allocate before the address point,
-  //    /// in words. This memory is zeroed out in the instantiated witness table
-  //    /// template.
-  //    /// The low bit is used to indicate whether this witness table is known
-  //    /// to require instantiation.
-  //    uint16_t WitnessTablePrivateSizeInWordsAndRequiresInstantiation;
-  //
-  //    /// The pattern.
-  //    RelativeDirectPointer<WitnessTable> WitnessTable;
-  //
-  //    /// The instantiation function, which is called after the template is copied.
-  //    RelativeDirectPointer<void(WitnessTable *, const Metadata *, void * const *)>
-  //                               Instantiator;
-  //
-  //    /// Private data for the instantiator.  Out-of-line so that the rest
-  //    /// of this structure can be constant.
-  //    RelativeDirectPointer<PrivateDataType> PrivateData;
-  //  };
-
-  // First, create the global.  We have to build this in two phases because
-  // it contains relative pointers.
-  auto cache = cast<llvm::GlobalVariable>(
-    IGM.getAddrOfGenericWitnessTableCache(&Conformance, ForDefinition));
-
-  // We need an instantiation function if the base conformance
-  // is non-dependent.
-  llvm::Constant *instantiationFn;
-  if (SpecializedBaseConformances.empty() &&
-      ConditionalRequirementPrivateDataIndices.empty()) {
-    instantiationFn = nullptr;
-  } else {
-    instantiationFn = buildInstantiationFunction();
-  }
-
-  // Fill in the global.
-  auto cacheTy = cast<llvm::StructType>(cache->getValueType());
-  ConstantInitBuilder cacheInitBuilder(IGM);
-  auto cacheData = cacheInitBuilder.beginStruct(cacheTy);
-  // WitnessTableSizeInWords
-  cacheData.addInt(IGM.Int16Ty, TableSize);
-  // WitnessTablePrivateSizeInWordsAndRequiresInstantiation
-  cacheData.addInt(IGM.Int16Ty,
-                   (NextPrivateDataIndex << 1) | RequiresSpecialization);
-  // RelativePointer<WitnessTable>
-  cacheData.addRelativeAddress(wtable);
-  // Instantiation function
-  cacheData.addRelativeAddressOrNull(instantiationFn);
-  // Private data
-  {
-    auto privateDataTy =
-      llvm::ArrayType::get(IGM.Int8PtrTy,
-                           swift::NumGenericMetadataPrivateDataWords);
-    auto privateDataInit = llvm::Constant::getNullValue(privateDataTy);
-    auto privateData =
-      new llvm::GlobalVariable(IGM.Module, privateDataTy, /*constant*/ false,
-                               llvm::GlobalVariable::InternalLinkage,
-                               privateDataInit, "");
-    cacheData.addRelativeAddress(privateData);
-  }
-  cacheData.finishAndSetAsInitializer(cache);
-  cache->setConstant(true);
-
-  auto call = IGF.Builder.CreateCall(IGM.getGetGenericWitnessTableFn(),
-                                     {cache, metadata, instantiationArgs});
+  // Okay, we need runtime specialization.  Build the call.
+  auto call = IGF.Builder.CreateCall(
+                IGM.getInstantiateWitnessTableFn(),
+                {conformanceDescriptor, metadata, instantiationArgs});
 
   call->setDoesNotThrow();
 
@@ -1988,6 +1938,12 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
 }
 
 llvm::Constant *WitnessTableBuilder::buildInstantiationFunction() {
+  // We need an instantiation function if the base conformance
+  // is non-dependent.
+  if (SpecializedBaseConformances.empty() &&
+      ConditionalRequirementPrivateDataIndices.empty())
+    return nullptr;
+
   llvm::Function *fn =
     IGM.getAddrOfGenericWitnessTableInstantiationFunction(&Conformance);
   IRGenFunction IGF(IGM, fn);
@@ -2062,18 +2018,16 @@ namespace {
     ConstantStructBuilder &B;
     const NormalProtocolConformance *Conformance;
     SILWitnessTable *SILWT;
-    ArrayRef<llvm::Constant *> ResilientWitnesses;
+    ConformanceDescription Description;
     ConformanceFlags Flags;
 
   public:
     ProtocolConformanceDescriptorBuilder(
                                  IRGenModule &IGM,
                                  ConstantStructBuilder &B,
-                                 const NormalProtocolConformance *conformance,
-                                 SILWitnessTable *SILWT,
-                                 ArrayRef<llvm::Constant *> resilientWitnesses)
-      : IGM(IGM), B(B), Conformance(conformance), SILWT(SILWT),
-        ResilientWitnesses(resilientWitnesses) { }
+                                 const ConformanceDescription &description)
+      : IGM(IGM), B(B), Conformance(description.conformance),
+        SILWT(description.wtable), Description(description) { }
 
     void layout() {
       addProtocol();
@@ -2083,6 +2037,7 @@ namespace {
       addContext();
       addConditionalRequirements();
       addResilientWitnesses();
+      addGenericWitnessTable();
 
       B.suggestType(IGM.ProtocolConformanceDescriptorTy);
     }
@@ -2144,7 +2099,10 @@ namespace {
       Flags = Flags.withIsRetroactive(Conformance->isRetroactive());
       Flags =
         Flags.withIsSynthesizedNonUnique(Conformance->isSynthesizedNonUnique());
-      Flags = Flags.withHasResilientWitnesses(!ResilientWitnesses.empty());
+      Flags = Flags.withHasResilientWitnesses(
+                                      !Description.resilientWitnesses.empty());
+      Flags =
+        Flags.withHasGenericWitnessTable(Description.requiresSpecialization);
 
       // Add the flags.
       B.addInt32(Flags.getIntValue());
@@ -2172,11 +2130,11 @@ namespace {
     }
 
     void addResilientWitnesses() {
-      if (ResilientWitnesses.empty())
+      if (Description.resilientWitnesses.empty())
         return;
 
       // TargetResilientWitnessesHeader
-      auto witnesses = ResilientWitnesses;
+      ArrayRef<llvm::Constant *> witnesses = Description.resilientWitnesses;
       B.addInt32(witnesses.size());
       for (const auto &entry : SILWT->getEntries()) {
         // Add the requirement descriptor.
@@ -2220,6 +2178,35 @@ namespace {
       }
       assert(witnesses.empty() && "Wrong # of resilient witnesses");
     }
+
+    void addGenericWitnessTable() {
+      if (!Description.requiresSpecialization)
+        return;
+
+      // WitnessTableSizeInWords
+      B.addInt(IGM.Int16Ty, Description.witnessTableSize);
+      // WitnessTablePrivateSizeInWordsAndRequiresInstantiation
+      B.addInt(IGM.Int16Ty,
+               (Description.witnessTablePrivateSize << 1) |
+                Description.requiresSpecialization);
+      // RelativePointer<WitnessTable>
+      B.addRelativeAddress(Description.pattern);
+      // Instantiation function
+      B.addRelativeAddressOrNull(Description.instantiationFn);
+      // Private data
+      {
+        auto privateDataTy =
+          llvm::ArrayType::get(IGM.Int8PtrTy,
+                               swift::NumGenericMetadataPrivateDataWords);
+        auto privateDataInit = llvm::Constant::getNullValue(privateDataTy);
+        auto privateData =
+          new llvm::GlobalVariable(IGM.Module, privateDataTy,
+                                   /*constant*/ false,
+                                   llvm::GlobalVariable::InternalLinkage,
+                                   privateDataInit, "");
+        B.addRelativeAddress(privateData);
+      }
+    }
   };
 }
 
@@ -2233,9 +2220,7 @@ void IRGenModule::emitProtocolConformance(
   // Form the protocol conformance descriptor.
   ConstantInitBuilder initBuilder(*this);
   auto init = initBuilder.beginStruct();
-  ProtocolConformanceDescriptorBuilder builder(*this, init, conformance,
-                                               record.wtable,
-                                               record.resilientWitnesses);
+  ProtocolConformanceDescriptorBuilder builder(*this, init, record);
   builder.layout();
 
   auto var =
@@ -2406,17 +2391,15 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
                                       conf->getType());
   PrettyStackTraceDecl stackTraceRAII2("...conforming to", conf->getProtocol());
 
-  // Build the witnesses.
+  // Build the witness table.
   ConstantInitBuilder builder(*this);
   auto wtableContents = builder.beginArray(Int8PtrTy);
   WitnessTableBuilder wtableBuilder(*this, wtableContents, wt);
   wtableBuilder.build();
 
-  // Collect the resilient witnesses, which will end up in the protocol
-  // conformance descriptor.
-  ConformanceDescription description(conf, wt);
-  wtableBuilder.collectResilientWitnesses(description.resilientWitnesses);
-  addProtocolConformance(std::move(description));
+  SmallVector<llvm::Constant *, 4> resilientWitnesses;
+  // Collect the resilient witnesses to go into the conformance descriptor.
+  wtableBuilder.collectResilientWitnesses(resilientWitnesses);
 
   // Produce the initializer value.
   auto initializer = wtableContents.finishAndCreateFuture();
@@ -2429,8 +2412,22 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   global->setConstant(isDependent || isConstantWitnessTable(wt));
   global->setAlignment(getWitnessTableAlignment().getValue());
 
+  // Collect the information that will go into the protocol conformance
+  // descriptor.
+  ConformanceDescription description(conf, wt, global,
+                                     wtableBuilder.getTableSize(),
+                                     wtableBuilder.getTablePrivateSize(),
+                                     wtableBuilder.requiresSpecialization());
+
+  // Build the instantiation function, we if need one.
+  description.instantiationFn = wtableBuilder.buildInstantiationFunction();
+  description.resilientWitnesses = std::move(resilientWitnesses);
+
   // Always emit an accessor function.
   wtableBuilder.buildAccessFunction(global);
+
+  // Record this conformance descriptor.
+  addProtocolConformance(std::move(description));
 
   // Behavior conformances can't be reflected.
   if (conf->isBehaviorConformance())

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -249,11 +249,6 @@ public:
     return mangleConformanceSymbol(Type(), C, "Wp");
   }
 
-  std::string mangleGenericProtocolWitnessTableCache(
-                                                const ProtocolConformance *C) {
-    return mangleConformanceSymbol(Type(), C, "WG");
-  }
-
   std::string mangleGenericProtocolWitnessTableInstantiationFunction(
                                                 const ProtocolConformance *C) {
     return mangleConformanceSymbol(Type(), C, "WI");

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -208,10 +208,6 @@ std::string LinkEntity::mangleAsString() const {
   case Kind::DirectProtocolWitnessTable:
     return mangler.mangleDirectProtocolWitnessTable(getProtocolConformance());
 
-  case Kind::GenericProtocolWitnessTableCache:
-    return mangler.mangleGenericProtocolWitnessTableCache(
-                                                    getProtocolConformance());
-
   case Kind::GenericProtocolWitnessTableInstantiationFunction:
     return mangler.mangleGenericProtocolWitnessTableInstantiationFunction(
                                                     getProtocolConformance());
@@ -493,7 +489,6 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
 
   case Kind::AssociatedTypeWitnessTableAccessFunction:
   case Kind::DefaultAssociatedConformanceAccessor:
-  case Kind::GenericProtocolWitnessTableCache:
   case Kind::GenericProtocolWitnessTableInstantiationFunction:
     return SILLinkage::Private;
 
@@ -633,7 +628,6 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
   case Kind::ProtocolWitnessTableLazyAccessFunction:
   case Kind::ProtocolWitnessTableLazyCacheVariable:
   case Kind::AssociatedTypeWitnessTableAccessFunction:
-  case Kind::GenericProtocolWitnessTableCache:
   case Kind::GenericProtocolWitnessTableInstantiationFunction:
   case Kind::SILFunction:
   case Kind::SILGlobalVariable:

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3763,13 +3763,13 @@ class WitnessTableCacheEntry :
   /// The generic table.  This is only kept around so that we can
   /// compute the size of an entry correctly in case of a race to
   /// allocate the entry.
-  GenericWitnessTable * const GenericTable;
+  const GenericWitnessTable * const GenericTable;
 
 public:
   /// Do the structural initialization necessary for this entry to appear
   /// in a concurrent map.
   WitnessTableCacheEntry(const Metadata *type,
-                         GenericWitnessTable *genericTable,
+                         const GenericWitnessTable *genericTable,
                          void ** const *instantiationArgs)
     : Type(type), GenericTable(genericTable) {}
 
@@ -3783,7 +3783,7 @@ public:
   }
 
   static size_t getExtraAllocationSize(const Metadata *type,
-                                       GenericWitnessTable *genericTable,
+                                       const GenericWitnessTable *genericTable,
                                        void ** const *instantiationArgs) {
     return getWitnessTableSize(genericTable);
   }
@@ -3792,7 +3792,7 @@ public:
     return getWitnessTableSize(GenericTable);
   }
 
-  static size_t getWitnessTableSize(GenericWitnessTable *genericTable) {
+  static size_t getWitnessTableSize(const GenericWitnessTable *genericTable) {
     auto protocol = genericTable->getProtocol();
     size_t numPrivateWords = genericTable->getWitnessTablePrivateSizeInWords();
     size_t numRequirementWords =
@@ -3800,7 +3800,7 @@ public:
     return (numPrivateWords + numRequirementWords) * sizeof(void*);
   }
 
-  WitnessTable *allocate(GenericWitnessTable *genericTable,
+  WitnessTable *allocate(const GenericWitnessTable *genericTable,
                          void ** const *instantiationArgs);
 };
 
@@ -3811,7 +3811,7 @@ using GenericWitnessTableCache =
 using LazyGenericWitnessTableCache = Lazy<GenericWitnessTableCache>;
 
 /// Fetch the cache for a generic witness-table structure.
-static GenericWitnessTableCache &getCache(GenericWitnessTable *gen) {
+static GenericWitnessTableCache &getCache(const GenericWitnessTable *gen) {
   // Keep this assert even if you change the representation above.
   static_assert(sizeof(LazyGenericWitnessTableCache) <=
                 sizeof(GenericWitnessTable::PrivateDataType),
@@ -3825,14 +3825,15 @@ static GenericWitnessTableCache &getCache(GenericWitnessTable *gen) {
 /// If there's no initializer, no private storage, and all requirements
 /// are present, we don't have to instantiate anything; just return the
 /// witness table template.
-static bool doesNotRequireInstantiation(GenericWitnessTable *genericTable) {
+static bool doesNotRequireInstantiation(
+                              ProtocolConformanceDescriptor *conformance,
+                              const GenericWitnessTable *genericTable) {
   // If the table says it requires instantiation, it does.
   if (genericTable->requiresInstantiation()) {
     return false;
   }
 
   // If we have resilient witnesses, we require instantiation.
-  auto conformance = genericTable->getConformance();
   if (!conformance->getResilientWitnesses().empty()) {
     return false;
   }
@@ -3857,8 +3858,9 @@ static bool doesNotRequireInstantiation(GenericWitnessTable *genericTable) {
 
 /// Initialize witness table entries from order independent resilient
 /// witnesses stored in the generic witness table structure itself.
-static void initializeResilientWitnessTable(GenericWitnessTable *genericTable,
-                                            void **table) {
+static void initializeResilientWitnessTable(
+                                        const GenericWitnessTable *genericTable,
+                                        void **table) {
   auto conformance = genericTable->getConformance();
   auto protocol = conformance->getProtocol();
 
@@ -3908,7 +3910,7 @@ static void initializeResilientWitnessTable(GenericWitnessTable *genericTable,
 /// Instantiate a brand new witness table for a resilient or generic
 /// protocol conformance.
 WitnessTable *
-WitnessTableCacheEntry::allocate(GenericWitnessTable *genericTable,
+WitnessTableCacheEntry::allocate(const GenericWitnessTable *genericTable,
                                  void ** const *instantiationArgs) {
   // The number of witnesses provided by the table pattern.
   size_t numPatternWitnesses = genericTable->WitnessTableSizeInWords;
@@ -3954,10 +3956,11 @@ WitnessTableCacheEntry::allocate(GenericWitnessTable *genericTable,
 }
 
 const WitnessTable *
-swift::swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
-                                    const Metadata *type,
-                                    void **const *instantiationArgs) {
-  if (doesNotRequireInstantiation(genericTable)) {
+swift::swift_instantiateWitnessTable(ProtocolConformanceDescriptor *conformance,
+                                     const Metadata *type,
+                                     void **const *instantiationArgs) {
+  auto genericTable = conformance->getGenericWitnessTable();
+  if (doesNotRequireInstantiation(conformance, genericTable)) {
     return genericTable->Pattern;
   }
 

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -84,28 +84,29 @@ struct Pair<T, U> : P, Q {}
 // GLOBAL-SAME:    i8* bitcast (i8** (%swift.type*, %swift.type*, i8**)* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAA5Assoc_AA1QPWT" to i8*)
 // GLOBAL-SAME:    @"symbolic 23associated_type_witness4PairVyxq_G"
 // GLOBAL-SAME:  ]
-//   Generic witness table cache for Computed : Assocked.
-// GLOBAL-LABEL: @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWG" = internal constant %swift.generic_witness_table_cache {
-// GLOBAL-SAME:    i16 4,
-// GLOBAL-SAME:    i16 1,
-
-//    Relative reference to witness table template
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([4 x i8*]* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWp" to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWG", i32 0, i32 2) to i64)) to i32
-
-//    No instantiator function
-// GLOBAL-SAME:    i32 0,
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* [[PRIVATE:@.*]] to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWG", i32 0, i32 4) to i64)) to i32)
-// GLOBAL-SAME:  }
-// GLOBAL:       [[PRIVATE]] = internal global [16 x i8*] zeroinitializer
 
 struct Computed<T, U> : Assocked {
   typealias Assoc = Pair<T, U>
 }
 
+//   Instantiation function for GenericComputed : DerivedFromSimpleAssoc.
+// CHECK-LABEL: define internal void @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI"(i8**, %swift.type* %"GenericComputed<T>", i8**)
+// CHECK:         [[T0:%.*]] = call i8** @"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type* %"GenericComputed<T>", i8*** undef)
+// CHECK-NEXT:    [[T1:%.*]] = bitcast i8** [[T0]] to i8*
+// CHECK-NEXT:    [[T2:%.*]] = getelementptr inbounds i8*, i8** %0, i32 1
+// CHECK-NEXT:    store i8* [[T1]], i8** [[T2]], align 8
+// CHECK-NEXT:    ret void
+
+//   Witness table accessor function for GenericComputed : HasSimpleAssoc..
+// CHECK-LABEL: define hidden i8** @"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type*, i8***)
+// CHECK-NEXT:   entry:
+// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAMc"{{.*}}, %swift.type* %0, i8*** %1)
+// CHECK-NEXT:    ret i8** [[WTABLE]]
+
 //   Witness table accessor function for Computed : Assocked.
 // CHECK-LABEL: define hidden i8** @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:     [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", %swift.type* %0, i8*** %1)
+// CHECK-NEXT:     [[WTABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAMc"{{.*}}, %swift.type* %0, i8*** %1)
 // CHECK-NEXT:     ret i8** [[WTABLE]]
 
 
@@ -121,36 +122,10 @@ protocol DerivedFromSimpleAssoc : HasSimpleAssoc {}
 // GLOBAL-SAME: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAMc"
 // GLOBAL-SAME: i8* null
 
-//   Generic witness table cache for GenericComputed : DerivedFromSimpleAssoc.
-// GLOBAL-LABEL: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG" = internal constant %swift.generic_witness_table_cache {
-// GLOBAL-SAME:    i16 2,
-// GLOBAL-SAME:    i16 1,
-
-//   Relative reference to witness table template
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([2 x i8*]* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWp" to i64
-
-//   Relative reference to instantiator function
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint (void (i8**, %swift.type*, i8**)* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI" to i64), i64 ptrtoint (i32* getelementptr inbounds (%swift.generic_witness_table_cache, %swift.generic_witness_table_cache* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", i32 0, i32 3) to i64)) to i32)
-
 //   Relative reference to private data
 struct GenericComputed<T: P> : DerivedFromSimpleAssoc {
   typealias Assoc = PBox<T>
 }
-
-//   Instantiation function for GenericComputed : DerivedFromSimpleAssoc.
-// CHECK-LABEL: define internal void @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI"(i8**, %swift.type* %"GenericComputed<T>", i8**)
-// CHECK:         [[T0:%.*]] = call i8** @"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type* %"GenericComputed<T>", i8*** undef)
-// CHECK-NEXT:    [[T1:%.*]] = bitcast i8** [[T0]] to i8*
-// CHECK-NEXT:    [[T2:%.*]] = getelementptr inbounds i8*, i8** %0, i32 1
-// CHECK-NEXT:    store i8* [[T1]], i8** [[T2]], align 8
-// CHECK-NEXT:    ret void
-
-//   Witness table accessor function for GenericComputed : HasSimpleAssoc..
-// CHECK-LABEL: define hidden i8** @"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type*, i8***)
-// CHECK-NEXT:   entry:
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWG", %swift.type* %0, i8*** %1)
-// CHECK-NEXT:    ret i8** [[WTABLE]]
-
 
 protocol HasAssocked {
   associatedtype Contents : Assocked
@@ -162,3 +137,27 @@ struct FulfilledFromAssociatedType<T : HasAssocked> : HasSimpleAssoc {
 struct UsesVoid : HasSimpleAssoc {
   typealias Assoc = ()
 }
+
+//   Protocol conformance descriptor for Computed : Assocked.
+// GLOBAL-LABEL: @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAMc" = hidden constant
+// GLOBAL-SAME:    i16 4,
+// GLOBAL-SAME:    i16 1,
+
+//    Relative reference to witness table template
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([4 x i8*]* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWp" to i64), i64 ptrtoint
+
+//    No instantiator function
+// GLOBAL-SAME:    i32 0,
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* [[PRIVATE:@.*]] to i64), i64 ptrtoint
+// GLOBAL-SAME:  }
+
+//   Protocol conformance descriptor for GenericComputed : DerivedFromSimpleAssoc.
+// GLOBAL-LABEL: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAMc" = hidden constant
+// GLOBAL-SAME:    i16 2,
+// GLOBAL-SAME:    i16 1,
+
+//   Relative reference to witness table template
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([2 x i8*]* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWp" to i64
+
+//   Relative reference to instantiator function
+// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint (void (i8**, %swift.type*, i8**)* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI" to i64),

--- a/test/IRGen/generic_wt_linkage.sil
+++ b/test/IRGen/generic_wt_linkage.sil
@@ -44,7 +44,6 @@ sil_default_witness_table hidden DerivedFromSimpleAssoc {
   no_default
 }
 
-// CHECK: @"$s4test15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG" = internal constant
 // CHECK: define internal void @"$s4test15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI"
 
 

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -90,7 +90,7 @@ use_metadata(NSRuncingOptions.mince)
 // CHECK:         call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}} @"$sSo16NSRuncingOptionsVN" {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
 
 // CHECK-LABEL: define linkonce_odr hidden i8** @"$sSo16NSRuncingOptionsVSQSCWa"()
-// CHECK:  [[NONUNIQUE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$sSo16NSRuncingOptionsVSQSCWG", %swift.type* null, i8*** null)
+// CHECK:  [[NONUNIQUE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$sSo16NSRuncingOptionsVSQSCMc" to %swift.protocol_conformance_descriptor*), %swift.type* null, i8*** null)
 // CHECK:  [[UNIQUE:%.*]] = call i8** @swift_getForeignWitnessTable(i8** [[NONUNIQUE]], %swift.type_descriptor* bitcast (<{ {{.*}} }>* @"$sSo16NSRuncingOptionsVMn" to %swift.type_descriptor*), %swift.protocol* @"$sSQMp")
 // CHECK:  ret i8** [[UNIQUE]]
 

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -8,22 +8,7 @@ public protocol Associate {
   associatedtype X
 }
 
-// Dependent conformance
-// CHECK-LABEL: @"$s28protocol_conformance_records9DependentVyxGAA9AssociateAAMc" ={{ dllexport | protected | }}constant
-// -- protocol descriptor
-// CHECK-SAME:           @"$s28protocol_conformance_records9AssociateMp"
-// -- nominal type descriptor
-// CHECK-SAME:           @"$s28protocol_conformance_records9DependentVMn"
-// -- witness table accessor
-// CHECK-SAME:           @"$s28protocol_conformance_records9DependentVyxGAA9AssociateAAWa"
-// -- flags
-// CHECK-SAME:           i32 1
-// CHECK-SAME:         }
 public struct Dependent<T> {}
-
-extension Dependent : Associate {
-  public typealias X = (T, T)
-}
 
 public protocol Runcible {
   func runce()
@@ -117,7 +102,7 @@ public protocol Spoon { }
 // -- witness table accessor
 // CHECK-SAME:           @"$s28protocol_conformance_records17NativeGenericTypeVyxGAA5SpoonA2aERzlWa
 // -- flags
-// CHECK-SAME:           i32 258
+// CHECK-SAME:           i32 131330
 // -- conditional requirement #1
 // CHECK-SAME:           i32 128,
 // CHECK-SAME:           i32 0,
@@ -136,11 +121,26 @@ extension NativeGenericType : Spoon where T: Spoon {
 // -- witness table accessor
 // CHECK-SAME:           @"$sSi18resilient_protocol22OtherResilientProtocol0B20_conformance_recordsWa"
 // -- flags
-// CHECK-SAME:           i32 73,
+// CHECK-SAME:           i32 131145,
 // -- module context for retroactive conformance
 // CHECK-SAME:           @"$s28protocol_conformance_recordsMXM"
 // CHECK-SAME:         }
 extension Int : OtherResilientProtocol { }
+
+// Dependent conformance
+// CHECK-LABEL: @"$s28protocol_conformance_records9DependentVyxGAA9AssociateAAMc" ={{ dllexport | protected | }}constant
+// -- protocol descriptor
+// CHECK-SAME:           @"$s28protocol_conformance_records9AssociateMp"
+// -- nominal type descriptor
+// CHECK-SAME:           @"$s28protocol_conformance_records9DependentVMn"
+// -- witness table accessor
+// CHECK-SAME:           @"$s28protocol_conformance_records9DependentVyxGAA9AssociateAAWa"
+// -- flags
+// CHECK-SAME:           i32 1
+// CHECK-SAME:         }
+extension Dependent : Associate {
+  public typealias X = (T, T)
+}
 
 // CHECK-LABEL: @"\01l_protocol_conformances" = private constant
 // CHECK-SAME: @"$s28protocol_conformance_records15NativeValueTypeVAA8RuncibleAAMc"

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -99,7 +99,7 @@ protocol InternalProtocol {
 
 // Protocol conformance descriptor for ResilientConformingType : OtherResilientProtocol
 
-// CHECK: @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAMc" = constant
+// CHECK: @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAMc" =
 
 // CHECK-SAME: i32 131073,
 

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -12,26 +12,6 @@ import SwiftShims
 import resilient_protocol
 
 
-// Generic witness table pattern for ConformingType : ResilientProtocol
-
-// CHECK: @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWG"
-
-// CHECK-SAME: internal constant %swift.generic_witness_table_cache {
-
-// -- number of witness table entries
-// CHECK-SAME:   i16 1,
-
-// -- size of private area + 'needs instantiation' bit
-// CHECK-SAME:   i16 1,
-
-// -- the template
-// CHECK-SAME:   @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWp"
-
-// -- instantiator function
-// CHECK-SAME:   i32 0
-
-// CHECK-SAME: }
-
 // Protocol descriptor for ResilientProtocol
 // CHECK: [[RESILIENT_PROTOCOL_NAME:@.*]] = private constant [18 x i8] c"ResilientProtocol\00
 // CHECK: [[ASSOCIATED_TYPES_T:@.*]] = private constant [2 x i8] c"T\00"
@@ -84,7 +64,6 @@ public protocol ResilientProtocol {
   static func defaultF()
 }
 
-
 // Protocol is not public -- doesn't need default witness table
 
 // CHECK: @"$s19protocol_resilience16InternalProtocolMp" = hidden constant
@@ -99,10 +78,9 @@ protocol InternalProtocol {
   func f()
 }
 
-
 // Generic witness table pattern for ConformsWithRequirements : ProtocolWithRequirements
 
-// CHECK: @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWp"
+// CHECK: @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWp" =
 
 // CHECK-SAME: internal constant [1 x i8*] [
 
@@ -112,7 +90,18 @@ protocol InternalProtocol {
 // CHECK-SAME: ]
 
 
-// CHECK: @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWG"
+// Witness table for conformance with resilient associated type
+
+// CHECK: @"$s19protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWP" = {{(protected )?}}hidden global [3 x i8*] [
+// CHECK-SAME:   i8* bitcast (i8** ()* @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa" to i8*)
+// CHECK-SAME:   @"symbolic 19protocol_resilience23ResilientConformingTypeV"
+// CHECK-SAME: ]
+
+// Protocol conformance descriptor for ResilientConformingType : OtherResilientProtocol
+
+// CHECK: @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAMc" = constant
+
+// CHECK-SAME: i32 131073,
 
 // -- number of witness table entries
 // CHECK-SAME:   i16 1,
@@ -121,26 +110,19 @@ protocol InternalProtocol {
 // CHECK-SAME:   i16 1,
 
 // -- the template
-// CHECK-SAME:   @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWp"
+// CHECK-SAME:   @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWp"
 
 // -- instantiator function
 // CHECK-SAME:   i32 0
 
 // CHECK-SAME: }
 
-// Witness table for conformance with resilient associated type
-
-// CHECK: @"$s19protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWP" = {{(protected )?}}hidden global [3 x i8*] [
-// CHECK-SAME:   i8* bitcast (i8** ()* @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa" to i8*)
-// CHECK-SAME:   @"symbolic 19protocol_resilience23ResilientConformingTypeV"
-// CHECK-SAME: ]
-
 // ConformsWithRequirements protocol conformance descriptor
 
 // CHECK: "$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAMc" = hidden constant {
 
 // -- flags
-// CHECK-SAME: i32 65537,
+// CHECK-SAME: i32 196609,
 
 // CHECK-SAME: i32 3,
 
@@ -153,6 +135,18 @@ protocol InternalProtocol {
 
 // CHECK-SAME: @"{{got.|__imp_}}$s18resilient_protocol24ProtocolWithRequirementsP6secondyyFTq"
 // CHECK-SAME: @secondWitness
+
+// -- number of witness table entries
+// CHECK-SAME:   i16 1,
+
+// -- size of private area + 'needs instantiation' bit
+// CHECK-SAME:   i16 1,
+
+// -- the template
+// CHECK-SAME:   @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWp"
+
+// -- instantiator function
+// CHECK-SAME:   i32 0
 
 // CHECK-SAME: }
 
@@ -391,7 +385,7 @@ bb0(%0 : $*ResilientConformingType):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i8** @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa"()
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWG", %swift.type* null, i8*** null)
+// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast ({{[{].*[}]}}* @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAMc" to %swift.protocol_conformance_descriptor*), %swift.type* null, i8*** null)
 // CHECK-NEXT:    ret i8** [[WTABLE]]
 
 

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -64,7 +64,7 @@ public func single_generic<T: P2>(_: T.Type) {
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i8** @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWG", %swift.type* %0, i8*** %1)
+// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlMc"{{.*}}, %swift.type* %0, i8*** %1)
 // CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
 
@@ -189,7 +189,7 @@ public func double_generic_generic<U: P2, V: P3>(_: U.Type, _: V.Type) {
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i8** @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWG", %swift.type* %0, i8*** %1)
+// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlMc"{{.*}}, %swift.type* %0, i8*** %1)
 // CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
 

--- a/test/Inputs/conditional_conformance_subclass.swift
+++ b/test/Inputs/conditional_conformance_subclass.swift
@@ -64,7 +64,7 @@ public func subclassgeneric_generic<T: P2>(_: T.Type) {
 
 // CHECK-LABEL: define{{( dllexport| protected)?}} i8** @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWG", %swift.type* %0, i8*** %1)
+// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlMc"{{.*}}, %swift.type* %0, i8*** %1)
 // CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
 


### PR DESCRIPTION
Collapse the generic witness table, which was used only as a uniquing
data structure during witness table instantiation, into the protocol
conformance record. This colocates all of the constant protocol conformance
metadata and makes it possible for us to recover the generic witness table
from the conformance descriptor (including looking at the pattern itself).

Rename swift_getGenericWitnessTable() to swift_instantiateWitnessTable()
to make it clearer what its purpose is, and take the conformance descriptor
directly.
