### PR TITLE
Foundation overlay needs to build with -swift-version 5

### DIFF
--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -239,7 +239,7 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
     
     public func inverted() -> AffineTransform? {
         let determinant = (m11 * m22) - (m12 * m21)
-        if fabs(determinant) <= ε {
+        if abs(determinant) <= ε {
             return nil
         }
         var inverse = AffineTransform()

--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -59,7 +59,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   UUID.swift
   CheckClass.mm
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "-Xllvm" "-sil-partial-specialization" "-swift-version" "3"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "-Xllvm" "-sil-partial-specialization" "-swift-version" "5"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreFoundation CoreGraphics Dispatch IOKit ObjectiveC # auto-updated

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -357,7 +357,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// - parameter component: A component to calculate a range for.
     /// - returns: The range, or nil if it could not be calculated.
     public func minimumRange(of component: Component) -> Range<Int>? {
-        return _handle.map { $0.minimumRange(of: Calendar._toCalendarUnit([component])).toRange() }
+        return _handle.map { Range($0.minimumRange(of: Calendar._toCalendarUnit([component]))) }
     }
     
     /// The maximum range limits of the values that a given component can take on in the receive
@@ -366,7 +366,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// - parameter component: A component to calculate a range for.
     /// - returns: The range, or nil if it could not be calculated.
     public func maximumRange(of component: Component) -> Range<Int>? {
-        return _handle.map { $0.maximumRange(of: Calendar._toCalendarUnit([component])).toRange() }
+        return _handle.map { Range($0.maximumRange(of: Calendar._toCalendarUnit([component]))) }
     }
     
     
@@ -383,7 +383,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// - parameter date: The absolute time for which the calculation is performed.
     /// - returns: The range of absolute time values smaller can take on in larger at the time specified by date. Returns `nil` if larger is not logically bigger than smaller in the calendar, or the given combination of components does not make sense (or is a computation which is undefined).
     public func range(of smaller: Component, in larger: Component, for date: Date) -> Range<Int>? {
-        return _handle.map { $0.range(of: Calendar._toCalendarUnit([smaller]), in: Calendar._toCalendarUnit([larger]), for: date).toRange() }
+        return _handle.map { Range($0.range(of: Calendar._toCalendarUnit([smaller]), in: Calendar._toCalendarUnit([larger]), for: date)) }
     }
     
     @available(*, unavailable, message: "use range(of:in:for:) instead")

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -141,6 +141,8 @@ internal final class _DataStorage {
                 return d.bytes.advanced(by: -_offset)
             case .customMutableReference(let d):
                 return d.bytes.advanced(by: -_offset)
+            @unknown default:
+                fatalError("Unknown Data backing type")
             }
         }
     }
@@ -267,6 +269,8 @@ internal final class _DataStorage {
                 return data.mutableBytes.advanced(by: -_offset)
             case .customMutableReference(let d):
                 return d.mutableBytes.advanced(by: -_offset)
+            @unknown default:
+                fatalError("Unknown Data backing type")
             }
         }
     }
@@ -287,6 +291,8 @@ internal final class _DataStorage {
                 return d.length
             case .customMutableReference(let d):
                 return d.length
+            @unknown default:
+                fatalError("Unknown Data backing type")
             }
         }
         @inlinable
@@ -447,6 +453,8 @@ internal final class _DataStorage {
             _backing = .customMutableReference(data)
         case .customMutableReference(let d):
             d.length = length
+        @unknown default:
+            fatalError("Unknown Data backing type")
         }
     }
     
@@ -478,6 +486,8 @@ internal final class _DataStorage {
             _backing = .customMutableReference(data)
         case .customMutableReference(let d):
             d.append(bytes, length: length)
+        @unknown default:
+            fatalError("Unknown Data backing type")
         }
         
     }
@@ -528,6 +538,8 @@ internal final class _DataStorage {
             _backing = .customReference(data)
         case .customMutableReference(let d):
             d.increaseLength(by: extraLength)
+        @unknown default:
+            fatalError("Unknown Data backing type")
         }
         
     }
@@ -614,6 +626,8 @@ internal final class _DataStorage {
             _backing = .customMutableReference(data)
         case .customMutableReference(let d):
             d.replaceBytes(in: NSRange(location: range.location - _offset, length: range.length), withBytes: bytes!)
+        @unknown default:
+            fatalError("Unknown Data backing type")
         }
     }
     
@@ -664,6 +678,8 @@ internal final class _DataStorage {
             _backing = .customMutableReference(data)
         case .customMutableReference(let d):
             d.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
+        @unknown default:
+            fatalError("Unknown Data backing type")
         }
     }
     
@@ -697,6 +713,8 @@ internal final class _DataStorage {
             _backing = .customMutableReference(data)
         case .customMutableReference(let d):
             d.resetBytes(in: range)
+        @unknown default:
+            fatalError("Unknown Data backing type")
         }
         
     }
@@ -887,6 +905,8 @@ internal final class _DataStorage {
             } else {
                 return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData, offset: range.lowerBound)
             }
+        @unknown default:
+            fatalError("Unknown Data backing type")
         }
     }
     

--- a/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
+++ b/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
@@ -15,19 +15,18 @@ extension String.UTF16View.Index {
   @available(swift, deprecated: 3.2)
   @available(swift, obsoleted: 4.0)
   public init(_ offset: Int) {
-    assert(offset >= 0, "Negative UTF16 index offset not allowed")
-    self.init(encodedOffset: offset)
+    fatalError()
   }
 
   @available(swift, deprecated: 3.2)
   @available(swift, obsoleted: 4.0)
   public func distance(to other: String.UTF16View.Index?) -> Int {
-    return _offset.distance(to: other!._offset)
+    fatalError()
   }
 
   @available(swift, deprecated: 3.2)
   @available(swift, obsoleted: 4.0)
   public func advanced(by n: Int) -> String.UTF16View.Index {
-    return String.UTF16View.Index(_offset.advanced(by: n))
+    fatalError()
   }
 }

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -1077,7 +1077,7 @@ open class JSONDecoder {
             guard !stringKey.isEmpty else { return stringKey }
         
             // Find the first non-underscore character
-            guard let firstNonUnderscore = stringKey.index(where: { $0 != "_" }) else {
+            guard let firstNonUnderscore = stringKey.firstIndex(where: { $0 != "_" }) else {
                 // Reached the end without finding an _
                 return stringKey
             }

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -428,16 +428,6 @@ public protocol _BridgedStoredNSError :
   init(_nsError error: NSError)
 }
 
-/// TODO: Better way to do this?
-internal func _stringDictToAnyHashableDict(_ input: [String : Any])
-    -> [AnyHashable : Any] {
-  var result = [AnyHashable : Any](minimumCapacity: input.count)
-  for (k, v) in input {
-    result[k] = v
-  }
-  return result
-}
-
 /// Various helper implementations for _BridgedStoredNSError
 extension _BridgedStoredNSError {
   public var code: Code {
@@ -449,7 +439,7 @@ extension _BridgedStoredNSError {
   public init(_ code: Code, userInfo: [String : Any] = [:]) {
     self.init(_nsError: NSError(domain: Self.errorDomain,
                                 code: unsafeBinaryIntegerToInt(code.rawValue),
-                                userInfo: _stringDictToAnyHashableDict(userInfo)))
+                                userInfo: userInfo))
   }
 
   /// The user-info dictionary for an error that was bridged from
@@ -483,8 +473,7 @@ public extension _BridgedStoredNSError {
   var errorUserInfo: [String : Any] {
     var result: [String : Any] = [:]
     for (key, value) in _nsError.userInfo {
-      guard let stringKey = key.base as? String else { continue }
-      result[stringKey] = value
+      result[key] = value
     }
     return result
   }
@@ -615,7 +604,7 @@ public extension CocoaError {
 
 extension CocoaError {
     public static func error(_ code: CocoaError.Code, userInfo: [AnyHashable : Any]? = nil, url: URL? = nil) -> Error {
-        var info: [AnyHashable : Any] = userInfo ?? [:]
+        var info: [String : Any] = userInfo as? [String : Any] ?? [:]
         if let url = url {
             info[NSURLErrorKey] = url
         }

--- a/stdlib/public/SDK/Foundation/NSObject.swift
+++ b/stdlib/public/SDK/Foundation/NSObject.swift
@@ -149,8 +149,8 @@ public class NSKeyValueObservation : NSObject {
         let bridgeClass: AnyClass = NSKeyValueObservation.self
         let observeSel = #selector(NSObject.observeValue(forKeyPath:of:change:context:))
         let swapSel = #selector(NSKeyValueObservation._swizzle_me_observeValue(forKeyPath:of:change:context:))
-        let rootObserveImpl = class_getInstanceMethod(bridgeClass, observeSel)
-        let swapObserveImpl = class_getInstanceMethod(bridgeClass, swapSel)
+        let rootObserveImpl = class_getInstanceMethod(bridgeClass, observeSel)!
+        let swapObserveImpl = class_getInstanceMethod(bridgeClass, swapSel)!
         method_exchangeImplementations(rootObserveImpl, swapObserveImpl)
         return nil
     }()

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -1217,12 +1217,12 @@ extension StringProtocol where Index == String.Index {
     let range = range.relative(to: self)
     _ns.enumerateLinguisticTags(
       in: _toRelativeNSRange(range),
-      scheme: tagScheme._ephemeralString,
+      scheme: NSLinguisticTagScheme(rawValue: tagScheme._ephemeralString),
       options: opts,
       orthography: orthography != nil ? orthography! : nil
     ) {
       var stop_ = false
-      body($0, self._range($1), self._range($2), &stop_)
+      body($0!.rawValue, self._range($1), self._range($2), &stop_)
       if stop_ {
         $3.pointee = true
       }
@@ -1463,7 +1463,7 @@ extension StringProtocol where Index == String.Index {
     let result = tokenRanges._withNilOrAddress(of: &nsTokenRanges) {
       self._ns.linguisticTags(
         in: _toRelativeNSRange(range.relative(to: self)),
-        scheme: tagScheme._ephemeralString,
+        scheme: NSLinguisticTagScheme(rawValue: tagScheme._ephemeralString),
         options: opts,
         orthography: orthography,
         tokenRanges: $0) as NSArray


### PR DESCRIPTION
<!-- What's in this pull request? -->
The Foundation overlay still builds in Swift 3 mode, which is going away. We should fix that!
