### PR TITLE
build: do not consult the legacy location for libraries

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3081,7 +3081,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 # If libdispatch is being built, TestFoundation will need access to it
                 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
-                    LIBDISPATCH_LIB_DIR=":$(build_directory ${host} libdispatch)/src/.libs"
+                    LIBDISPATCH_LIB_DIR=":$(build_directory ${host} libdispatch):$(build_directory ${host} libdispatch)/src"
                 else
                     LIBDISPATCH_LIB_DIR=""
                 fi


### PR DESCRIPTION
Update the commands to use the CMake based output directory locations instead of
the legacy staging location.  This will allow us to stop copying the files for
compatibility.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
