### PR TITLE
[ParseableInterface] Expose non-public types required for layout

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -455,7 +455,7 @@ struct PrintOptions {
   /// consistent and well-formed.
   ///
   /// \see swift::emitParseableInterface
-  static PrintOptions printParseableInterfaceFile();
+  static PrintOptions printParseableInterfaceFile(ModuleDecl *module);
 
   static PrintOptions printModuleInterface();
   static PrintOptions printTypeInterface(Type T);

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -50,6 +50,7 @@ add_swift_library(swiftAST STATIC
   RawComment.cpp
   RequirementEnvironment.cpp
   SyntaxASTMap.cpp
+  ShouldPrintForParseableInterface.cpp
   SILLayout.cpp
   Stmt.cpp
   SubstitutionMap.cpp

--- a/lib/AST/ShouldPrintForParseableInterface.cpp
+++ b/lib/AST/ShouldPrintForParseableInterface.cpp
@@ -1,0 +1,155 @@
+//=== ShouldPrintForParseableInterface.cpp - Parseable Interface filtering ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "ShouldPrintForParseableInterface.h"
+#include "swift/AST/ASTWalker.h"
+#include "swift/AST/TypeWalker.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/Type.h"
+
+using namespace swift;
+
+bool swift::isPublicOrUsableFromInline(const ValueDecl *VD) {
+  AccessScope scope =
+  VD->getFormalAccessScope(/*useDC*/nullptr,
+                           /*treatUsableFromInlineAsPublic*/true);
+  return scope.isPublic();
+}
+
+bool swift::contributesToParentTypeStorage(const AbstractStorageDecl *ASD) {
+  auto *DC = ASD->getDeclContext()->getAsDecl();
+  if (!DC) return false;
+  auto *ND = dyn_cast<NominalTypeDecl>(DC);
+  if (!ND) return false;
+  return !ND->isResilient() && ASD->hasStorage() && !ASD->isStatic();
+}
+
+/// Finds type decls that need to be printed to ensure the layout of public
+/// types are correct for non-resilient types.
+///
+/// For example:
+///
+/// ```
+/// private struct B {}
+/// public struct A {
+///   internal let b: B
+/// }
+/// ```
+/// Since `A`'s size depends on `B`, we need to print `B` even though it's
+/// private. `B`'s children will also be checked for types that contribute to
+/// its layout, and so on.
+class FindReferencedNonPublicTypeDecls: public ASTWalker {
+  using TypeDecls = SmallPtrSetImpl<TypeDecl *>;
+
+  /// Finds all nominal types or typealiases referenced in the type being
+  /// walked.
+  class FindTypeDecls: public TypeWalker {
+    TypeDecls &foundDecls;
+  public:
+    FindTypeDecls(TypeDecls &foundDecls): foundDecls(foundDecls) {}
+
+    void addIfNonPublic(TypeDecl *typeDecl) {
+      if (isPublicOrUsableFromInline(typeDecl))
+        return;
+      foundDecls.insert(typeDecl);
+    }
+
+    /// Finds all nominal types or typealiases referenced by the
+    Action walkToTypePre(Type type) override {
+      if (auto nominal =
+          dyn_cast<NominalOrBoundGenericNominalType>(type.getPointer()))
+        addIfNonPublic(nominal->getDecl());
+      if (auto alias = dyn_cast<NameAliasType>(type.getPointer())) {
+        // Add the typealias to the found decls
+        auto decl = alias->getDecl();
+        addIfNonPublic(decl);
+
+        // Also walk into the RHS of the typealias to find extra types we need.
+        decl->getUnderlyingTypeLoc().getType().walk(*this);
+      }
+      return Action::Continue;
+    }
+  };
+  FindTypeDecls findTypeDecls;
+public:
+  FindReferencedNonPublicTypeDecls(TypeDecls &foundDecls):
+    findTypeDecls(foundDecls) {}
+  bool walkToDeclPre(Decl *decl) {
+    auto asd = dyn_cast<AbstractStorageDecl>(decl);
+    if (!asd) return true;
+    if (contributesToParentTypeStorage(asd))
+      asd->getInterfaceType().walk(findTypeDecls);
+    return true;
+  }
+};
+
+std::shared_ptr<ShouldPrintForParseableInterface>
+ShouldPrintForParseableInterface::create(ModuleDecl *module) {
+  auto shouldPrint = std::make_shared<ShouldPrintForParseableInterface>();
+
+  // Walk the module to find stored properties whose type is non-public but
+  // required to reconstruct the layout of their containing type.
+  // We need to keep track of these type declarations, so we make sure to
+  // print them.
+  auto findTypeDecls = FindReferencedNonPublicTypeDecls(
+    shouldPrint->referencedNonPublicTypeDecls);
+  module->walk(findTypeDecls);
+  return shouldPrint;
+}
+
+bool ShouldPrintForParseableInterface::shouldPrint(
+  const Decl *D, const PrintOptions &options) {
+  // Skip anything that isn't 'public' or '@usableFromInline'.
+  if (auto *VD = dyn_cast<ValueDecl>(D)) {
+    if (!isPublicOrUsableFromInline(VD)) {
+      // We do want to print private stored properties, without their
+      // original names present.
+      if (auto *ASD = dyn_cast<AbstractStorageDecl>(VD))
+        if (contributesToParentTypeStorage(ASD))
+          return true;
+
+      // If this is a type that contributes to the layout of any
+      // types in this module, then we should print it.
+      if (auto typeDecl = dyn_cast<TypeDecl>(VD))
+        return referencedNonPublicTypeDecls.count(typeDecl) != 0;
+      return false;
+    }
+  }
+
+  // Skip extensions that extend things we wouldn't print.
+  if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
+    if (!shouldPrint(ED->getExtendedNominal(), options))
+      return false;
+    // FIXME: We also need to check the generic signature for constraints
+    // that we can't reference.
+  }
+
+  // Skip typealiases that just redeclare generic parameters.
+  if (auto *alias = dyn_cast<TypeAliasDecl>(D)) {
+    if (alias->isImplicit()) {
+      const Decl *parent =
+      D->getDeclContext()->getAsDecl();
+      if (auto *genericCtx = parent->getAsGenericContext()) {
+        bool matchesGenericParam =
+        llvm::any_of(genericCtx->getInnermostGenericParamTypes(),
+                     [alias](const GenericTypeParamType *param) {
+                       return param->getName() == alias->getName();
+                     });
+        if (matchesGenericParam)
+          return false;
+      }
+    }
+  }
+
+  return ShouldPrintChecker::shouldPrint(D, options);
+}

--- a/lib/AST/ShouldPrintForParseableInterface.h
+++ b/lib/AST/ShouldPrintForParseableInterface.h
@@ -1,0 +1,46 @@
+//===- ShouldPrintForParseableInterface.h - Parseable Interface filtering -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_SHOULDPRINTFORPARSEABLEINTERFACE_H
+#define SWIFT_AST_SHOULDPRINTFORPARSEABLEINTERFACE_H
+
+#include "swift/AST/PrintOptions.h"
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+namespace swift {
+
+class AbstractStorageDecl;
+class Decl;
+class TypeDecl;
+class ValueDecl;
+
+class ShouldPrintForParseableInterface : public ShouldPrintChecker {
+  SmallPtrSet<TypeDecl *, 8> referencedNonPublicTypeDecls;
+public:
+  static std::shared_ptr<ShouldPrintForParseableInterface>
+  create(ModuleDecl *module);
+
+  bool shouldPrint(const Decl *D, const PrintOptions &options) override;
+};
+
+/// Determines if a declaration is public or has the @usableFromInline
+/// attribute.
+bool isPublicOrUsableFromInline(const ValueDecl *VD);
+
+/// Determines if this storage decl resides as a stored instance member
+/// of a non-resilient nominal type.
+bool contributesToParentTypeStorage(const AbstractStorageDecl *ASD);
+
+} // end namespace swift
+
+#endif // !defined(SWIFT_AST_SHOULDPRINTFORPARSEABLEINTERFACE_H)

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -408,7 +408,8 @@ bool swift::emitParseableInterface(raw_ostream &out,
   printToolVersionAndFlagsComment(out, Opts, M);
   printImports(out, M);
 
-  const PrintOptions printOptions = PrintOptions::printParseableInterfaceFile();
+  const PrintOptions printOptions =
+    PrintOptions::printParseableInterfaceFile(M);
   SmallVector<Decl *, 16> topLevelDecls;
   M->getTopLevelDecls(topLevelDecls);
   for (const Decl *D : topLevelDecls) {

--- a/test/ParseableInterface/non-public-required-types.swift
+++ b/test/ParseableInterface/non-public-required-types.swift
@@ -115,34 +115,34 @@ public class Foo {
 // COMMON: }
 }
 
-// COMMON: private protocol InheritedProtocol {
-// COMMON-NEXT: }
+// NONRESILIENT: private protocol InheritedProtocol {
+// NONRESILIENT-NEXT: }
 private protocol InheritedProtocol {
 }
 
-// COMMON: private protocol UsableAsExistential : InheritedProtocol {
-// COMMON-NEXT: }
+// NONRESILIENT: private protocol UsableAsExistential : InheritedProtocol {
+// NONRESILIENT-NEXT: }
 private protocol UsableAsExistential: InheritedProtocol {
 }
 
-// COMMON: @objc private protocol ObjCUsableAsExistential {
-// COMMON-NEXT: }
+// NONRESILIENT: @objc private protocol ObjCUsableAsExistential {
+// NONRESILIENT-NEXT: }
 @objc private protocol ObjCUsableAsExistential {
 }
 
-// COMMON: private protocol ClassUsableAsExistential : AnyObject {
-// COMMON-NEXT: }
+// NONRESILIENT: private protocol ClassUsableAsExistential : AnyObject {
+// NONRESILIENT-NEXT: }
 private protocol ClassUsableAsExistential: class {
   func foo()
 }
 
-// COMMON: internal protocol CompositionA {
-// COMMON-NEXT: }
+// NONRESILIENT: internal protocol CompositionA {
+// NONRESILIENT-NEXT: }
 internal protocol CompositionA {
 }
 
-// COMMON: internal protocol CompositionB {
-// COMMON-NEXT: }
+// NONRESILIENT: internal protocol CompositionB {
+// NONRESILIENT-NEXT: }
 internal protocol CompositionB {
 }
 
@@ -151,20 +151,18 @@ internal protocol CompositionB {
 internal protocol NeverReferenced {
 }
 
-// COMMON: @objc @_fixed_layout public class ContainsExistentials {
-@objc
-@_fixed_layout
-public class ContainsExistentials {
-// COMMON-NEXT: private var _: UsableAsExistential
+// COMMON: @objc public class ContainsExistentials {
+@objc public class ContainsExistentials {
+// NONRESILIENT: private var _: UsableAsExistential
   private var existential: UsableAsExistential
 
-// COMMON-NEXT: private var _: ObjCUsableAsExistential
+// NONRESILIENT-NEXT: private var _: ObjCUsableAsExistential
   private var objcExistential: ObjCUsableAsExistential
 
-// COMMON-NEXT: private var _: ClassUsableAsExistential
+// NONRESILIENT-NEXT: private var _: ClassUsableAsExistential
   private var classExistential: ClassUsableAsExistential
 
-// COMMON-NEXT: private var _: CompositionA & CompositionB
+// NONRESILIENT-NEXT: private var _: CompositionA & CompositionB
   private var composition: CompositionA & CompositionB
 
 // COMMON-NOT: private init
@@ -202,5 +200,31 @@ internal struct SatisfiesConstraint: GenericConstraint {
 public struct HasGenericClassMember {
   // NONRESILIENT: internal let _: {{.*}}HasConstraint<{{.*}}SatisfiesConstraint>
   internal let member: HasConstraint<SatisfiesConstraint>
+// COMMON: }
+}
+
+// NONRESILIENT: internal protocol ExtensionConformance {
+internal protocol ExtensionConformance {
+  // NONRESILIENT-NOT: associatedtype MyType
+  associatedtype MyType
+// NONRESILIENT: }
+}
+
+// NONRESILIENT internal class GetsConformanceThroughExtension {
+// NONRESILIENT: }
+internal class GetsConformanceThroughExtension {
+}
+
+// NONRESILIENT: extension GetsConformanceThroughExtension : ExtensionConformance {
+extension GetsConformanceThroughExtension: ExtensionConformance {
+  // COMMON-NOT: typealias MyType = {{.*}}Int
+  typealias MyType = Int
+// NONRESILIENT: }
+}
+
+// COMMON: public struct HasClassMemberWithExtensionConformance {
+public struct HasClassMemberWithExtensionConformance {
+  // NONRESILIENT: internal let _: {{.*}}GetsConformanceThroughExtension
+  let member: GetsConformanceThroughExtension
 // COMMON: }
 }

--- a/test/ParseableInterface/non-public-required-types.swift
+++ b/test/ParseableInterface/non-public-required-types.swift
@@ -1,0 +1,91 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t-resilient.swiftinterface -enable-resilience %s
+// RUN: %FileCheck %s < %t-resilient.swiftinterface
+
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-parseable-module-interface-path - | %FileCheck %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-resilience %t.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-resilience -emit-parseable-module-interface-path - | %FileCheck %s
+
+
+// CHECK: internal struct GenericStruct<T> {
+internal struct GenericStruct<T> {
+  // CHECK-NEXT: internal let _: T
+  internal let x: T
+
+  // CHECK-NOT: internal func shouldNotAppear()
+  internal func shouldNotAppear() {}
+
+// CHECK: }
+}
+
+private struct OnlyReferencedFromPrivateType {}
+
+// CHECK: @_fixed_layout public class Foo {
+@_fixed_layout
+public class Foo {
+  // CHECK-NEXT: internal typealias MyCustomInt = {{.*}}Int
+  internal typealias MyCustomInt = Int
+  // CHECK-NEXT: internal typealias MyCustomBool = {{.*}}Bool
+  internal typealias MyCustomBool = Bool
+  // CHECK-NEXT: internal typealias MyCustomTuple = ({{.*}}MyCustomInt, {{.*}}MyCustomBool)
+  internal typealias MyCustomTuple = (MyCustomInt, MyCustomBool)
+  // CHECK-NEXT: internal typealias MyCustomString = {{.*}}String
+  internal typealias MyCustomString = String
+  // CHECK-NOT: internal typealias NotReferenced = {{.*}}String
+  internal typealias NotReferenced = String
+
+  // CHECK: private class Bar {
+  private class Bar {
+    // CHECK-NEXT: private let _: {{.*}}MyCustomInt
+    private let x: MyCustomInt
+
+    // CHECK-NEXT: private let _: [{{.*}}MyCustomTuple]
+    private let y: [MyCustomTuple]
+
+    // CHECK-NEXT: private let _: {{.*}}OnlyReferencedFromPrivateType
+    private let z: OnlyReferencedFromPrivateType
+
+    // CHECK-NOT: internal func shouldNotAppear(_ type: {{.*}}NotReferenced)
+    internal func shouldNotAppear(_ type: NotReferenced) {}
+
+    // CHECK-NOT: init
+    init() {
+      self.x = 0
+      self.y = []
+      self.z = OnlyReferencedFromPrivateType()
+    }
+
+  // CHECK: }
+  }
+
+  // CHECK-NEXT: private let _: {{.*}}Bar
+  private let privateLet: Bar
+
+  // CHECK-NEXT: internal var _: ({{.*}}MyCustomInt, {{.*}}MyCustomInt)
+  internal var internalVar: (MyCustomInt, MyCustomInt)
+
+  // CHECK-NEXT: private var _: {{.*}}GenericStruct<{{.*}}MyCustomString>
+  private var privateVar: GenericStruct<MyCustomString>
+
+  // CHECK-NEXT: private var privateVarHasInitialValue: {{.*}}MyCustomInt = 0
+  private var privateVarHasInitialValue: MyCustomInt = 0
+
+  // CHECK-NEXT: public var publicVar: {{.*}}Int
+  public var publicVar: Int
+
+  // CHECK-NOT: {{^}}  init
+  init() {
+    self.privateLet = Bar()
+    self.internalVar = (0, 0)
+    self.publicVar = 0
+    self.privateVar = GenericStruct<MyCustomString>(x: "Hello")
+  }
+
+// CHECK: }
+}


### PR DESCRIPTION
This patch does a pass over the module looking for stored properties
that contribute to the parent's storage but that use
non-public-or-usableFromInline types. It marks these types for printing,
while also hiding their non-required members.

For example, in a non-resilient module, a user may write this type:

```swift
internal class FileHandle {
  internal var fd: Int32
  init(fileDescriptor: Int32) { self.fd = fileDescriptor }
  deinit { close(fd) }
}

public struct File {
  internal var handle: FileHandle
}
```

Since `handle` contributes to the storage of the `File` type, we need to print it inside the declaration of `File`. Right now, we print the property as:

```swift
  internal var _: FileHandle
```
which signifies that the value was meant to be internal and not accessible from client code. But this caused an issue, because `FileHandle` is itself `internal`, and thus wouldn't be printed. Now, we find decls like FileHandle and elect to print their layout-required members as well. This example would be printed as:

```swift
internal class FileHandle {
  internal var _: Int32
}
public struct File {
  internal var _: FileHandle
}
```

Now, we could take this a step further and hide all the members of `FileHandle`, as we know it'll always be heap-allocated and pointer-sized, but that's not part of this patch.

It also splits off `ShouldPrintForParseableInterface` into its own file,
because it's grown significantly since it was first introduced in
`ASTPrinter`.