### PR TITLE
allow @differentiable on protocol requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2694,9 +2694,9 @@ ERROR(differentiable_attr_no_parameters,none,
 ERROR(differentiable_attr_void_result,none,
       "cannot differentiate void function %0", (DeclName))
 ERROR(differentiable_attr_primal_no_definition,none,
-      "cannot specify primal on function declaration without definition", ())
+      "cannot specify primal on protocol requirement", ())
 ERROR(differentiable_attr_adjoint_no_definition,none,
-      "cannot specify adjoint on function declaration without definition", ())
+      "cannot specify adjoint on protocol requirement", ())
 ERROR(differentiable_attr_has_primal_but_not_adjoint,none,
       "a corresponding adjoint must be specified when the primal is provided; "
       "if you want this function to be automatically differentiated, do not "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2693,6 +2693,10 @@ ERROR(differentiable_attr_no_parameters,none,
       "%0 has no parameters to differentiate with respect to", (DeclName))
 ERROR(differentiable_attr_void_result,none,
       "cannot differentiate void function %0", (DeclName))
+ERROR(differentiable_attr_primal_no_definition,none,
+      "cannot specify primal on function declaration without definition", ())
+ERROR(differentiable_attr_adjoint_no_definition,none,
+      "cannot specify adjoint on function declaration without definition", ())
 ERROR(differentiable_attr_has_primal_but_not_adjoint,none,
       "a corresponding adjoint must be specified when the primal is provided; "
       "if you want this function to be automatically differentiated, do not "

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -809,8 +809,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
         AFD->getAttrs().getAttribute(DeclAttrKind::DAK_Differentiable))) {
     switch (diffAttr->getMode()) {
     case AutoDiffMode::Forward:
-      // TODO: Handle forward mode once [forward_differentiable] is
-      // implemented.
+      // TODO: Handle forward mode once [forward_differentiable] is implemented.
       llvm_unreachable("Unimplemented");
       break;
     case AutoDiffMode::Reverse: {
@@ -822,12 +821,11 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
       if (auto *primFn = diffAttr->getPrimalFunction())
         primName = getFunction(SILDeclRef(primFn), ForDefinition)->getName();
       if (auto *adjointFn = diffAttr->getAdjointFunction()) {
-        // If the adjoint is specified but the primal is not, then we treat
-        // the original as the primal.
+        // If the adjoint is specified but the primal is not, then we treat the
+        // original as the primal.
         if (primName.empty())
           primName = silOriginalFn->getName();
-        adjName =
-            getFunction(SILDeclRef(adjointFn), ForDefinition)->getName();
+        adjName = getFunction(SILDeclRef(adjointFn), ForDefinition)->getName();
         hasPrimitiveAdjoint = true;
       }
       else {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -794,49 +794,54 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  // If the declaration has a @differentiable(reverse) attribute, turn it into a
-  // SIL [reverse_differentiable] attribute with lowered primal and adjoint
-  // function names and lowered differentiation parameter indices.
+  // If the declaration has a definition and a @differentiable(reverse)
+  // attribute, turn it into a SIL [reverse_differentiable] attribute with
+  // lowered primal and adjoint function names and lowered differentiation
+  // parameter indices.
   //
   // FIXME: Handle multiple @differentiable attributes.
-  if (auto *diffAttr = cast_or_null<DifferentiableAttr>(
-        AFD->getAttrs().getAttribute(DeclAttrKind::DAK_Differentiable))) {
-    switch (diffAttr->getMode()) {
-    case AutoDiffMode::Forward:
-      // TODO: Handle forward mode once [forward_differentiable] is implemented.
-      llvm_unreachable("Unimplemented");
-      break;
-    case AutoDiffMode::Reverse: {
-      auto silOriginalFn = getFunction(SILDeclRef(AFD), ForDefinition);
-      // Either only adjoint is specified, or both primal and adjoint are
-      // spcified.
-      StringRef primName, adjName;
-      bool hasPrimitiveAdjoint = false;
-      if (auto *primFn = diffAttr->getPrimalFunction())
-        primName = getFunction(SILDeclRef(primFn), ForDefinition)->getName();
-      if (auto *adjointFn = diffAttr->getAdjointFunction()) {
-        // If the adjoint is specified but the primal is not, then we treat the
-        // original as the primal.
-        if (primName.empty())
-          primName = silOriginalFn->getName();
-        adjName = getFunction(SILDeclRef(adjointFn), ForDefinition)->getName();
-        hasPrimitiveAdjoint = true;
+  if (AFD->hasBody()) {
+    if (auto *diffAttr = cast_or_null<DifferentiableAttr>(
+          AFD->getAttrs().getAttribute(DeclAttrKind::DAK_Differentiable))) {
+      switch (diffAttr->getMode()) {
+      case AutoDiffMode::Forward:
+        // TODO: Handle forward mode once [forward_differentiable] is
+        // implemented.
+        llvm_unreachable("Unimplemented");
+        break;
+      case AutoDiffMode::Reverse: {
+        auto silOriginalFn = getFunction(SILDeclRef(AFD), ForDefinition);
+        // Either only adjoint is specified, or both primal and adjoint are
+        // spcified.
+        StringRef primName, adjName;
+        bool hasPrimitiveAdjoint = false;
+        if (auto *primFn = diffAttr->getPrimalFunction())
+          primName = getFunction(SILDeclRef(primFn), ForDefinition)->getName();
+        if (auto *adjointFn = diffAttr->getAdjointFunction()) {
+          // If the adjoint is specified but the primal is not, then we treat
+          // the original as the primal.
+          if (primName.empty())
+            primName = silOriginalFn->getName();
+          adjName =
+              getFunction(SILDeclRef(adjointFn), ForDefinition)->getName();
+          hasPrimitiveAdjoint = true;
+        }
+        else {
+          assert(primName.empty() &&
+                 "Primal cannot be present if adjoint is not");
+        }
+        // Get lowered argument indices.
+        auto paramIndices =
+            getLoweredAutoDiffParameterIndices(*this, AFD, silOriginalFn,
+                                               diffAttr);
+        SILReverseAutoDiffIndices indices(/*source*/ 0, paramIndices);
+        silOriginalFn->addReverseDifferentiableAttr(
+            SILReverseDifferentiableAttr::create(
+              M, indices, primName, adjName,
+              /*primitive*/ hasPrimitiveAdjoint));
+        break;
       }
-      else {
-        assert(primName.empty() &&
-               "Primal cannot be present if adjoint is not");
       }
-      // Get lowered argument indices.
-      auto paramIndices =
-          getLoweredAutoDiffParameterIndices(*this, AFD, silOriginalFn,
-                                             diffAttr);
-      SILReverseAutoDiffIndices indices(/*source*/ 0, paramIndices);
-      silOriginalFn->addReverseDifferentiableAttr(
-          SILReverseDifferentiableAttr::create(
-            M, indices, primName, adjName,
-            /*primitive*/ hasPrimitiveAdjoint));
-      break;
-    }
     }
   }
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2205,6 +2205,24 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   
   // Start type-checking the arguments of the @differentiable attribute. This
   // covers 'wrt:', 'primal:' and 'adjoint:', all of which are optional.
+
+  // If the declaration has no definition (e.g. it is a protocol requirement),
+  // then you are not allowed to specify a primal or adjoint.
+  if (!original->hasBody()) {
+    if (attr->getPrimal()) {
+      TC.diagnose(attr->getPrimal()->Loc,
+                  diag::differentiable_attr_primal_no_definition);
+      attr->setInvalid();
+      return;
+    }
+    if (attr->getAdjoint()) {
+      TC.diagnose(attr->getAdjoint()->Loc,
+                  diag::differentiable_attr_adjoint_no_definition);
+      attr->setInvalid();
+      return;
+    }
+  }
+
   // If primal exists but adjoint does not, this is an error.
   if (attr->getPrimal() && !attr->getAdjoint()) {
     TC.diagnose(attr->getPrimal()->Loc,

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -464,11 +464,11 @@ protocol ProtoWithDiffReqs {
   @differentiable(reverse, wrt: (.1))
   func req5(x: Float) -> Float
 
-  // expected-error @+1 {{cannot specify primal on function declaration without definition}}
+  // expected-error @+1 {{cannot specify primal on protocol requirement}}
   @differentiable(reverse, primal: dummyPrimal)
   func req6(x: Float) -> Float
 
-  // expected-error @+1 {{cannot specify adjoint on function declaration without definition}}
+  // expected-error @+1 {{cannot specify adjoint on protocol requirement}}
   @differentiable(reverse, adjoint: dummyAdjoint)
   func req7(x: Float) -> Float
 }

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -437,3 +437,38 @@ class ClassWithDifferentiableMethods {
     return ClassWithDifferentiableMethods()
   }
 }
+
+// @differentiable attribute on protocol requirements
+
+func dummyPrimal() {}
+func dummyAdjoint() {}
+
+protocol ProtoWithDiffReqs {
+  // OK
+  @differentiable(reverse)
+  func req1(x: Float) -> Float
+
+  // OK
+  @differentiable(reverse, wrt: (self))
+  func req2(x: Float) -> Float
+
+  // OK
+  @differentiable(reverse, wrt: (.0))
+  func req3(x: Float) -> Float
+
+  // OK
+  @differentiable(reverse)
+  static func req4(x: Float) -> Float
+
+  // expected-error @+1 {{parameter index out of bounds}}
+  @differentiable(reverse, wrt: (.1))
+  func req5(x: Float) -> Float
+
+  // expected-error @+1 {{cannot specify primal on function declaration without definition}}
+  @differentiable(reverse, primal: dummyPrimal)
+  func req6(x: Float) -> Float
+
+  // expected-error @+1 {{cannot specify adjoint on function declaration without definition}}
+  @differentiable(reverse, adjoint: dummyAdjoint)
+  func req7(x: Float) -> Float
+}


### PR DESCRIPTION
The parser already allows `@differentiable` on protocol requirements, but then it crashes in SILGen when it tries to find the original function. This PR fixes that crash.

This PR also forbids custom primals and adjoints on protocol requirements so that we don't have to deal with them for now.