### PR TITLE
Fix SILCombiner::propagateConcreteTypeOfInitExistential.

### DIFF
--- a/test/SILOptimizer/sil_combine_concrete_existential.sil
+++ b/test/SILOptimizer/sil_combine_concrete_existential.sil
@@ -370,3 +370,42 @@ bb0:
   %v = tuple ()
   return %v : $()
 }
+
+//===----------------------------------------------------------------------===//
+// testWitnessCopiedSelfWithIndirectResult: Call to a witness method
+// with an existential self that can be type-propagated. Exercise
+// `SILCombiner::canReplaceArg` when `self` is not in argument position zero.
+//
+// rdar://45415719 Assertion failed: (Index < Length && "Invalid index!")
+// ===----------------------------------------------------------------------===//
+
+protocol AnyP {
+  func returnsSelf() -> Self
+}
+
+struct StructOfAnyP : AnyP {
+  func returnsSelf() -> StructOfAnyP
+}
+
+// CHECK-LABEL: sil @testWitnessCopiedSelfWithIndirectResult : $@convention(thin) () -> () {
+// CHECK: [[IN:%[0-9]+]] = alloc_stack $StructOfAnyP
+// CHECK: [[OUT:%[0-9]+]] = alloc_stack $StructOfAnyP
+// CHECK: witness_method $StructOfAnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> @dynamic_self Self : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
+// CHECK: apply %{{.*}}<StructOfAnyP>([[OUT]], [[IN]]) : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
+// CHECK-LABEL: } // end sil function 'testWitnessCopiedSelfWithIndirectResult'
+sil @testWitnessCopiedSelfWithIndirectResult : $() -> () {
+bb0:
+  %a0 = alloc_stack $AnyP
+  %ie0 = init_existential_addr %a0 : $*AnyP, $StructOfAnyP
+  %a1 = alloc_stack $AnyP
+  copy_addr %a0 to [initialization] %a1 : $*AnyP
+  %o0 = open_existential_addr immutable_access %a1 : $*AnyP to $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP
+  %a2 = alloc_stack $StructOfAnyP
+  %w0 = witness_method $@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> @dynamic_self Self, %o0 : $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
+  %c0 = apply %w0<@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP>(%a2, %o0) : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
+  dealloc_stack %a2 : $*StructOfAnyP
+  dealloc_stack %a1 : $*AnyP
+  dealloc_stack %a0 : $*AnyP
+  %v = tuple ()
+  return %v : $()
+}


### PR DESCRIPTION
A SIL argument index was being passed as an AST function type
parameter index. Don't do this.

I also cleaned up the peephole to avoid processing indirect results as
parameter indices, but that part is NFC.

Fixes rdar://45415719 Assertion failed: (Index < Length && "Invalid index!")
