### PR TITLE
[IRGen] Use symbolic references to (file)private entities in mangled names

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -101,7 +101,10 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
       // TODO: We ought to be able to use indirect symbolic references even
       // when the referent may be in another file, once the on-disk
       // ObjectMemoryReader can handle them.
-      if (!IGM.CurSourceFile || IGM.CurSourceFile != type->getParentSourceFile())
+      // Private entities are known to be accessible.
+      if (type->getEffectiveAccess() >= AccessLevel::Internal &&
+          (!IGM.CurSourceFile ||
+           IGM.CurSourceFile != type->getParentSourceFile()))
         return false;
       
       // @objc protocols don't have descriptors.
@@ -114,6 +117,7 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
       llvm_unreachable("symbolic referent not handled");
     }
   };
+
   SymbolicReferences.clear();
   
   body();

--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-stdlib %s -module-name main -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+
+import Swift
+import StdlibUnittest
+
+protocol P {
+  associatedtype A
+}
+
+fileprivate struct Foo {
+  fileprivate struct Inner: P {
+    fileprivate struct Innermost { }
+    typealias A = Innermost
+  }
+}
+
+func getP_A<T: P>(_: T.Type) -> Any.Type {
+  return T.A.self
+}
+
+let AssociatedTypeDemangleTests = TestSuite("AssociatedTypeDemangle")
+
+
+AssociatedTypeDemangleTests.test("private types") {
+  expectEqual(Foo.Inner.Innermost.self, getP_A(Foo.Inner.self))
+}
+
+runAllTests()


### PR DESCRIPTION
(file)private entities are always available in the current file, so use
symbolic references to refer to them within mangled names (always). This
also eliminates problems stemming from our inability to demangle names
referring to private entities, because we (intentionally) don't allow
lookup for them.

Should fix rdar://problem/44977236.
