### PR TITLE
[CodeCompletion] Don't try to resolve generic env for extension in inactive block

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4970,6 +4970,13 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
   if (!isa<SourceFile>(dc))
     return;
 
+  // If this is not bound to any decls at this point, this extension is in
+  // inactive coditional compilation block. It's not safe to typecheck this
+  // extension. This happens if code completion is triggered in inactive
+  // conditional complation block.
+  if (!ext->alreadyBoundToNominal())
+    return;
+
   // Validate the nominal type declaration being extended.
   validateDecl(nominal);
 

--- a/validation-test/IDE/crashers_2_fixed/sr9001.swift
+++ b/validation-test/IDE/crashers_2_fixed/sr9001.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE_1 -source-filename=%s
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE_2 -source-filename=%s
+
+struct MyStruct<T> {
+}
+
+protocol MyProto {
+  associatedtype Assoc
+  func foo(x: Assoc) -> Assoc
+}
+
+#if false
+extension MyStruct {
+  #^COMPLETE_1^#
+}
+
+extension MyStruct: MyProto {
+  #^COMPLETE_2^#
+}
+#endif


### PR DESCRIPTION
Fixes code-completion crash in `validateExtension()`.

When code completion happens, it tries to validate decl contexts. If it's in an extension in inactive conditional block, the extension haven't been bound to the nominal type. That used to cause crash because its `GenericParams` hasn't been set.

rdar://problem/45275782
https://bugs.swift.org/browse/SR-9001