### PR TITLE
[ConstraintSystem] Allow getPotentialBindings to find supertypes of o…

### DIFF
--- a/test/Constraints/rdar45490737.swift
+++ b/test/Constraints/rdar45490737.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol X {}
+class B : Equatable {
+  static func == (lhs: B, rhs: B) -> Bool { fatalError() }
+}
+class C : B {}
+extension C : X {}
+
+func f<T: Equatable>(_ lhs: T, _ rhs: T) {}
+
+extension Optional where Wrapped : Equatable {
+  static func f(_ lhs: Wrapped?, _ rhs: Wrapped?) {}
+}
+
+// Ensure that we can call both a function that has generic parameters
+// as well as one that has the generic parameters wrapped in
+// Optionals.
+func test(x: (X & B)?, y: C?) {
+  f(x, y)
+  Optional.f(x, y)
+}


### PR DESCRIPTION
…ptionals.

Improve enumerateDirectSupertypes so that for T? it will return U? if
U is a supertype of T. This is another form of direct supertype.

This is making up for a deficiency in the completeness of our Type
join implementation, which should be able to directly compute a join
of disparate types that share some common supertype, but sometimes
fails to in cases involving protocol compositions.

Fixes rdar://problem/45490737

(cherry picked from commit 85237aa0717d9ffc709326a4f7de41e8f717cf34)
