### PR TITLE
[Index][CodeCompletion] Fix #keyPath indexing when a type is referenced

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4944,6 +4944,7 @@ public:
       OptionalWrap,
       Identity,
       TupleElement,
+      Type,
     };
   
   private:
@@ -5052,7 +5053,17 @@ public:
                        propertyType,
                        loc);
     }
-    
+
+    /// Create a component for a type.
+    static Component forType(ConcreteDeclRef typeRef,
+                             Type type,
+                             SourceLoc loc) {
+      return Component(nullptr, typeRef, nullptr, {}, {},
+                       Kind::Type,
+                       type,
+                       loc);
+    }
+
     /// Create a component for a subscript.
     static Component forSubscript(ASTContext &ctx,
                               ConcreteDeclRef subscript,
@@ -5135,6 +5146,7 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
+      case Kind::Type:
         return true;
 
       case Kind::UnresolvedSubscript:
@@ -5159,6 +5171,7 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
+      case Kind::Type:
         return nullptr;
       }
       llvm_unreachable("unhandled kind");
@@ -5178,6 +5191,7 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
+      case Kind::Type:
         llvm_unreachable("no subscript labels for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5200,6 +5214,7 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
+      case Kind::Type:
         return {};
       }
       llvm_unreachable("unhandled kind");
@@ -5222,6 +5237,7 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
+      case Kind::Type:
         llvm_unreachable("no unresolved name for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5231,6 +5247,7 @@ public:
       switch (getKind()) {
       case Kind::Property:
       case Kind::Subscript:
+      case Kind::Type:
         return Decl.ResolvedDecl;
 
       case Kind::Invalid:
@@ -5260,6 +5277,7 @@ public:
         case Kind::Identity:
         case Kind::Property:
         case Kind::Subscript:
+        case Kind::Type:
           llvm_unreachable("no field number for this kind");
       }
       llvm_unreachable("unhandled kind");

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2734,6 +2734,7 @@ public:
         PrintWithColorRAII(OS, ASTNodeColor) << "unresolved_subscript";
         printArgumentLabels(component.getSubscriptLabels());
         break;
+
       case KeyPathExpr::Component::Kind::Identity:
         PrintWithColorRAII(OS, ASTNodeColor) << "identity";
         break;
@@ -2742,6 +2743,10 @@ public:
         PrintWithColorRAII(OS, ASTNodeColor) << "tuple_element ";
         PrintWithColorRAII(OS, DiscriminatorColor)
           << "#" << component.getTupleIndex();
+        break;
+
+      case KeyPathExpr::Component::Kind::Type:
+        OS << "type_ref ";
         break;
       }
       PrintWithColorRAII(OS, TypeColor)

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1071,6 +1071,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       case KeyPathExpr::Component::Kind::Invalid:
       case KeyPathExpr::Component::Kind::Identity:
       case KeyPathExpr::Component::Kind::TupleElement:
+      case KeyPathExpr::Component::Kind::Type:
         // No subexpr to visit.
         break;
       }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2141,6 +2141,7 @@ void KeyPathExpr::Component::setSubscriptIndexHashableConformances(
   case Kind::Property:
   case Kind::Identity:
   case Kind::TupleElement:
+  case Kind::Type:
     llvm_unreachable("no hashable conformances for this kind");
   }
 }

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -350,7 +350,8 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
     for (auto &component : KPE->getComponents()) {
       switch (component.getKind()) {
       case KeyPathExpr::Component::Kind::Property:
-      case KeyPathExpr::Component::Kind::Subscript: {
+      case KeyPathExpr::Component::Kind::Subscript:
+      case KeyPathExpr::Component::Kind::Type: {
         auto *decl = component.getDeclRef().getDecl();
         auto loc = component.getLoc();
         SourceRange range(loc, loc);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3564,7 +3564,8 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
   for (auto &component : E->getComponents()) {
     switch (auto kind = component.getKind()) {
     case KeyPathExpr::Component::Kind::Property:
-    case KeyPathExpr::Component::Kind::Subscript: {
+    case KeyPathExpr::Component::Kind::Subscript:
+    case KeyPathExpr::Component::Kind::Type: {
       auto decl = cast<AbstractStorageDecl>(component.getDeclRef().getDecl());
 
       unsigned numOperands = operands.size();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -246,7 +246,8 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
     }
     case KeyPathExpr::Component::Kind::TupleElement:
     case KeyPathExpr::Component::Kind::Subscript:
-      // Subscripts and tuples aren't generally represented in KVC.
+    case KeyPathExpr::Component::Kind::Type:
+      // Subscripts, tuples and types aren't generally represented in KVC.
       // TODO: There are some subscript forms we could map to KVC, such as
       // when indexing a Dictionary or NSDictionary by string, or when applying
       // a mapping subscript operation to Array/Set or NSArray/NSSet.
@@ -4265,6 +4266,7 @@ namespace {
         case KeyPathExpr::Component::Kind::Subscript:
         case KeyPathExpr::Component::Kind::OptionalWrap:
         case KeyPathExpr::Component::Kind::TupleElement:
+        case KeyPathExpr::Component::Kind::Type:
           llvm_unreachable("already resolved");
         }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3049,7 +3049,8 @@ namespace {
         case KeyPathExpr::Component::Kind::UnresolvedProperty:
         // This should only appear in resolved ASTs, but we may need to
         // re-type-check the constraints during failure diagnosis.
-        case KeyPathExpr::Component::Kind::Property: {
+        case KeyPathExpr::Component::Kind::Property:
+        case KeyPathExpr::Component::Kind::Type: {
           auto memberTy = CS.createTypeVariable(resultLocator,
                                                 TVO_CanBindToLValue |
                                                 TVO_CanBindToNoEscape);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6949,6 +6949,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
       
     case KeyPathExpr::Component::Kind::Property:
     case KeyPathExpr::Component::Kind::Subscript:
+    case KeyPathExpr::Component::Kind::Type:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript: {
       auto *componentLoc = getConstraintLocator(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -466,7 +466,8 @@ ConstraintSystem::getCalleeLocator(ConstraintLocator *locator,
           anchor, {*componentElt, ConstraintLocator::SubscriptMember});
     case ComponentKind::UnresolvedProperty:
     case ComponentKind::Property:
-      // For a property, the choice is just given by the component.
+    case ComponentKind::Type:
+      // For properties and types, the choice is just given by the component.
       return getConstraintLocator(anchor, *componentElt);
     case ComponentKind::TupleElement:
       llvm_unreachable("Not implemented by CSGen");

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2472,7 +2472,8 @@ private:
     for (auto &component : KP->getComponents()) {
       switch (component.getKind()) {
       case KeyPathExpr::Component::Kind::Property:
-      case KeyPathExpr::Component::Kind::Subscript: {
+      case KeyPathExpr::Component::Kind::Subscript:
+      case KeyPathExpr::Component::Kind::Type: {
         auto *decl = component.getDeclRef().getDecl();
         auto loc = component.getLoc();
         SourceRange range(loc, loc);

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -218,8 +218,16 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
                      diag::expr_unsupported_objc_key_path_component,
                      (unsigned)kind);
       continue;
-    case KeyPathExpr::Component::Kind::OptionalWrap:
     case KeyPathExpr::Component::Kind::Property:
+    case KeyPathExpr::Component::Kind::Type: {
+      //For code completion purposes, we only care about the last expression.
+      if (&component == &expr->getComponents().back()) {
+        return component.getComponentType();
+      } else {
+        continue;
+      }
+    }
+    case KeyPathExpr::Component::Kind::OptionalWrap:
     case KeyPathExpr::Component::Kind::Subscript:
       llvm_unreachable("already resolved!");
     }
@@ -321,10 +329,11 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     if (auto var = dyn_cast<VarDecl>(found)) {
       // Resolve this component to the variable we found.
       auto varRef = ConcreteDeclRef(var);
+      Type type = var->getInterfaceType();
       auto resolved =
-        KeyPathExpr::Component::forProperty(varRef, Type(), componentNameLoc);
+        KeyPathExpr::Component::forProperty(varRef, type, componentNameLoc);
       resolvedComponents.push_back(resolved);
-      updateState(/*isProperty=*/true, var->getInterfaceType());
+      updateState(/*isProperty=*/true, type);
 
       // Check that the property is @objc.
       if (!var->isObjC()) {
@@ -390,6 +399,11 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
         break;
       }
 
+      // Resolve this component to the type we found.
+      auto typeRef = ConcreteDeclRef(type);
+      auto resolved =
+      KeyPathExpr::Component::forType(typeRef, newType, componentNameLoc);
+      resolvedComponents.push_back(resolved);
       updateState(/*isProperty=*/false, newType);
       continue;
     }

--- a/test/IDE/complete_pound_keypath.swift
+++ b/test/IDE/complete_pound_keypath.swift
@@ -6,6 +6,8 @@
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=IN_KEYPATH_2 | %FileCheck -check-prefix=CHECK-IN_KEYPATH %s
 
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=IN_KEYPATH_3 | %FileCheck -check-prefix=CHECK-IN_KEYPATH_3 %s
+
 
 // REQUIRES: objc_interop
 
@@ -34,6 +36,10 @@ func completeInKeyPath2() {
   _ = #keyPath(ObjCClass.#^IN_KEYPATH_2^#
 }
 
+func completeInKeyPath3() {
+  _ = #keyPath(ObjCClass.prop1.#^IN_KEYPATH_3^#
+}
+
 // CHECK-AFTER_POUND-NOT: keyPath
 
 // CHECK-KEYPATH_ARG: Keyword/None/TypeRelation[Identical]: #keyPath({#@objc property sequence#})[#String#]; name=#keyPath(@objc property sequence)
@@ -42,4 +48,5 @@ func completeInKeyPath2() {
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop2[#ObjCClass?#]; name=prop2
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/Super:            hashValue[#Int#]; name=hashValue
 
+// CHECK-IN_KEYPATH_3: Decl[InstanceVar]/CurrNominal:    hashValue[#Int#]; name=hashValue
 

--- a/test/Index/index_keypaths.swift
+++ b/test/Index/index_keypaths.swift
@@ -7,21 +7,31 @@ struct MyStruct {
   }
 }
 
-class MyClass {
-  class Inner {
-    @objc var myProp = 1
-  }
-}
-
 let a = \MyStruct.Inner.myProp
 // CHECK: [[@LINE-1]]:25 | {{.*}} | myProp
 // CHECK: [[@LINE-2]]:10 | {{.*}} | MyStruct
 // CHECK: [[@LINE-3]]:19 | {{.*}} | Inner
 let b: KeyPath<MyStruct.Inner, Int> = \.myProp
 // CHECK: [[@LINE-1]]:41 | {{.*}} | myProp
-let c = \MyClass.Inner.myProp
+
+class MyClass {
+  class Inner {
+    @objc var myProp = 1
+    func method() {
+      let c: String = #keyPath(myProp)
+      // CHECK: [[@LINE-1]]:32 | {{.*}} | myProp
+    }
+  }
+}
+
+let d: String = #keyPath(MyClass.Inner.myProp)
+// CHECK: [[@LINE-1]]:26 | {{.*}} | MyClass
+// CHECK: [[@LINE-2]]:34 | {{.*}} | Inner
+// CHECK: [[@LINE-3]]:40 | {{.*}} | myProp
+
+let e = \MyClass.Inner.myProp
 // CHECK: [[@LINE-1]]:24 | {{.*}} | myProp
 // CHECK: [[@LINE-2]]:10 | {{.*}} | MyClass
 // CHECK: [[@LINE-3]]:18 | {{.*}} | Inner
-let d: KeyPath<MyClass.Inner, Int> = \.myProp
+let f: KeyPath<MyClass.Inner, Int> = \.myProp
 // CHECK: [[@LINE-1]]:40 | {{.*}} | myProp

--- a/test/expr/primary/keypath/keypath-objc.swift
+++ b/test/expr/primary/keypath/keypath-objc.swift
@@ -57,7 +57,7 @@ func testKeyPath(a: A, b: B) {
   let _: String = #keyPath(A.propString)
 
   // Property of String property (which looks on NSString)
-  let _: String = #keyPath(A.propString.URLsInText)
+  let _: String = #keyPath(A.propString.urlsInText)
 
   // String property with a suffix
   let _: String = #keyPath(A.propString).description
@@ -72,7 +72,7 @@ func testKeyPath(a: A, b: B) {
 
   // Array property (make sure we look at the array element).
   let _: String = #keyPath(A.propArray)
-  let _: String = #keyPath(A.propArray.URLsInText)
+  let _: String = #keyPath(A.propArray.urlsInText)
 
   // Dictionary property (make sure we look at the value type).
   let _: String = #keyPath(A.propDict.anyKeyName)
@@ -80,20 +80,20 @@ func testKeyPath(a: A, b: B) {
 
   // Set property (make sure we look at the set element).
   let _: String = #keyPath(A.propSet)
-  let _: String = #keyPath(A.propSet.URLsInText)
+  let _: String = #keyPath(A.propSet.urlsInText)
 
   // AnyObject property
-  let _: String = #keyPath(A.propAnyObject.URLsInText)  
+  let _: String = #keyPath(A.propAnyObject.urlsInText)
   let _: String = #keyPath(A.propAnyObject.propA)  
   let _: String = #keyPath(A.propAnyObject.propB)  
   let _: String = #keyPath(A.propAnyObject.description)  
 
   // NSString property
-  let _: String = #keyPath(A.propNSString.URLsInText)  
+  let _: String = #keyPath(A.propNSString.urlsInText)
 
   // NSArray property (AnyObject array element).
   let _: String = #keyPath(A.propNSArray)
-  let _: String = #keyPath(A.propNSArray.URLsInText)
+  let _: String = #keyPath(A.propNSArray.urlsInText)
 
   // NSDictionary property (AnyObject value type).
   let _: String = #keyPath(A.propNSDict.anyKeyName)
@@ -101,7 +101,7 @@ func testKeyPath(a: A, b: B) {
 
   // NSSet property (AnyObject set element).
   let _: String = #keyPath(A.propNSSet)
-  let _: String = #keyPath(A.propNSSet.URLsInText)
+  let _: String = #keyPath(A.propNSSet.urlsInText)
 
   // Property with keyword name.
   let _: String = #keyPath(A.repeat)


### PR DESCRIPTION
From [SR-9020](https://bugs.swift.org/browse/SR-9020): Type references in `#keyPath` were being resolved but were not being added to the components list, which prevented the expression from being indexed when the expression included a type.

I think referencing a type in `#keyPath` is rather common as this keyword is normally created outside the scope of the watched property (like in iOS with AVFoundation types), so I created a new component type and assigned the resolved reference to it, which fixed the indexing issue. 

It also seems like code completion was crashing when accessing inner properties, so I made a change to it in order to make expressions like `#keyPath(myInt.hashValue)` complete.