### PR TITLE
[Name lookup] Look through parentheses when finding type references.

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2438,6 +2438,15 @@ directReferencesForTypeRepr(Evaluator &evaluator,
   case TypeReprKind::Dictionary:
     return { 1, ctx.getDictionaryDecl()};
 
+  case TypeReprKind::Tuple: {
+    auto tupleRepr = cast<TupleTypeRepr>(typeRepr);
+    if (tupleRepr->isParenType()) {
+      return directReferencesForTypeRepr(evaluator, ctx,
+                                         tupleRepr->getElementType(0), dc);
+    }
+    return { };
+  }
+
   case TypeReprKind::Error:
   case TypeReprKind::Function:
   case TypeReprKind::InOut:
@@ -2446,7 +2455,6 @@ directReferencesForTypeRepr(Evaluator &evaluator,
   case TypeReprKind::Protocol:
   case TypeReprKind::Shared:
   case TypeReprKind::SILBox:
-  case TypeReprKind::Tuple:
     return { };
 
   case TypeReprKind::Fixed:

--- a/test/decl/protocol/inherited.swift
+++ b/test/decl/protocol/inherited.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift
+
+// Allow inheritance from parenthesized protocol names.
+protocol DefaultItem {}
+
+extension DefaultItem {
+  var isEnabled: Bool { return true }
+}
+
+protocol Item: (DefaultItem) {}
+
+func test(item: Item) {
+  _ = item.isEnabled
+}


### PR DESCRIPTION
When resolving type declarations in, e.g., the inherited type declarations
request, look through parenthesized types. Fixes rdar://problem/45527696.
