### PR TITLE
[Build System] Remove the use of sub-shells when running test targets

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -330,6 +330,7 @@ foreach(SDK ${SWIFT_SDKS})
               ${LIT_ARGS}
               "--param" "swift_test_subset=${test_subset}"
               "--param" "swift_test_mode=${test_mode}"
+              ${SWIFT_LIT_TEST_PATHS}
             DEPENDS ${dependencies}
             COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE} from custom test locations"
             USES_TERMINAL)

--- a/utils/build-script
+++ b/utils/build-script
@@ -290,16 +290,6 @@ class BuildScriptInvocation(object):
             args.build_subdir = \
                 workspace.compute_build_subdir(args)
 
-        # --test-paths implies --test and/or --validation-test
-        # depending on what directories/files have been specified.
-        if args.test_paths:
-            for path in args.test_paths:
-                if path.startswith('test'):
-                    args.test = True
-                elif path.startswith('validation-test'):
-                    args.test = True
-                    args.validation_test = True
-
         # Add optional stdlib-deployment-targets
         if args.android:
             args.stdlib_deployment_targets.append(

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1954,6 +1954,21 @@ for host in "${ALL_HOSTS[@]}"; do
         -DSWIFT_RUNTIME_ENABLE_LEAK_CHECKER:BOOL=$(true_false "${SWIFT_RUNTIME_ENABLE_LEAK_CHECKER}")
     )
 
+    if [[ "${TEST_PATHS}" ]]; then
+        build_dir=$(build_directory ${host} "swift")
+
+        test_paths=()
+        for path in ${TEST_PATHS}; do
+            test_paths+=(
+                "${build_dir}/$(echo ${path} | sed -E "s/^(validation-test|test)/\1-${host}/")"
+            )
+        done
+
+        swift_cmake_options=(
+            "${swift_cmake_options[@]}"
+            -DSWIFT_LIT_TEST_PATHS="${test_paths}")
+    fi
+
     if [[ "${SKIP_TEST_SOURCEKIT}" ]] ; then
         swift_cmake_options=(
             "${swift_cmake_options[@]}"
@@ -3174,43 +3189,12 @@ for host in "${ALL_HOSTS[@]}"; do
                 trap "tests_busted ${product} '(${target})'" ERR
 
                 test_target="$target"
-                test_paths=()
-
-                if [[ ${test_target} == check-swift* ]]; then
-                    if [[ "${TEST_PATHS}" ]]; then
-                        test_target="${test_target}-custom"
-                        for path in ${TEST_PATHS}; do
-                            test_paths+=(
-                                "${build_dir}/$(echo ${path} | sed -E "s/^(validation-test|test)/\1-${host}/")"
-                            )
-                        done
-                    fi
+                if [[ ${test_target} == check-swift* ]] && [[ "${TEST_PATHS}" ]]; then
+                    test_target="${test_target}-custom"
                 fi
 
-                # NOTE: In dry-run mode, build_dir might not exist yet. In that
-                #       case, -n query will fail. So, in dry-run mode,
-                #       we don't expand test script.
-                if [[ ! "${DRY_RUN}" && "${CMAKE_GENERATOR}" == Ninja ]] && !( "${build_cmd[@]}" --version 2>&1 | grep -i -q llbuild ) && [[ -z "${DISTCC_PUMP}" ]]; then
-                    # Ninja buffers command output to avoid scrambling the output
-                    # of parallel jobs, which is awesome... except that it
-                    # interferes with the progress meter when testing.  Instead of
-                    # executing ninja directly, have it dump the commands it would
-                    # run, strip Ninja's progress prefix with sed, and tell the
-                    # shell to execute that.
-                    # However, if we do this in a subshell in the ``sh -e -x -c`` line,
-                    # errors in the command will not stop the script as they should.
-                    echo "Generating dry run test command from: ${build_cmd[@]} -n -v ${test_target}"
-                    dry_run_command_output="$(${build_cmd[@]} -n -v ${test_target} | sed -e 's/[^]]*] //')"
-                    echo "Test command: ${dry_run_command_output}"
+                call "${build_cmd[@]}" ${BUILD_TARGET_FLAG} ${test_target}
 
-                    if [[ ! "${test_paths}" ]]; then
-                        env bash -ex <(echo -e "${dry_run_command_output}")
-                    else
-                        env bash -ex <(echo -e "${dry_run_command_output}" "${test_paths[@]}")
-                    fi
-                else
-                    call "${build_cmd[@]}" ${BUILD_TARGET_FLAG} ${test_target}
-                fi
                 echo "-- ${target} finished --"
             fi
         done

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -166,6 +166,16 @@ def _apply_default_arguments(args):
     if not args.android or not args.build_android:
         args.build_android = False
 
+    # --test-paths implies --test and/or --validation-test
+    # depending on what directories/files have been specified.
+    if args.test_paths:
+        for path in args.test_paths:
+            if path.startswith('test'):
+                args.test = True
+            elif path.startswith('validation-test'):
+                args.test = True
+                args.validation_test = True
+
     # --validation-test implies --test.
     if args.validation_test:
         args.test = True


### PR DESCRIPTION
Removes the use of sub-shells when running the test targets in `build-script-impl`. We were generating a "dry-run" test command using Ninja's `-n` option and then executing it via `/usr/env bash` to avoid Ninja's output buffering when running lit in non-verbose mode. However, local testing shows the output test bar does not seem affected any longer.

As a result of this change we also needed to update the `--test-paths` option to pass the test paths through to CMake rather than appending them onto the test command. That worked before because the generated test command ended with the lit.py invocation (which seems very flimsy).

rdar://43165161
rdar://33714951