### PR TITLE
[RemoteAST] Stop bypassing resilience when doing queries.

### DIFF
--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -75,7 +75,6 @@ private:
 
   static IRGenOptions createIRGenOptions() {
     IRGenOptions IROpts;
-    IROpts.EnableResilienceBypass = true;
     return IROpts;
   }
 
@@ -185,7 +184,7 @@ private:
     VarDecl *member = findField(typeDecl, memberName);
 
     // If we found a member, try to find its offset statically.
-    if (member) {
+    if (member && member->hasStorage() && !typeDecl->isResilient()) {
       if (auto irgen = getIRGen()) {
         return getOffsetOfFieldFromIRGen(irgen->IGM, type, typeDecl,
                                           optMetadata, member);


### PR DESCRIPTION
Avoid going to IRGen with a resilient type to avoid crashing.
This is tested in lldb.

<rdar://problem/45049259>
