### PR TITLE
[CSDiag] Fix crash related to failures in contextual type requirements

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1289,7 +1289,8 @@ diagnoseUnresolvedDotExprTypeRequirementFailure(ConstraintSystem &cs,
   // If we actually resolved the member to use, use it.
   auto loc = cs.getConstraintLocator(UDE, ConstraintLocator::Member);
   auto *member = cs.findResolvedMemberRef(loc);
-  if (!member)
+  // If the problem is contextual it's diagnosed elsewhere.
+  if (!member || !member->getAsGenericContext())
     return false;
 
   auto req = member->getAsGenericContext()

--- a/test/Constraints/rdar45511837.swift
+++ b/test/Constraints/rdar45511837.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol A: RawRepresentable {}
+
+extension A {
+  static func +(lhs: RawValue, rhs: Self) -> Self {
+    fatalError()
+  }
+}
+
+class Foo<Bar: NSObject> {
+  var foobar: Bar {
+    fatalError()
+  }
+
+  lazy var foo: () -> Void = {
+    // TODO: improve diagnostic message
+    _ = self.foobar + nil // expected-error {{'Foo<Bar>' requires that 'Bar' inherit from 'NSObject'}}
+  }
+}


### PR DESCRIPTION
If failed constraint mentions member declaration which is not
generic, it means that generic requirements came from context
and should not be diagnosed by `diagnoseUnresolvedDotExprTypeRequirementFailure`.

Resolved: rdar://problem/45511837

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
