### PR TITLE
build: switch swift-corelibs-foundation to CMake

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1756,8 +1756,7 @@ function set_swiftpm_bootstrap_command() {
     )
 
     if [[ ! "${SKIP_BUILD_FOUNDATION}" ]] ; then
-        swiftpm_bootstrap_command+=(
-            --foundation="${FOUNDATION_BUILD_DIR}/Foundation")
+        swiftpm_bootstrap_command+=( --foundation="${FOUNDATION_BUILD_DIR}" )
         if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
             swiftpm_bootstrap_command+=(
                 $LIBDISPATCH_BUILD_ARGS)
@@ -2496,7 +2495,7 @@ for host in "${ALL_HOSTS[@]}"; do
                   call "${XCTEST_SOURCE_DIR}"/build_script.py \
                       --swiftc="${SWIFTC_BIN}" \
                       --build-dir="${XCTEST_BUILD_DIR}" \
-                      --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
+                      --foundation-build-dir="${FOUNDATION_BUILD_DIR}" \
                       --swift-build-dir="${SWIFT_BUILD_DIR}" \
                       $LIBDISPATCH_BUILD_ARGS \
                       $XCTEST_BUILD_ARGS
@@ -2520,11 +2519,11 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_INSTALL_LIBDIR:PATH="lib"
 
                     -DXCTEST_PATH_TO_LIBDISPATCH_SOURCE:PATH=${LIBDISPATCH_SOURCE_DIR}
-                    -DXCTEST_PATH_TO_LIBDISPATCH_BUILD:PATH=${LIBDISPATCH_BUILD_DIR}
+                    -DXCTEST_PATH_TO_LIBDISPATCH_BUILD:PATH=$(build_directory ${host} libdispatch)
 
                     -DXCTEST_PATH_TO_FOUNDATION_BUILD:PATH=${FOUNDATION_BUILD_DIR}
 
-                    -DXCTEST_PATH_TO_COREFOUNDATION_BUILD:PATH=${FOUNDATION_BUILD_DIR}/Foundation/CoreFoundation
+                    -DXCTEST_PATH_TO_COREFOUNDATION_BUILD:PATH=${FOUNDATION_BUILD_DIR}/CoreFoundation-prefix
 
                     -DCMAKE_PREFIX_PATH:PATH=$(build_directory ${host} llvm)
 
@@ -2539,33 +2538,24 @@ for host in "${ALL_HOSTS[@]}"; do
                 # location for building and running the tests. Note that XCTest
                 # is not yet built at this point.
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
+
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
-                SWIFT_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swift"
-                SWIFT_BUILD_PATH="$(build_directory ${host} swift)"
                 LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
+
+                if [[ ${host} == "macosx"* ]]; then
+                    echo "Skipping Foundation on OS X -- use the Xcode project instead"
+                    continue
+                fi
 
                 # Staging: require opt-in for building with dispatch
                 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
                     LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
-                    LIBDISPATCH_BUILD_ARGS="-DLIBDISPATCH_SOURCE_DIR=${LIBDISPATCH_SOURCE_DIR} -DLIBDISPATCH_BUILD_DIR=${LIBDISPATCH_BUILD_DIR}"
-                fi
-
-                # FIXME CROSSCOMPILING:
-                # Foundation is a target library (like the Swift standard library),
-                # so technically we should build it for all stdlib_targets, not just for the host.
-                # However, we only have the triple and sysroot for the host.
-                # Also, we will need to tell it which linker to use.
-                FOUNDATION_BUILD_ARGS=()
-                if [[ $(is_cross_tools_host ${host}) ]]; then
-                    FOUNDATION_BUILD_ARGS+=(
-                        "--target=${SWIFT_HOST_TRIPLE}"
+                    LIBDISPATCH_BUILD_ARGS=(
+                      -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=${LIBDISPATCH_SOURCE_DIR}
+                      -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=${LIBDISPATCH_BUILD_DIR}
                     )
-                fi
-
-                # FIXME: Foundation doesn't build from the script on OS X
-                if [[ ${host} == "macosx"* ]]; then
-                    echo "Skipping Foundation on OS X -- use the Xcode project instead"
-                    continue
+                else
+                    LIBDISPATCH_BUILD_ARGS=( -DFOUNDATION_ENABLE_LIBDISPATCH=NO )
                 fi
 
                 # FIXME: Always re-build foundation on non-darwin platforms.
@@ -2573,14 +2563,21 @@ for host in "${ALL_HOSTS[@]}"; do
                 echo "Cleaning the Foundation build directory"
                 call rm -rf "${build_dir}"
 
-                with_pushd "${FOUNDATION_SOURCE_DIR}" \
-                    call env SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
-                      SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="$(get_host_install_destdir ${host})" PREFIX="$(get_host_install_prefix ${host})" ./configure "${FOUNDATION_BUILD_TYPE}" ${FOUNDATION_BUILD_ARGS[@]} -DXCTEST_BUILD_DIR=${XCTEST_BUILD_DIR} $LIBDISPATCH_BUILD_ARGS
-                with_pushd "${FOUNDATION_SOURCE_DIR}" \
-                    call ${NINJA_BIN}
+                cmake_options=(
+                  ${cmake_options[@]}
+                  -DCMAKE_BUILD_TYPE:STRING=${FOUNDATION_BUILD_TYPE}
+                  -DCMAKE_C_COMPILER:PATH=${LLVM_BIN}/clang
+                  -DCMAKE_CXX_COMPILER:PATH=${LLVM_BIN}/clang++
+                  -DCMAKE_SWIFT_COMPILER:PATH=${SWIFTC_BIN}
+                  -DCMAKE_INSTALL_PREFIX:PATH=$(get_host_install_prefix ${host})
 
-                # Foundation builds itself and doesn't use cmake
-                continue
+                  ${LIBDISPATCH_BUILD_ARGS[@]}
+
+                  # NOTE(compnerd) we disable tests because XCTest is not ready
+                  # yet, but we will reconfigure when the time comes.
+                  -DENABLE_TESTING:BOOL=NO
+                )
+
                 ;;
             libdispatch)
                 LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
@@ -2960,14 +2957,15 @@ for host in "${ALL_HOSTS[@]}"; do
                 else
                     # This assumes that there are no spaces in any on these paths.
                     FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
-                    DOTEST_EXTRA="-I${FOUNDATION_BUILD_DIR}/Foundation"
-                    DOTEST_EXTRA="${DOTEST_EXTRA} -I${FOUNDATION_BUILD_DIR}/Foundation/usr/lib/swift"
+                    DOTEST_EXTRA="-I${FOUNDATION_BUILD_DIR}"
+                    DOTEST_EXTRA="-F${FOUNDATION_BUILD_DIR}/CoreFoundation-prefix/System/Library/Frameworks"
+                    DOTEST_EXTRA="${DOTEST_EXTRA} -I${FOUNDATION_BUILD_DIR}/swift"
                     DOTEST_EXTRA="${DOTEST_EXTRA} -I${LIBDISPATCH_SOURCE_DIR}"
-                    DOTEST_EXTRA="${DOTEST_EXTRA} -L${FOUNDATION_BUILD_DIR}/Foundation"
+                    DOTEST_EXTRA="${DOTEST_EXTRA} -L${FOUNDATION_BUILD_DIR}"
                     DOTEST_EXTRA="${DOTEST_EXTRA} -L${LIBDISPATCH_BUILD_DIR}"
                     DOTEST_EXTRA="${DOTEST_EXTRA} -L${LIBDISPATCH_BUILD_DIR}/src"
                     DOTEST_EXTRA="${DOTEST_EXTRA} -Xlinker -rpath -Xlinker ${LIBDISPATCH_BUILD_DIR}/src"
-                    DOTEST_EXTRA="${DOTEST_EXTRA} -Xlinker -rpath -Xlinker ${FOUNDATION_BUILD_DIR}/Foundation"
+                    DOTEST_EXTRA="${DOTEST_EXTRA} -Xlinker -rpath -Xlinker ${FOUNDATION_BUILD_DIR}"
                 fi
                 call mkdir -p "${results_dir}"
 
@@ -3058,32 +3056,41 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ "${SKIP_TEST_XCTEST}" ]]; then
                     continue
                 fi
-                # If libdispatch is being built then XCTest will need access to it
-                if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
-                    LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
-                    LIBDISPATCH_BUILD_ARGS="--libdispatch-src-dir=${LIBDISPATCH_SOURCE_DIR} --libdispatch-build-dir=${LIBDISPATCH_BUILD_DIR}"
-                fi
 
-                # Use XCTEST_BUILD_TYPE to build either --debug or --release.
-                if [[ "${XCTEST_BUILD_TYPE}" ==  "Debug" ]] ; then
-                    XCTEST_BUILD_ARGS="--debug"
-                else
-                    XCTEST_BUILD_ARGS="--release"
-                fi
+                case ${host} in
+                macosx-*)
+                  # If libdispatch is being built then XCTest will need access to it
+                  if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
+                      LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
+                      LIBDISPATCH_BUILD_ARGS="--libdispatch-src-dir=${LIBDISPATCH_SOURCE_DIR} --libdispatch-build-dir=${LIBDISPATCH_BUILD_DIR}"
+                  fi
 
-                echo "--- Running tests for ${product} ---"
-                SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
-                FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
-                XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
-                call "${XCTEST_SOURCE_DIR}"/build_script.py test \
-                    --swiftc="${SWIFTC_BIN}" \
-                    --lit="${LLVM_SOURCE_DIR}/utils/lit/lit.py" \
-                    --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
-                    ${LIBDISPATCH_BUILD_ARGS} \
-                    $XCTEST_BUILD_ARGS \
-                    "${XCTEST_BUILD_DIR}"
-                echo "--- Finished tests for ${product} ---"
-                continue
+                  # Use XCTEST_BUILD_TYPE to build either --debug or --release.
+                  if [[ "${XCTEST_BUILD_TYPE}" ==  "Debug" ]] ; then
+                      XCTEST_BUILD_ARGS="--debug"
+                  else
+                      XCTEST_BUILD_ARGS="--release"
+                  fi
+
+                  echo "--- Running tests for ${product} ---"
+                  SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+                  FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
+                  XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
+                  call "${XCTEST_SOURCE_DIR}"/build_script.py test \
+                      --swiftc="${SWIFTC_BIN}" \
+                      --lit="${LLVM_SOURCE_DIR}/utils/lit/lit.py" \
+                      --foundation-build-dir="${FOUNDATION_BUILD_DIR}" \
+                      ${LIBDISPATCH_BUILD_ARGS} \
+                      $XCTEST_BUILD_ARGS \
+                      "${XCTEST_BUILD_DIR}"
+                  echo "--- Finished tests for ${product} ---"
+                  continue
+                ;;
+                *)
+                  results_targets=( "check-xctest" )
+                  executable_target=""
+                ;;
+                esac
                 ;;
             foundation)
                 # FIXME: Foundation doesn't build from the script on OS X
@@ -3091,23 +3098,46 @@ for host in "${ALL_HOSTS[@]}"; do
                     echo "Skipping Foundation on OS X -- use the Xcode project instead"
                     continue
                 fi
+
                 if [[ "${SKIP_TEST_FOUNDATION}" ]]; then
                     continue
                 fi
-                # If libdispatch is being built, TestFoundation will need access to it
-                if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
-                    LIBDISPATCH_LIB_DIR=":$(build_directory ${host} libdispatch):$(build_directory ${host} libdispatch)/src"
-                else
-                    LIBDISPATCH_LIB_DIR=""
+
+                if [[ "${SKIP_BUILD_XCTEST}" ]]; then
+                    continue
                 fi
-                echo "--- Running tests for ${product} ---"
-                build_dir=$(build_directory ${host} ${product})
-                XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
-                with_pushd "${FOUNDATION_SOURCE_DIR}" \
-                    call ${NINJA_BIN} TestFoundation
-                call env LD_LIBRARY_PATH="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"/lib/swift/:"${build_dir}/Foundation":"${XCTEST_BUILD_DIR}""${LIBDISPATCH_LIB_DIR}":${LD_LIBRARY_PATH} "${build_dir}"/TestFoundation/TestFoundation
-                echo "--- Finished tests for ${product} ---"
-                continue
+
+                if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
+                    LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
+                    LIBDISPATCH_BUILD_ARGS=(
+                      -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=${LIBDISPATCH_SOURCE_DIR}
+                      -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=${LIBDISPATCH_BUILD_DIR}
+                    )
+                else
+                    LIBDISPATCH_BUILD_ARGS=( -DFOUNDATION_ENABLE_LIBDISPATCH=NO )
+                fi
+
+                cmake_options=(
+                  ${cmake_options[@]}
+                  -DCMAKE_BUILD_TYPE:STRING=${FOUNDATION_BUILD_TYPE}
+                  -DCMAKE_C_COMPILER:PATH=${LLVM_BIN}/clang
+                  -DCMAKE_CXX_COMPILER:PATH=${LLVM_BIN}/clang++
+                  -DCMAKE_SWIFT_COMPILER:PATH=${SWIFTC_BIN}
+                  -DCMAKE_INSTALL_PREFIX:PATH=$(get_host_install_prefix ${host})
+
+                  ${LIBDISPATCH_BUILD_ARGS[@]}
+
+                  # NOTE(compnerd) the time has come to enable tests now
+                  -DENABLE_TESTING:BOOL=YES
+                  -DFOUNDATION_PATH_TO_XCTEST_BUILD:PATH=$(build_directory ${host} xctest)
+                )
+
+                [[ -z "${DISTCC}" ]] || EXTRA_DISTCC_OPTIONS=("DISTCC_HOSTS=localhost,lzo,cpp")
+                with_pushd "$(build_directory ${host} foundation)" \
+                    call env "${EXTRA_DISTCC_OPTIONS[@]}" "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${FOUNDATION_SOURCE_DIR}"
+
+                results_targets=( "test" )
+                executable_target=("TestFoundation")
                 ;;
             libdispatch)
                 if [[ "${SKIP_TEST_LIBDISPATCH}" ]]; then
@@ -3330,20 +3360,16 @@ for host in "${ALL_HOSTS[@]}"; do
                     echo "Skipping Foundation on OS X -- use the Xcode project instead"
                     continue
                 fi
+
                 if [[ -z "${INSTALL_FOUNDATION}" ]] ; then
                     continue
                 fi
+
                 if [[ -z "${INSTALL_DESTDIR}" ]] ; then
                     echo "--install-destdir is required to install products."
                     exit 1
                 fi
-                echo "--- Installing ${product} ---"
-                build_dir=$(build_directory ${host} ${product})
-                with_pushd "${FOUNDATION_SOURCE_DIR}" \
-                    call ${NINJA_BIN} install
 
-                # As foundation installation is self-contained, we break early here.
-                continue
                 ;;
             libdispatch)
                 if [[ -z "${INSTALL_LIBDISPATCH}" ]] ; then


### PR DESCRIPTION
swift-corelibs-foundation has had a CMake based build system for a while
now.  Switch the official builds over to it.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
