### PR TITLE
[silgen] When emitting a top level error, destroy the error after we …

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1535,6 +1535,14 @@ public:
                             sgm.getASTContext().getIdentifier("errorInMain"),
                             sgm.Types.getEmptyTupleType(), {}, {error});
 
+        // Then end the lifetime of the error.
+        //
+        // We do this to appease the ownership verifier. We do not care about
+        // actually destroying the value since we are going to immediately exit,
+        // so this saves us a slight bit of code-size since end_lifetime is
+        // stripped out after ownership is removed.
+        SGF.B.createEndLifetime(moduleLoc, error);
+
         // Signal an abnormal exit by returning 1.
         SGF.Cleanups.emitCleanupsForReturn(CleanupLocation::get(moduleLoc),
                                            IsForUnwind);

--- a/test/SILGen/toplevel_errors.swift
+++ b/test/SILGen/toplevel_errors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
 
 enum MyError : Error {
   case A, B
@@ -21,6 +21,7 @@ throw MyError.A
 
 // CHECK: bb2([[T0:%.*]] : @owned $Error):
 // CHECK: builtin "errorInMain"([[T0]] : $Error)
+// CHECK: end_lifetime [[T0]]
 // CHECK: [[T0:%.*]] = integer_literal $Builtin.Int32, 1
 // CHECK: [[T1:%.*]] = struct $Int32 ([[T0]] : $Builtin.Int32)
 // CHECK: br bb1([[T1]] : $Int32)


### PR DESCRIPTION
…have logged it.

This is not strictly necessary since we are going to be exiting the program, but
the ownership verifier thinks that the error is leaked otherwise.

rdar://29791263
