### PR TITLE
 [IRGen] Narrow the “requires instantiation” bit for conformances.

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -470,6 +470,9 @@ struct ConformanceDescription {
   /// Whether this witness table requires runtime specialization.
   const unsigned requiresSpecialization : 1;
 
+  /// Whether this witness table contains dependent associated type witnesses.
+  const unsigned hasDependentAssociatedTypeWitnesses : 1;
+
   /// The instantiation function, to be run at the end of witness table
   /// instantiation.
   llvm::Constant *instantiationFn = nullptr;
@@ -482,11 +485,15 @@ struct ConformanceDescription {
                          llvm::Constant *pattern,
                          uint16_t witnessTableSize,
                          uint16_t witnessTablePrivateSize,
-                         bool requiresSpecialization)
+                         bool requiresSpecialization,
+                         bool hasDependentAssociatedTypeWitnesses)
     : conformance(conformance), wtable(wtable), pattern(pattern),
       witnessTableSize(witnessTableSize),
       witnessTablePrivateSize(witnessTablePrivateSize),
-      requiresSpecialization(requiresSpecialization) { }
+      requiresSpecialization(requiresSpecialization),
+      hasDependentAssociatedTypeWitnesses(hasDependentAssociatedTypeWitnesses)
+  {
+  }
 };
 
 /// IRGenModule - Primary class for emitting IR for global declarations.

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -167,7 +167,7 @@ struct UsesVoid : HasSimpleAssoc {
 //   Protocol conformance descriptor for GenericComputed : DerivedFromSimpleAssoc.
 // GLOBAL-LABEL: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAMc" = hidden constant
 // GLOBAL-SAME:    i16 2,
-// GLOBAL-SAME:    i16 1,
+// GLOBAL-SAME:    i16 0,
 
 //   Relative reference to witness table template
 // GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([2 x i8*]* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWp" to i64

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -137,6 +137,10 @@ extension Int : OtherResilientProtocol { }
 // CHECK-SAME:           @"$s28protocol_conformance_records9DependentVyxGAA9AssociateAAWa"
 // -- flags
 // CHECK-SAME:           i32 1
+// -- number of words in witness table
+// CHECK-SAME:           i16 2,
+// -- number of private words in witness table + bit for "needs instantiation"
+// CHECK-SAME:           i16 1
 // CHECK-SAME:         }
 extension Dependent : Associate {
   public typealias X = (T, T)

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -106,8 +106,8 @@ protocol InternalProtocol {
 // -- number of witness table entries
 // CHECK-SAME:   i16 1,
 
-// -- size of private area + 'needs instantiation' bit
-// CHECK-SAME:   i16 1,
+// -- size of private area + 'requires instantiation' bit (not set)
+// CHECK-SAME:   i16 0,
 
 // -- the template
 // CHECK-SAME:   @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWp"
@@ -139,8 +139,8 @@ protocol InternalProtocol {
 // -- number of witness table entries
 // CHECK-SAME:   i16 1,
 
-// -- size of private area + 'needs instantiation' bit
-// CHECK-SAME:   i16 1,
+// -- size of private area + 'requires instantiation' bit (not set)
+// CHECK-SAME:   i16 0,
 
 // -- the template
 // CHECK-SAME:   @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWp"

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -56,6 +56,12 @@ public protocol P { }
 public struct ConditionallyConforms<Element> { }
 public struct Y { }
 
+// CHECK-USAGE-LABEL: @"$s31protocol_resilience_descriptors1YV010resilient_A022OtherResilientProtocolAAMc" =
+// CHECK-USAGE-SAME: i32 131073,
+// CHECK-USAGE-SAME: i16 1,
+// CHECK-USAGE-SAME: i16 0
+extension Y: OtherResilientProtocol { }
+
 // CHECK-USAGE: @"$s31protocol_resilience_descriptors29ConformsWithAssocRequirementsV010resilient_A008ProtocoleF12TypeDefaultsAAMc" =
 // CHECK-USAGE-SAME: $s18resilient_protocol29ProtocolWithAssocTypeDefaultsP2T2AC_AA014OtherResilientC0Tn
 // CHECK-USAGE-SAME: $s31protocol_resilience_descriptors29ConformsWithAssocRequirementsV010resilient_A008ProtocoleF12TypeDefaultsAA2T2AdEP_AD014OtherResilientI0PWT


### PR DESCRIPTION
The “requires instantiation” bit for protocol conformances that
might require runtime instantiation was set for essentially every
resilient conformance, so we would always be forced to create a
copy of the table. Narrow the “requires instantiation” bit to those
cases where there is something in the pattern that needs it to be
copied (for now, only associated type witnesses involving a type
parameter, which need to be cached differently). This optimizes
some narrow cases where we wouldn’t otherwise need a copy.