### PR TITLE
[5.0] [PrintAsObjC] Look through "compatibility" typealiases

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -2014,10 +2014,12 @@ class ReferencedTypeFinder : public TypeVisitor<ReferencedTypeFinder> {
   }
 
   void visitNameAliasType(NameAliasType *aliasTy) {
-    if (aliasTy->getDecl()->hasClangNode())
+    if (aliasTy->getDecl()->hasClangNode() &&
+        !aliasTy->getDecl()->isCompatibilityAlias()) {
       Callback(*this, aliasTy->getDecl());
-    else
+    } else {
       visit(aliasTy->getSinglyDesugaredType());
+    }
   }
 
   void visitParenType(ParenType *parenTy) {

--- a/test/PrintAsObjC/versioned.swift
+++ b/test/PrintAsObjC/versioned.swift
@@ -24,6 +24,9 @@ import VersionedFMWK
   // CHECK-NEXT: - (nullable instancetype)initFormerlyFailableValue:(NSInteger)value OBJC_DESIGNATED_INITIALIZER;
 } // CHECK-NEXT: @end
 
+// Make sure we use forward declarations like we would for non-versioned names.
+// CHECK: @class InnerClass;
+
 // CHECK-LABEL: @interface UsesNestedClass
 @objc class UsesNestedClass : NSObject {
   // CHECK-NEXT: - (InnerClass * _Nullable)foo SWIFT_WARN_UNUSED_RESULT;


### PR DESCRIPTION
Early cherry-pick of #20027 to the 5.0 branch, to fix an Apple-internal test. Reviewed by @DougGregor.

rdar://problem/45491607