### PR TITLE
[stdlib] Tinker with some inlining to see perf impact

### DIFF
--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -94,24 +94,19 @@ public protocol _ObjectiveCBridgeable {
 /// a metatype, make it conform to _ObjectiveCBridgeable, and its witness table
 /// will be ABI-compatible with one that directly provided conformance to the
 /// metatype type itself.
-@_fixed_layout
 public struct _BridgeableMetatype: _ObjectiveCBridgeable {
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var value: AnyObject.Type
 
-  @inlinable // FIXME(sil-serialize-all)
   internal init(value: AnyObject.Type) {
     self.value = value
   }
 
   public typealias _ObjectiveCType = AnyObject
 
-  @inlinable // FIXME(sil-serialize-all)
   public func _bridgeToObjectiveC() -> AnyObject {
     return value
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func _forceBridgeFromObjectiveC(
     _ source: AnyObject,
     result: inout _BridgeableMetatype?
@@ -119,7 +114,6 @@ public struct _BridgeableMetatype: _ObjectiveCBridgeable {
     result = _BridgeableMetatype(value: source as! AnyObject.Type)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func _conditionallyBridgeFromObjectiveC(
     _ source: AnyObject,
     result: inout _BridgeableMetatype?
@@ -133,7 +127,6 @@ public struct _BridgeableMetatype: _ObjectiveCBridgeable {
     return false
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @_effects(readonly)
   public static func _unconditionallyBridgeFromObjectiveC(_ source: AnyObject?)
       -> _BridgeableMetatype {

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -302,7 +302,6 @@ public func _bridgeNonVerbatimFromObjectiveCConditional<T>(
 ///
 /// - If `T` is a class type, returns `true`;
 /// - otherwise, returns whether `T` conforms to `_ObjectiveCBridgeable`.
-@inlinable // FIXME(sil-serialize-all)
 public func _isBridgedToObjectiveC<T>(_: T.Type) -> Bool {
   if _fastPath(_isClassOrObjCExistential(T.self)) {
     return true

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -14,9 +14,9 @@
 ///
 /// In Swift, only class instances and metatypes have unique identities. There
 /// is no notion of identity for structs, enums, functions, or tuples.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // trivial-implementation
 public struct ObjectIdentifier {
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // trivial-implementation
   internal let _value: Builtin.RawPointer
 
   /// Creates an instance that uniquely identifies the given class instance.
@@ -47,7 +47,7 @@ public struct ObjectIdentifier {
   ///     // Prints "false"
   ///
   /// - Parameter x: An instance of a class.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public init(_ x: AnyObject) {
     self._value = Builtin.bridgeToRawPointer(x)
   }
@@ -55,7 +55,7 @@ public struct ObjectIdentifier {
   /// Creates an instance that uniquely identifies the given metatype.
   ///
   /// - Parameter: A metatype.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public init(_ x: Any.Type) {
     self._value = unsafeBitCast(x, to: Builtin.RawPointer.self)
   }
@@ -69,14 +69,14 @@ extension ObjectIdentifier : CustomDebugStringConvertible {
 }
 
 extension ObjectIdentifier: Equatable {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public static func == (x: ObjectIdentifier, y: ObjectIdentifier) -> Bool {
     return Bool(Builtin.cmp_eq_RawPointer(x._value, y._value))
   }
 }
 
 extension ObjectIdentifier: Comparable {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public static func < (lhs: ObjectIdentifier, rhs: ObjectIdentifier) -> Bool {
     return UInt(bitPattern: lhs) < UInt(bitPattern: rhs)
   }
@@ -97,7 +97,7 @@ extension ObjectIdentifier: Hashable {
 extension UInt {
   /// Creates an integer that captures the full value of the given object
   /// identifier.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public init(bitPattern objectID: ObjectIdentifier) {
     self.init(Builtin.ptrtoint_Word(objectID._value))
   }
@@ -106,7 +106,7 @@ extension UInt {
 extension Int {
   /// Creates an integer that captures the full value of the given object
   /// identifier.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public init(bitPattern objectID: ObjectIdentifier) {
     self.init(bitPattern: UInt(bitPattern: objectID))
   }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -668,13 +668,11 @@ public func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T?)
 #if _runtime(_ObjC)
 extension Optional : _ObjectiveCBridgeable {
   // The object that represents `none` for an Optional of this type.
-  @inlinable // FIXME(sil-serialize-all)
   internal static var _nilSentinel : AnyObject {
     @_silgen_name("_swift_Foundation_getOptionalNilSentinelObject")
     get
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public func _bridgeToObjectiveC() -> AnyObject {
     // Bridge a wrapped value by unwrapping.
     if let value = self {
@@ -684,7 +682,6 @@ extension Optional : _ObjectiveCBridgeable {
     return type(of: self)._nilSentinel
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func _forceBridgeFromObjectiveC(
     _ source: AnyObject,
     result: inout Optional<Wrapped>?
@@ -702,7 +699,6 @@ extension Optional : _ObjectiveCBridgeable {
     result = .some(.some(unwrappedResult))
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func _conditionallyBridgeFromObjectiveC(
     _ source: AnyObject,
     result: inout Optional<Wrapped>?
@@ -726,7 +722,6 @@ extension Optional : _ObjectiveCBridgeable {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @_effects(readonly)
   public static func _unconditionallyBridgeFromObjectiveC(_ source: AnyObject?)
       -> Optional<Wrapped> {

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -267,11 +267,9 @@ public protocol CustomDebugStringConvertible {
 // Default (ad-hoc) printing
 //===----------------------------------------------------------------------===//
 
-@usableFromInline // FIXME(sil-serialize-all)
 @_silgen_name("swift_EnumCaseName")
 internal func _getEnumCaseName<T>(_ value: T) -> UnsafePointer<CChar>?
 
-@usableFromInline // FIXME(sil-serialize-all)
 @_silgen_name("swift_OpaqueSummary")
 internal func _opaqueSummary(_ metadata: Any.Type) -> UnsafePointer<CChar>?
 

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -557,7 +557,6 @@ extension String : TextOutputStream {
   /// Appends the given string to this string.
   /// 
   /// - Parameter other: A string to append.
-  @inlinable // FIXME(sil-serialize-all)
   public mutating func write(_ other: String) {
     self += other
   }
@@ -571,7 +570,6 @@ extension String : TextOutputStreamable {
   /// Writes the string into the given output stream.
   /// 
   /// - Parameter target: An output stream.
-  @inlinable // FIXME(sil-serialize-all)
   public func write<Target : TextOutputStream>(to target: inout Target) {
     target.write(self)
   }
@@ -581,7 +579,6 @@ extension Character : TextOutputStreamable {
   /// Writes the character into the given output stream.
   ///
   /// - Parameter target: An output stream.
-  @inlinable // FIXME(sil-serialize-all)
   public func write<Target : TextOutputStream>(to target: inout Target) {
     target.write(String(self))
   }
@@ -592,7 +589,6 @@ extension Unicode.Scalar : TextOutputStreamable {
   /// output stream.
   ///
   /// - Parameter target: An output stream.
-  @inlinable // FIXME(sil-serialize-all)
   public func write<Target : TextOutputStream>(to target: inout Target) {
     target.write(String(Character(self)))
   }

--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -27,12 +27,12 @@ internal func _makeSwiftNSFastEnumerationState()
 
 /// A dummy value to be used as the target for `mutationsPtr` in fast
 /// enumeration implementations.
-@usableFromInline // FIXME(sil-serialize-all)
+@usableFromInline
 internal var _fastEnumerationStorageMutationsTarget: CUnsignedLong = 0
 
 /// A dummy pointer to be used as `mutationsPtr` in fast enumeration
 /// implementations.
-@usableFromInline // FIXME(sil-serialize-all)
+@usableFromInline
 internal let _fastEnumerationStorageMutationsPtr =
   UnsafeMutablePointer<CUnsignedLong>(Builtin.addressof(&_fastEnumerationStorageMutationsTarget))
 #endif

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -387,11 +387,9 @@ extension Double : _CVarArgPassedAsDouble, _CVarArgAligned {
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.
-@_fixed_layout // FIXME(sil-serialize-all)
-@_fixed_layout // c-abi
+@_fixed_layout
 @usableFromInline // c-abi
 final internal class _VaListBuilder {
-
   @_fixed_layout // c-abi
   @usableFromInline
   internal struct Header {
@@ -408,6 +406,17 @@ final internal class _VaListBuilder {
     @usableFromInline // c-abi
     internal var reg_save_area: UnsafeMutablePointer<Int>?
   }
+
+  @usableFromInline // c-abi
+  internal var gpRegistersUsed = 0
+  @usableFromInline // c-abi
+  internal var fpRegistersUsed = 0
+
+  @usableFromInline // c-abi
+  final  // Property must be final since it is used by Builtin.addressof.
+  internal var header = Header()
+  @usableFromInline // c-abi
+  internal var storage: ContiguousArray<Int>
 
   @inlinable // c-abi
   internal init() {
@@ -469,25 +478,13 @@ final internal class _VaListBuilder {
              _fromUnsafeMutablePointer: UnsafeMutableRawPointer(
                Builtin.addressof(&self.header)))
   }
-
-  @usableFromInline // c-abi
-  internal var gpRegistersUsed = 0
-  @usableFromInline // c-abi
-  internal var fpRegistersUsed = 0
-
-  @usableFromInline // c-abi
-  final  // Property must be final since it is used by Builtin.addressof.
-  internal var header = Header()
-  @usableFromInline // c-abi
-  internal var storage: ContiguousArray<Int>
 }
 
 #else
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.
-@_fixed_layout // FIXME(sil-serialize-all)
-@_fixed_layout // c-abi
+@_fixed_layout
 @usableFromInline // c-abi
 final internal class _VaListBuilder {
 

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -124,7 +124,7 @@ internal typealias _VAInt  = Int32
 ///     The pointer argument is valid only for the duration of the function's
 ///     execution.
 /// - Returns: The return value, if any, of the `body` closure parameter.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // c-abi
 public func withVaList<R>(_ args: [CVarArg],
   _ body: (CVaListPointer) -> R) -> R {
   let builder = _VaListBuilder()
@@ -135,7 +135,7 @@ public func withVaList<R>(_ args: [CVarArg],
 }
 
 /// Invoke `body` with a C `va_list` argument derived from `builder`.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // c-abi
 internal func _withVaList<R>(
   _ builder: _VaListBuilder,
   _ body: (CVaListPointer) -> R
@@ -166,7 +166,7 @@ internal func _withVaList<R>(
 ///   pointer.
 /// - Returns: A pointer that can be used with C functions that take a
 ///   `va_list` argument.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // c-abi
 public func getVaList(_ args: [CVarArg]) -> CVaListPointer {
   let builder = _VaListBuilder()
   for a in args {
@@ -179,7 +179,7 @@ public func getVaList(_ args: [CVarArg]) -> CVaListPointer {
 }
 #endif
 
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // c-abi
 public func _encodeBitsAsWords<T>(_ x: T) -> [Int] {
   let result = [Int](
     repeating: 0,
@@ -201,7 +201,7 @@ public func _encodeBitsAsWords<T>(_ x: T) -> [Int] {
 extension Int : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
@@ -216,14 +216,14 @@ extension Bool : CVarArg {
 extension Int64 : CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
 
   /// Returns the required alignment in bytes of
   /// the value returned by `_cVarArgEncoding`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgAlignment: Int {
     // FIXME: alignof differs from the ABI alignment on some architectures
     return MemoryLayout.alignment(ofValue: self)
@@ -233,7 +233,7 @@ extension Int64 : CVarArg, _CVarArgAligned {
 extension Int32 : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(_VAInt(self))
   }
@@ -242,7 +242,7 @@ extension Int32 : CVarArg {
 extension Int16 : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(_VAInt(self))
   }
@@ -251,7 +251,7 @@ extension Int16 : CVarArg {
 extension Int8 : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(_VAInt(self))
   }
@@ -261,7 +261,7 @@ extension Int8 : CVarArg {
 extension UInt : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
@@ -270,14 +270,14 @@ extension UInt : CVarArg {
 extension UInt64 : CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
 
   /// Returns the required alignment in bytes of
   /// the value returned by `_cVarArgEncoding`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgAlignment: Int {
     // FIXME: alignof differs from the ABI alignment on some architectures
     return MemoryLayout.alignment(ofValue: self)
@@ -287,7 +287,7 @@ extension UInt64 : CVarArg, _CVarArgAligned {
 extension UInt32 : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(_VAUInt(self))
   }
@@ -296,7 +296,7 @@ extension UInt32 : CVarArg {
 extension UInt16 : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(_VAUInt(self))
   }
@@ -305,7 +305,7 @@ extension UInt16 : CVarArg {
 extension UInt8 : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(_VAUInt(self))
   }
@@ -314,7 +314,7 @@ extension UInt8 : CVarArg {
 extension OpaquePointer : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
@@ -323,7 +323,7 @@ extension OpaquePointer : CVarArg {
 extension UnsafePointer : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
@@ -332,7 +332,7 @@ extension UnsafePointer : CVarArg {
 extension UnsafeMutablePointer : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
@@ -352,14 +352,14 @@ extension AutoreleasingUnsafeMutablePointer : CVarArg {
 extension Float : _CVarArgPassedAsDouble, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(Double(self))
   }
 
   /// Returns the required alignment in bytes of
   /// the value returned by `_cVarArgEncoding`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgAlignment: Int {
     // FIXME: alignof differs from the ABI alignment on some architectures
     return MemoryLayout.alignment(ofValue: Double(self))
@@ -369,14 +369,14 @@ extension Float : _CVarArgPassedAsDouble, _CVarArgAligned {
 extension Double : _CVarArgPassedAsDouble, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(self)
   }
 
   /// Returns the required alignment in bytes of
   /// the value returned by `_cVarArgEncoding`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   public var _cVarArgAlignment: Int {
     // FIXME: alignof differs from the ABI alignment on some architectures
     return MemoryLayout.alignment(ofValue: self)
@@ -388,36 +388,37 @@ extension Double : _CVarArgPassedAsDouble, _CVarArgAligned {
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.
 @_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout // c-abi
+@usableFromInline // c-abi
 final internal class _VaListBuilder {
 
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // c-abi
   @usableFromInline
   internal struct Header {
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // c-abi
     internal init() {}
 
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // c-abi
     internal var gp_offset = CUnsignedInt(0)
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // c-abi
     internal var fp_offset =
       CUnsignedInt(_countGPRegisters * MemoryLayout<Int>.stride)
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // c-abi
     internal var overflow_arg_area: UnsafeMutablePointer<Int>?
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // c-abi
     internal var reg_save_area: UnsafeMutablePointer<Int>?
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   internal init() {
     // prepare the register save area
     storage = ContiguousArray(repeating: 0, count: _registerSaveWords)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   deinit {}
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   internal func append(_ arg: CVarArg) {
     var encoded = arg._cVarArgEncoding
 
@@ -459,7 +460,7 @@ final internal class _VaListBuilder {
 
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   internal func va_list() -> CVaListPointer {
     header.reg_save_area = storage._baseAddress
     header.overflow_arg_area
@@ -469,15 +470,15 @@ final internal class _VaListBuilder {
                Builtin.addressof(&self.header)))
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   internal var gpRegistersUsed = 0
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   internal var fpRegistersUsed = 0
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   final  // Property must be final since it is used by Builtin.addressof.
   internal var header = Header()
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   internal var storage: ContiguousArray<Int>
 }
 
@@ -486,13 +487,14 @@ final internal class _VaListBuilder {
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.
 @_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout // c-abi
+@usableFromInline // c-abi
 final internal class _VaListBuilder {
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   internal init() {}
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   internal func append(_ arg: CVarArg) {
     // Write alignment padding if necessary.
     // This is needed on architectures where the ABI alignment of some
@@ -519,7 +521,7 @@ final internal class _VaListBuilder {
   // Marking it inlinable will cause it to resiliently use accessors to
   // project `_VaListBuilder.alignedStorageForEmptyVaLists` as a computed
   // property.
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   internal func va_list() -> CVaListPointer {
     // Use Builtin.addressof to emphasize that we are deliberately escaping this
     // pointer and assuming it is safe to do so.
@@ -532,7 +534,7 @@ final internal class _VaListBuilder {
   // but possibly more aligned than that.
   // FIXME: this should be packaged into a better storage type
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   internal func appendWords(_ words: [Int]) {
     let newCount = count + words.count
     if newCount > allocated {
@@ -558,7 +560,7 @@ final internal class _VaListBuilder {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   internal func rawSizeAndAlignment(
     _ wordCount: Int
   ) -> (Builtin.Word, Builtin.Word) {
@@ -566,14 +568,14 @@ final internal class _VaListBuilder {
       requiredAlignmentInBytes._builtinWordValue)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   internal func allocStorage(wordCount: Int) -> UnsafeMutablePointer<Int> {
     let (rawSize, rawAlignment) = rawSizeAndAlignment(wordCount)
     let rawStorage = Builtin.allocRaw(rawSize, rawAlignment)
     return UnsafeMutablePointer<Int>(rawStorage)
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   internal func deallocStorage(
     wordCount: Int,
     storage: UnsafeMutablePointer<Int>
@@ -582,7 +584,7 @@ final internal class _VaListBuilder {
     Builtin.deallocRaw(storage._rawValue, rawSize, rawAlignment)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // c-abi
   deinit {
     if let allocatedStorage = storage {
       deallocStorage(wordCount: allocated, storage: allocatedStorage)
@@ -590,13 +592,13 @@ final internal class _VaListBuilder {
   }
 
   // FIXME: alignof differs from the ABI alignment on some architectures
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   internal let requiredAlignmentInBytes = MemoryLayout<Double>.alignment
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   internal var count = 0
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   internal var allocated = 0
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // c-abi
   internal var storage: UnsafeMutablePointer<Int>?
 
   internal static var alignedStorageForEmptyVaLists: Double = 0

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -7,6 +7,7 @@
 Constructor AnyHashable.init(_box:) has been removed
 Constructor AnyHashable.init(_usingDefaultRepresentationOf:) has been removed
 Constructor ManagedBufferPointer.init(_:_:_:) has been removed
+Constructor _BridgeableMetatype.init(value:) has been removed
 Func AnyHashable._downCastConditional(into:) has been removed
 Func _CocoaDictionary.Index.copy() has been removed
 Func _ContiguousArrayStorage._getNonVerbatimBridgedHeapBuffer() has been removed
@@ -14,6 +15,8 @@ Func _ContiguousArrayStorage._withVerbatimBridgedUnsafeBufferImpl(_:) has been r
 Func __ContiguousArrayStorageBase._getNonVerbatimBridgedHeapBuffer() has been removed
 Func __EmptyArrayStorage._getNonVerbatimBridgedHeapBuffer() has been removed
 Func __SwiftDeferredNSArray._destroyBridgedStorage(_:) has been removed
+Func _getEnumCaseName(_:) has been removed
+Func _opaqueSummary(_:) has been removed
 Func _stdlib_NSDictionary_allKeys(_:) has been removed
 Func _stdlib_NSSet_allObjects(_:) has been removed
 Protocol _HeapBufferHeader_ has been removed
@@ -23,6 +26,8 @@ Subscript ManagedBufferPointer.subscript(_:) has been removed
 Var ManagedBufferPointer.baseAddress has been removed
 Var ManagedBufferPointer.storage has been removed
 Var ManagedBufferPointer.value has been removed
+Var Optional._nilSentinel has been removed
+Var _BridgeableMetatype.value has been removed
 Var _CocoaDictionary.Index._object has been removed
 Var _CocoaSet.Index._object has been removed
 Var __SwiftDeferredNSArray._heapBufferBridged has been removed
@@ -33,6 +38,7 @@ Var __SwiftDeferredNSArray._heapBufferBridgedPtr has been removed
 /* Renamed Decls */
 
 /* Type Changes */
+Struct _BridgeableMetatype is now without @_fixed_layout
 Func __ContiguousArrayStorageBase._getNonVerbatimBridgingBuffer() is added to a non-resilient type
 Var _CocoaDictionary.Index._offset is added to a non-resilient type
 Var _CocoaDictionary.Index._storage in a non-resilient type changes position from 1 to 0


### PR DESCRIPTION
A grab-bag.

- Uninline _BridgeableMetatype
- Uninline some streaming methods
- Uninline some optional bridging
- fastEnumerationStorage is legitimately usable from inline
- `ObjectIdentifier` is never likely to change and needs to be fast
- var args are unlikely to change given the C ABI
