### PR TITLE
[ABI] Eliminate witness table accessors.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -128,7 +128,7 @@ Globals
 
   global ::= protocol-conformance 'Mc'   // protocol conformance descriptor
   global ::= protocol-conformance 'WP'   // protocol witness table
-  global ::= protocol-conformance 'Wa'   // protocol witness table accessor
+  global ::= protocol-conformance 'Wa'   // protocol witness table accessor (HISTORICAL)
 
   global ::= protocol-conformance 'WG'   // generic protocol witness table (HISTORICAL)
   global ::= protocol-conformance 'Wp'   // protocol witness table pattern

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -600,24 +600,9 @@ class ConformanceFlags {
 public:
   typedef uint32_t int_type;
 
-  enum class ConformanceKind {
-    /// A direct reference to a protocol witness table.
-    WitnessTable,
-    /// A function pointer that can be called to access the protocol witness
-    /// table.
-    WitnessTableAccessor,
-    /// A function pointer that can be called to access the protocol witness
-    /// table whose conformance is conditional on additional requirements that
-    /// must first be evaluated and then provided to the accessor function.
-    ConditionalWitnessTableAccessor,
-
-    First_Kind = WitnessTable,
-    Last_Kind = ConditionalWitnessTableAccessor,
-  };
-
 private:
   enum : int_type {
-    ConformanceKindMask = 0x07,      // 8 conformance kinds
+    UnusedLowBits = 0x07,      // historical conformance kind
 
     TypeMetadataKindMask = 0x7 << 3, // 8 type reference kinds
     TypeMetadataKindShift = 3,
@@ -636,10 +621,6 @@ private:
 
 public:
   ConformanceFlags(int_type value = 0) : Value(value) {}
-
-  ConformanceFlags withConformanceKind(ConformanceKind kind) const {
-    return ConformanceFlags((Value & ~ConformanceKindMask) | int_type(kind));
-  }
 
   ConformanceFlags withTypeReferenceKind(TypeReferenceKind kind) const {
     return ConformanceFlags((Value & ~TypeMetadataKindMask)
@@ -675,11 +656,6 @@ public:
                             | (hasGenericWitnessTable
                                  ? HasGenericWitnessTableMask
                                  : 0));
-  }
-
-  /// Retrieve the conformance kind.
-  ConformanceKind getConformanceKind() const {
-    return ConformanceKind(Value & ConformanceKindMask);
   }
 
   /// Retrieve the type reference kind kind.

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -258,10 +258,6 @@ public:
   /// Get the substitutions associated with this conformance.
   SubstitutionMap getSubstitutions(ModuleDecl *M) const;
 
-  /// Determine whether the witness table access function for this conformance
-  /// needs to be passed information when called, or if it stands alone.
-  bool witnessTableAccessorRequiresArguments() const;
-
   /// Get the underlying normal conformance.
   const NormalProtocolConformance *getRootNormalConformance() const;
 

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -244,10 +244,6 @@ class LinkEntity {
     /// ProtocolConformance*.
     ProtocolWitnessTablePattern,
 
-    /// A witness accessor function. The secondary pointer is a
-    /// ProtocolConformance*.
-    ProtocolWitnessTableAccessFunction,
-
     /// The instantiation function for a generic protocol witness table.
     /// The secondary pointer is a ProtocolConformance*.
     GenericProtocolWitnessTableInstantiationFunction,
@@ -724,14 +720,6 @@ public:
   forProtocolWitnessTablePattern(const ProtocolConformance *C) {
     LinkEntity entity;
     entity.setForProtocolConformance(Kind::ProtocolWitnessTablePattern, C);
-    return entity;
-  }
-
-  static LinkEntity
-  forProtocolWitnessTableAccessFunction(const ProtocolConformance *C) {
-    LinkEntity entity;
-    entity.setForProtocolConformance(Kind::ProtocolWitnessTableAccessFunction,
-                                     C);
     return entity;
   }
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -406,9 +406,9 @@ MetadataResponse swift_checkMetadataState(MetadataRequest request,
 ///   conformances.
 SWIFT_RUNTIME_EXPORT
 const WitnessTable *
-swift_instantiateWitnessTable(ProtocolConformanceDescriptor *conformance,
+swift_instantiateWitnessTable(const ProtocolConformanceDescriptor *conformance,
                               const Metadata *type,
-                              void **const *instantiationArgs);
+                              const void * const *instantiationArgs);
 
 /// Retrieve an associated type witness from the given witness table.
 ///
@@ -489,13 +489,6 @@ SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 MetadataResponse
 swift_getForeignTypeMetadata(MetadataRequest request,
                              ForeignTypeMetadata *nonUnique);
-
-/// \brief Fetch a unique witness table for a foreign witness table.
-SWIFT_RUNTIME_EXPORT
-const WitnessTable *
-swift_getForeignWitnessTable(const WitnessTable *nonUniqueWitnessCandidate,
-                             const TypeContextDescriptor *forForeignType,
-                             const ProtocolDescriptor *forProtocol);
 
 /// \brief Fetch a uniqued metadata for a tuple type.
 ///

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -385,18 +385,13 @@ SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 MetadataResponse swift_checkMetadataState(MetadataRequest request,
                                           const Metadata *type);
 
-/// Instantiate a resilient or generic protocol witness table.
+/// Retrieve a witness table based on a given conformance.
 ///
 /// \param conformance - The protocol conformance descriptor, which
-///   contains the generic witness table record. It may either have fields
-///   that require runtime initialization, or be missing requirements at the
-///   end for which default witnesses are available.
+///   contains any information required to form the witness table.
 ///
 /// \param type - The conforming type, used to form a uniquing key
-///   for the conformance. If the witness table is not dependent on
-///   the substituted type of the conformance, this can be set to
-///   nullptr, in which case there will only be one instantiated
-///   witness table per witness table template.
+///   for the conformance.
 ///
 /// \param instantiationArgs - An opaque pointer that's forwarded to
 ///   the instantiation function, used for conditional conformances.
@@ -406,9 +401,9 @@ MetadataResponse swift_checkMetadataState(MetadataRequest request,
 ///   conformances.
 SWIFT_RUNTIME_EXPORT
 const WitnessTable *
-swift_instantiateWitnessTable(const ProtocolConformanceDescriptor *conformance,
-                              const Metadata *type,
-                              const void * const *instantiationArgs);
+swift_getWitnessTable(const ProtocolConformanceDescriptor *conformance,
+                      const Metadata *type,
+                      const void * const *instantiationArgs);
 
 /// Retrieve an associated type witness from the given witness table.
 ///

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -585,16 +585,6 @@ FUNCTION(GetForeignTypeMetadata, swift_getForeignTypeMetadata, SwiftCC,
          ARGS(SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone)) // only writes to runtime-private fields
 
-// WitnessTable *swift_getForeignWitnessTable(
-//                                  const WitnessTable *candidate,
-//                                  const TypeContextDescriptor *forType,
-//                                  const ProtocolDescriptor *forProtocol);
-FUNCTION(GetForeignWitnessTable, swift_getForeignWitnessTable, C_CC,
-         RETURNS(WitnessTablePtrTy),
-         ARGS(WitnessTablePtrTy, TypeContextDescriptorPtrTy,
-              ProtocolDescriptorPtrTy),
-         ATTRS(NoUnwind, ReadNone))
-
 // MetadataResponse swift_getSingletonMetadata(MetadataRequest request,
 //                                             TypeContextDescriptor *type);
 FUNCTION(GetSingletonMetadata, swift_getSingletonMetadata, SwiftCC,
@@ -637,7 +627,7 @@ FUNCTION(CheckMetadataState, swift_checkMetadataState, SwiftCC,
 // const ProtocolWitnessTable *
 // swift_instantiateWitnessTable(const ProtocolConformanceDescriptor *conf,
 //                               const Metadata *type,
-//                               void ** const *instantiationArgs);
+//                               const void * const *instantiationArgs);
 FUNCTION(InstantiateWitnessTable, swift_instantiateWitnessTable, C_CC,
          RETURNS(WitnessTablePtrTy),
          ARGS(ProtocolConformanceDescriptorPtrTy,

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -625,10 +625,10 @@ FUNCTION(CheckMetadataState, swift_checkMetadataState, SwiftCC,
          ATTRS(NoUnwind, ReadOnly))
 
 // const ProtocolWitnessTable *
-// swift_instantiateWitnessTable(const ProtocolConformanceDescriptor *conf,
-//                               const Metadata *type,
-//                               const void * const *instantiationArgs);
-FUNCTION(InstantiateWitnessTable, swift_instantiateWitnessTable, C_CC,
+// swift_getWitnessTable(const ProtocolConformanceDescriptor *conf,
+//                       const Metadata *type,
+//                       const void * const *instantiationArgs);
+FUNCTION(GetWitnessTable, swift_getWitnessTable, C_CC,
          RETURNS(WitnessTablePtrTy),
          ARGS(ProtocolConformanceDescriptorPtrTy,
               TypeMetadataPtrTy,

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1079,10 +1079,6 @@ ProtocolConformance::getRootNormalConformance() const {
   return cast<NormalProtocolConformance>(C);
 }
 
-bool ProtocolConformance::witnessTableAccessorRequiresArguments() const {
-  return getRootNormalConformance()->getDeclContext()->isGenericContext();
-}
-
 bool ProtocolConformance::isVisibleFrom(const DeclContext *dc) const {
   // FIXME: Implement me!
   return true;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3643,36 +3643,6 @@ IRGenModule::getAddrOfGenericWitnessTableInstantiationFunction(
   return entry;
 }
 
-/// Fetch the witness table access function for a protocol conformance.
-llvm::Function *
-IRGenModule::getAddrOfWitnessTableAccessFunction(
-                                      const NormalProtocolConformance *conf,
-                                              ForDefinition_t forDefinition) {
-  IRGen.addLazyWitnessTable(conf);
-
-  LinkEntity entity = LinkEntity::forProtocolWitnessTableAccessFunction(conf);
-  llvm::Function *&entry = GlobalFuncs[entity];
-  if (entry) {
-    if (forDefinition) updateLinkageForDefinition(*this, entry, entity);
-    return entry;
-  }
-
-  llvm::FunctionType *fnType;
-  if (conf->witnessTableAccessorRequiresArguments()) {
-    // conditional requirements are passed indirectly, as an array of witness
-    // tables.
-    fnType = llvm::FunctionType::get(
-        WitnessTablePtrTy, {TypeMetadataPtrTy, WitnessTablePtrPtrTy}, false);
-  } else {
-    fnType = llvm::FunctionType::get(WitnessTablePtrTy, false);
-  }
-
-  Signature signature(fnType, llvm::AttributeList(), DefaultCC);
-  LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
-  entry = createFunction(*this, link, signature);
-  return entry;
-}
-
 /// Fetch the lazy witness table access function for a protocol conformance.
 llvm::Function *
 IRGenModule::getAddrOfWitnessTableLazyAccessFunction(

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1074,7 +1074,7 @@ static llvm::Value *emitWitnessTableAccessorCall(
   auto conditionalTables =
       emitConditionalConformancesBuffer(IGF, conformance);
 
-  auto call = IGF.Builder.CreateCall(IGF.IGM.getInstantiateWitnessTableFn(),
+  auto call = IGF.Builder.CreateCall(IGF.IGM.getGetWitnessTableFn(),
                                      {conformanceDescriptor, *srcMetadataCache,
                                       conditionalTables});
 

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -255,11 +255,6 @@ public:
     return mangleConformanceSymbol(Type(), C, "WI");
   }
 
-  std::string mangleProtocolWitnessTableAccessFunction(
-                                                const ProtocolConformance *C) {
-    return mangleConformanceSymbol(Type(), C, "Wa");
-  }
-
   std::string mangleProtocolWitnessTableLazyAccessFunction(Type type,
                                                 const ProtocolConformance *C) {
     return mangleConformanceSymbol(type, C, "Wl");

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1315,9 +1315,6 @@ public:
   Address getAddrOfSILGlobalVariable(SILGlobalVariable *var,
                                      const TypeInfo &ti,
                                      ForDefinition_t forDefinition);
-  llvm::Function *getAddrOfWitnessTableAccessFunction(
-                                           const NormalProtocolConformance *C,
-                                               ForDefinition_t forDefinition);
   llvm::Function *getAddrOfWitnessTableLazyAccessFunction(
                                            const NormalProtocolConformance *C,
                                                CanType conformingType,

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -212,10 +212,6 @@ std::string LinkEntity::mangleAsString() const {
     return mangler.mangleGenericProtocolWitnessTableInstantiationFunction(
                                                     getProtocolConformance());
 
-  case Kind::ProtocolWitnessTableAccessFunction:
-    return mangler.mangleProtocolWitnessTableAccessFunction(
-                                                    getProtocolConformance());
-
   case Kind::ProtocolWitnessTablePattern:
     return mangler.mangleProtocolWitnessTablePattern(getProtocolConformance());
 
@@ -466,7 +462,6 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
                          forDefinition);
 
   case Kind::DirectProtocolWitnessTable:
-  case Kind::ProtocolWitnessTableAccessFunction:
   case Kind::ProtocolConformanceDescriptor:
     return getLinkageAsConformance();
 
@@ -624,7 +619,6 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
   case Kind::TypeMetadataAccessFunction:
   case Kind::TypeMetadataLazyCacheVariable:
   case Kind::FieldOffset:
-  case Kind::ProtocolWitnessTableAccessFunction:
   case Kind::ProtocolWitnessTableLazyAccessFunction:
   case Kind::ProtocolWitnessTableLazyCacheVariable:
   case Kind::AssociatedTypeWitnessTableAccessFunction:
@@ -827,7 +821,6 @@ const SourceFile *LinkEntity::getSourceFileForEmission() const {
     
   case Kind::DirectProtocolWitnessTable:
   case Kind::ProtocolWitnessTablePattern:
-  case Kind::ProtocolWitnessTableAccessFunction:
   case Kind::GenericProtocolWitnessTableInstantiationFunction:
   case Kind::AssociatedTypeWitnessTableAccessFunction:
   case Kind::ReflectionAssociatedTypeDescriptor:

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -120,8 +120,6 @@ void TBDGenVisitor::addConformances(DeclContext *DC) {
       continue;
 
     addSymbol(LinkEntity::forDirectProtocolWitnessTable(normalConformance));
-    addSymbol(
-        LinkEntity::forProtocolWitnessTableAccessFunction(normalConformance));
     addSymbol(LinkEntity::forProtocolConformanceDescriptor(normalConformance));
 
     // FIXME: the logic around visibility in extensions is confusing, and

--- a/stdlib/public/SDK/Foundation/NSError.h
+++ b/stdlib/public/SDK/Foundation/NSError.h
@@ -27,11 +27,9 @@ namespace swift {
 /// The items that ErrorObject.mm needs for bridging. The
 /// ERROR_BRIDGING_SYMBOL_NAME symbol will contain an instance of this struct.
 struct ErrorBridgingInfo {
-  const SWIFT_CC(swift) WitnessTable *(*GetCFErrorErrorConformance)();
-  
-  const SWIFT_CC(swift) hashable_support::HashableWitnessTable *
-    (*GetNSObjectHashableConformance)();
-  
+  const ProtocolConformanceDescriptor *CFErrorErrorConformance;
+  const ProtocolConformanceDescriptor *NSObjectHashableConformance;
+
   SWIFT_CC(swift) NSDictionary *(*GetErrorDefaultUserInfo)(const OpaqueValue *error,
                                                            const Metadata *T,
                                                            const WitnessTable *Error);

--- a/stdlib/public/SDK/Foundation/NSError.mm
+++ b/stdlib/public/SDK/Foundation/NSError.mm
@@ -17,11 +17,11 @@
 using namespace swift;
 
 // Declare the mangled Swift symbols that we'll be putting in the bridging info.
-extern "C" const SWIFT_CC(swift) WitnessTable *
-  MANGLE_SYM(So10CFErrorRefas5Error10FoundationWa)();
+extern "C" const ProtocolConformanceDescriptor
+  MANGLE_SYM(So10CFErrorRefas5Error10FoundationMc);
 
-extern "C" const SWIFT_CC(swift) hashable_support::HashableWitnessTable *
-  MANGLE_SYM(So8NSObjectCSH10ObjectiveCWa)();
+extern "C" const ProtocolConformanceDescriptor
+  MANGLE_SYM(So8NSObjectCSH10ObjectiveCMc);
 
 extern "C" SWIFT_CC(swift)
   NSDictionary *MANGLE_SYM(10Foundation24_getErrorDefaultUserInfoyyXlSgxs0C0RzlF)(
@@ -36,8 +36,8 @@ extern "C" const ProtocolDescriptor
 
 // Define the bridging info struct.
 extern "C" ErrorBridgingInfo ERROR_BRIDGING_SYMBOL_NAME = {
-  MANGLE_SYM(So10CFErrorRefas5Error10FoundationWa),
-  MANGLE_SYM(So8NSObjectCSH10ObjectiveCWa),
+  &MANGLE_SYM(So10CFErrorRefas5Error10FoundationMc),
+  &MANGLE_SYM(So8NSObjectCSH10ObjectiveCMc),
   MANGLE_SYM(10Foundation24_getErrorDefaultUserInfoyyXlSgxs0C0RzlF),
   MANGLE_SYM(10Foundation21_bridgeNSErrorToError_3outSbSo0C0C_SpyxGtAA021_ObjectiveCBridgeableE0RzlF),
   &MANGLE_SYM(10Foundation26_ObjectiveCBridgeableErrorMp)

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -250,9 +250,9 @@ static const WitnessTable *getNSErrorConformanceToError() {
   assert(conformance &&
          "Foundation overlay not loaded, or 'CFError : Error' conformance "
          "not available");
-  return swift_instantiateWitnessTable(conformance,
-                                       conformance->getCanonicalTypeMetadata(),
-                                       nullptr);
+  return swift_getWitnessTable(conformance,
+                               conformance->getCanonicalTypeMetadata(),
+                               nullptr);
 }
 
 static const HashableWitnessTable *getNSErrorConformanceToHashable() {
@@ -260,7 +260,7 @@ static const HashableWitnessTable *getNSErrorConformanceToHashable() {
   assert(conformance &&
          "ObjectiveC overlay not loaded, or 'NSObject : Hashable' conformance "
          "not available");
-  return (const HashableWitnessTable *)swift_instantiateWitnessTable(
+  return (const HashableWitnessTable *)swift_getWitnessTable(
            conformance,
            conformance->getCanonicalTypeMetadata(),
            nullptr);

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -246,19 +246,24 @@ static const WitnessTable *getNSErrorConformanceToError() {
   // safe to assume that that's been linked in if a user is using NSError in
   // their Swift source.
 
-  auto getter = getErrorBridgingInfo().GetCFErrorErrorConformance;
-  assert(getter &&
+  auto conformance = getErrorBridgingInfo().CFErrorErrorConformance;
+  assert(conformance &&
          "Foundation overlay not loaded, or 'CFError : Error' conformance "
          "not available");
-  return getter();
+  return swift_instantiateWitnessTable(conformance,
+                                       conformance->getCanonicalTypeMetadata(),
+                                       nullptr);
 }
 
 static const HashableWitnessTable *getNSErrorConformanceToHashable() {
-  auto getter = getErrorBridgingInfo().GetNSObjectHashableConformance;
-  assert(getter &&
+  auto conformance = getErrorBridgingInfo().NSObjectHashableConformance;
+  assert(conformance &&
          "ObjectiveC overlay not loaded, or 'NSObject : Hashable' conformance "
          "not available");
-  return getter();
+  return (const HashableWitnessTable *)swift_instantiateWitnessTable(
+           conformance,
+           conformance->getCanonicalTypeMetadata(),
+           nullptr);
 }
 
 bool SwiftError::isPureNSError() const {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3962,10 +3962,9 @@ WitnessTableCacheEntry::allocate(
 }
 
 const WitnessTable *
-swift::swift_instantiateWitnessTable(
-                               const ProtocolConformanceDescriptor *conformance,
-                               const Metadata *type,
-                               const void * const *instantiationArgs) {
+swift::swift_getWitnessTable(const ProtocolConformanceDescriptor *conformance,
+                             const Metadata *type,
+                             const void * const *instantiationArgs) {
   /// Local function to unique a foreign witness table, if needed.
   auto uniqueForeignWitnessTableRef =
       [conformance, type](const WitnessTable *candidate)

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3967,13 +3967,12 @@ swift::swift_getWitnessTable(const ProtocolConformanceDescriptor *conformance,
                              const void * const *instantiationArgs) {
   /// Local function to unique a foreign witness table, if needed.
   auto uniqueForeignWitnessTableRef =
-      [conformance, type](const WitnessTable *candidate)
-          -> const WitnessTable * {
+      [conformance](const WitnessTable *candidate) {
         if (!candidate || !conformance->isSynthesizedNonUnique())
           return candidate;
 
         return _getForeignWitnessTable(candidate,
-                                       type->getTypeContextDescriptor(),
+                                       conformance->getTypeContextDescriptor(),
                                        conformance->getProtocol());
       };
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3977,14 +3977,11 @@ swift::swift_getWitnessTable(const ProtocolConformanceDescriptor *conformance,
                                        conformance->getProtocol());
       };
 
-  // When there is no generic table, use the static witness table or
+  // When there is no generic table, or it doesn't require instantiation,
+  // use the pattern directly.
   // accessor directly.
   auto genericTable = conformance->getGenericWitnessTable();
-  if (!genericTable) {
-    return uniqueForeignWitnessTableRef(conformance->getWitnessTablePattern());
-  }
-
-  if (doesNotRequireInstantiation(conformance, genericTable)) {
+  if (!genericTable || doesNotRequireInstantiation(conformance, genericTable)) {
     return uniqueForeignWitnessTableRef(conformance->getWitnessTablePattern());
   }
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -167,7 +167,7 @@ ProtocolConformanceDescriptor::getWitnessTable(const Metadata *type) const {
     if (failed) return nullptr;
   }
 
-  return swift_instantiateWitnessTable(this, type, conditionalArgs.data());
+  return swift_getWitnessTable(this, type, conditionalArgs.data());
 }
 
 namespace {

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -37,16 +37,16 @@ protocol HasThreeAssocTypes {
 }
 
 //   Witness table access functions for Universal : P and Universal : Q.
-// CHECK-LABEL: define hidden i8** @"$s23associated_type_witness9UniversalVAA1PAAWa"()
-// CHECK:         ret i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s23associated_type_witness9UniversalVAA1PAAWP", i32 0, i32 0)
-// CHECK-LABEL: define hidden i8** @"$s23associated_type_witness9UniversalVAA1QAAWa"()
-// CHECK:         ret i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s23associated_type_witness9UniversalVAA1QAAWP", i32 0, i32 0)
+// CHECK-LABEL: define linkonce_odr hidden i8** @"$s23associated_type_witness9UniversalVAcA1PAAWl"
+// CHECK:         call i8** @swift_getWitnessTable(%swift.protocol_conformance_descriptor* @"$s23associated_type_witness9UniversalVAA1PAAMc"
+// CHECK-LABEL: define linkonce_odr hidden i8** @"$s23associated_type_witness9UniversalVAcA1QAAWl"()
+// CHECK:         call i8** @swift_getWitnessTable(%swift.protocol_conformance_descriptor* @"$s23associated_type_witness9UniversalVAA1QAAMc"
 
 //   Witness table for WithUniversal : Assocked.
 // GLOBAL-LABEL: @"$s23associated_type_witness13WithUniversalVAA8AssockedAAWP" = hidden global [4 x i8*] [
 // GLOBAL-SAME:    @"$s23associated_type_witness13WithUniversalVAA8AssockedAAMc"
-// GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAA1PAAWa" to i8*)
-// GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAA1QAAWa" to i8*)  
+// GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAcA1PAAWl" to i8*) 
+// GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAcA1QAAWl" to i8*)  
 // GLOBAL-SAME:    i64 add (i64 ptrtoint (<{ [36 x i8], i8 }>* @"symbolic 23associated_type_witness9UniversalV" to i64), i64 1) to i8*)
 // GLOBAL-SAME:  ]
 struct WithUniversal : Assocked {
@@ -56,8 +56,8 @@ struct WithUniversal : Assocked {
 //   Witness table for GenericWithUniversal : Assocked.
 // GLOBAL-LABEL: @"$s23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAAWP" = hidden global [4 x i8*] [
 // GLOBAL-SAME:    @"$s23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAAMc"
-// GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAA1PAAWa" to i8*)
-// GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAA1QAAWa" to i8*)  
+// GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAcA1PAAWl" to i8*)
+// GLOBAL-SAME:    i8* bitcast (i8** ()* @"$s23associated_type_witness9UniversalVAcA1QAAWl" to i8*)  
 // GLOBAL-SAME:    @"symbolic 23associated_type_witness9UniversalV"
 // GLOBAL-SAME:  ]
 struct GenericWithUniversal<T> : Assocked {
@@ -105,23 +105,11 @@ struct Computed<T, U> : Assocked {
 
 //   Instantiation function for GenericComputed : DerivedFromSimpleAssoc.
 // CHECK-LABEL: define internal void @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI"(i8**, %swift.type* %"GenericComputed<T>", i8**)
-// CHECK:         [[T0:%.*]] = call i8** @"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type* %"GenericComputed<T>", i8*** undef)
+// CHECK:         [[T0:%.*]] = call i8** @swift_getWitnessTable({{.*}}@"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAMc"
 // CHECK-NEXT:    [[T1:%.*]] = bitcast i8** [[T0]] to i8*
 // CHECK-NEXT:    [[T2:%.*]] = getelementptr inbounds i8*, i8** %0, i32 1
 // CHECK-NEXT:    store i8* [[T1]], i8** [[T2]], align 8
 // CHECK-NEXT:    ret void
-
-//   Witness table accessor function for GenericComputed : HasSimpleAssoc..
-// CHECK-LABEL: define hidden i8** @"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type*, i8***)
-// CHECK-NEXT:   entry:
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAMc"{{.*}}, %swift.type* %0, i8*** %1)
-// CHECK-NEXT:    ret i8** [[WTABLE]]
-
-//   Witness table accessor function for Computed : Assocked.
-// CHECK-LABEL: define hidden i8** @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWa"(%swift.type*, i8***)
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:     [[WTABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAMc"{{.*}}, %swift.type* %0, i8*** %1)
-// CHECK-NEXT:     ret i8** [[WTABLE]]
 
 
 struct PBox<T: P> {}
@@ -156,9 +144,6 @@ struct UsesVoid : HasSimpleAssoc {
 // GLOBAL-SAME:    i16 4,
 // GLOBAL-SAME:    i16 1,
 
-//    Relative reference to witness table template
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([4 x i8*]* @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWp" to i64), i64 ptrtoint
-
 //    No instantiator function
 // GLOBAL-SAME:    i32 0,
 // GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([16 x i8*]* [[PRIVATE:@.*]] to i64), i64 ptrtoint
@@ -168,9 +153,6 @@ struct UsesVoid : HasSimpleAssoc {
 // GLOBAL-LABEL: @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAMc" = hidden constant
 // GLOBAL-SAME:    i16 2,
 // GLOBAL-SAME:    i16 0,
-
-//   Relative reference to witness table template
-// GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([2 x i8*]* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWp" to i64
 
 //   Relative reference to instantiator function
 // GLOBAL-SAME:    i32 trunc (i64 sub (i64 ptrtoint (void (i8**, %swift.type*, i8**)* @"$s23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI" to i64),

--- a/test/IRGen/deserialize-clang-importer-witness-tables.swift
+++ b/test/IRGen/deserialize-clang-importer-witness-tables.swift
@@ -9,8 +9,8 @@ public func foo(line: String) {
   // from the default argument expression passed to `RegEx(pattern:options:)`
   // below. Ensure that a local copy of the definition was deserialized
   // and lowered to IR.
-  // CHECK-LABEL: define {{.*}} i8** @"$sSo26NSRegularExpressionOptionsVs10SetAlgebraSCWa"
   // CHECK-LABEL: define {{.*}} void @"$sSo26NSRegularExpressionOptionsVs10SetAlgebraSCsACPxycfCTW"
+  // CHECK-LABEL: define {{.*}} i8** @"$sSo26NSRegularExpressionOptionsVABSQSCWl"()
   let versionRegex = try! RegEx(pattern: "Apple")
   _ = versionRegex.firstMatch(in: line)  
 }

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -11,7 +11,7 @@ import gizmo
 // CHECK: @"$sSo16NSRuncingOptionsVMn" = linkonce_odr hidden constant
 // CHECK: @"$sSo16NSRuncingOptionsVN" = linkonce_odr hidden constant
 //   CHECK-SAME: @"$sBi{{[0-9]+}}_WV"
-// CHECK: @"$sSo16NSRuncingOptionsVSQSCMc" = linkonce_odr hidden constant{{.*}}@"$sSo16NSRuncingOptionsVSQSCWa
+// CHECK: @"$sSo16NSRuncingOptionsVSQSCMc" = linkonce_odr hidden constant
 // CHECK-NOT: @"$sSo28NeverActuallyMentionedByNameVSQSCWp" = linkonce_odr hidden constant
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i32 @main
@@ -88,11 +88,6 @@ use_metadata(NSRuncingOptions.mince)
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSo16NSRuncingOptionsVMa"(i64)
 // CHECK:         call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}} @"$sSo16NSRuncingOptionsVN" {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
-
-// CHECK-LABEL: define linkonce_odr hidden i8** @"$sSo16NSRuncingOptionsVSQSCWa"()
-// CHECK:  [[NONUNIQUE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$sSo16NSRuncingOptionsVSQSCMc" to %swift.protocol_conformance_descriptor*), %swift.type* null, i8*** null)
-// CHECK:  [[UNIQUE:%.*]] = call i8** @swift_getForeignWitnessTable(i8** [[NONUNIQUE]], %swift.type_descriptor* bitcast (<{ {{.*}} }>* @"$sSo16NSRuncingOptionsVMn" to %swift.type_descriptor*), %swift.protocol* @"$sSQMp")
-// CHECK:  ret i8** [[UNIQUE]]
 
 @objc enum ExportedToObjC: Int {
   case Foo = -1, Bar, Bas

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -98,7 +98,7 @@ sil hidden_external @takingEmptyAndQ : $@convention(thin) <τ_0_0 where  τ_0_0 
 // CHECK:   [[GENPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
 // CHECK:   [[PARAMTYADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 10|i32 13)}}
 // CHECK:   %"BaseProducer<\CF\84_0_1>" = load %swift.type*, %swift.type** [[PARAMTYADDR]]
-// CHECK:   [[WITNESS:%.*]] = call i8** @"$s23partial_apply_forwarder12BaseProducerVyxGAA1QAAWa"(%swift.type* %"BaseProducer<\CF\84_0_1>", i8*** undef)
+// CHECK:   [[WITNESS:%.*]] = call i8** @swift_getWitnessTable(
 // CHECK:   [[OBJ:%.*]] = bitcast %swift.refcounted* %0 to %T23partial_apply_forwarder7WeakBoxC.1*
 // CHECK:   tail call swiftcc void @takingQ(%T23partial_apply_forwarder7WeakBoxC.1* [[OBJ]], i8** [[WITNESS]])
 // CHECK: }
@@ -157,7 +157,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
 // CHECK:   [[TYPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
 // CHECK:   [[TYPARAM:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[TYPARAMSADDR]], {{(i64 10|i32 13)}}
 // CHECK:   %"BaseProducer<\CF\84_0_1>" = load %swift.type*, %swift.type** [[TYPARAM]]
-// CHECK:   [[WITNESS:%.*]] = call i8** @"$s23partial_apply_forwarder12BaseProducerVyxGAA1QAAWa"(%swift.type* %"BaseProducer<\CF\84_0_1>", i8*** undef)
+// CHECK:   [[WITNESS:%.*]] = call i8** @swift_getWitnessTable
 // CHECK:   tail call swiftcc void @takingQ(%T23partial_apply_forwarder7WeakBoxC.1* [[CAST]], i8** [[WITNESS]])
 // CHECK:   ret void
 
@@ -211,7 +211,7 @@ sil hidden_external @takingQAndS : $@convention(thin) <τ_0_0 where  τ_0_0 : Q>
 // CHECK:   [[GENPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
 // CHECK:   [[GENPARAMADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 10|i32 13)}}
 // CHECK:   %"BaseProducer<\CF\84_0_1>" = load %swift.type*, %swift.type** [[GENPARAMADDR]]
-// CHECK:   [[WITNESS:%.*]] = call i8** @"$s23partial_apply_forwarder12BaseProducerVyxGAA1QAAWa"(%swift.type* %"BaseProducer<\CF\84_0_1>", i8*** undef)
+// CHECK:   [[WITNESS:%.*]] = call i8** @swift_getWitnessTable
 // CHECK:   tail call swiftcc void @takingQAndS(i64 [[X]], %T23partial_apply_forwarder7WeakBoxC.1* %.asUnsubstituted, i8** [[WITNESS]])
 
 sil public @bind_polymorphic_param_from_context_with_layout : $@convention(thin) <τ_0_1>(@in τ_0_1, S) -> @owned @callee_owned () -> () {

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -100,9 +100,9 @@ public protocol Spoon { }
 // -- nominal type descriptor
 // CHECK-SAME:           @"$s28protocol_conformance_records17NativeGenericTypeVMn"
 // -- witness table accessor
-// CHECK-SAME:           @"$s28protocol_conformance_records17NativeGenericTypeVyxGAA5SpoonA2aERzlWa
+// CHECK-SAME:           @"$s28protocol_conformance_records17NativeGenericTypeVyxGAA5Spoon
 // -- flags
-// CHECK-SAME:           i32 131330
+// CHECK-SAME:           i32 131328
 // -- conditional requirement #1
 // CHECK-SAME:           i32 128,
 // CHECK-SAME:           i32 0,
@@ -118,10 +118,10 @@ extension NativeGenericType : Spoon where T: Spoon {
 // CHECK-SAME:           @"{{got.|__imp_}}$s18resilient_protocol22OtherResilientProtocolMp"
 // -- nominal type descriptor
 // CHECK-SAME:           @"{{got.|__imp_}}$sSiMn"
-// -- witness table accessor
-// CHECK-SAME:           @"$sSi18resilient_protocol22OtherResilientProtocol0B20_conformance_recordsWa"
+// -- witness table pattern
+// CHECK-SAME:           @"$sSi18resilient_protocol22OtherResilientProtocol0B20_conformance_recordsWp"
 // -- flags
-// CHECK-SAME:           i32 131145,
+// CHECK-SAME:           i32 131144,
 // -- module context for retroactive conformance
 // CHECK-SAME:           @"$s28protocol_conformance_recordsMXM"
 // CHECK-SAME:         }
@@ -133,10 +133,10 @@ extension Int : OtherResilientProtocol { }
 // CHECK-SAME:           @"$s28protocol_conformance_records9AssociateMp"
 // -- nominal type descriptor
 // CHECK-SAME:           @"$s28protocol_conformance_records9DependentVMn"
-// -- witness table accessor
-// CHECK-SAME:           @"$s28protocol_conformance_records9DependentVyxGAA9AssociateAAWa"
+// -- witness table pattern
+// CHECK-SAME:           @"$s28protocol_conformance_records9DependentVyxGAA9AssociateAAWp"
 // -- flags
-// CHECK-SAME:           i32 1
+// CHECK-SAME:           i32 0
 // -- number of words in witness table
 // CHECK-SAME:           i16 2,
 // -- number of private words in witness table + bit for "needs instantiation"

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -93,7 +93,7 @@ protocol InternalProtocol {
 // Witness table for conformance with resilient associated type
 
 // CHECK: @"$s19protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWP" = {{(protected )?}}hidden global [3 x i8*] [
-// CHECK-SAME:   i8* bitcast (i8** ()* @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa" to i8*)
+// CHECK-SAME:   i8* bitcast (i8** ()* @"$s19protocol_resilience23ResilientConformingTypeVAC010resilient_A005OtherC8ProtocolAAWl"
 // CHECK-SAME:   @"symbolic 19protocol_resilience23ResilientConformingTypeV"
 // CHECK-SAME: ]
 
@@ -101,16 +101,13 @@ protocol InternalProtocol {
 
 // CHECK: @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAMc" =
 
-// CHECK-SAME: i32 131073,
+// CHECK-SAME: i32 131072,
 
 // -- number of witness table entries
 // CHECK-SAME:   i16 1,
 
 // -- size of private area + 'requires instantiation' bit (not set)
 // CHECK-SAME:   i16 0,
-
-// -- the template
-// CHECK-SAME:   @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWp"
 
 // -- instantiator function
 // CHECK-SAME:   i32 0
@@ -122,7 +119,7 @@ protocol InternalProtocol {
 // CHECK: "$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAMc" = hidden constant {
 
 // -- flags
-// CHECK-SAME: i32 196609,
+// CHECK-SAME: i32 196608,
 
 // CHECK-SAME: i32 3,
 
@@ -141,9 +138,6 @@ protocol InternalProtocol {
 
 // -- size of private area + 'requires instantiation' bit (not set)
 // CHECK-SAME:   i16 0,
-
-// -- the template
-// CHECK-SAME:   @"$s19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWp"
 
 // -- instantiator function
 // CHECK-SAME:   i32 0
@@ -373,20 +367,13 @@ bb0(%0 : $*ResilientConformingType):
 // CHECK-NEXT:    br i1 [[COND]], label %cacheIsNull, label %cont
 
 // CHECK:       cacheIsNull:
-// CHECK:         [[WTABLE:%.*]] = call i8** @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa"()
+// CHECK:         [[WTABLE:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    store atomic i8** [[WTABLE]], i8*** @"$s19protocol_resilience23ResilientConformingTypeVAC010resilient_A005OtherC8ProtocolAAWL" release
 // CHECK-NEXT:    br label %cont
 
 // CHECK:       cont:
 // CHECK-NEXT:    [[RESULT:%.*]] = phi i8** [ [[CCHE:%.*]], %entry ], [ [[WTABLE:%.*]], %cacheIsNull ]
 // CHECK-NEXT:    ret i8** [[RESULT]]
-
-// Resilient conformance -- must call a runtime function
-
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i8** @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa"()
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast ({{[{].*[}]}}* @"$s19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAMc" to %swift.protocol_conformance_descriptor*), %swift.type* null, i8*** null)
-// CHECK-NEXT:    ret i8** [[WTABLE]]
 
 
 //
@@ -494,13 +481,3 @@ sil_witness_table ConformsWithRequirements : ProtocolWithRequirements module pro
   method #ProtocolWithRequirements.first!1: @firstWitness
   method #ProtocolWithRequirements.second!1: @secondWitness
 }
-
-//
-// Witness table accessors for fragile conformances are emitted last
-//
-
-// Fragile conformance -- no runtime calls needed
-
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden i8** @"$s19protocol_resilience16ConformingStructVAA17ResilientProtocolAAWa"()
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i8** getelementptr inbounds ([9 x i8*], [9 x i8*]* @"$s19protocol_resilience16ConformingStructVAA17ResilientProtocolAAWP", i32 0, i32 0)

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -57,7 +57,7 @@ public struct ConditionallyConforms<Element> { }
 public struct Y { }
 
 // CHECK-USAGE-LABEL: @"$s31protocol_resilience_descriptors1YV010resilient_A022OtherResilientProtocolAAMc" =
-// CHECK-USAGE-SAME: i32 131073,
+// CHECK-USAGE-SAME: i32 131072,
 // CHECK-USAGE-SAME: i16 1,
 // CHECK-USAGE-SAME: i16 0
 extension Y: OtherResilientProtocol { }

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -42,7 +42,7 @@ struct Conformer: Q, QQ {
 // CHECK:   i8* bitcast (void (%T18sil_witness_tables9ConformerV*, %swift.type*, i8**)* @"$s18sil_witness_tables9ConformerVAA1QA2aDP7qMethod{{[_0-9a-zA-Z]*}}FTW" to i8*)
 // CHECK: ]
 // CHECK: [[CONFORMER_P_WITNESS_TABLE]] = hidden global [5 x i8*] [
-// CHECK:   i8* bitcast (i8** ()* @"$s18sil_witness_tables14AssocConformerVAA1AAAWa" to i8*)
+// CHECK:   i8* bitcast (i8** ()* @"$s18sil_witness_tables14AssocConformerVAcA1AAAWl" to i8*)
 // CHECK:   "symbolic 18sil_witness_tables14AssocConformerV"
 // CHECK:   i8* bitcast (void (%swift.type*, %swift.type*, i8**)* @"$s18sil_witness_tables9ConformerVAA1PA2aDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW" to i8*),
 // CHECK:   i8* bitcast (void (%T18sil_witness_tables9ConformerV*, %swift.type*, i8**)* @"$s18sil_witness_tables9ConformerVAA1PA2aDP14instanceMethod{{[_0-9a-zA-Z]*}}FTW" to i8*)

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -66,7 +66,7 @@ struct SyncUp<Deliverable> : Synergy {
 // CHECK: entry:
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s14witness_method6SyncUpVMa"([[INT]] 0, %swift.type* %T)
 // CHECK:   [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-// CHECK:   [[WTABLE:%.*]] = call i8** @"$s14witness_method6SyncUpVyxGAA7SynergyAAWa"(%swift.type* [[METADATA]], i8*** undef)
+// CHECK:   [[WTABLE:%.*]] = call i8** @swift_getWitnessTable(
 // CHECK:   [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[WTABLE]], i32 2
 // CHECK:   [[WITNESS_FN:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK:   [[WITNESS:%.*]] = bitcast i8* [[WITNESS_FN]] to void (%swift.opaque*, %swift.opaque*, %swift.type*, i8**)*

--- a/test/IRGen/witness_table_indirect_conformances.swift
+++ b/test/IRGen/witness_table_indirect_conformances.swift
@@ -32,7 +32,7 @@ struct Z: P2 {
 
 // CHECK: @"$s35witness_table_indirect_conformances1WVAA2P3AAWP" = hidden global [5 x i8*] [
 // CHECK-SAME: @"$s35witness_table_indirect_conformances1WVAA2P3AAMc"
-// CHECK-SAME: i8* bitcast (i8** ()* @"$s35witness_table_indirect_conformances1YVAA1QAAWa" to i8*),
+// CHECK-SAME: i8* bitcast (i8** ()* @"$s35witness_table_indirect_conformances1ZVAcA2P2AAWl
 // CHECK-SAME: @"symbolic 35witness_table_indirect_conformances1ZV"
 // CHECK-SAME: i8* bitcast (void (%T35witness_table_indirect_conformances1ZV*, %T35witness_table_indirect_conformances1WV*, %swift.type*, i8**)* @"$s35witness_table_indirect_conformances1WVAA2P3A2aDP08getAssocE00gE0QzyFTW" to i8*)]
 struct W: P3 {
@@ -40,14 +40,6 @@ struct W: P3 {
 
 	func getAssocP3() -> Z { return Z() }
 }
-
-// CHECK-LABEL: define hidden i8** @"$s35witness_table_indirect_conformances1YVAA1QAAWa"()
-// CHECK-NEXT: entry:
-// CHECK-NEXT: ret i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s35witness_table_indirect_conformances1YVAA1QAAWP", i32 0, i32 0)
-
-// CHECK-LABEL: define hidden i8** @"$s35witness_table_indirect_conformances1ZVAA2P2AAWa"()
-// CHECK-NEXT: entry:
-// CHECK: ret i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @"$s35witness_table_indirect_conformances1ZVAA2P2AAWP", i32 0, i32 0)
 
 // CHECK-LABEL: define hidden swiftcc %swift.metadata_response @"$s35witness_table_indirect_conformances1ZVMa"
 // CHECK-SAME:    ([[INT]])

--- a/test/IRGen/witness_table_objc_associated_type.swift
+++ b/test/IRGen/witness_table_objc_associated_type.swift
@@ -20,7 +20,7 @@ struct SB: B {
   func foo() {}
 }
 // CHECK-LABEL: @"$s34witness_table_objc_associated_type2SBVAA1BAAWP" = hidden global [4 x i8*] [
-// CHECK:         i8* bitcast (i8** ()* @"$s34witness_table_objc_associated_type2SAVAA1AAAWa" to i8*)
+// CHECK:         i8* bitcast (i8** ()* @"$s34witness_table_objc_associated_type2SAVAcA1AAAWl
 // CHECK:         @"symbolic 34witness_table_objc_associated_type2SAV"
 // CHECK:         i8* bitcast {{.*}} @"$s34witness_table_objc_associated_type2SBVAA1BA2aDP3fooyyFTW"
 // CHECK:       ]

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -55,17 +55,9 @@ public func single_generic<T: P2>(_: T.Type) {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[T_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** %T.P2, i8*** [[T_P2_PTR]], align 8
-// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Single_TYPE]], %swift.type* [[Single_TYPE]], i8** [[Single_P1]])
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-// Witness table accessor for Single : P1
-
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i8** @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlMc"{{.*}}, %swift.type* %0, i8*** %1)
-// CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
 
 
@@ -99,7 +91,7 @@ public func single_concrete() {
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s42conditional_conformance_basic_conformances4IsP2VAA0F0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
 
-// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]]) [[ATTRS:#[0-9]+]]
+// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    store atomic i8** [[Single_P1]], i8*** @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGACyxGAA2P1A2A0G0RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -180,19 +172,10 @@ public func double_generic_generic<U: P2, V: P3>(_: U.Type, _: V.Type) {
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 1
 // CHECK-NEXT:    store i8** %V.P3, i8*** [[C_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
-
-// witness table accessor for Double : P1
-
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i8** @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type*, i8***)
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlMc"{{.*}}, %swift.type* %0, i8*** %1)
-// CHECK-NEXT:    ret i8** [[TABLE]]
-// CHECK-NEXT:  }
-
 
 public func double_generic_concrete<X: P2>(_: X.Type) {
   takes_p1(Double<X, IsP3>.self)
@@ -209,7 +192,7 @@ public func double_generic_concrete<X: P2>(_: X.Type) {
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 1
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s42conditional_conformance_basic_conformances4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[C_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
@@ -245,7 +228,7 @@ public func double_concrete_concrete() {
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 1
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s42conditional_conformance_basic_conformances4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[C_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    store atomic i8** [[Double_P1]], i8*** @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGACyxq_GAA2P1A2A0G0RzAA0H0R_rlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -303,5 +286,3 @@ protocol P5 {}
 
 struct SR7101<T> {}
 extension SR7101 : P5 where T == P4Typealias {}
-
-// CHECK: attributes [[ATTRS]] = { nounwind }

--- a/test/Inputs/conditional_conformance_recursive.swift
+++ b/test/Inputs/conditional_conformance_recursive.swift
@@ -21,10 +21,10 @@ extension Wrapper: P3 where T: P3 { }
 // instantiation function for Wrapper<T>: P3
 // CHECK-LABEL: define internal void @"$s33conditional_conformance_recursive7WrapperVyxGAA2P3A2aERzrlWI"
 // CHECK-NOT: ret
-// CHECK: call i8** @"$s33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrlWa"
+// CHECK: call i8** @swift_getWitnessTable
 
 // associated type witness table accessor for A : P2 in Wrapper<T>: P2
 // CHECK-LABEL: define internal swiftcc i8** @"$s33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrl1A_AaEPWT"
 // CHECK: [[CONDITIONAL_REQ_BUFFER:%.*]] = alloca [1 x i8**]
 // CHECK: [[FIRST_REQ:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* [[CONDITIONAL_REQ_BUFFER]]
-// CHECK: call i8** @"$s33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrlWa"(%swift.type* [[WRAPPER_TO_A:%.*]], i8*** [[FIRST_REQ]])
+// CHECK: call i8** @swift_getWitnessTable

--- a/test/Inputs/conditional_conformance_subclass.swift
+++ b/test/Inputs/conditional_conformance_subclass.swift
@@ -55,17 +55,9 @@ public func subclassgeneric_generic<T: P2>(_: T.Type) {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[T_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** %T.P2, i8*** [[T_P2_PTR]], align 8
-// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass8takes_p1yyxmAA2P1RzlF"(%swift.type* [[SubclassGeneric_TYPE]], %swift.type* [[SubclassGeneric_TYPE]], i8** [[Base_P1]])
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-// witness table accessor for Base : P1
-
-// CHECK-LABEL: define{{( dllexport| protected)?}} i8** @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_instantiateWitnessTable(%swift.protocol_conformance_descriptor* bitcast{{.*}}@"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlMc"{{.*}}, %swift.type* %0, i8*** %1)
-// CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
 
 public func subclassgeneric_concrete() {
@@ -96,7 +88,7 @@ public func subclassgeneric_concrete() {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s32conditional_conformance_subclass4IsP2VAA0E0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
-// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    store atomic i8** [[Base_P1]], i8*** @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGAA4BaseCyxGAA2P1A2A0G0RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -131,7 +123,7 @@ public func subclassconcrete() {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s32conditional_conformance_subclass4IsP2VAA0E0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
-// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    store atomic i8** [[Base_P1]], i8*** @"$s32conditional_conformance_subclass16SubclassConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -166,7 +158,7 @@ public func subclassgenericconcrete() {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s32conditional_conformance_subclass4IsP2VAA0E0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
-// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    store atomic i8** [[Base_P1]], i8*** @"$s32conditional_conformance_subclass23SubclassGenericConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 

--- a/test/Inputs/conditional_conformance_with_assoc.swift
+++ b/test/Inputs/conditional_conformance_with_assoc.swift
@@ -123,7 +123,7 @@ public func generic_generic<T: P2, U>(_: T.Type, _: U.Type)
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 2
 // CHECK-NEXT:    store i8** %T.AT2.AT2.AT3.P3, i8*** [[B_AT2_AT2_AT3_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    call swiftcc void @"$s34conditional_conformance_with_assoc8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
@@ -147,7 +147,7 @@ public func generic_concrete<T: P2>(_: T.Type)
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 2
 // CHECK-NEXT:    store i8** %T.AT2.AT2.AT3.P3, i8*** [[B_AT2_AT2_AT3_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    call swiftcc void @"$s34conditional_conformance_with_assoc8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
@@ -171,7 +171,7 @@ public func concrete_generic<U>(_: U.Type)
 // CHECK-NEXT:  store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @"$s34conditional_conformance_with_assoc6IsBothVAA2P2AAWP", i32 0, i32 0), i8*** [[B_AT2_P2_PTR]], align 8
 // CHECK-NEXT:  [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 2
 // CHECK-NEXT:  store i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"$s34conditional_conformance_with_assoc4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[B_AT2_AT2_AT3_P3_PTR]], align 8
-// CHECK-NEXT:  [[Double_P1:%.*]] = call i8** @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:  [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:  call swiftcc void @"$s34conditional_conformance_with_assoc8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:  ret void
 // CHECK-NEXT:}
@@ -209,7 +209,7 @@ public func concrete_concrete() {
 // CHECK-NEXT:    store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @"$s34conditional_conformance_with_assoc6IsBothVAA2P2AAWP", i32 0, i32 0), i8*** [[B_AT2_P2_PTR]], align 8
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 2
 // CHECK-NEXT:    store i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"$s34conditional_conformance_with_assoc4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[B_AT2_AT2_AT3_P3_PTR]], align 8
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
 // CHECK-NEXT:    store atomic i8** [[Double_P1]], i8*** @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGACyxq_GAA2P1A2A0I0R_AA0H03AT2RpzAakM_AmaLP3AT3RPzrlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 

--- a/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
+++ b/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
@@ -14,4 +14,4 @@ void swift_allocateGenericValueMetadata(void) {}
 void swift_initEnumMetadataSinglePayload(void) {}
 void swift_retain(){}
 void swift_allocBox(){}
-void swift_instantiateWitnessTable(void) {}
+void swift_getWitnessTable(void) {}

--- a/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
+++ b/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
@@ -14,3 +14,4 @@ void swift_allocateGenericValueMetadata(void) {}
 void swift_initEnumMetadataSinglePayload(void) {}
 void swift_retain(){}
 void swift_allocBox(){}
+void swift_instantiateWitnessTable(void) {}

--- a/validation-test/stdlib/SetAnyHashableExtensions.swift
+++ b/validation-test/stdlib/SetAnyHashableExtensions.swift
@@ -126,10 +126,7 @@ SetTests.test("insert<Hashable>(_:)") {
   expectEqual(expected, s)
 }
 
-SetTests.test("insert<Hashable>(_:)/CastTrap")
-  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
-  .crashOutputMatches("to 'main.TestHashableDerivedB'")
-  .code {
+SetTests.test("insert<Hashable>(_:)/FormerCastTrap") {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
   ]
@@ -141,7 +138,6 @@ SetTests.test("insert<Hashable>(_:)/CastTrap")
     expectEqual(1, memberAfterInsert.identity)
   }
 
-  expectCrashLater()
   _ = s.insert(TestHashableDerivedB(1010, identity: 3))
 }
 
@@ -181,10 +177,7 @@ SetTests.test("update<Hashable>(with:)") {
   expectEqual(expected, s)
 }
 
-SetTests.test("update<Hashable>(with:)/CastTrap")
-  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
-  .crashOutputMatches("to 'main.TestHashableDerivedB'")
-  .code {
+SetTests.test("update<Hashable>(with:)/FormerCastTrap") {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
   ]
@@ -194,7 +187,6 @@ SetTests.test("update<Hashable>(with:)/CastTrap")
     expectEqual(1, old.identity)
   }
 
-  expectCrashLater()
   s.update(with: TestHashableDerivedB(1010, identity: 3))
 }
 
@@ -228,10 +220,7 @@ SetTests.test("remove<Hashable>(_:)") {
   }
 }
 
-SetTests.test("remove<Hashable>(_:)/CastTrap")
-  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
-  .crashOutputMatches("to 'main.TestHashableDerivedB'")
-  .code {
+SetTests.test("remove<Hashable>(_:)/FormerCastTrap") {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
     AnyHashable(TestHashableDerivedA(2020, identity: 1)),
@@ -243,7 +232,6 @@ SetTests.test("remove<Hashable>(_:)/CastTrap")
     expectEqual(1, old.identity)
   }
 
-  expectCrashLater()
   s.remove(TestHashableDerivedB(2020, identity: 2))
 }
 


### PR DESCRIPTION
Witness table accessors return a witness table for a given type's
conformance to a protocol. They are called directly from IRGen
(when we need the witness table instance) and from runtime conformance
checking (swift_conformsToProtocol digs the access function out of the
protocol conformance record). They have two interesting functions:

1) For witness tables requiring instantiation, they call
swift_instantiateWitnessTable directly.
2) For synthesized witness tables that might not be unique, they call
swift_getForeignWitnessTable.

Extend swift_instantiateWitnessTable() to handle both runtime
uniquing (for #2) as well as handling witness tables that don't have
a "generic table", i.e., don't need any actual instantiation. Use it
as the universal entry point for "get a witness table given a specific
conformance descriptor and type", eliminating witness table accessors
entirely.

Make a few related simplifications:

* Drop the "pattern" from the generic witness table. Instead, store
  the pattern in the main part of the conformance descriptor, always.
* Drop the "conformance kind" from the protocol conformance
  descriptor, since it was only there to distinguish between witness
  table (pattern) vs. witness table accessor.
* Internalize swift_getForeignWitnessTable(); IRGen no longer needs to
  call it.

Reduces the code size of the standard library (+assertions build) by
~149k.

Addresses rdar://problem/45489388.
