### PR TITLE
support static large string literal generation for the new UTF8 String implementation

### DIFF
--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -158,6 +158,11 @@ public:
   static bool isValidStaticInitializerInst(const SILInstruction *I,
                                            SILModule &M);
 
+  /// Returns the usub_with_overflow builtin if \p TE extracts the result of
+  /// such a subtraction, which is required to have an integer_literal as right
+  /// operand.
+  static BuiltinInst *getOffsetSubtract(const TupleExtractInst *TE, SILModule &M);
+
   void dropAllReferences() {
     StaticInitializerBlock.dropAllReferences();
   }

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -280,7 +280,7 @@ public:
   inline Operand *getSingleUse() const;
 
   template <class T>
-  inline T *getSingleUserOfType();
+  inline T *getSingleUserOfType() const;
 
   /// Return the instruction that defines this value, or null if it is
   /// not defined by an instruction.
@@ -706,7 +706,7 @@ inline Operand *ValueBase::getSingleUse() const {
 }
 
 template <class T>
-inline T *ValueBase::getSingleUserOfType() {
+inline T *ValueBase::getSingleUserOfType() const {
   T *Result = nullptr;
   for (auto *Op : getUses()) {
     if (auto *Tmp = dyn_cast<T>(Op->getUser())) {

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -105,9 +105,7 @@ static llvm::Constant *emitConstantValue(IRGenModule &IGM, SILValue operand) {
         llvm_unreachable("unsupported builtin for constant expression");
     }
   } else if (auto *VTBI = dyn_cast<ValueToBridgeObjectInst>(operand)) {
-    auto *SI = cast<StructInst>(VTBI->getOperand());
-    assert(SI->getElements().size() == 1);
-    auto *val = emitConstantValue(IGM, SI->getElements()[0]);
+    auto *val = emitConstantValue(IGM, VTBI->getOperand());
     auto *sTy = IGM.getTypeInfo(VTBI->getType()).getStorageType();
     return llvm::ConstantExpr::getIntToPtr(val, sTy);
   } else {

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -458,7 +458,7 @@ public func _bridgeObject(
 @inlinable
 public func _bridgeObject(fromTagged x: UInt) -> Builtin.BridgeObject {
   _sanityCheck(x & _bridgeObjectTaggedPointerBits != 0)
-  let object: Builtin.BridgeObject = Builtin.valueToBridgeObject(x)
+  let object: Builtin.BridgeObject = Builtin.valueToBridgeObject(x._value)
   _sanityCheck(_isTaggedObject(object))
   return object
 }

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -103,6 +103,25 @@ sil_global @static_array_with_empty_element : $TestArrayStorage = {
 }
 // CHECK: @static_array_with_empty_element = {{( dllexport)?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems3c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems3 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef, [1 x i8] undef }> }, align 8
 
+struct MyString {
+  var buffer: Builtin.BridgeObject
+}
+
+sil_global [let] @string_with_offset : $MyString = {
+  %0 = integer_literal $Builtin.Int64, -9223372036854775808
+  %1 = integer_literal $Builtin.Int1, 0
+  %2 = integer_literal $Builtin.Int64, 32
+  %3 = string_literal utf8 "abc123asd3sdj3basfasdf"
+  %4 = builtin "ptrtoint_Word"(%3 : $Builtin.RawPointer) : $Builtin.Word
+  %5 = builtin "zextOrBitCast_Word_Int64"(%4 : $Builtin.Word) : $Builtin.Int64
+  %6 = builtin "usub_with_overflow_Int64"(%5 : $Builtin.Int64, %2 : $Builtin.Int64, %1 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %7 = tuple_extract %6 : $(Builtin.Int64, Builtin.Int1), 0
+  %8 = builtin "stringObjectOr_Int64"(%7 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int64
+  %9 = value_to_bridge_object %8 : $Builtin.Int64
+  %initval = struct $MyString (%9 : $Builtin.BridgeObject)
+}
+// CHECK: @string_with_offset = {{.*global .*}} <{ %swift.bridge* inttoptr (i64 add (i64 ptrtoint ([23 x i8]* @0 to i64), i64 9223372036854775776) to %swift.bridge*) }>, align 8
+
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @_TF2cha1xSi() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret i8* bitcast (%Ts5Int32V* @"$s2ch1xSiv" to i8*)

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -809,12 +809,13 @@ func once(control: Builtin.RawPointer) {
 
 // CHECK-LABEL: sil hidden @$s8builtins19valueToBridgeObjectyBbSuF : $@convention(thin) (UInt) -> @owned Builtin.BridgeObject {
 // CHECK: bb0([[UINT:%.*]] : @trivial $UInt):
-// CHECK:   [[CAST:%.*]] = value_to_bridge_object [[UINT]] : $UInt
+// CHECK:   [[BI:%.*]] = struct_extract [[UINT]] : $UInt, #UInt._value
+// CHECK:   [[CAST:%.*]] = value_to_bridge_object [[BI]]
 // CHECK:   [[RET:%.*]] = copy_value [[CAST]] : $Builtin.BridgeObject
 // CHECK:   return [[RET]] : $Builtin.BridgeObject
 // CHECK: } // end sil function '$s8builtins19valueToBridgeObjectyBbSuF'
 func valueToBridgeObject(_ x: UInt) -> Builtin.BridgeObject {
-  return Builtin.valueToBridgeObject(x)
+  return Builtin.valueToBridgeObject(x._value)
 }
 
 // CHECK-LABEL: sil hidden @$s8builtins10assumeTrueyyBi1_F


### PR DESCRIPTION
In the new string implementation there is a subtract of a (small) constant from the literal pointer. We convert
    ((ptr - offset) | bits
to
    (ptr + (bits - offset))
which can still be represented as a relocation.

Also in this PR: Require Builtin.valueToBridgeObject to have a builtin integer as argument
