### PR TITLE
Add insert-bb tool to utils

### DIFF
--- a/utils/insert-bb
+++ b/utils/insert-bb
@@ -1,9 +1,23 @@
 #!/usr/bin/perl
 
+# utils/insert-bb - Insert placeholder basic block into SIL
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# -----------------------------------------------------------------------------
+#
 # This script is mainly useful when you're trying to diff two SIL files where
 # most BBs correspond to a BB in the opposite file, but some BBs in one file are
 # missing from the other. You can use it to insert a placeholder block and make
 # the numbering match up.
+# 
+# -----------------------------------------------------------------------------
 
 use strict;
 use warnings;

--- a/utils/insert-bb
+++ b/utils/insert-bb
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+# This script is mainly useful when you're trying to diff two SIL files where
+# most BBs correspond to a BB in the opposite file, but some BBs in one file are
+# missing from the other. You can use it to insert a placeholder block and make
+# the numbering match up.
+
+use strict;
+use warnings;
+
+my $start_num = shift @ARGV;
+
+die <<"END" unless $start_num + 0;
+Usage: $0 <bb-number> [<files>...]
+
+Insert a placeholder basic block with the specified number into a fragment of
+textual SIL, editing references to higher-numbered blocks to match.
+
+  <bb-number>   The number of the basic block to insert, without the bb prefix.
+      <files>   Files to be used as input. If not specified, stdin is used
+                instead.
+END
+
+while(<>) {
+  if (/^bb$start_num:/) {
+    print "bb$start_num:\n  placeholder\n\n";
+  }
+
+  s{ bb (\d+) \b }{ 'bb' . ($1 >= $start_num ? $1 + 1 : $1) }xeg;
+
+  print;
+}
+


### PR DESCRIPTION
This is a little script I wrote to help with SIL diffing. It prints a modified version of its SIL input which adds a new basic block containing only “placeholder”—but more importantly, it updates all references to existing higher-numbered basic blocks. This can help to reduce the amount of noise in SIL diffs without removing any information from the file.