### PR TITLE
Remote: explicitly qualify type

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1528,7 +1528,7 @@ private:
     if (!demangling)
       return nullptr;
 
-    NodePointer top;
+    Demangle::NodePointer top;
     // References to type nodes behave as types in the mangling.
     if (isa<TargetTypeContextDescriptor<Runtime>>(descriptor.getLocalBuffer()) ||
         isa<TargetProtocolDescriptor<Runtime>>(descriptor.getLocalBuffer())) {


### PR DESCRIPTION
When building the remote mirror for Windows, the build would fail due to the
symbol resolution being slightly different on Windows.  Explicitly qualify the
name to resolve the ambiguity.  This reapirs the build of the remote mirror for
Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
