### PR TITLE
Add more type checker performance tests.

### DIFF
--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -306,7 +306,6 @@ CharacterTests.test(
   let asciiDomain = Array(0..<127)
   let ascii0to126 = asciiDomain.map({ UnicodeScalar(Int($0))! })
   let ascii1to127 = asciiDomain.map({ UnicodeScalar(Int($0 + 1))! })
-  typealias PredicateFn = (UnicodeScalar) -> (UnicodeScalar) -> Bool
   expectEqualMethodsForDomain(
     ascii0to126,
     ascii1to127,

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -310,8 +310,8 @@ CharacterTests.test(
   expectEqualMethodsForDomain(
     ascii0to126,
     ascii1to127,
-    { x in { String(x) < String($0) } } as PredicateFn,
-    { x in { String(Character(x)) < String(Character($0)) } } as PredicateFn)
+    { x in { String(x) < String($0) } },
+    { x in { String(Character(x)) < String(Character($0)) } })
 }
 
 CharacterTests.test("String.append(_: Character)") {

--- a/validation-test/Sema/type_checker_perf/fast/rdar18522024.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18522024.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// REQUIRES: tools-release,no_asserts
+
+func test(a: [String], b: String, c: String) -> [String] {
+  return a.map { $0 + ": " + b + "(" + c + $0 + ")" }
+}

--- a/validation-test/Sema/type_checker_perf/fast/rdar19157118.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19157118.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+public func expectEqualMethodsForDomain<
+SelfType, ArgumentType, Result : Equatable
+>(
+  _ selfs: [SelfType], _ arguments: [ArgumentType],
+  _ function1: (SelfType) -> (ArgumentType) -> Result,
+  _ function2: (SelfType) -> (ArgumentType) -> Result
+) { fatalError() }
+
+func test(ascii0to126: [UnicodeScalar], ascii1to127: [UnicodeScalar]) {
+  expectEqualMethodsForDomain(
+    ascii0to126,
+    ascii1to127,
+    { x in { String(x) < String($0) } },
+    { x in { String(Character(x)) < String(Character($0)) } })
+}

--- a/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// REQUIRES: tools-release,no_asserts
+
+func test(strings: [String]) {
+  for string in strings {
+    let _ = string.split(omittingEmptySubsequences: false) { $0 == "C" || $0 == "D" || $0 == "H" || $0 == "S"}
+  }
+}

--- a/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
@@ -1,8 +1,0 @@
-// RUN: %scale-test --begin 7 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
-// REQUIRES: OS=macosx
-// REQUIRES: asserts
-let a = [0]
-let d = a[0] * 1
-%for i in range(0, N):
-  + a[0] * 1
-%end

--- a/validation-test/Sema/type_checker_perf/slow/rdar18994321.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar18994321.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+precedencegroup ExponentiationPrecedence {
+  associativity: right
+  higherThan: BitwiseShiftPrecedence
+}
+
+infix operator ** : ExponentiationPrecedence
+
+func ** (num: Float, power: Float) -> Float {
+  fatalError()
+}
+
+func test(f: Float) {
+  let v1: Float = 1.1
+  let v2 = 2.2
+  let v3 = 3.3
+
+  // NOTE: This is using mixed types, and would result in a type checking error if it completed.
+  let _ = v2*7.1**(1.97276*(1-v1/f)-7.02202*v3+1.70373*1e-3*(1.0-10**(-2.29692*(f/v1-1.0)))+0.32273*1e-3*(10**(3.76977*(1.0-v1/f))-1)-2.2195923)
+  // expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions}}
+}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19915443.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19915443.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asserts
+
+var counts = [ 0, 0, 0, 0 ]
+// NOTE: This is using mixed types, and would result in a type checking error if it completed.
+let d = counts[0] * 1000 + counts[1] * 100 + counts[2] * 10 + counts
+// expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions}}


### PR DESCRIPTION
Also move one from fast to slow based on the fact that it wasn't
representative of the original issue (which was an expression that
didn't typecheck successfully).
