### PR TITLE
[typelowering] Look through 1 level of optionality when determining i…

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1869,7 +1869,9 @@ public:
       break;
     }
 
-    auto type = tl.getLoweredType().getASTType();
+    // Get the underlying AST type, potentially stripping off one level of
+    // optionality while we do it.
+    CanType type = tl.getLoweredType().unwrapOptionalType().getASTType();
     if (type->hasRetainablePointerRepresentation()
         || (type->getSwiftNewtypeUnderlyingType() && !tl.isTrivial()))
       return ResultConvention::Autoreleased;

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -135,12 +135,16 @@ class ObjCTest {
   // CHECK-LABEL: define hidden %0* @"$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGFTo"
   // CHECK: [[CASTED:%.+]] = ptrtoint %0* %2 to i{{32|64}}
   // CHECK: [[RESULT:%.+]] = call swiftcc i{{32|64}} @"$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGF"(i{{32|64}} [[CASTED]], %T7newtype8ObjCTestC* swiftself {{%.+}})
-  // CHECK: [[OPAQUE_RESULT:%.+]] = inttoptr i{{32|64}} [[RESULT]] to %0*
+  // CHECK: [[AUTORELEASE_RESULT:%.+]] = {{(tail )?}}call {{.*}} @objc_autoreleaseReturnValue {{.*}}(i{{32|64}} [[RESULT]])
+  // CHECK: [[OPAQUE_RESULT:%.+]] = inttoptr i{{32|64}} [[AUTORELEASE_RESULT]] to %0*
   // CHECK: ret %0* [[OPAQUE_RESULT]]
   // CHECK: {{^}$}}
 
   // OPT-LABEL: define hidden %0* @"$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGFTo"
-  // OPT: ret %0* %2
+  // OPT: [[CAST_VALUE:%.*]] = bitcast %0* %2 to %objc_object*
+  // OPT: [[RESULT:%.*]] = {{(tail )?}}call %objc_object* @objc_autoreleaseReturnValue(%objc_object* [[CAST_VALUE]])
+  // OPT: [[RESULT_CAST:%.*]] = bitcast %objc_object* [[RESULT]] to %0*
+  // OPT: ret %0* [[RESULT_CAST]]
   // OPT: {{^}$}}
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed

--- a/test/Interpreter/Inputs/newtype.m
+++ b/test/Interpreter/Inputs/newtype.m
@@ -1,0 +1,23 @@
+
+#include <stdio.h>
+#include "newtype.h"
+
+@implementation NSMyObject
+
+@synthesize lifetimeTracked;
+
+-(instancetype)init {
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+  self.lifetimeTracked = nil;
+  return self;
+}
+
+- (void)print {
+  printf("I am alive?!\n");
+  fflush(stdout);
+}
+
+@end

--- a/test/Interpreter/Inputs/usr/include/module.map
+++ b/test/Interpreter/Inputs/usr/include/module.map
@@ -1,0 +1,4 @@
+module Newtype {
+  header "newtype.h"
+  export *
+}

--- a/test/Interpreter/Inputs/usr/include/newtype.h
+++ b/test/Interpreter/Inputs/usr/include/newtype.h
@@ -1,0 +1,13 @@
+
+@import ObjectiveC;
+
+@interface NSMyObject : NSObject
+
+-(NSMyObject *)init;
+-(void)print;
+
+@property(retain) id lifetimeTracked;
+
+@end
+
+typedef NSMyObject *MyObject __attribute((swift_newtype(struct))) __attribute((swift_name("MyObject")));

--- a/test/Interpreter/NewtypeLeak.swift
+++ b/test/Interpreter/NewtypeLeak.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/newtype.m -o %t/newtype.objc.o -I %S/Inputs/usr/include -fmodules
+// RUN: %target-build-swift -c -I %S/Inputs/usr/include -o %t/newtype.swift.o %s
+// RUN: %swiftc_driver %t/newtype.objc.o %t/newtype.swift.o -o %t/newtype
+// RUN: %target-codesign %t/newtype
+// RUN: %target-run %t/newtype
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+import Newtype
+
+class ObjCLifetimeTracked : NSMyObject {
+  var a = LifetimeTracked(0)
+}
+
+// Make sure that we do properly autorelease newtypes and do not leak them.
+class ObjCTest : NSObject {
+  @objc dynamic func optionalPassThrough(_ ed: MyObject?) -> MyObject? {
+    return ed
+  }
+}
+
+func main() {
+  let e = MyObject(ObjCLifetimeTracked())
+  let c = ObjCTest()
+  let x = c.optionalPassThrough(e)!
+  x.rawValue.print()
+}
+
+var Tests = TestSuite("newtypeleak")
+
+Tests.test("dontLeak") {
+  autoreleasepool {
+    main()
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+runAllTests()

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -48,7 +48,7 @@ func getRawValue(ed: ErrorDomain) -> String {
 
 class ObjCTest {
   // CHECK-RAW-LABEL: sil hidden @$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGF : $@convention(method) (@guaranteed Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
-  // CHECK-RAW: sil hidden [thunk] @$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
+  // CHECK-RAW: sil hidden [thunk] @$s7newtype8ObjCTestC19optionalPassThroughySo14SNTErrorDomainaSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> @autoreleased Optional<ErrorDomain> {
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed
   }  


### PR DESCRIPTION
…f a value has a NewType representation.

This is necessary to ensure that we autorelease such values in objc thunks.
Previously, we were returning the value as unowned, leaking it. I added a test
to interpreter that will make sure in the future we do not leak like this
again.

rdar://45543138
