### PR TITLE
[stdlib] Inline the small-string check from String.reserveCapacity(_:)

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -910,17 +910,22 @@ extension _StringGuts {
     _invariantCheck()
   }
 
-  @usableFromInline // @testable
+  @inlinable // @testable
   mutating func reserveCapacity(_ capacity: Int) {
+    // Small strings can accomodate small capacities, and we can often determine
+    // if a reservation is small at compile time
+    if capacity <= _SmallUTF8String.capacity {
+      return
+    }
+    reserveCapacitySlow(capacity)
+  }
+
+  @usableFromInline
+  mutating func reserveCapacitySlow(_ capacity: Int) {
     if _fastPath(_isUniqueNative()) {
       if _fastPath(_object.nativeRawStorage.capacity >= capacity) {
         return
       }
-    }
-
-    // Small strings can accomodate small capacities
-    if capacity <= _SmallUTF8String.capacity {
-      return
     }
 
     let selfCount = self.count

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -125,6 +125,7 @@ extension String {
   ///   to allocate.
   ///
   /// - Complexity: O(*n*)
+  @inlinable
   public mutating func reserveCapacity(_ n: Int) {
     _guts.reserveCapacity(n)
   }


### PR DESCRIPTION
This is an optimization I tried on the string interpolation branch. I’m not sure I’ll need it there, but it looks like it may be independently profitable. Let’s find out.