### PR TITLE
[sil] Give the methods for querying ownership on SILFunction clearer …

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -232,12 +232,13 @@ private:
   /// *) It is a function referenced by the specialization information.
   bool Zombie = false;
 
-  /// True if SILOwnership is enabled for this function.
+  /// True if this function is in Ownership SSA form and thus must pass
+  /// ownership verification.
   ///
   /// This enables the verifier to easily prove that before the Ownership Model
   /// Eliminator runs on a function, we only see a non-semantic-arc world and
   /// after the pass runs, we only see a semantic-arc world.
-  bool HasQualifiedOwnership = true;
+  bool HasOwnership = true;
 
   /// Set if the function body was deserialized from canonical SIL. This implies
   /// that the function's home module performed SIL diagnostics prior to
@@ -423,12 +424,12 @@ public:
   bool isZombie() const { return Zombie; }
 
   /// Returns true if this function has qualified ownership instructions in it.
-  bool hasQualifiedOwnership() const { return HasQualifiedOwnership; }
+  bool hasOwnership() const { return HasOwnership; }
 
-  /// Sets the HasQualifiedOwnership flag to false. This signals to SIL that no
+  /// Sets the HasOwnership flag to false. This signals to SIL that no
   /// ownership instructions should be in this function any more.
-  void setUnqualifiedOwnership() {
-    HasQualifiedOwnership = false;
+  void setOwnershipEliminated() {
+    HasOwnership = false;
   }
 
   /// Returns true if this function was deserialized from canonical

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1037,7 +1037,7 @@ static AllocStackInst *allocate(StructLoweringState &pass,
 
 static StoreOwnershipQualifier
 getStoreInitOwnership(StructLoweringState &pass, SILType type) {
-  if (!pass.F->hasQualifiedOwnership()) {
+  if (!pass.F->hasOwnership()) {
     return StoreOwnershipQualifier::Unqualified;
   } else if (type.isTrivial(pass.F->getModule())) {
     return StoreOwnershipQualifier::Trivial;
@@ -1517,7 +1517,7 @@ void LoadableStorageAllocation::allocateForArg(SILValue value) {
       ++II;
       loadBuilder.setInsertionPoint(II);
     }
-    if (!pass.F->hasQualifiedOwnership()) {
+    if (!pass.F->hasOwnership()) {
       load = loadBuilder.createLoad(applyInst->getLoc(), value,
                                     LoadOwnershipQualifier::Unqualified);
     } else {
@@ -1552,7 +1552,7 @@ void LoadableStorageAllocation::allocateForArg(SILValue value) {
   auto *applyOutlinedCopy =
       createOutlinedCopyCall(allocBuilder, value, allocInstr, pass);
 
-  if (!pass.F->hasQualifiedOwnership()) {
+  if (!pass.F->hasOwnership()) {
     loadCopy = allocBuilder.createLoad(applyOutlinedCopy->getLoc(), allocInstr,
                                        LoadOwnershipQualifier::Unqualified);
   } else {
@@ -1858,7 +1858,7 @@ static void createResultTyInstrAndLoad(LoadableStorageAllocation &allocator,
       currStructExtractInst->getType().getAddressType());
   // Load the struct element then see if we can get rid of the load:
   LoadInst *loadArg = nullptr;
-  if (!pass.F->hasQualifiedOwnership()) {
+  if (!pass.F->hasOwnership()) {
     loadArg = builder.createLoad(newInstr->getLoc(), newInstr,
                                  LoadOwnershipQualifier::Unqualified);
   } else {
@@ -1914,7 +1914,7 @@ static void rewriteFunction(StructLoweringState &pass,
 
           // Load the enum addr then see if we can get rid of the load:
           LoadInst *loadArg = nullptr;
-          if (!pass.F->hasQualifiedOwnership()) {
+          if (!pass.F->hasOwnership()) {
             loadArg = argBuilder.createLoad(
                 newArg->getLoc(), newArg, LoadOwnershipQualifier::Unqualified);
           } else {
@@ -2458,7 +2458,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
       if (oldValue->getType() != newValue->getType() &&
           !oldValue->getType().isAddress()) {
         LoadOwnershipQualifier ownership;
-        if (!F->hasQualifiedOwnership()) {
+        if (!F->hasOwnership()) {
           ownership = LoadOwnershipQualifier::Unqualified;
         } else if (newValue->getType().isTrivial(*getModule())) {
           ownership = LoadOwnershipQualifier::Trivial;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5182,10 +5182,10 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
   bool AssumeUnqualifiedOwnershipWhenParsing =
     F->getModule().getOptions().AssumeUnqualifiedOwnershipWhenParsing;
   if (AssumeUnqualifiedOwnershipWhenParsing) {
-    F->setUnqualifiedOwnership();
+    F->setOwnershipEliminated();
   }
   B.setInsertionPoint(BB);
-  B.setHasOwnership(F->hasQualifiedOwnership());
+  B.setHasOwnership(F->hasOwnership());
   do {
     if (parseSILInstruction(B))
       return true;

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -539,7 +539,7 @@ bool FunctionOwnershipEvaluator::evaluate(SILInstruction *I) {
   case OwnershipQualifiedKind::Unqualified: {
     // If we already know that the function has unqualified ownership, just
     // return early.
-    if (!F.get()->hasQualifiedOwnership())
+    if (!F.get()->hasOwnership())
       return true;
 
     // Ok, so we know at this point that we have qualified ownership. If we have
@@ -551,7 +551,7 @@ bool FunctionOwnershipEvaluator::evaluate(SILInstruction *I) {
     // Otherwise, set the function to have unqualified ownership. This will
     // ensure that no more Qualified instructions can be added to the given
     // function.
-    F.get()->setUnqualifiedOwnership();
+    F.get()->setOwnershipEliminated();
     return true;
   }
   case OwnershipQualifiedKind::Qualified: {
@@ -559,7 +559,7 @@ bool FunctionOwnershipEvaluator::evaluate(SILInstruction *I) {
     // have unqualified ownership, then we know that we have already seen an
     // unqualified ownership instruction. This means the function has both
     // qualified and unqualified instructions. =><=.
-    if (!F.get()->hasQualifiedOwnership())
+    if (!F.get()->hasOwnership())
       return false;
 
     // Ok, at this point we know that we are still qualified. Since functions

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -514,7 +514,7 @@ void SILBuilder::emitShallowDestructureValueOperation(
   }
 
   // Otherwise, we want to destructure add the destructure and return.
-  if (getFunction().hasQualifiedOwnership()) {
+  if (getFunction().hasOwnership()) {
     auto *DI = emitDestructureValueOperation(Loc, V);
     copy(DI->getResults(), std::back_inserter(Results));
     return;

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -637,7 +637,7 @@ void SILInstruction::verifyOperandOwnership() const {
 
   // If the given function has unqualified ownership or we have been asked by
   // the user not to verify this function, there is nothing to verify.
-  if (!getFunction()->hasQualifiedOwnership() ||
+  if (!getFunction()->hasOwnership() ||
       !getFunction()->shouldVerifyOwnership())
     return;
 
@@ -701,7 +701,7 @@ void SILValue::verifyOwnership(SILModule &mod,
 
   // If the given function has unqualified ownership or we have been asked by
   // the user not to verify this function, there is nothing to verify.
-  if (!f->hasQualifiedOwnership() || !f->shouldVerifyOwnership())
+  if (!f->hasOwnership() || !f->shouldVerifyOwnership())
     return;
 
   ErrorBehaviorKind errorBehavior;
@@ -737,7 +737,7 @@ bool OwnershipChecker::checkValue(SILValue value) {
 
   // If the given function has unqualified ownership, there is nothing further
   // to verify.
-  if (!f->hasQualifiedOwnership())
+  if (!f->hasOwnership())
     return false;
 
   ErrorBehaviorKind errorBehavior(ErrorBehaviorKind::ReturnFalse);

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -561,7 +561,7 @@ public:
 
     // If SIL ownership is enabled and the given function has not had ownership
     // stripped out, print out ownership of SILArguments.
-    if (BB->getParent()->hasQualifiedOwnership()) {
+    if (BB->getParent()->hasOwnership()) {
       *this << getIDAndTypeAndOwnership(Args[0]);
       for (SILArgument *Arg : Args.drop_front()) {
         *this << ", " << getIDAndTypeAndOwnership(Arg);

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -561,7 +561,7 @@ namespace {
 
     void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
                    SILValue addr, StoreOwnershipQualifier qual) const override {
-      if (B.getFunction().hasQualifiedOwnership()) {
+      if (B.getFunction().hasOwnership()) {
         B.createStore(loc, value, addr, StoreOwnershipQualifier::Trivial);
         return;
       }
@@ -570,7 +570,7 @@ namespace {
 
     SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
                       LoadOwnershipQualifier qual) const override {
-      if (B.getFunction().hasQualifiedOwnership())
+      if (B.getFunction().hasOwnership())
         return B.createLoad(loc, addr, LoadOwnershipQualifier::Trivial);
       return B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
     }
@@ -638,7 +638,7 @@ namespace {
 
     void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
                    SILValue addr, StoreOwnershipQualifier qual) const override {
-      if (B.getFunction().hasQualifiedOwnership()) {
+      if (B.getFunction().hasOwnership()) {
         B.createStore(loc, value, addr, qual);
         return;
       }
@@ -662,7 +662,7 @@ namespace {
 
     SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
                       LoadOwnershipQualifier qual) const override {
-      if (B.getFunction().hasQualifiedOwnership())
+      if (B.getFunction().hasOwnership())
         return B.createLoad(loc, addr, qual);
 
       SILValue loadValue =
@@ -760,7 +760,7 @@ namespace {
 
     SILValue emitCopyValue(SILBuilder &B, SILLocation loc,
                            SILValue value) const override {
-      if (B.getFunction().hasQualifiedOwnership())
+      if (B.getFunction().hasOwnership())
         return B.createCopyValue(loc, value);
       B.createRetainValue(loc, value, B.getDefaultAtomicity());
       return value;
@@ -793,7 +793,7 @@ namespace {
 
     void emitDestroyValue(SILBuilder &B, SILLocation loc,
                           SILValue aggValue) const override {
-      if (B.getFunction().hasQualifiedOwnership()) {
+      if (B.getFunction().hasOwnership()) {
         B.createDestroyValue(loc, aggValue);
         return;
       }
@@ -898,7 +898,7 @@ namespace {
 
     SILValue emitCopyValue(SILBuilder &B, SILLocation loc,
                            SILValue value) const override {
-      if (B.getFunction().hasQualifiedOwnership())
+      if (B.getFunction().hasOwnership())
         return B.createCopyValue(loc, value);
       B.createRetainValue(loc, value, B.getDefaultAtomicity());
       return value;
@@ -907,7 +907,7 @@ namespace {
     SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                   SILValue value,
                                   TypeExpansionKind style) const override {
-      if (B.getFunction().hasQualifiedOwnership())
+      if (B.getFunction().hasOwnership())
         return B.createCopyValue(loc, value);
       B.createRetainValue(loc, value, B.getDefaultAtomicity());
       return value;
@@ -915,7 +915,7 @@ namespace {
 
     void emitDestroyValue(SILBuilder &B, SILLocation loc,
                           SILValue value) const override {
-      if (B.getFunction().hasQualifiedOwnership()) {
+      if (B.getFunction().hasOwnership()) {
         B.createDestroyValue(loc, value);
         return;
       }
@@ -961,7 +961,7 @@ namespace {
           isa<PreviousDynamicFunctionRefInst>(value))
         return value;
 
-      if (B.getFunction().hasQualifiedOwnership())
+      if (B.getFunction().hasOwnership())
         return B.createCopyValue(loc, value);
 
       B.createStrongRetain(loc, value, B.getDefaultAtomicity());
@@ -970,7 +970,7 @@ namespace {
 
     void emitDestroyValue(SILBuilder &B, SILLocation loc,
                           SILValue value) const override {
-      if (B.getFunction().hasQualifiedOwnership()) {
+      if (B.getFunction().hasOwnership()) {
         B.createDestroyValue(loc, value);
         return;
       }
@@ -987,14 +987,14 @@ namespace {
                                  IsReferenceCounted) {} \
     SILValue emitCopyValue(SILBuilder &B, SILLocation loc, \
                            SILValue value) const override { \
-      if (B.getFunction().hasQualifiedOwnership()) \
+      if (B.getFunction().hasOwnership()) \
         return B.createCopyValue(loc, value); \
       B.create##Name##Retain(loc, value, B.getDefaultAtomicity()); \
       return value; \
     } \
     void emitDestroyValue(SILBuilder &B, SILLocation loc, \
                           SILValue value) const override { \
-      if (B.getFunction().hasQualifiedOwnership()) { \
+      if (B.getFunction().hasOwnership()) { \
         B.createDestroyValue(loc, value); \
         return; \
       } \

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -510,8 +510,8 @@ void ExistentialTransform::createExistentialSpecializedFunction() {
     NewF->addSemanticsAttr(Attr);
 
   /// Set Unqualified ownership, if any.
-  if (!F->hasQualifiedOwnership()) {
-    NewF->setUnqualifiedOwnership();
+  if (!F->hasOwnership()) {
+    NewF->setOwnershipEliminated();
   }
 
   /// Step 1a: Populate the body of NewF.

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -506,8 +506,8 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
       /*classSubclassScope=*/SubclassScope::NotApplicable,
       F->getInlineStrategy(), F->getEffectsKind(), nullptr, F->getDebugScope());
   SILFunction *NewF = TransformDescriptor.OptimizedFunction.get();
-  if (!F->hasQualifiedOwnership()) {
-    NewF->setUnqualifiedOwnership();
+  if (!F->hasOwnership()) {
+    NewF->setOwnershipEliminated();
   }
 
   if (F->isSpecialization()) {

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -265,8 +265,8 @@ SILFunction *CapturePropagation::specializeConstClosure(PartialApplyInst *PAI,
       OrigF->getEntryCount(), OrigF->isThunk(), OrigF->getClassSubclassScope(),
       OrigF->getInlineStrategy(), OrigF->getEffectsKind(),
       /*InsertBefore*/ OrigF, OrigF->getDebugScope());
-  if (!OrigF->hasQualifiedOwnership()) {
-    NewF->setUnqualifiedOwnership();
+  if (!OrigF->hasOwnership()) {
+    NewF->setOwnershipEliminated();
   }
   LLVM_DEBUG(llvm::dbgs() << "  Specialize callee as ";
              NewF->printName(llvm::dbgs());

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -664,8 +664,8 @@ ClosureSpecCloner::initCloned(SILOptFunctionBuilder &FunctionBuilder,
       /*classSubclassScope=*/SubclassScope::NotApplicable,
       ClosureUser->getInlineStrategy(), ClosureUser->getEffectsKind(),
       ClosureUser, ClosureUser->getDebugScope());
-  if (!ClosureUser->hasQualifiedOwnership()) {
-    Fn->setUnqualifiedOwnership();
+  if (!ClosureUser->hasOwnership()) {
+    Fn->setOwnershipEliminated();
   }
   for (auto &Attr : ClosureUser->getSemanticsAttrs())
     Fn->addSemanticsAttr(Attr);

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -303,8 +303,8 @@ static SILFunction *genGetterFromInit(SILOptFunctionBuilder &FunctionBuilder,
                                           varDecl);
 
   GetterF->setDebugScope(Store->getFunction()->getDebugScope());
-  if (!Store->getFunction()->hasQualifiedOwnership())
-    GetterF->setUnqualifiedOwnership();
+  if (!Store->getFunction()->hasOwnership())
+    GetterF->setOwnershipEliminated();
   auto *EntryBB = GetterF->createBasicBlock();
 
   // Copy instructions into GetterF
@@ -545,8 +545,8 @@ static SILFunction *genGetterFromInit(SILOptFunctionBuilder &FunctionBuilder,
                                           InitF->getModule(),
                                           InitF->getLocation(),
                                           varDecl);
-  if (!InitF->hasQualifiedOwnership())
-    GetterF->setUnqualifiedOwnership();
+  if (!InitF->hasOwnership())
+    GetterF->setOwnershipEliminated();
 
   // Copy InitF into GetterF, including the entry arguments.
   SILFunctionCloner Cloner(GetterF);

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -615,8 +615,8 @@ initCloned(SILOptFunctionBuilder &FuncBuilder, SILFunction *Orig,
   for (auto &Attr : Orig->getSemanticsAttrs()) {
     Fn->addSemanticsAttr(Attr);
   }
-  if (!Orig->hasQualifiedOwnership()) {
-    Fn->setUnqualifiedOwnership();
+  if (!Orig->hasOwnership()) {
+    Fn->setOwnershipEliminated();
   }
   return Fn;
 }

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -879,7 +879,7 @@ void CopyPropagation::run() {
                           << "\n");
 
   // This algorithm fundamentally assumes ownership.
-  if (!getFunction()->hasQualifiedOwnership())
+  if (!getFunction()->hasOwnership())
     return;
 
   // Step 1. Find all copied defs.

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -378,8 +378,8 @@ BridgedProperty::outline(SILModule &M) {
     return std::make_pair(nullptr, std::prev(StartBB->end()));
   }
 
-  if (!OutlinedEntryBB->getParent()->hasQualifiedOwnership())
-    Fun->setUnqualifiedOwnership();
+  if (!OutlinedEntryBB->getParent()->hasOwnership())
+    Fun->setOwnershipEliminated();
 
   Fun->setInlineStrategy(NoInline);
 
@@ -977,8 +977,8 @@ ObjCMethodCall::outline(SILModule &M) {
     return std::make_pair(Fun, I);
   }
 
-  if (!ObjCMethod->getFunction()->hasQualifiedOwnership())
-    Fun->setUnqualifiedOwnership();
+  if (!ObjCMethod->getFunction()->hasOwnership())
+    Fun->setOwnershipEliminated();
 
   Fun->setInlineStrategy(NoInline);
 

--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -298,7 +298,7 @@ struct OwnershipModelEliminator : SILModuleTransform {
         continue;
 
       // Set F to have unqualified ownership.
-      F.setUnqualifiedOwnership();
+      F.setOwnershipEliminated();
 
       bool MadeChange = false;
       SILBuilder B(F);

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -50,8 +50,8 @@ SILFunction *GenericCloner::initCloned(SILOptFunctionBuilder &FunctionBuilder,
   for (auto &Attr : Orig->getSemanticsAttrs()) {
     NewF->addSemanticsAttr(Attr);
   }
-  if (!Orig->hasQualifiedOwnership()) {
-    NewF->setUnqualifiedOwnership();
+  if (!Orig->hasOwnership()) {
+    NewF->setOwnershipEliminated();
   }
   return NewF;
 }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1874,7 +1874,7 @@ SILFunction *GenericFuncSpecializer::tryCreateSpecialization() {
           SpecializedF->getGenericEnvironment()) ||
          (!SpecializedF->getLoweredFunctionType()->isPolymorphic() &&
           !SpecializedF->getGenericEnvironment()));
-  assert(!SpecializedF->hasQualifiedOwnership());
+  assert(!SpecializedF->hasOwnership());
   // Check if this specialization should be linked for prespecialization.
   linkSpecialization(M, SpecializedF);
   // Store the meta-information about how this specialization was created.
@@ -2127,8 +2127,8 @@ SILFunction *ReabstractionThunkGenerator::createThunk() {
   // inline qualified into unqualified functions /or/ have the
   // OwnershipModelEliminator run as part of the normal compilation pipeline
   // (which we are not doing yet).
-  if (!SpecializedFunc->hasQualifiedOwnership()) {
-    Thunk->setUnqualifiedOwnership();
+  if (!SpecializedFunc->hasOwnership()) {
+    Thunk->setOwnershipEliminated();
   }
 
   if (!SILModuleConventions(M).useLoweredAddresses()) {
@@ -2365,7 +2365,7 @@ void swift::trySpecializeApplyOfGeneric(
                             << SpecializedF->getName() << "\n"
                             << "Specialized function type: "
                             << SpecializedF->getLoweredFunctionType() << "\n");
-    assert(!SpecializedF->hasQualifiedOwnership());
+    assert(!SpecializedF->hasOwnership());
     NewFunctions.push_back(SpecializedF);
   }
 

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1039,7 +1039,7 @@ void swift::releasePartialApplyCapturedArg(SILBuilder &Builder, SILLocation Loc,
   // possible for that value.
 
   // If we have qualified ownership, we should just emit a destroy value.
-  if (Arg->getFunction()->hasQualifiedOwnership()) {
+  if (Arg->getFunction()->hasOwnership()) {
     Callbacks.CreatedNewInst(Builder.createDestroyValue(Loc, Arg));
     return;
   }

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -593,7 +593,7 @@ void SILInlineCloner::fixUp(SILFunction *calleeFunction) {
 
 SILValue SILInlineCloner::borrowFunctionArgument(SILValue callArg,
                                                  FullApplySite AI) {
-  if (!AI.getFunction()->hasQualifiedOwnership()
+  if (!AI.getFunction()->hasOwnership()
       || callArg.getOwnershipKind() != ValueOwnershipKind::Owned) {
     return callArg;
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -662,7 +662,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
   }
 
   if (!hasQualifiedOwnership)
-    fn->setUnqualifiedOwnership();
+    fn->setOwnershipEliminated();
 
   NumDeserializedFunc++;
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -401,7 +401,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       (unsigned)F.isThunk(), (unsigned)F.isWithoutActuallyEscapingThunk(),
       (unsigned)F.isGlobalInit(), (unsigned)F.getInlineStrategy(),
       (unsigned)F.getOptimizationMode(), (unsigned)F.getEffectsKind(),
-      (unsigned)numSpecAttrs, (unsigned)F.hasQualifiedOwnership(),
+      (unsigned)numSpecAttrs, (unsigned)F.hasOwnership(),
       F.isWeakLinked(), (unsigned)F.isDynamicallyReplaceable(), FnID,
       replacedFunctionID, genericEnvID, clangNodeOwnerID, SemanticsIDs);
 


### PR DESCRIPTION
…names.

These functions were created in the very beginning of bringing up ownership in
SIL. The concepts have evolved over time slightly so we can now give these
better names. The renames are specifically:

1. hasQualifiedOwnership => hasOwnership.
2. setUnquaifiedOwnership => setOwnershipEliminated.

This is a pure rename, so I did not do any reformatting/etc.
