### PR TITLE
[CodeCompletion] Enable completion for subscript after dot

### DIFF
--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -145,7 +145,7 @@ public:
 
   /// \brief Complete expr-super after we have consumed the 'super' keyword and
   /// a dot.
-  virtual void completeExprSuperDot(SuperRefExpr *SRE) = 0;
+  virtual void completeExprSuperDot(SuperRefExpr *SRE, SourceLoc DotLoc) = 0;
 
   /// \brief Complete the argument to an Objective-C #keyPath
   /// expression.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1622,7 +1622,7 @@ class CompletionLookup final : public swift::VisibleDeclConsumer {
   bool NeedLeadingDot = false;
 
   bool NeedOptionalUnwrap = false;
-  unsigned NumBytesToEraseForOptionalUnwrap = 0;
+  unsigned NumBytesToEraseDot = 0;
 
   bool HaveLParen = false;
   bool IsSuperRefExpr = false;
@@ -1952,7 +1952,7 @@ public:
 
   void addLeadingDot(CodeCompletionResultBuilder &Builder) {
     if (NeedOptionalUnwrap) {
-      Builder.setNumBytesToErase(NumBytesToEraseForOptionalUnwrap);
+      Builder.setNumBytesToErase(NumBytesToEraseDot);
       Builder.addQuestionMark();
       Builder.addLeadingDot();
       return;
@@ -2671,7 +2671,7 @@ public:
       Builder.addLeadingDot();
 
     if (NeedOptionalUnwrap) {
-      Builder.setNumBytesToErase(NumBytesToEraseForOptionalUnwrap);
+      Builder.setNumBytesToErase(NumBytesToEraseDot);
       Builder.addQuestionMark();
     }
 
@@ -3157,13 +3157,12 @@ public:
       llvm::SaveAndRestore<bool> ChangeNeedOptionalUnwrap(NeedOptionalUnwrap,
                                                           true);
       if (DotLoc.isValid()) {
-        NumBytesToEraseForOptionalUnwrap = Ctx.SourceMgr.getByteDistance(
+        NumBytesToEraseDot = Ctx.SourceMgr.getByteDistance(
             DotLoc, Ctx.SourceMgr.getCodeCompletionLoc());
       } else {
-        NumBytesToEraseForOptionalUnwrap = 0;
+        NumBytesToEraseDot = 0;
       }
-      if (NumBytesToEraseForOptionalUnwrap <=
-          CodeCompletionResult::MaxNumBytesToErase) {
+      if (NumBytesToEraseDot <= CodeCompletionResult::MaxNumBytesToErase) {
         if (!tryTupleExprCompletions(Unwrapped)) {
           lookupVisibleMemberDecls(*this, Unwrapped, CurrDeclContext,
                                    TypeResolver,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -894,7 +894,7 @@ ParserResult<Expr> Parser::parseExprSuper(bool isExprBasic) {
     if (Tok.is(tok::code_complete)) {
       if (CodeCompletion) {
         if (auto *SRE = dyn_cast<SuperRefExpr>(superRef))
-          CodeCompletion->completeExprSuperDot(SRE);
+          CodeCompletion->completeExprSuperDot(SRE, dotLoc);
       }
 
       // Eat the code completion token because we handled it.

--- a/test/IDE/complete_after_self.swift
+++ b/test/IDE/complete_after_self.swift
@@ -153,7 +153,9 @@ class ThisDerived1 : ThisBase1 {
 
 // COMMON_SELF_DOT_1: Begin completions
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceVar]/CurrNominal:    derivedInstanceVar[#Int#]{{; name=.+$}}
-// COMMON_SELF_DOT_1-DAG: Decl[InstanceMethod]/CurrNominal: derivedFunc0()[#Void#]{{; name=.+$}}
+// COMMON_SELF_DOT_1-DAG: Decl[InstanceMethod]/CurrNominal: derivedFunc0()[#Void#]
+// COMMON_SELF_DOT_1-DAG: Decl[Subscript]/CurrNominal/Erase[1]: [{#Double#}][#Int#]{{; name=.+$}}
+// COMMON_SELF_DOT_1-DAG: Decl[Subscript]/CurrNominal/Erase[1]: [{#s: String#}][#Int#]{{; name=.+$}}
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceMethod]/CurrNominal: test1()[#Void#]{{; name=.+$}}
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceMethod]/CurrNominal: test2()[#Void#]{{; name=.+$}}
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceVar]/CurrNominal:    derivedExtProp[#Int#]{{; name=.+$}}
@@ -162,6 +164,7 @@ class ThisDerived1 : ThisBase1 {
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceVar]/Super:          baseInstanceVar[#Int#]{{; name=.+$}}
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceMethod]/Super:       baseFunc0()[#Void#]{{; name=.+$}}
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceMethod]/Super:       baseFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
+// COMMON_SELF_DOT_1-DAG: Decl[Subscript]/Super/Erase[1]:   [{#Int#}][#Double#]{{; name=.+$}}
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceVar]/Super:          baseExtProp[#Int#]{{; name=.+$}}
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceMethod]/Super:       baseExtInstanceFunc0()[#Void#]{{; name=.+$}}
 // COMMON_SELF_DOT_1-DAG: Decl[InstanceVar]/Super:          baseExtStaticProp[#Int#]{{; name=.+$}}
@@ -179,7 +182,7 @@ class ThisDerived1 : ThisBase1 {
 
   init(a : Int) {
     self.#^CONSTRUCTOR_SELF_DOT_1^#
-// CONSTRUCTOR_SELF_DOT_1: Begin completions, 16 items
+// CONSTRUCTOR_SELF_DOT_1: Begin completions, 19 items
 // CONSTRUCTOR_SELF_DOT_1-NOT: Decl[Constructor]
 
 // CONSTRUCTOR_SELF_DOT_1: End completions
@@ -193,7 +196,7 @@ class ThisDerived1 : ThisBase1 {
 // DESTRUCTOR_SELF_NO_DOT_1: End completions
 
     self.#^DESTRUCTOR_SELF_DOT_1^#
-// DESTRUCTOR_SELF_DOT_1: Begin completions, 16 items
+// DESTRUCTOR_SELF_DOT_1: Begin completions, 19 items
 // DESTRUCTOR_SELF_DOT_1: End completions
   }
 
@@ -205,7 +208,7 @@ class ThisDerived1 : ThisBase1 {
 
   func test2() {
     self.#^FUNC_SELF_DOT_1^#
-// FUNC_SELF_DOT_1: Begin completions, 16 items
+// FUNC_SELF_DOT_1: Begin completions, 19 items
 // FUNC_SELF_DOT_1: End completions
   }
 

--- a/test/IDE/complete_after_super.swift
+++ b/test/IDE/complete_after_super.swift
@@ -223,6 +223,7 @@ extension SuperBaseA {
 // COMMON_BASE_A_DOT-DAG: Decl[InstanceVar]/CurrNominal:    baseProp[#Int#]{{; name=.+$}}
 // COMMON_BASE_A_DOT-DAG: Decl[InstanceMethod]/CurrNominal: baseFunc0()[#Void#]{{; name=.+$}}
 // COMMON_BASE_A_DOT-DAG: Decl[InstanceMethod]/CurrNominal: baseFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
+// COMMON_BASE_A_DOT-DAG: Decl[Subscript]/CurrNominal/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // COMMON_BASE_A_DOT-DAG: Decl[InstanceVar]/CurrNominal:    baseExtProp[#Int#]{{; name=.+$}}
 // COMMON_BASE_A_DOT-DAG: Decl[InstanceMethod]/CurrNominal: baseExtFunc0()[#Void#]{{; name=.+$}}
 // COMMON_BASE_A_DOT: End completions
@@ -242,7 +243,7 @@ class SuperDerivedA : SuperBaseA {
   init(a: Int) {
     super.#^CONSTRUCTOR_SUPER_DOT_1^#
     super(#^CONSTRUCTOR_SUPER_PAREN^#
-// CONSTRUCTOR_SUPER_DOT_1: Begin completions, 7 items
+// CONSTRUCTOR_SUPER_DOT_1: Begin completions, 8 items
 // CONSTRUCTOR_SUPER_DOT_1-DAG: Decl[Constructor]/CurrNominal: init()[#SuperBaseA#]{{; name=.+$}}
 // CONSTRUCTOR_SUPER_DOT_1: End completions
   }
@@ -273,7 +274,7 @@ class SuperDerivedA : SuperBaseA {
     var resyncParser = 42
 
     super.#^DESTRUCTOR_SUPER_DOT_1^#
-// DESTRUCTOR_SUPER_DOT_1: Begin completions, 6 items
+// DESTRUCTOR_SUPER_DOT_1: Begin completions, 7 items
 // DESTRUCTOR_SUPER_DOT_1: End completions
   }
 
@@ -285,7 +286,7 @@ class SuperDerivedA : SuperBaseA {
 
   func test2() {
     super.#^FUNC_SUPER_DOT_1^#
-// FUNC_SUPER_DOT_1: Begin completions, 6 items
+// FUNC_SUPER_DOT_1: Begin completions, 7 items
 // FUNC_SUPER_DOT_1: End completions
   }
 }
@@ -307,6 +308,7 @@ class SuperDerivedA : SuperBaseA {
 // COMMON_BASE_B_DOT-DAG: Decl[InstanceVar]/CurrNominal:    baseProp[#Int#]{{; name=.+$}}
 // COMMON_BASE_B_DOT-DAG: Decl[InstanceMethod]/CurrNominal: baseFunc0()[#Void#]{{; name=.+$}}
 // COMMON_BASE_B_DOT-DAG: Decl[InstanceMethod]/CurrNominal: baseFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
+// COMMON_BASE_B_DOT-DAG: Decl[Subscript]/CurrNominal/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // COMMON_BASE_B_DOT-DAG: Decl[InstanceVar]/CurrNominal:    baseExtProp[#Int#]{{; name=.+$}}
 // COMMON_BASE_B_DOT-DAG: Decl[InstanceMethod]/CurrNominal: baseExtFunc0()[#Void#]{{; name=.+$}}
 // COMMON_BASE_B_DOT: End completions
@@ -409,7 +411,7 @@ class SuperDerivedB : SuperBaseB {
 
   init(int a: Int) {
     super.#^CONSTRUCTOR_SUPER_DOT_2^#
-// CONSTRUCTOR_SUPER_DOT_2: Begin completions, 9 items
+// CONSTRUCTOR_SUPER_DOT_2: Begin completions, 10 items
 // CONSTRUCTOR_SUPER_DOT_2-DAG: Decl[Constructor]/CurrNominal: init()[#SuperBaseB#]{{; name=.+$}}
 // CONSTRUCTOR_SUPER_DOT_2-DAG: Decl[Constructor]/CurrNominal: init({#a: Double#})[#SuperBaseB#]{{; name=.+$}}
 // CONSTRUCTOR_SUPER_DOT_2-DAG: Decl[Constructor]/ExprSpecific: init({#int: Int#})[#SuperBaseB#]{{; name=.+$}}
@@ -424,7 +426,7 @@ class SuperDerivedB : SuperBaseB {
     var resyncParser = 42
 
     super.#^DESTRUCTOR_SUPER_DOT_2^#
-// DESTRUCTOR_SUPER_DOT_2: Begin completions, 6 items
+// DESTRUCTOR_SUPER_DOT_2: Begin completions, 7 items
 // DESTRUCTOR_SUPER_DOT_2: End completions
   }
 
@@ -436,7 +438,7 @@ class SuperDerivedB : SuperBaseB {
 
   func test2() {
     super.#^FUNC_SUPER_DOT_2^#
-// FUNC_SUPER_DOT_2: Begin completions, 6 items
+// FUNC_SUPER_DOT_2: Begin completions, 7 items
 // FUNC_SUPER_DOT_2: End completions
   }
 
@@ -506,14 +508,14 @@ class Closures : SuperBaseA {
   func foo() {
     func inner() {
       super.#^CLOSURE_1^#
-      // CLOSURE_1: Begin completions, 6 items
+      // CLOSURE_1: Begin completions, 7 items
       // CLOSURE_1: End completions
     }
   }
 
   func bar() {
     let inner = { () -> Void in
-      // CLOSURE_2: Begin completions, 6 items
+      // CLOSURE_2: Begin completions, 7 items
       // CLOSURE_2: End completions
       super.#^CLOSURE_2^#
     }

--- a/test/IDE/complete_dynamic_lookup.swift
+++ b/test/IDE/complete_dynamic_lookup.swift
@@ -241,6 +241,7 @@ protocol Bar { func bar() }
 // TLOC_MEMBERS_DOT-NEXT: Keyword[self]/CurrNominal: self[#TopLevelObjcClass#]; name=self
 // TLOC_MEMBERS_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: returnsObjcClass({#(i): Int#})[#TopLevelObjcClass#]{{; name=.+$}}
 // TLOC_MEMBERS_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: topLevelObjcClass_InstanceFunc1()[#Void#]{{; name=.+$}}
+// TLOC_MEMBERS_DOT-NEXT: Decl[Subscript]/CurrNominal/Erase[1]: [{#Int8#}][#Int#]{{; name=.+$}}
 // TLOC_MEMBERS_DOT-NEXT: Decl[InstanceVar]/CurrNominal:    topLevelObjcClass_Property1[#Int#]{{; name=.+$}}
 // TLOC_MEMBERS_DOT-NEXT: End completions
 

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -73,11 +73,12 @@ let _ = \Person.friends[0]#^OBJ_NODOT^#
 // OBJ-NODOT-NEXT: Decl[Subscript]/CurrNominal:        [{#Int#}][#Int#]; name=[Int]
 
 let _ = \Person.friends[0].#^OBJ_DOT^#
-// OBJ-DOT: Begin completions, 4 items
+// OBJ-DOT: Begin completions, 5 items
 // OBJ-DOT-NEXT: Decl[InstanceVar]/CurrNominal:      name[#String#]; name=name
 // OBJ-DOT-NEXT: Decl[InstanceVar]/CurrNominal:      friends[#[Person]#]; name=friends
 // OBJ-DOT-NEXT: Decl[InstanceVar]/CurrNominal:      bestFriend[#Person?#]; name=bestFriend
 // OBJ-DOT-NEXT: Decl[InstanceVar]/CurrNominal:      itself[#Person#]; name=itself
+// OBJ-DOT-NEXT: Decl[Subscript]/CurrNominal/Erase[1]: [{#Int#}][#Int#]; name=[Int]
 
 let _ = \Person.bestFriend#^OPTIONAL_NODOT^#
 // OPTIONAL-NODOT: Begin completions
@@ -94,6 +95,7 @@ let _ = \Person.bestFriend.#^OPTIONAL_DOT^#
 // OPTIONAL-DOT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.friends[#[Person]#]; name=friends
 // OPTIONAL-DOT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.bestFriend[#Person?#]; name=bestFriend
 // OPTIONAL-DOT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.itself[#Person#]; name=itself
+// OPTIONAL-DOT-NEXT: Decl[Subscript]/CurrNominal/Erase[1]: ?[{#Int#}][#Int#]; name=[Int]
 // OPTIONAL-DOT: Decl[InstanceVar]/CurrNominal:      unsafelyUnwrapped[#Person#]; name=unsafelyUnwrapped
 
 let _ = \Person.bestFriend?#^UNWRAPPED_NODOT^#

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -340,6 +340,8 @@ var fooObject: FooStruct
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: overloadedInstanceFunc2({#(x): Int#})[#Int#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: overloadedInstanceFunc2({#(x): Double#})[#Int#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: builderFunc1({#(a): Int#})[#FooStruct#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[Subscript]/CurrNominal/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[Subscript]/CurrNominal/Erase[1]: [{#Int#}, {#Int#}][#Double#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: selectorVoidFunc1({#(a): Int#}, {#b: Float#})[#Void#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: selectorVoidFunc2({#(a): Int#}, {#b: Float#}, {#c: Double#})[#Void#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: selectorVoidFunc3({#(a): Int#}, {#b: (Float, Double)#})[#Void#]{{; name=.+$}}
@@ -948,6 +950,7 @@ func testLookInProto1() {
 // PROTO_MEMBERS_1-NEXT: Decl[InstanceVar]/CurrNominal:    fooInstanceVar2[#Int#]{{; name=.+$}}
 // PROTO_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// PROTO_MEMBERS_1-NEXT: Decl[Subscript]/CurrNominal/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_1-NEXT: End completions
 }
 
@@ -962,6 +965,7 @@ func testLookInProto2() {
 // PROTO_MEMBERS_2-NEXT: Decl[InstanceVar]/CurrNominal:    fooInstanceVar2[#Int#]{{; name=.+$}}
 // PROTO_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// PROTO_MEMBERS_2-NEXT: Decl[Subscript]/CurrNominal/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_2-NEXT: End completions
 }
 
@@ -977,6 +981,7 @@ func testLookInProto3() {
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceVar]/Super:          fooInstanceVar2[#Int#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/Super:       fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/Super:       fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// PROTO_MEMBERS_3-NEXT: Decl[Subscript]/Super/Erase[1]:   [{#Int#}][#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/CurrNominal: fooExInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: End completions
 }
@@ -1010,6 +1015,7 @@ func testResolveFuncParam3<Foo : FooProtocol>(_ foo: Foo) {
 // RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_3-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_3-NEXT: Decl[Subscript]/Super/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_3-NEXT: End completions
 }
 
@@ -1024,6 +1030,7 @@ func testResolveFuncParam4<FooBar : FooProtocol & BarProtocol>(_ fooBar: FooBar)
 // RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_4-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_4-NEXT: Decl[Subscript]/Super/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_4-NEXT: End completions
 }
 
@@ -1039,6 +1046,7 @@ func testResolveFuncParam5<FooExBarEx : FooExProtocol & BarExProtocol>(_ a: FooE
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_5-NEXT: Decl[Subscript]/Super/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: fooExInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: End completions
 }
@@ -1051,6 +1059,7 @@ func testResolveFuncParam6<Foo : FooProtocol where Foo : FooClass>(_ foo: Foo) {
 // RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_6-NEXT: Decl[Subscript]/Super/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceVar]/Super:    fooClassInstanceVar[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/Super: fooClassInstanceFunc0()[#Void#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_6-NEXT: Decl[InstanceMethod]/Super: fooClassInstanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
@@ -1072,6 +1081,7 @@ class TestResolveConstructorParam2 {
 // RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: Decl[Subscript]/Super/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_2-NEXT: End completions
   }
 }
@@ -1085,6 +1095,7 @@ class TestResolveConstructorParam3<Foo : FooProtocol> {
 // RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceVar]/Super:    fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
+// RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: Decl[Subscript]/Super/Erase[1]: [{#Int#}][#Double#]{{; name=.+$}}
 // RESOLVE_CONSTRUCTOR_PARAM_3-NEXT: End completions
   }
 }

--- a/test/SourceKit/CodeComplete/complete_member.swift.response
+++ b/test/SourceKit/CodeComplete/complete_member.swift.response
@@ -1,6 +1,17 @@
 {
   key.results: [
     {
+      key.kind: source.lang.swift.decl.function.subscript,
+      key.name: "[]",
+      key.sourcetext: "[<#T##Int#>]",
+      key.description: "[Int]",
+      key.typename: "Double",
+      key.context: source.codecompletion.context.thisclass,
+      key.num_bytes_to_erase: 1,
+      key.associated_usrs: "s:15complete_member11FooProtocolPySdSicip",
+      key.modulename: "complete_member"
+    },
+    {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "fooInstanceFunc0()",
       key.sourcetext: "fooInstanceFunc0()",


### PR DESCRIPTION
For:

```swift
  func test(str: String) {
    str.#^COMPLETE^#
  }
```

Suggest `[<#String.Index#>]`, `[<#Range<String.Index>#>]`, etc. with erasing dot instruction.

rdar://problem/28874899