### PR TITLE
[stdlib] Remove _preprocessingPass

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift
@@ -88,6 +88,7 @@ public func checkSequence<
     expectedCount, sequence.underestimatedCount, message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
 
+  /*
   // Test `_copyContents(initializing:)` if we can do so without destroying the
   // sequence.
   _ = sequence._preprocessingPass { () -> Void in
@@ -113,6 +114,7 @@ public func checkSequence<
     expectEqualSequence(expected, copy, message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), sameValue: sameValue)
   }
+  */
 }
 
 public func checkSequence<
@@ -207,6 +209,7 @@ public func checkSequence<
     expectedCount, sequence.underestimatedCount, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
 
+/*
   // Test `_copyContents(initializing:)` if we can do so without destroying the
   // sequence.
   _ = sequence._preprocessingPass { () -> Void in
@@ -232,6 +235,7 @@ public func checkSequence<
     expectEqualSequence(expected, copy, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), sameValue: sameValue)
   }
+*/
 }
 
 public func checkSequence<

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
@@ -85,7 +85,6 @@ public class SequenceLog {
   public static var suffixMaxLength = TypeIndexed(0)
   public static var split = TypeIndexed(0)
   public static var _customContainsEquatableElement = TypeIndexed(0)
-  public static var _preprocessingPass = TypeIndexed(0)
   public static var _copyToContiguousArray = TypeIndexed(0)
   public static var _copyContents = TypeIndexed(0)  
   // Collection
@@ -263,16 +262,6 @@ extension LoggingSequence: Sequence {
   public func _customContainsEquatableElement(_ element: Element) -> Bool? {
     SequenceLog._customContainsEquatableElement[selfType] += 1
     return base._customContainsEquatableElement(element)
-  }
-
-  /// If `self` is multi-pass (i.e., a `Collection`), invoke
-  /// `preprocess` on `self` and return its result.  Otherwise, return
-  /// `nil`.
-  public func _preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R? {
-    SequenceLog._preprocessingPass[selfType] += 1
-    return try base._preprocessingPass(preprocess)
   }
 
   /// Create a native array buffer containing the elements of `self`,

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1668,13 +1668,3 @@ extension Collection where SubSequence == Self {
     self = self[index(startIndex, offsetBy: k)..<endIndex]
   }
 }
-
-extension Collection {
-  @inlinable
-  @inline(__always)
-  public func _preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R? {
-    return try preprocess()
-  }
-}

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -221,13 +221,6 @@ internal class _AnyRandomAccessCollectionBox<Element>
   }
 
   @inlinable
-  internal func __preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R? {
-    _abstract()
-  }
-
-  @inlinable
   internal func __copyToContiguousArray() -> ContiguousArray<Element> {
     _abstract()
   }
@@ -441,12 +434,6 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
     _ element: Element
   ) -> Bool? {
     return _base._customContainsEquatableElement(element)
-  }
-  @inlinable
-  internal override func __preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R? {
-    return try _base._preprocessingPass(preprocess)
   }
   @inlinable
   internal override func __copyToContiguousArray() -> ContiguousArray<Element> {
@@ -780,13 +767,6 @@ extension Any${Kind} {
     _ element: Element
   ) -> Bool? {
     return _box.__customContainsEquatableElement(element)
-  }
-
-  @inlinable
-  public func _preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R? {
-    return try _box.__preprocessingPass(preprocess)
   }
 
   @inlinable

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -135,19 +135,6 @@ extension JoinedSequence: Sequence {
     var result = ContiguousArray<Element>()
     let separatorSize: Int = numericCast(_separator.count)
 
-    let reservation = _base._preprocessingPass {
-      () -> Int in
-      var r = 0
-      for chunk in _base {
-        r += separatorSize + chunk.underestimatedCount
-      }
-      return r - separatorSize
-    }
-
-    if let n = reservation {
-      result.reserveCapacity(numericCast(n))
-    }
-
     if separatorSize == 0 {
       for x in _base {
         result.append(contentsOf: x)

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -533,12 +533,6 @@ public protocol Sequence {
     _ element: Element
   ) -> Bool?
 
-  /// If `self` is multi-pass (i.e., a `Collection`), invoke `preprocess` and
-  /// return its result.  Otherwise, return `nil`.
-  func _preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R?
-
   /// Create a native array buffer containing the elements of `self`,
   /// in the same order.
   __consuming func _copyToContiguousArray() -> ContiguousArray<Element>
@@ -832,14 +826,6 @@ extension Sequence {
   @inlinable
   public var underestimatedCount: Int {
     return 0
-  }
-
-  @inlinable
-  @inline(__always)
-  public func _preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R? {
-    return nil
   }
 
   @inlinable

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -31,13 +31,6 @@ extension _SequenceWrapper  {
   public var underestimatedCount: Int {
     return _base.underestimatedCount
   }
-
-  @inlinable // generic-performance
-  public func _preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R? {
-    return try _base._preprocessingPass(preprocess)
-  }
 }
 
 extension _SequenceWrapper where Iterator == Base.Iterator {

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -290,13 +290,6 @@ extension StrideTo: Sequence {
   }
 
   @inlinable
-  public func _preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R? {
-    return try preprocess()
-  }
-
-  @inlinable
   public func _customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
@@ -502,13 +495,6 @@ extension StrideThrough: Sequence {
       count += 1
     }
     return count
-  }
-
-  @inlinable
-  public func _preprocessingPass<R>(
-    _ preprocess: () throws -> R
-  ) rethrows -> R? {
-    return try preprocess()
   }
 
   @inlinable

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -902,19 +902,9 @@ extension Sequence where Element: StringProtocol {
     let separatorSize = separator._guts.count
     var width = separator._guts.byteWidth
 
-    let reservation = self._preprocessingPass {
-      () -> Int in
-      var r = 0
-      for chunk in self {
-        r += separatorSize + chunk._encodedOffsetRange.count
-        width = Swift.max(width, chunk._wholeString._guts.byteWidth)
-      }
-      return r > 0 ? r - separatorSize : 0
-    }
-
-    let capacity = reservation ?? separatorSize
     var result = ""
-    result.reserveCapacity(capacity)
+    result.reserveCapacity(separatorSize)
+
     if separator.isEmpty {
       for x in self {
         result._guts.append(x)

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -10,18 +10,32 @@ Constructor ManagedBufferPointer.init(_:_:_:) has been removed
 Constructor Zip2Sequence.init(_sequence1:_sequence2:) has been removed
 Constructor _BridgeStorage.init(native:bits:) has been removed
 Constructor _BridgeableMetatype.init(value:) has been removed
+Func AnyBidirectionalCollection._preprocessingPass(_:) has been removed
+Func AnyCollection._preprocessingPass(_:) has been removed
 Func AnyHashable._downCastConditional(into:) has been removed
+Func AnyRandomAccessCollection._preprocessingPass(_:) has been removed
+Func AnySequence._preprocessingPass(_:) has been removed
+Func Collection._preprocessingPass(_:) has been removed
 Func Collection.prefix(through:) has been removed
 Func Collection.prefix(upTo:) has been removed
 Func Collection.suffix(from:) has been removed
+Func Sequence._preprocessingPass(_:) has been removed
 Func Sequence.filter(_:) has been removed
 Func Sequence.forEach(_:) has been removed
 Func Sequence.map(_:) has been removed
+Func StrideThrough._preprocessingPass(_:) has been removed
+Func StrideTo._preprocessingPass(_:) has been removed
+Func _AnySequenceBox.__preprocessingPass(_:) has been removed
+Func _BidirectionalCollectionBox.__preprocessingPass(_:) has been removed
 Func _BridgeStorage.isNativeWithClearedSpareBits(_:) has been removed
 Func _BridgeStorage.isUniquelyReferenced_native_noSpareBits() has been removed
 Func _CocoaDictionary.Index.copy() has been removed
+Func _CollectionBox.__preprocessingPass(_:) has been removed
 Func _ContiguousArrayStorage._getNonVerbatimBridgedHeapBuffer() has been removed
 Func _ContiguousArrayStorage._withVerbatimBridgedUnsafeBufferImpl(_:) has been removed
+Func _RandomAccessCollectionBox.__preprocessingPass(_:) has been removed
+Func _SequenceBox.__preprocessingPass(_:) has been removed
+Func _SequenceWrapper._preprocessingPass(_:) has been removed
 Func _SequenceWrapper.filter(_:) has been removed
 Func _SequenceWrapper.forEach(_:) has been removed
 Func _SequenceWrapper.map(_:) has been removed
@@ -74,13 +88,22 @@ Var _RandomAccessCollectionBox._last has been removed
 Var __SwiftDeferredNSArray._heapBufferBridged has been removed
 Var __SwiftDeferredNSArray._heapBufferBridgedPtr has been removed
 Var Hasher._core has declared type change from _BufferingHasher<_SipHash13Core> to _BufferingHasher<Hasher._Core>
+Struct _BridgeableMetatype is now without @_fixed_layout
+Func _AnySequenceBox.__copyContents(initializing:) in a non-resilient type changes position from 7 to 6
+Func _AnySequenceBox.__copyToContiguousArray() in a non-resilient type changes position from 6 to 5
+Func _AnySequenceBox._drop(while:) in a non-resilient type changes position from 8 to 7
+Func _AnySequenceBox._dropFirst(_:) in a non-resilient type changes position from 9 to 8
+Func _AnySequenceBox._dropLast(_:) in a non-resilient type changes position from 10 to 9
+Func _AnySequenceBox._prefix(_:) in a non-resilient type changes position from 11 to 10
+Func _AnySequenceBox._prefix(while:) in a non-resilient type changes position from 12 to 11
+Func _AnySequenceBox._split(maxSplits:omittingEmptySubsequences:whereSeparator:) in a non-resilient type changes position from 14 to 13
+Func _AnySequenceBox._suffix(_:) in a non-resilient type changes position from 13 to 12
 
 /* Moved Decls */
 
 /* Renamed Decls */
 
 /* Type Changes */
-Struct _BridgeableMetatype is now without @_fixed_layout
 Func __ContiguousArrayStorageBase._getNonVerbatimBridgingBuffer() is added to a non-resilient type
 Var _CocoaDictionary.Index._offset is added to a non-resilient type
 Var _CocoaDictionary.Index._storage in a non-resilient type changes position from 1 to 0

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -183,10 +183,6 @@ tests.test("${TestedType}: dispatch to wrapped, SequenceLog") {
     _ = s._customContainsEquatableElement(OpaqueValue(42))
   }
 
-  Log._preprocessingPass.expectIncrement(Base.self) {
-    _ = s._preprocessingPass {}
-  }
-
   Log._copyToContiguousArray.expectIncrement(Base.self) {
     _ = s._copyToContiguousArray()
   }

--- a/validation-test/stdlib/SequenceWrapperTest.swift
+++ b/validation-test/stdlib/SequenceWrapperTest.swift
@@ -67,13 +67,6 @@ sequenceWrapperTests.test("Dispatch/_customContainsEquatableElement") {
     dispatchLog._customContainsEquatableElement)
 }
 
-sequenceWrapperTests.test("Dispatch/_preprocessingPass") {
-  expectWrapperDispatch(
-    direct._preprocessingPass { 1 },
-    indirect._preprocessingPass { 1 },
-    dispatchLog._preprocessingPass)
-}
-
 sequenceWrapperTests.test("Dispatch/_copyToContiguousArray") {
   expectWrapperDispatch(
     direct._copyToContiguousArray(), indirect._copyToContiguousArray(),


### PR DESCRIPTION
It was only used in one place (`joined` implementation) which is not enough justification for an internal customization point on such a key protocol.