### PR TITLE
[stdlib] Set, Dictionary: Change second word in Cocoa indices to an integer offset

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1943,7 +1943,7 @@ extension Dictionary.Index: Hashable {
 #if _runtime(_ObjC)
     guard _isNative else {
       hasher.combine(1 as UInt8)
-      hasher.combine(_asCocoa.storage.currentKeyIndex)
+      hasher.combine(_asCocoa._offset)
       return
     }
     hasher.combine(0 as UInt8)

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -449,7 +449,7 @@ extension _CocoaDictionary: _DictionaryBuffer {
     @_effects(releasenone)
     get {
       let allKeys = _stdlib_NSDictionary_allKeys(self.object)
-      return Index(Index.Storage(self, allKeys, 0))
+      return Index(Index.Storage(self, allKeys), offset: 0)
     }
   }
 
@@ -458,30 +458,29 @@ extension _CocoaDictionary: _DictionaryBuffer {
     @_effects(releasenone)
     get {
       let allKeys = _stdlib_NSDictionary_allKeys(self.object)
-      return Index(Index.Storage(self, allKeys, allKeys.count))
+      return Index(Index.Storage(self, allKeys), offset: allKeys.count)
     }
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
   @_effects(releasenone)
   internal func index(after index: Index) -> Index {
-    var result = index.copy()
-    formIndex(after: &result, isUnique: true)
+    validate(index)
+    var result = index
+    result._offset += 1
     return result
   }
 
   internal func validate(_ index: Index) {
     _precondition(index.storage.base.object === self.object, "Invalid index")
-    _precondition(index.storage.currentKeyIndex < index.storage.allKeys.count,
+    _precondition(index._offset < index.storage.allKeys.count,
       "Attempt to access endIndex")
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
   internal func formIndex(after index: inout Index, isUnique: Bool) {
     validate(index)
-    if !isUnique { index = index.copy() }
-    let storage = index.storage // FIXME: rdar://problem/44863751
-    storage.currentKeyIndex += 1
+    index._offset += 1
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
@@ -498,7 +497,7 @@ extension _CocoaDictionary: _DictionaryBuffer {
     let allKeys = _stdlib_NSDictionary_allKeys(object)
     for i in 0..<allKeys.count {
       if _stdlib_NSObject_isEqual(key, allKeys[i]) {
-        return Index(Index.Storage(self, allKeys, i))
+        return Index(Index.Storage(self, allKeys), offset: i)
       }
     }
     _sanityCheckFailure(
@@ -526,7 +525,7 @@ extension _CocoaDictionary: _DictionaryBuffer {
   @_effects(releasenone)
   internal func lookup(_ index: Index) -> (key: Key, value: Value) {
     _precondition(index.storage.base.object === self.object, "Invalid index")
-    let key: Key = index.storage.allKeys[index.storage.currentKeyIndex]
+    let key: Key = index.storage.allKeys[index._offset]
     let value: Value = index.storage.base.object.object(forKey: key)!
     return (key, value)
   }
@@ -542,7 +541,7 @@ extension _CocoaDictionary: _DictionaryBuffer {
   @_effects(releasenone)
   func value(at index: Index) -> Value {
     _precondition(index.storage.base.object === self.object, "Invalid index")
-    let key = index.storage.allKeys[index.storage.currentKeyIndex]
+    let key = index.storage.allKeys[index._offset]
     return index.storage.base.object.object(forKey: key)!
   }
 }
@@ -566,17 +565,8 @@ extension _CocoaDictionary {
   @_fixed_layout
   @usableFromInline
   internal struct Index {
-    @usableFromInline
-    internal var _object: Builtin.BridgeObject
-    @usableFromInline
     internal var _storage: Builtin.BridgeObject
-
-    internal var object: AnyObject {
-      @inline(__always)
-      get {
-        return _bridgeObject(toNonTaggedObjC: _object)
-      }
-    }
+    internal var _offset: Int
 
     internal var storage: Storage {
       @inline(__always)
@@ -586,9 +576,9 @@ extension _CocoaDictionary {
       }
     }
 
-    internal init(_ storage: Storage) {
-      self._object = _bridgeObject(fromNonTaggedObjC: storage.base.object)
+    internal init(_ storage: Storage, offset: Int) {
       self._storage = _bridgeObject(fromNative: storage)
+      self._offset = offset
     }
   }
 }
@@ -611,17 +601,12 @@ extension _CocoaDictionary.Index {
     /// An unowned array of keys.
     internal var allKeys: _BridgingBuffer
 
-    /// Index into `allKeys`
-    internal var currentKeyIndex: Int
-
     internal init(
       _ base: __owned _CocoaDictionary,
-      _ allKeys: __owned _BridgingBuffer,
-      _ currentKeyIndex: Int
+      _ allKeys: __owned _BridgingBuffer
     ) {
       self.base = base
       self.allKeys = allKeys
-      self.currentKeyIndex = currentKeyIndex
     }
   }
 }
@@ -642,15 +627,6 @@ extension _CocoaDictionary.Index {
       return storage.base
     }
   }
-
-  @usableFromInline
-  internal func copy() -> _CocoaDictionary.Index {
-    let storage = self.storage
-    return _CocoaDictionary.Index(Storage(
-        storage.base,
-        storage.allKeys,
-        storage.currentKeyIndex))
-  }
 }
 
 extension _CocoaDictionary.Index {
@@ -659,9 +635,9 @@ extension _CocoaDictionary.Index {
   internal var key: AnyObject {
     @_effects(readonly)
     get {
-      _precondition(storage.currentKeyIndex < storage.allKeys.count,
+      _precondition(_offset < storage.allKeys.count,
         "Attempting to access Dictionary elements using an invalid index")
-      return storage.allKeys[storage.currentKeyIndex]
+      return storage.allKeys[_offset]
     }
   }
 
@@ -670,7 +646,7 @@ extension _CocoaDictionary.Index {
   internal var age: Int32 {
     @_effects(readonly)
     get {
-      return _HashTable.age(for: object)
+      return _HashTable.age(for: storage.base.object)
     }
   }
 }
@@ -684,7 +660,7 @@ extension _CocoaDictionary.Index: Equatable {
   ) -> Bool {
     _precondition(lhs.storage.base.object === rhs.storage.base.object,
       "Comparing indexes from different dictionaries")
-    return lhs.storage.currentKeyIndex == rhs.storage.currentKeyIndex
+    return lhs._offset == rhs._offset
   }
 }
 
@@ -697,7 +673,7 @@ extension _CocoaDictionary.Index: Comparable {
   ) -> Bool {
     _precondition(lhs.storage.base.object === rhs.storage.base.object,
       "Comparing indexes from different dictionaries")
-    return lhs.storage.currentKeyIndex < rhs.storage.currentKeyIndex
+    return lhs._offset < rhs._offset
   }
 }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1437,7 +1437,7 @@ extension Set.Index: Hashable {
 #if _runtime(_ObjC)
     guard _isNative else {
       hasher.combine(1 as UInt8)
-      hasher.combine(_asCocoa.storage.currentKeyIndex)
+      hasher.combine(_asCocoa._offset)
       return
     }
     hasher.combine(0 as UInt8)

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -324,7 +324,7 @@ extension _CocoaSet: _SetBuffer {
     @_effects(releasenone)
     get {
       let allKeys = _stdlib_NSSet_allObjects(self.object)
-      return Index(Index.Storage(self, allKeys, 0))
+      return Index(Index.Storage(self, allKeys), offset: 0)
     }
   }
 
@@ -333,31 +333,30 @@ extension _CocoaSet: _SetBuffer {
     @_effects(releasenone)
     get {
       let allKeys = _stdlib_NSSet_allObjects(self.object)
-      return Index(Index.Storage(self, allKeys, allKeys.count))
+      return Index(Index.Storage(self, allKeys), offset: allKeys.count)
     }
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
   @_effects(releasenone)
   internal func index(after index: Index) -> Index {
-    var result = index.copy()
-    formIndex(after: &result, isUnique: true)
+    validate(index)
+    var result = index
+    result._offset += 1
     return result
   }
 
   internal func validate(_ index: Index) {
     _precondition(index.storage.base.object === self.object,
       "Invalid index")
-    _precondition(index.storage.currentKeyIndex < index.storage.allKeys.count,
+    _precondition(index._offset < index.storage.allKeys.count,
       "Attempt to access endIndex")
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
   internal func formIndex(after index: inout Index, isUnique: Bool) {
     validate(index)
-    if !isUnique { index = index.copy() }
-    let storage = index.storage // FIXME: rdar://problem/44863751
-    storage.currentKeyIndex += 1
+    index._offset += 1
   }
 
   @usableFromInline // FIXME(cocoa-index): Should be inlinable
@@ -374,7 +373,7 @@ extension _CocoaSet: _SetBuffer {
     let allKeys = _stdlib_NSSet_allObjects(object)
     for i in 0..<allKeys.count {
       if _stdlib_NSObject_isEqual(element, allKeys[i]) {
-        return Index(Index.Storage(self, allKeys, i))
+        return Index(Index.Storage(self, allKeys), offset: i)
       }
     }
     _sanityCheckFailure(
@@ -404,17 +403,8 @@ extension _CocoaSet {
   @_fixed_layout
   @usableFromInline
   internal struct Index {
-    @usableFromInline
-    internal var _object: Builtin.BridgeObject
-    @usableFromInline
     internal var _storage: Builtin.BridgeObject
-
-    internal var object: AnyObject {
-      @inline(__always)
-      get {
-        return _bridgeObject(toNonTaggedObjC: _object)
-      }
-    }
+    internal var _offset: Int
 
     internal var storage: Storage {
       @inline(__always)
@@ -424,9 +414,9 @@ extension _CocoaSet {
       }
     }
 
-    internal init(_ storage: __owned Storage) {
-      self._object = _bridgeObject(fromNonTaggedObjC: storage.base.object)
+    internal init(_ storage: __owned Storage, offset: Int) {
       self._storage = _bridgeObject(fromNative: storage)
+      self._offset = offset
     }
   }
 }
@@ -449,17 +439,12 @@ extension _CocoaSet.Index {
     /// An unowned array of keys.
     internal var allKeys: _BridgingBuffer
 
-    /// Index into `allKeys`
-    internal var currentKeyIndex: Int
-
     internal init(
       _ base: __owned _CocoaSet,
-      _ allKeys: __owned _BridgingBuffer,
-      _ currentKeyIndex: Int
+      _ allKeys: __owned _BridgingBuffer
     ) {
       self.base = base
       self.allKeys = allKeys
-      self.currentKeyIndex = currentKeyIndex
     }
   }
 }
@@ -472,14 +457,6 @@ extension _CocoaSet.Index {
       return unsafeBitCast(storage, to: UInt.self)
     }
   }
-
-  internal func copy() -> _CocoaSet.Index {
-    let storage = self.storage
-    return _CocoaSet.Index(Storage(
-        storage.base,
-        storage.allKeys,
-        storage.currentKeyIndex))
-  }
 }
 
 extension _CocoaSet.Index {
@@ -488,9 +465,9 @@ extension _CocoaSet.Index {
   internal var element: AnyObject {
     @_effects(readonly)
     get {
-      _precondition(storage.currentKeyIndex < storage.allKeys.count,
+      _precondition(_offset < storage.allKeys.count,
         "Attempting to access Set elements using an invalid index")
-      return storage.allKeys[storage.currentKeyIndex]
+      return storage.allKeys[_offset]
     }
   }
 
@@ -499,7 +476,7 @@ extension _CocoaSet.Index {
   internal var age: Int32 {
     @_effects(releasenone)
     get {
-      return _HashTable.age(for: object)
+      return _HashTable.age(for: storage.base.object)
     }
   }
 }
@@ -510,7 +487,7 @@ extension _CocoaSet.Index: Equatable {
   internal static func == (lhs: _CocoaSet.Index, rhs: _CocoaSet.Index) -> Bool {
     _precondition(lhs.storage.base.object === rhs.storage.base.object,
       "Comparing indexes from different sets")
-    return lhs.storage.currentKeyIndex == rhs.storage.currentKeyIndex
+    return lhs._offset == rhs._offset
   }
 }
 
@@ -520,7 +497,7 @@ extension _CocoaSet.Index: Comparable {
   internal static func < (lhs: _CocoaSet.Index, rhs: _CocoaSet.Index) -> Bool {
     _precondition(lhs.storage.base.object === rhs.storage.base.object,
       "Comparing indexes from different sets")
-    return lhs.storage.currentKeyIndex < rhs.storage.currentKeyIndex
+    return lhs._offset < rhs._offset
   }
 }
 

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -8,6 +8,7 @@ Constructor AnyHashable.init(_box:) has been removed
 Constructor AnyHashable.init(_usingDefaultRepresentationOf:) has been removed
 Constructor ManagedBufferPointer.init(_:_:_:) has been removed
 Func AnyHashable._downCastConditional(into:) has been removed
+Func _CocoaDictionary.Index.copy() has been removed
 Func _ContiguousArrayStorage._getNonVerbatimBridgedHeapBuffer() has been removed
 Func _ContiguousArrayStorage._withVerbatimBridgedUnsafeBufferImpl(_:) has been removed
 Func __ContiguousArrayStorageBase._getNonVerbatimBridgedHeapBuffer() has been removed
@@ -22,6 +23,8 @@ Subscript ManagedBufferPointer.subscript(_:) has been removed
 Var ManagedBufferPointer.baseAddress has been removed
 Var ManagedBufferPointer.storage has been removed
 Var ManagedBufferPointer.value has been removed
+Var _CocoaDictionary.Index._object has been removed
+Var _CocoaSet.Index._object has been removed
 Var __SwiftDeferredNSArray._heapBufferBridged has been removed
 Var __SwiftDeferredNSArray._heapBufferBridgedPtr has been removed
 
@@ -31,6 +34,10 @@ Var __SwiftDeferredNSArray._heapBufferBridgedPtr has been removed
 
 /* Type Changes */
 Func __ContiguousArrayStorageBase._getNonVerbatimBridgingBuffer() is added to a non-resilient type
+Var _CocoaDictionary.Index._offset is added to a non-resilient type
+Var _CocoaDictionary.Index._storage in a non-resilient type changes position from 1 to 0
+Var _CocoaSet.Index._offset is added to a non-resilient type
+Var _CocoaSet.Index._storage in a non-resilient type changes position from 1 to 0
 
 /* Decl Attribute changes */
 


### PR DESCRIPTION
`_BridgeObject` turned out not to be a great choice, because it doesn’t support tagged values on 32-bit platforms. Extracting the offset from index storage is a good idea anyway!
