### PR TITLE
[TypeJoin] Return Unimplemented (aka Type()) for things we cannot yet…

### DIFF
--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -397,7 +397,7 @@ CanType TypeJoin::visitProtocolCompositionType(CanType second) {
 
   // FIXME: Handle other types here.
   if (!First->isExistentialType())
-    return TheAnyType;
+    return Unimplemented;
 
   SmallVector<Type, 1> protocolType;
   ArrayRef<Type> firstMembers;


### PR DESCRIPTION
… compute.

It's important not to return `Any` for joins that we cannot compute to
distinguish them from ones that we currently can compute but result in
`Any`.

I don't have a test case for this that is independent of other changes
that I have that are not yet ready to merge. With the testing
infrastructure we have for join we don't currently have a way to test
out cases that fail in this fashion.
