### PR TITLE
[closure-lifetime-fixup] When emitting a load_borrow, make sure to em…

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -665,6 +665,13 @@ public:
                       BeginBorrowInst(getSILDebugLocation(Loc), LV));
   }
 
+  // Pass in an address or value, perform a begin_borrow/load_borrow and pass
+  // the value to the passed in closure. After the closure has finished
+  // executing, automatically insert the end_borrow. The closure can assume that
+  // it will receive a loaded loadable value.
+  void emitScopedBorrowOperation(SILLocation loc, SILValue original,
+                                 function_ref<void(SILValue)> &&fun);
+
   /// Utility function that returns a trivial store if the stored type is
   /// trivial and a \p Qualifier store if the stored type is non-trivial.
   ///

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -567,3 +567,16 @@ DebugValueAddrInst *SILBuilder::createDebugValueAddr(SILLocation Loc,
   return insert(DebugValueAddrInst::create(getSILDebugLocation(Loc), src,
                                            getModule(), Var));
 }
+
+void SILBuilder::emitScopedBorrowOperation(SILLocation loc, SILValue original,
+                                           function_ref<void(SILValue)> &&fun) {
+  if (original->getType().isAddress()) {
+    original = createLoadBorrow(loc, original);
+  } else {
+    original = createBeginBorrow(loc, original);
+  }
+
+  fun(original);
+
+  createEndBorrow(loc, original);
+}

--- a/test/SILOptimizer/Inputs/usr/include/closure_lifetime_fixup_objc.h
+++ b/test/SILOptimizer/Inputs/usr/include/closure_lifetime_fixup_objc.h
@@ -1,0 +1,6 @@
+
+#define SWIFT_NOESCAPE __attribute__((__noescape__))
+
+typedef void (^block_t)(void);
+
+block_t block_create_noescape(block_t SWIFT_NOESCAPE block);

--- a/test/SILOptimizer/Inputs/usr/include/module.map
+++ b/test/SILOptimizer/Inputs/usr/include/module.map
@@ -1,0 +1,5 @@
+
+module ClosureLifetimeFixupObjC {
+  header "closure_lifetime_fixup_objc.h"
+  export *
+}

--- a/test/SILOptimizer/closure_lifetime_fixup.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -sil-verify-all -enable-sil-ownership -emit-sil -o - | %FileCheck %s
 
 func use_closure(_ c : () -> () ) {
   c()

--- a/test/SILOptimizer/closure_lifetime_fixup_objc.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_objc.swift
@@ -1,7 +1,8 @@
-// RUN: %target-swift-frontend %s -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -enable-sil-ownership -sil-verify-all -emit-sil -o - -I %S/Inputs/usr/include | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation
+import ClosureLifetimeFixupObjC
 
 @objc
 public protocol DangerousEscaper {
@@ -100,3 +101,10 @@ class C: NSObject {
     getDispatchQueue().sync(execute: { _ = self })
   }
 }
+
+// Make sure that we obey ownership invariants when we emit load_borrow.
+internal typealias MyBlock = @convention(block) () -> Void
+func getBlock(noEscapeBlock: () -> Void ) -> MyBlock {
+  return block_create_noescape(noEscapeBlock)
+}
+


### PR DESCRIPTION
…it the end_borrow for it as well.

In this commit I added a more convenient API for doing this sort of operation.
Specifically: SILBuilder::emitScopedBorrowOperation. This performs either a
load_borrow or begin_borrow, then calls a user provided closure, and finally
inserts the end_borrow after the scope has closed.

rdar://43398898