### PR TITLE
Sema: Fix a failure to emit a diagnostic when generic requirements aren't satisfied

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -824,7 +824,6 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
   SmallVector<RequirementSet, 8> pendingReqs;
   pendingReqs.push_back({requirements, {}});
 
-  auto *env = dc->getGenericEnvironmentOfContext();
   ASTContext &ctx = dc->getASTContext();
   while (!pendingReqs.empty()) {
     auto current = pendingReqs.pop_back_val();
@@ -845,21 +844,15 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
       auto kind = req.getKind();
       Type rawFirstType = rawReq.getFirstType();
       Type firstType = req.getFirstType();
-      if (firstType->hasTypeParameter()) {
-        if (!env)
-          continue;
-        firstType = env->mapTypeIntoContext(firstType);
-      }
+      if (firstType->hasTypeParameter())
+        firstType = dc->mapTypeIntoContext(firstType);
 
       Type rawSecondType, secondType;
       if (kind != RequirementKind::Layout) {
         rawSecondType = rawReq.getSecondType();
         secondType = req.getSecondType();
-        if (secondType->hasTypeParameter()) {
-          if (!env)
-            continue;
-          secondType = env->mapTypeIntoContext(secondType);
-        }
+        if (secondType->hasTypeParameter())
+          secondType = dc->mapTypeIntoContext(secondType);
       }
 
       // Don't do further checking on error types.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -817,7 +817,8 @@ Type TypeChecker::applyUnboundGenericArguments(
   // Check the generic arguments against the requirements of the declaration's
   // generic signature.
   auto dc = resolution.getDeclContext();
-  if (!hasTypeVariable) {
+  if (!hasTypeVariable &&
+      resolution.getStage() > TypeResolutionStage::Structural) {
     auto result =
       checkGenericArguments(dc, loc, noteLoc, unboundType,
                             genericSig->getGenericParams(),

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -117,3 +117,10 @@ protocol Foo {
 }
 
 protocol Wibble : Foo where Bar.EvenMoreNonsense == Int { } // expected-error{{'EvenMoreNonsense' is not a member type of 'Self.Bar'}}
+
+// rdar://45271500 - failure to emit a diagnostic
+enum Cat<A> {}
+protocol Tail { associatedtype T }
+struct Dog<B, C : Tail> where C.T == B {}
+func foo<B, A>() -> Dog<B, Cat<A>> {}
+// expected-error@-1 {{type 'Cat<A>' does not conform to protocol 'Tail'}}


### PR DESCRIPTION
In the stuctural type resolution stage we don't have enough information
to check conformance and same-type requirements involving type
parameters, so we would just ignore such requirements, assuming they
will be checked later in the interface stage.

However, there was a case where we would return an error type without
emitting a diagnostic, assuming that at least one other requirement
fails. If a TypeLoc has an error type we don't resolve it again in
the interface type stage. So we would end up with an error type and
no diagnostic.

Fix this by not checking generic arguments in the structural stage at
all; we will do the complete check in interface stage, where we know
how to check everything and emit all the right diagnostics.

Fixes <rdar://problem/45271500>.
