### PR TITLE
Allow cross-compile Android while compiling libicu in Linux.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1834,8 +1834,13 @@ function(add_swift_target_library name)
 
       foreach(lib ${SWIFTLIB_PRIVATE_LINK_LIBRARIES})
         if("${lib}" STREQUAL "ICU_UC")
-          list(APPEND swiftlib_private_link_libraries_targets
-               "${SWIFT_${sdk}_${arch}_ICU_UC}")
+          if("${sdk}" STREQUAL "ANDROID" OR "${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "")
+            list(APPEND swiftlib_private_link_libraries_targets
+                 "${SWIFT_${sdk}_${arch}_ICU_UC}")
+          else()
+            list(APPEND swiftlib_private_link_libraries_targets -licuucswift -licudataswift)
+          endif()
+
           # temporary fix for atomic needing to be
           # after object files for libswiftCore.so
           if("${sdk}" STREQUAL "ANDROID")
@@ -1848,8 +1853,12 @@ function(add_swift_target_library name)
                  "${SWIFTLIB_DIR}/clang/lib/freebsd/libclang_rt.builtins-${arch}.a")
           endif()
         elseif("${lib}" STREQUAL "ICU_I18N")
-          list(APPEND swiftlib_private_link_libraries_targets
-               "${SWIFT_${sdk}_${arch}_ICU_I18N}")
+          if("${sdk}" STREQUAL "ANDROID" OR "${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "")
+            list(APPEND swiftlib_private_link_libraries_targets
+                 "${SWIFT_${sdk}_${arch}_ICU_I18N}")
+          else()
+            list(APPEND swiftlib_private_link_libraries_targets -licui18nswift)
+          endif()
         elseif(TARGET "${lib}${VARIANT_SUFFIX}")
           list(APPEND swiftlib_private_link_libraries_targets
               "${lib}${VARIANT_SUFFIX}")

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -227,12 +227,7 @@ else()
   # effort has been completed.
   #set(LINK_FLAGS
   #  -Wl,--whole-archive swiftRuntime -Wl,--no-whole-archive)
-  if("${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "")
-    list(APPEND swift_core_private_link_libraries
-      ICU_UC ICU_I18N)
-  else()
-    list(APPEND swift_core_private_link_libraries -licui18nswift -licuucswift -licudataswift)
-  endif()
+  list(APPEND swift_core_private_link_libraries ICU_UC ICU_I18N)
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "CYGWIN")


### PR DESCRIPTION
Before this commit, if one used the `--libicu` parameter of the build script to compile ICU in Linux, the variable `SWIFT_PATH_TO_LIBICU_BUILD` is set. While evaluating which link flags to use in `stdlib/public/core/CMakeLists.txt`, the presence of that variable will set all the SDKs to use `-licuuc` style link libraries, which will not work while cross-compiling Android (since Android libraries have a `swift` suffix, and they are not in the library search path).

This commit delays the selection of `-licuuc` style or full paths to later in the process, where the current SDK is already know, and the script can distinguish between the Android SDK case and other SDKs.

This change will become more important if #19860 is merged. It might need to be modified slightly to always use the `swift` suffixes, though.

/cc @spevans 