### PR TITLE
[PrintAsObjC] Disable -Watimport-in-framework-header warning in generated headers

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -2727,6 +2727,10 @@ public:
   void writeImports(raw_ostream &out) {
     out << "#if __has_feature(modules)\n";
 
+    out << "#if __has_warning(\"-Watimport-in-framework-header\")\n"
+        << "#pragma clang diagnostic ignored \"-Watimport-in-framework-header\"\n"
+        << "#endif\n";
+
     // Sort alphabetically for determinism and consistency.
     SmallVector<ImportModuleTy, 8> sortedImports{imports.begin(),
                                                  imports.end()};

--- a/test/PrintAsObjC/arc-conventions.swift
+++ b/test/PrintAsObjC/arc-conventions.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c %s -parse-as-library -force-single-frontend-invocation -o %t/swift.o -emit-objc-header-path %t/swift.h
 
-// RUN: %target-clang -c -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -fobjc-arc -fmodules %S/Inputs/arc-conventions.m -o %t/main.o -I %t
+// RUN: %clang -c %target-cc-options -isysroot %sdk -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -fobjc-arc -fmodules %S/Inputs/arc-conventions.m -o %t/main.o -I %t
 // RUN: %target-build-swift %t/swift.o %t/main.o -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %S/Inputs/arc-conventions.m
 
-// RUN: %target-clang -c -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -fno-objc-arc -fmodules %S/Inputs/arc-conventions.m -o %t/main.o -I %t
+// RUN: %clang -c %target-cc-options -isysroot %sdk -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -fno-objc-arc -fmodules %S/Inputs/arc-conventions.m -o %t/main.o -I %t
 // RUN: %target-build-swift %t/swift.o %t/main.o -o %t/main2
 // RUN: %target-codesign %t/main2
 // RUN: %target-run %t/main2 | %FileCheck %S/Inputs/arc-conventions.m

--- a/test/PrintAsObjC/empty.swift
+++ b/test/PrintAsObjC/empty.swift
@@ -35,6 +35,9 @@
 // CHECK: # define OBJC_DESIGNATED_INITIALIZER
 
 // CHECK-LABEL: #if __has_feature(modules)
+// CHECK-NEXT: #if __has_warning
+// CHECK-NEXT: #pragma clang diagnostic
+// CHECK-NEXT: #endif
 // CHECK-NEXT: #endif
 
 

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -9,12 +9,6 @@
 
 // REQUIRES: objc_interop
 
-// CHECK: #pragma clang diagnostic push
-
-// CHECK: #if __has_warning("-Watimport-in-framework-header")
-// CHECK-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
-// CHECK-NEXT: #endif
-
 // CHECK: @import Base;
 // CHECK-NEXT: @import Base.ExplicitSub;
 // CHECK-NEXT: @import Base.ExplicitSub.ExSub;
@@ -24,8 +18,6 @@
 // CHECK-NEXT: @import MostlyPrivate1_Private;
 // CHECK-NEXT: @import MostlyPrivate2_Private;
 // CHECK-NEXT: @import ctypes.bits;
-
-// CHECK: #pragma clang diagnostic pop
 
 // NEGATIVE-NOT: ctypes;
 // NEGATIVE-NOT: ImSub;

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -5,9 +5,15 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -F %S/Inputs/ -parse-as-library %t/imports.swiftmodule -typecheck -emit-objc-header-path %t/imports.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/imports.h
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/imports.h
-// RUN: %check-in-clang %t/imports.h -I %S/Inputs/custom-modules/ -F %S/Inputs/
+// RUN: %check-in-clang %t/imports.h -I %S/Inputs/custom-modules/ -F %S/Inputs/ -Watimport-in-framework-header
 
 // REQUIRES: objc_interop
+
+// CHECK: #pragma clang diagnostic push
+
+// CHECK: #if __has_warning("-Watimport-in-framework-header")
+// CHECK-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
+// CHECK-NEXT: #endif
 
 // CHECK: @import Base;
 // CHECK-NEXT: @import Base.ExplicitSub;
@@ -18,6 +24,8 @@
 // CHECK-NEXT: @import MostlyPrivate1_Private;
 // CHECK-NEXT: @import MostlyPrivate2_Private;
 // CHECK-NEXT: @import ctypes.bits;
+
+// CHECK: #pragma clang diagnostic pop
 
 // NEGATIVE-NOT: ctypes;
 // NEGATIVE-NOT: ImSub;

--- a/test/PrintAsObjC/mixed-framework-fwd.swift
+++ b/test/PrintAsObjC/mixed-framework-fwd.swift
@@ -18,6 +18,9 @@
 // REQUIRES: objc_interop
 
 // CHECK-LABEL: #if __has_feature(modules)
+// CHECK-NEXT: #if __has_warning
+// CHECK-NEXT: #pragma clang diagnostic
+// CHECK-NEXT: #endif
 // CHECK-NEXT: @import Foundation;
 // CHECK-NEXT: #endif
 

--- a/test/PrintAsObjC/mixed-framework.swift
+++ b/test/PrintAsObjC/mixed-framework.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 
 // CHECK-LABEL: #if __has_feature(modules)
+// CHECK-NEXT: #if __has_warning
+// CHECK-NEXT: #pragma clang diagnostic
+// CHECK-NEXT: #endif
 // CHECK-NEXT: @import Foundation;
 // CHECK-NEXT: #endif
 

--- a/test/PrintAsObjC/mixed-framework.swift
+++ b/test/PrintAsObjC/mixed-framework.swift
@@ -4,9 +4,9 @@
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=FRAMEWORK %s < %t.framework/Headers/mixed.h
 // RUN: %check-in-clang -Watimport-in-framework-header -F %S/Inputs/ %t.framework/Headers/mixed.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -emit-objc-header-path %t.framework/mixed-header.h
-// RUN: %FileCheck -check-prefix=CHECK -check-prefix=HEADER %s < %t.framework/mixed-header.h
-// RUN: %check-in-clang -Watimport-in-framework-header -include %S/Inputs/Mixed.framework/Headers/Mixed.h %t.framework/mixed-header.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -emit-objc-header-path %t.framework/Headers/mixed-header.h
+// RUN: %FileCheck -check-prefix=CHECK -check-prefix=HEADER %s < %t.framework/Headers/mixed-header.h
+// RUN: %check-in-clang -Watimport-in-framework-header -include %S/Inputs/Mixed.framework/Headers/Mixed.h %t.framework/Headers/mixed-header.h
 
 // REQUIRES: objc_interop
 

--- a/test/PrintAsObjC/mixed-framework.swift
+++ b/test/PrintAsObjC/mixed-framework.swift
@@ -1,17 +1,20 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module -parse-as-library %s -typecheck -emit-objc-header-path %t/mixed.h
-// RUN: %FileCheck -check-prefix=CHECK -check-prefix=FRAMEWORK %s < %t/mixed.h
-// RUN: %check-in-clang -F %S/Inputs/ %t/mixed.h
+// RUN: %empty-directory(%t.framework)
+// RUN: %empty-directory(%t.framework/Headers)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module -parse-as-library %s -typecheck -emit-objc-header-path %t.framework/Headers/mixed.h
+// RUN: %FileCheck -check-prefix=CHECK -check-prefix=FRAMEWORK %s < %t.framework/Headers/mixed.h
+// RUN: %check-in-clang -Watimport-in-framework-header -F %S/Inputs/ %t.framework/Headers/mixed.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -emit-objc-header-path %t/mixed-header.h
-// RUN: %FileCheck -check-prefix=CHECK -check-prefix=HEADER %s < %t/mixed-header.h
-// RUN: %check-in-clang -include %S/Inputs/Mixed.framework/Headers/Mixed.h %t/mixed-header.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name Mixed -import-objc-header %S/Inputs/Mixed.framework/Headers/Mixed.h %s -typecheck -emit-objc-header-path %t.framework/mixed-header.h
+// RUN: %FileCheck -check-prefix=CHECK -check-prefix=HEADER %s < %t.framework/mixed-header.h
+// RUN: %check-in-clang -Watimport-in-framework-header -include %S/Inputs/Mixed.framework/Headers/Mixed.h %t.framework/mixed-header.h
 
 // REQUIRES: objc_interop
 
+// CHECK: #pragma clang diagnostic push
+
 // CHECK-LABEL: #if __has_feature(modules)
-// CHECK-NEXT: #if __has_warning
-// CHECK-NEXT: #pragma clang diagnostic
+// CHECK-NEXT: #if __has_warning("-Watimport-in-framework-header")
+// CHECK-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
 // CHECK-NEXT: #endif
 // CHECK-NEXT: @import Foundation;
 // CHECK-NEXT: #endif
@@ -35,3 +38,5 @@ public class Dummy: NSNumber {
   // HEADER: @property (nonatomic) NSInteger extraData;
   @objc public internal(set) var extraData: Int = 0
 } // CHECK: @end
+
+// CHECK: #pragma clang diagnostic pop


### PR DESCRIPTION
This is a new warning in clang when you use @import in a framework header. That’s often a mistake, but it isn’t in our generated `-Swift.h` headers. If we’re building with a clang that supports this warning, we’ll now emit a pragma to disable it.

Fixes rdar://41552597.