### PR TITLE
[ConstraintSystem] NFC: Print type-checked expression after all callb…

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2038,19 +2038,19 @@ Type TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
     return Type();
   }
 
-  if (getLangOpts().DebugConstraintSolver) {
-    auto &log = Context.TypeCheckerDebug->getStream();
-    log << "---Type-checked expression---\n";
-    result->dump(log);
-    log << "\n";
-  }
-
   // If there's a listener, notify it that we've applied the solution.
   if (listener) {
     result = listener->appliedSolution(solution, result);
     if (!result) {
       return Type();
     }
+  }
+
+  if (getLangOpts().DebugConstraintSolver) {
+    auto &log = Context.TypeCheckerDebug->getStream();
+    log << "---Type-checked expression---\n";
+    result->dump(log);
+    log << "\n";
   }
 
   // Unless the client has disabled them, perform syntactic checks on the


### PR DESCRIPTION
…acks

`appliedSolution` callback is allowed to modify AST, which means
it's only valid to print "final" type-checked expression after
all of the callbacks are done.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
