### PR TITLE
Runtime: Unconditionally realize superclass metadata in swift_updateClassMetadata() [5.0]

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2616,7 +2616,6 @@ swift::swift_updateClassMetadata(ClassMetadata *self,
                                  size_t numFields,
                                  const TypeLayout * const *fieldTypes,
                                  size_t *fieldOffsets) {
-#ifndef NDEBUG
   // If there is a mangled superclass name, demangle it to the superclass
   // type.
   const ClassMetadata *super = nullptr;
@@ -2645,7 +2644,6 @@ swift::swift_updateClassMetadata(ClassMetadata *self,
     assert(self->Superclass == getRootSuperclass());
   else
     assert(self->Superclass == super);
-#endif
 
   // FIXME: Plumb this through
 #if 1

--- a/test/Interpreter/objc_class_resilience.swift
+++ b/test/Interpreter/objc_class_resilience.swift
@@ -38,4 +38,15 @@ ResilientClassTestSuite.test("Category") {
   expectEqual(42, takesMyProtocol(ResilientFieldWithCategory()))
 }
 
+// rdar://problem/45569020 - Make sure we initialize the superclass first
+class ResilientSuperclass {
+  var value: ResilientInt?
+}
+
+class ResilientSubclass : ResilientSuperclass {}
+
+ResilientClassTestSuite.test("Superclass") {
+  _blackHole(ResilientSubclass())
+}
+
 runAllTests()


### PR DESCRIPTION
Previously we were only doing this in assert builds, or if the
new Objective-C runtime metadata update hook mechanism was
available.

However, swift_checkMetadataState() gets called on the superclass
of a class, and it assumes that the metadata entry for the
superclass already exists in the singleton cache.

So even on an older runtime when there's no initialization work
to be done, we have to realize the superclass to populate the
singleton cache so that the check can succeed.

Fixes <rdar://problem/45569020>.