### PR TITLE
[Diagnostics] Improve never-returning call diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -245,7 +245,7 @@ WARNING(unreachable_code,none, "will never be executed", ())
 NOTE(unreachable_code_branch,none,
      "condition always evaluates to %select{false|true}0", (bool))
 NOTE(call_to_noreturn_note,none,
-     "a call to a never-returning function", ())
+     "call to never-returning function terminates the program", ())
 WARNING(unreachable_code_after_stmt,none,
         "code after '%select{return|break|continue|throw}0' will never "
         "be executed", (unsigned))

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -179,7 +179,7 @@ public class A {
 // This used to crash during mandatory inlining because noreturn folding would
 // create sil instructions with undef in unreachable code.
 func dontCrash() {
-  fatalError() // expected-note {{a call to a never-returning function}}
+  fatalError() // expected-note {{call to never-returning function terminates the program}}
   let k = "foo" // expected-warning {{will never be executed}}
   switch k {
   case "bar":

--- a/test/SILOptimizer/return.swift
+++ b/test/SILOptimizer/return.swift
@@ -111,7 +111,7 @@ func whileTrueLoop() -> Int {
 }
 
 func testUnreachableAfterNoReturn(x: Int) -> Int {
-  exit(); // expected-note{{a call to a never-returning function}}
+  exit(); // expected-note{{call to never-returning function terminates the program}}
   return x; // expected-warning {{will never be executed}}
 }
 
@@ -132,13 +132,13 @@ func testReachableAfterNoReturnInADifferentBlock(x: Int) -> Int {
 
 func testUnreachableAfterNoReturnFollowedByACall() -> Int {
   let x:Int = 5
-  exit(); // expected-note{{a call to a never-returning function}}
+  exit(); // expected-note{{call to never-returning function terminates the program}}
   exit(); // expected-warning {{will never be executed}}
   return x
 }
 
 func testUnreachableAfterNoReturnMethod() -> Int {
-  TuringMachine().halt(); // expected-note{{a call to a never-returning function}}
+  TuringMachine().halt(); // expected-note{{call to never-returning function terminates the program}}
   return 0; // expected-warning {{will never be executed}}
 }
 

--- a/test/SILOptimizer/unreachable_code.swift
+++ b/test/SILOptimizer/unreachable_code.swift
@@ -287,7 +287,7 @@ func test_raise_1() throws -> Int {
 }
 
 func test_raise_2() throws -> Int {
-  try raise() // expected-note {{a call to a never-returning function}}
+  try raise() // expected-note {{call to never-returning function terminates the program}}
   try raise() // expected-warning {{will never be executed}}
 }
 
@@ -330,7 +330,7 @@ func deferTryNoReturn() throws {
 func noReturnInDefer() {
   defer { // expected-warning {{'defer' statement before end of scope always executes immediately}}{{3-8=do}}
     _ = Lisp()
-    die() // expected-note {{a call to a never-returning function}}
+    die() // expected-note {{call to never-returning function terminates the program}}
     die() // expected-warning {{will never be executed}}
   }
 }


### PR DESCRIPTION
This patch just improves the wording and provides a little more clarity about why this code is unreachable.