### PR TITLE
[Mangling] Mangle protocol symbolic references in any-generic-type production.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1569,8 +1569,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
   // Try to mangle a symbolic reference for a nominal type.
   if (AllowSymbolicReferences) {
     auto nominal = key->getAnyNominal();
-    if (nominal && !isa<ProtocolDecl>(nominal)
-        && (!CanSymbolicReference || CanSymbolicReference(nominal))) {
+    if (nominal && (!CanSymbolicReference || CanSymbolicReference(nominal))) {
       appendSymbolicReference(nominal);
       // Substitutions can refer back to the symbolic reference.
       addSubstitution(key.getPointer());

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1684,6 +1684,10 @@ NodePointer Demangler::popAssocTypeName() {
   if (Proto && !isProtocolNode(Proto))
     return nullptr;
 
+  // If we haven't seen a protocol, check for a symbolic reference.
+  if (!Proto)
+    Proto = popNode(Node::Kind::ProtocolSymbolicReference);
+
   NodePointer Id = popNode(Node::Kind::Identifier);
   NodePointer AssocTy = changeKind(Id, Node::Kind::DependentAssociatedTypeRef);
   addChild(AssocTy, Proto);

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -475,6 +475,8 @@ swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
       if (node->getKind() == Demangle::Node::Kind::Protocol) {
         auto proto = llvm::cast<ProtocolDescriptor>(context);
         auto nameNode = node->getChild(1);
+        if (nameNode->getKind() != Demangle::Node::Kind::Identifier)
+          return false;
         if (nameNode->getText() == proto->Name.get()) {
           node = node->getChild(0);
           break;

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -23,7 +23,7 @@
 
 // Associated type default + flags
 // CHECK-DEFINITION-SAME: [[INT]] add
-// CHECK-DEFINITION-SAME: @"default assoc type _____y2T118resilient_protocol29ProtocolWithAssocTypeDefaultsPQzG 18resilient_protocol7WrapperV"
+// CHECK-DEFINITION-SAME: @"default assoc type _____y2T1_____QzG 18resilient_protocol7WrapperV AA29ProtocolWithAssocTypeDefaultsP"
 // CHECK-DEFINITION-SAME: [[INT]] 1
 
 // Protocol requirements base descriptor

--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -29,4 +29,20 @@ AssociatedTypeDemangleTests.test("private types") {
   expectEqual(Foo.Inner.Innermost.self, getP_A(Foo.Inner.self))
 }
 
+private protocol P2 {
+  associatedtype A
+}
+
+struct Bar: P2 {
+  typealias A = Int
+}
+
+class C1<T> { }
+
+private class C2<T: P2>: C1<T.A> { }
+
+AssociatedTypeDemangleTests.test("private protocols") {
+  expectEqual("C2<Bar>", String(describing: C2<Bar>.self))
+}
+
 runAllTests()


### PR DESCRIPTION
We were strangely excluding protocols from being symbolically referenced
in the any-generic-type production, which meant that we could not resolve
(e.g.) associated type references to private protocols at runtime. Allow
protocol symbolic references in this position, and cope with it in the
demangler.

Fixes the rest of rdar://problem/44977236.
