### PR TITLE
[Sema] Generalize CaseIterable synthesis for availability

### DIFF
--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -79,8 +79,7 @@ bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
         //
         // FIXME: Lift the availability restriction.
       case KnownProtocolKind::CaseIterable:
-        return !enumDecl->hasPotentiallyUnavailableCaseValue()
-            && enumDecl->hasOnlyCasesWithoutAssociatedValues();
+        return enumDecl->hasOnlyCasesWithoutAssociatedValues();
 
         // @objc enums can explicitly derive their _BridgedNSError conformance.
       case KnownProtocolKind::BridgedNSError:

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -204,14 +204,15 @@ public func != <T : Equatable>(lhs: T, rhs: T) -> Bool
 /// =======================================
 ///
 /// The compiler can automatically provide an implementation of the
-/// `CaseIterable` requirements for any enumeration without associated values
-/// or `@available` attributes on its cases. The synthesized `allCases`
-/// collection provides the cases in order of their declaration.
+/// `CaseIterable` requirements for any enumeration without associated values.
+/// The synthesized `allCases` collection provides the cases in order of their
+/// declaration.
 ///
 /// You can take advantage of this compiler support when defining your own
 /// custom enumeration by declaring conformance to `CaseIterable` in the
-/// enumeration's original declaration. The `CompassDirection` example above
-/// demonstrates this automatic implementation.
+/// enumeration's original declaration or an extension in the same file. The
+/// `CompassDirection` example above demonstrates this automatic
+/// implementation.
 public protocol CaseIterable {
   /// A type that can represent a collection of all values of this type.
   associatedtype AllCases: Collection

--- a/test/Interpreter/synthesized_extension_conformances.swift
+++ b/test/Interpreter/synthesized_extension_conformances.swift
@@ -45,6 +45,21 @@ enum NoValues {
 }
 extension NoValues: CaseIterable {}
 
+enum SomeAvailable: CaseIterable {
+    case a
+    @available(*, unavailable)
+    case b // Should not be included in allCases
+    @available(*, deprecated)
+    case c
+    case d
+    case e
+    @available(swift, obsoleted: 4.0)
+    case f // Should not be included in allCases
+    @available(swift, obsoleted: 5.0)
+    case g
+    case h
+}
+
 // Cache some values, and make them all have the same width (within a type) for
 // formatting niceness.
 let SIOne = SInt(x: 1)
@@ -243,6 +258,9 @@ class TestCaseIterable : TestSuper {
     func test_allCases() {
         expectEqual(NoValues.allCases, [.a, .b, .c])
     }
+    func test_availableCases() {
+        expectEqual(SomeAvailable.allCases, [.a, .c, .d, .e, .g, .h])
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -270,6 +288,7 @@ for (name, test) in codable {
 
 var caseIterable = [
   "TestCaseIterable.test_allCases": TestCaseIterable.test_allCases,
+  "TestCaseIterable.test_availableCases": TestCaseIterable.test_availableCases,
 ]
 
 var CaseIterableTests = TestSuite("TestCaseIterable")

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -245,6 +245,13 @@ extension OtherFileNonconforming: Hashable {
 extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}
 extension YetOtherFileNonconforming: CaseIterable {} // expected-error {{does not conform}}
 
+// Verify conformance can be synthesized for enums with unavailable cases
+enum Availability: CaseIterable {
+  case available
+  @available(*, deprecated) case deprecated
+  @available(*, unavailable) case unavailable
+}
+
 // Verify that an indirect enum doesn't emit any errors as long as its "leaves"
 // are conformant.
 enum StringBinaryTree: Hashable {


### PR DESCRIPTION
Allow a synthesized conformance to CaseIterable for enums having cases with availability attributes, as described in SE-0194.
This resolves [SR-7151](https://bugs.swift.org/browse/SR-7151).

