### PR TITLE
[Sema] Exclude unavailable enum cases from synthesized init(rawValue:)

### DIFF
--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -233,6 +233,9 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl) {
   SmallVector<ASTNode, 4> cases;
   unsigned Idx = 0;
   for (auto elt : enumDecl->getAllElements()) {
+    if(AvailableAttr::isUnavailable(elt)) {
+      continue;
+    }
     LiteralExpr *litExpr = cloneRawLiteralExpr(C, elt->getRawValueExpr());
     if (isStringEnum) {
       // In case of a string enum we are calling the _findStringSwitchCase

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -188,3 +188,10 @@ enum ArrayOfNewEquatable : Array<NotEquatable> { }
 // expected-error@-1{{raw type 'Array<NotEquatable>' is not expressible by a string, integer, or floating-point literal}}
 // expected-error@-2{{'ArrayOfNewEquatable' declares raw type 'Array<NotEquatable>', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-3{{RawRepresentable conformance cannot be synthesized because raw type 'Array<NotEquatable>' is not Equatable}}
+
+enum SR9094: String {
+  case a
+  @available(*, unavailable)
+  case b
+  case c
+}


### PR DESCRIPTION
Do not include unavailable enum cases in the switch statement used inside the synthesized RawRepresentable initializer. This usage would cause an error to be emitted due to the attempted use of the case.
This resolves SR-9094

This means that this code now compiles:

```
enum TrafficLight: String {

    @available(*, unavailable) case red

    case green

    case yellow

}
```

Whereas before the compiler would output this error:

```
:4:37: note: 'red' has been explicitly marked unavailable here
@available(*, unavailable) case red
~~~~~~~~~~~~~~~~~~~~~~~~~ ^
```