### PR TITLE
[SDK] Fix multiple issues with Swift KVO

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSObject.swift
+++ b/stdlib/public/Darwin/Foundation/NSObject.swift
@@ -52,7 +52,7 @@ fileprivate extension NSObject {
 // must coexist, so it was renamed. The old name must not be used in the
 // new runtime.
 @objc private class __KVOKeyPathBridgeMachinery : NSObject {
-    @nonobjc static var swizzler: ()? = {
+    @nonobjc static let swizzler: () = {
         /*
          Move all our methods into place. We want the following:
          __KVOKeyPathBridgeMachinery's automaticallyNotifiesObserversForKey:, and keyPathsForValuesAffectingValueForKey: methods replaces NSObject's versions of them
@@ -61,8 +61,6 @@ fileprivate extension NSObject {
          */
         threeWaySwizzle(#selector(NSObject.keyPathsForValuesAffectingValue(forKey:)), with: #selector(NSObject.__old_unswizzled_keyPathsForValuesAffectingValue(forKey:)))
         threeWaySwizzle(#selector(NSObject.automaticallyNotifiesObservers(forKey:)), with: #selector(NSObject.__old_unswizzled_automaticallyNotifiesObservers(forKey:)))
-        
-        return nil
     }()
     
     /// Performs a 3-way swizzle between `NSObject` and `__KVOKeyPathBridgeMachinery`.
@@ -174,13 +172,12 @@ public class NSKeyValueObservation : NSObject {
         
         // workaround for <rdar://problem/31640524> Erroneous (?) error when using bridging in the Foundation overlay
         // specifically, overriding observeValue(forKeyPath:of:change:context:) complains that it's not Obj-C-compatible
-        @nonobjc static var swizzler: ()? = {
+        @nonobjc static let swizzler: () = {
             let bridgeClass: AnyClass = Helper.self
             let observeSel = #selector(NSObject.observeValue(forKeyPath:of:change:context:))
             let swapSel = #selector(Helper._swizzle_me_observeValue(forKeyPath:of:change:context:))
             let swapObserveMethod = class_getInstanceMethod(bridgeClass, swapSel)!
             class_addMethod(bridgeClass, observeSel, method_getImplementation(swapObserveMethod), method_getTypeEncoding(swapObserveMethod))
-            return nil
         }()
         
         @nonobjc init(object: NSObject, keyPath: AnyKeyPath, options: NSKeyValueObservingOptions, callback: @escaping (NSObject, NSKeyValueObservedChange<Any>) -> Void) {

--- a/stdlib/public/Darwin/Foundation/NSObject.swift
+++ b/stdlib/public/Darwin/Foundation/NSObject.swift
@@ -134,10 +134,6 @@ func _bridgeKeyPathToString(_ keyPath:AnyKeyPath) -> String {
     return __KVOKeyPathBridgeMachinery._bridgeKeyPath(keyPath)
 }
 
-func _bridgeStringToKeyPath(_ keyPath:String) -> AnyKeyPath? {
-    return __KVOKeyPathBridgeMachinery._bridgeKeyPath(keyPath)
-}
-
 // NOTE: older overlays called this NSKeyValueObservation. We now use
 // that name in the source code, but add an underscore to the runtime
 // name to avoid conflicts when both are loaded into the same process.

--- a/stdlib/public/Darwin/Foundation/NSSet.swift
+++ b/stdlib/public/Darwin/Foundation/NSSet.swift
@@ -17,7 +17,7 @@ extension Set {
   ///
   /// The provided `NSSet` will be copied to ensure that the copy can
   /// not be mutated by other code.
-  fileprivate init(_cocoaSet: __shared AnyObject) {
+  fileprivate init(_cocoaSet: __shared NSSet) {
     assert(_isBridgedVerbatimToObjectiveC(Element.self),
       "Set can be backed by NSSet _variantStorage only when the member type can be bridged verbatim to Objective-C")
     // FIXME: We would like to call CFSetCreateCopy() to avoid doing an

--- a/stdlib/public/Darwin/Foundation/NSSortDescriptor.swift
+++ b/stdlib/public/Darwin/Foundation/NSSortDescriptor.swift
@@ -11,18 +11,22 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import Foundation // Clang module
+import ObjectiveC
 
 extension NSSortDescriptor {
     public convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool) {
         self.init(key: _bridgeKeyPathToString(keyPath), ascending: ascending)
+        objc_setAssociatedObject(self, UnsafeRawPointer(&associationKey), keyPath, .OBJC_ASSOCIATION_RETAIN)
     }
     
     public convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool, comparator cmptr: @escaping Foundation.Comparator) {
         self.init(key: _bridgeKeyPathToString(keyPath), ascending: ascending, comparator: cmptr)
+        objc_setAssociatedObject(self, UnsafeRawPointer(&associationKey), keyPath, .OBJC_ASSOCIATION_RETAIN)
     }
     
     public var keyPath: AnyKeyPath? {
-        guard let key = self.key else { return nil }
-        return _bridgeStringToKeyPath(key)
+        return objc_getAssociatedObject(self, UnsafeRawPointer(&associationKey)) as? AnyKeyPath
     }
 }
+
+private var associationKey: ()?

--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -115,10 +115,10 @@ print("target removed")
 //===----------------------------------------------------------------------===//
 
 class Target2 : NSObject, NSKeyValueObservingCustomization {
-    dynamic var name: String?
+    @objc dynamic var name: String?
 
     class Dummy : NSObject {
-        dynamic var name: String?
+        @objc dynamic var name: String?
     }
 
     // In both of the callbacks, observe another property with the same key path.

--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -105,7 +105,68 @@ print("target removed")
 // CHECK-NEXT: swiftValue 42, objcValue three
 // CHECK-NEXT: swiftValue 42, objcValue four
 // CHECK-NEXT: swiftValue 13, objcValue four
+// The next 2 logs are actually a bug and shouldn't happen
 // CHECK-NEXT: swiftValue 13, objcValue four
 // CHECK-NEXT: swiftValue 13, objcValue four
 // CHECK-NEXT: target removed
 
+//===----------------------------------------------------------------------===//
+// Test NSKeyValueObservingCustomization issue with observing from the callbacks
+//===----------------------------------------------------------------------===//
+
+class Target2 : NSObject, NSKeyValueObservingCustomization {
+    dynamic var name: String?
+
+    class Dummy : NSObject {
+        dynamic var name: String?
+    }
+
+    // In both of the callbacks, observe another property with the same key path.
+    // We do it in both because we're not sure which callback is invoked first.
+    // This ensures that using KVO with key paths from one callback doesn't interfere
+    // with the ability to look up the key path using the other.
+    static func keyPathsAffectingValue(for key: AnyKeyPath) -> Set<AnyKeyPath> {
+        print("keyPathsAffectingValue: key == \\.name:", key == \Target2.name)
+        _ = Dummy().observe(\.name) { (_, _) in }
+        return []
+    }
+
+    static func automaticallyNotifiesObservers(for key: AnyKeyPath) -> Bool {
+        print("automaticallyNotifiesObservers: key == \\.name:", key == \Target2.name)
+        _ = Dummy().observe(\.name) { (_, _) in }
+        return true
+    }
+}
+
+print("registering observer for Target2")
+withExtendedLifetime(Target2()) { (target) in
+    _ = target.observe(\.name) { (_, _) in }
+}
+print("observer removed")
+
+// CHECK-LABEL: registering observer for Target2
+// CHECK-DAG: keyPathsAffectingValue: key == \.name: true
+// CHECK-DAG: automaticallyNotifiesObservers: key == \.name: true
+// CHECK-NEXT: observer removed
+
+//===----------------------------------------------------------------------===//
+// Test NSSortDescriptor keyPath support
+//===----------------------------------------------------------------------===//
+
+// This one doesn't really match the context of "KVO KeyPaths" but it's close enough
+
+class Sortable1 : NSObject {
+    @objc var name: String?
+}
+
+class Sortable2 : NSObject {
+    @objc var name: String?
+}
+
+print("creating NSSortDescriptor")
+let descriptor = NSSortDescriptor(keyPath: \Sortable1.name, ascending: true)
+_ = NSSortDescriptor(keyPath: \Sortable2.name, ascending: true)
+print("keyPath == \\Sortable1.name:", descriptor.keyPath == \Sortable1.name)
+
+// CHECK-LABEL: creating NSSortDescriptor
+// CHECK-NEXT: keyPath == \Sortable1.name: true


### PR DESCRIPTION
This PR fixes a number of issues with Swift KVO. It fixes a bad thread safety issue, a problem where `NSKeyValueObservation` was incorrectly replacing `NSObject.observeValue(forKeyPath:of:change:context:)`, a potential race with `NSKeyValueObservation` handling a KVO notice during `deinit`, an issue with `NSSortDescriptor.keyPath` returning the wrong value, and a problem where the `NSKeyValueObservingCustomization` methods could be called with the wrong `KeyPath` if `KeyPath`-related work is happening concurrently on another thread.

Resolves [SR-6795](https://bugs.swift.org/browse/SR-6795), [SR-9074](https://bugs.swift.org/browse/SR-9074), [SR-9075](https://bugs.swift.org/browse/SR-9075), [SR-9076](https://bugs.swift.org/browse/SR-9076), and [SR-9077](https://bugs.swift.org/browse/SR-9077).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->