### PR TITLE
[build-preset] Add no_test variants of all of the buildbot_linux_* pr…

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -765,11 +765,7 @@ install-foundation
 install-libdispatch
 reconfigure
 
-
-# Linux package with out test
-[preset: buildbot_linux,no_test]
-mixin-preset=buildbot_linux
-
+[preset: mixin_buildbot_linux,no_test]
 dash-dash
 
 skip-test-cmark
@@ -782,6 +778,12 @@ skip-test-foundation
 skip-test-libdispatch
 skip-test-playgroundsupport
 skip-test-libicu
+
+# Linux package with out test
+[preset: buildbot_linux,no_test]
+mixin-preset=
+    buildbot_linux
+    mixin_buildbot_linux,no_test
 
 [preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build]
 mixin-preset=buildbot_linux
@@ -804,22 +806,56 @@ android-icu-i18n-include=%(arm_dir)s/icu/source/i18n
 [preset: buildbot_linux_1804]
 mixin-preset=buildbot_linux
 
+# Ubuntu 18.04 preset that skips all tests except for integration testing of the
+# package.
+[preset: buildbot_linux_1804,notest]
+mixin-preset=
+    buildbot_linux_1804
+    mixin_buildbot_linux,no_test
 
 # Ubuntu 16.10 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1610]
 mixin-preset=buildbot_linux
 
+# Ubuntu 16.10 preset that skips all tests except for integration testing of the
+# package.
+[preset: buildbot_linux_1610,notest]
+mixin-preset=
+    buildbot_linux_1610
+    mixin_buildbot_linux,no_test
+
 # Ubuntu 16.04 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1604]
 mixin-preset=buildbot_linux
+
+# Ubuntu 16.04 preset that skips all tests except for integration testing of the
+# package.
+[preset: buildbot_linux_1604,notest]
+mixin-preset=
+    buildbot_linux_1604
+    mixin_buildbot_linux,no_test
 
 # Ubuntu 15.10 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1510]
 mixin-preset=buildbot_linux
 
+# Ubuntu 15.10 preset that skips all tests except for integration testing of the
+# package.
+[preset: buildbot_linux_1510,notest]
+mixin-preset=
+    buildbot_linux_1510
+    mixin_buildbot_linux,no_test
+
 # Ubuntu 14.04 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1404]
 mixin-preset=buildbot_linux
+
+# Ubuntu 14.04 preset that skips all tests except for integration testing of the
+# package.
+[preset: buildbot_linux_1404,notest]
+mixin-preset=
+    buildbot_linux_1404
+    mixin_buildbot_linux,no_test
 
 [preset: buildbot_linux,smoketest]
 mixin-preset=mixin_linux_installation


### PR DESCRIPTION
…esets.

The key thing is that these skip all testing except for the integration testing
and thus are perfect for subproject buildbot testing.

The reason why I am doing this is I discovered that dispatch is not using
build-presets. This means that dispatch may not get updated properly (resulting
in integration test failures) when we add new package installation dependencies
(like llvm-cov, llvm-profdata) for the integration tests.

This is functionally the same as dispatch's build today except that we /will/
build lldb. That being said I think it makes sense to build the entire package
for dispatch so if we have any integration issues in between lldb and dispatch
we can test them.

SR-9080
