### PR TITLE
runtime: adjust known metadata for SIMD vector types

### DIFF
--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -104,11 +104,16 @@ namespace pointer_types {
 }
 
 namespace {
-  template<typename T>
-  constexpr size_t getAlignment() { return alignof(T); }
+  template <typename T>
+  struct BuiltinType {
+    static constexpr const size_t Alignment = alignof(T);
+  };
 
-#define SET_FIXED_ALIGNMENT(Type, Align) \
-template<> constexpr size_t getAlignment<Type>() { return Align; }
+#define SET_FIXED_ALIGNMENT(Type, Align)                                       \
+  template <>                                                                  \
+  struct BuiltinType<Type> {                                                   \
+    static constexpr const size_t Alignment = Align;                           \
+  };
 
   SET_FIXED_ALIGNMENT(uint8_t, 1)
   SET_FIXED_ALIGNMENT(uint16_t, 2)
@@ -120,27 +125,40 @@ template<> constexpr size_t getAlignment<Type>() { return Align; }
 
 #undef SET_FIXED_ALIGNMENT
 
-  template<typename T, unsigned N>
-  struct SwiftVecT {
-    typedef T type __attribute__((ext_vector_type(N)));
+  template <typename T, unsigned N>
+  struct SIMDVector {
+    using Type = T __attribute__((__ext_vector_type__(N)));
   };
 
-  template<typename T, unsigned N>
-  using SwiftVec = typename SwiftVecT<T, N>::type;
+  template <>
+  struct SIMDVector<float, 3> {
+    using Type = float __attribute__((__ext_vector_type__(4)));
+  };
+
+  template <>
+  struct SIMDVector<double, 3> {
+    using Type = double __attribute__((__ext_vector_type__(4)));
+  };
+
+  template <typename T, unsigned N>
+  using SIMDVectorType = typename SIMDVector<T, N>::Type;
 }
 
-#define BUILTIN_TYPE(Symbol, Name)                         \
-const ValueWitnessTable swift::VALUE_WITNESS_SYM(Symbol) = \
-  ValueWitnessTableForBox<NativeBox<ctypes::Symbol,        \
-                                    getAlignment<ctypes::Symbol>()>>::table;
+#define BUILTIN_TYPE(Symbol, Name)                                             \
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Symbol) =                     \
+  ValueWitnessTableForBox<NativeBox<ctypes::Symbol,                            \
+                                    BuiltinType<ctypes::Symbol>::Alignment>>::table;
+
 #define BUILTIN_POINTER_TYPE(Symbol, Name)                 \
-const ExtraInhabitantsValueWitnessTable swift::VALUE_WITNESS_SYM(Symbol) = \
+const ExtraInhabitantsValueWitnessTable swift::VALUE_WITNESS_SYM(Symbol) =     \
   ValueWitnessTableForBox<pointer_types::Symbol>::table;
-#define BUILTIN_VECTOR_TYPE(ElementSymbol, _, Width)                          \
-  const ValueWitnessTable                                                     \
-  swift::VALUE_WITNESS_SYM(VECTOR_BUILTIN_SYMBOL_NAME(ElementSymbol,Width)) = \
-  ValueWitnessTableForBox<NativeBox<SwiftVec<ctypes::ElementSymbol,           \
-                                             Width>>>::table;
+
+#define BUILTIN_VECTOR_TYPE(ElementSymbol, _, Width)                           \
+  const ValueWitnessTable                                                      \
+  swift::VALUE_WITNESS_SYM(VECTOR_BUILTIN_SYMBOL_NAME(ElementSymbol,Width)) =  \
+  ValueWitnessTableForBox<NativeBox<SIMDVectorType<ctypes::ElementSymbol,      \
+                                                   Width>>>::table;
+
 #include "swift/Runtime/BuiltinTypes.def"
 
 /// The value-witness table for pointer-aligned unmanaged pointer types.


### PR DESCRIPTION
Rather than use a function, use a templated structure with a constant
expression to metaprogram the alignment of the type.  NFC.

Adjust the templating for the SIMD vector types.  Use the reserved
spelling for the clang extension, and rename the types.  NFC.

The meat of this change is the explicit template specialization for the
float 3 vector and double 3 vector.  Since they are going to be emitted
as float 4 vector underneath everything, we can simply treat them the
same.  This has a benefit of allowing us to share the same
specialization of the witness tables.  Additionally, it works around a
bug in clang where we cannot correctly decorate the extended type with
Microsoft's ABI (which is a separate issue).  Since this saves some
bytes, this is still beneficial.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
