### PR TITLE
buil: install the import libraries for windows

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2223,8 +2223,19 @@ function(add_swift_target_library name)
           FILES "${UNIVERSAL_LIBRARY_NAME}"
           DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}"
           PERMISSIONS ${file_permissions})
-      swift_is_installing_component("${SWIFTLIB_INSTALL_IN_COMPONENT}" is_installing)
+      if(sdk STREQUAL WINDOWS)
+        foreach(arch ${SWIFT_SDK_WINDOWS_ARCHITECTURES})
+          if(TARGET ${name}-windows-${arch}_IMPLIB)
+            get_target_property(import_library ${name}-windows-${arch}_IMPLIB IMPORTED_LOCATION)
+            swift_install_in_component(${SWIFTLIB_INSTALL_IN_COMPONENT}
+              FILES ${import_library}
+              DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${arch}"
+              PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+          endif()
+        endforeach()
+      endif()
 
+      swift_is_installing_component("${SWIFTLIB_INSTALL_IN_COMPONENT}" is_installing)
       if(NOT is_installing)
         set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${VARIANT_NAME})
       else()


### PR DESCRIPTION
When building the target libraries, we need to install the import
library as well.  Unfortunately, due to the way that the swift build
system works, we do not have the ability to rely on CMake doing the
right thing and taking care of this for us.  We have to manually
construct and track the import library due to the fact that we fight the
cross-compilation support.  Add some logic to extract the import
libraries and install them so that uses can actually build for Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
