### PR TITLE
[benchmark] Add two benchmarks that show performance of flattening an…

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -84,6 +84,7 @@ set(SWIFT_BENCH_MODULES
     single-source/Exclusivity
     single-source/ExistentialPerformance
     single-source/Fibonacci
+    single-source/FlattenList
     single-source/FloatingPointPrinting
     single-source/Hanoi
     single-source/Hash

--- a/benchmark/single-source/FlattenList.swift
+++ b/benchmark/single-source/FlattenList.swift
@@ -1,0 +1,61 @@
+//===--- FlattenList.swift ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+public let FlattenListLoop = BenchmarkInfo(
+  name: "FlattenListLoop",
+  runFunction: run_FlattenListLoop,
+  tags: [.api, .validation],
+  setUpFunction: { blackHole(inputArray) })
+
+public let FlattenListFlatMap = BenchmarkInfo(
+  name: "FlattenListFlatMap",
+  runFunction: run_FlattenListFlatMap,
+  tags: [.api, .validation],
+  setUpFunction: { blackHole(inputArray) })
+
+let inputArray: [(Int, Int, Int, Int)] = (0..<(1<<16)).map { _ in
+  (5, 6, 7, 8)
+}
+
+func flattenFlatMap(_ input: [(Int, Int, Int, Int)]) -> [Int] {
+  return input.flatMap { [$0.0, $0.1, $0.2, $0.3] }
+}
+
+func flattenLoop(_ input: [(Int, Int, Int, Int)]) -> [Int] {
+  var flattened: [Int] = []
+  flattened.reserveCapacity(input.count * 4)
+
+  for (x, y, z, w) in input {
+    flattened.append(x)
+    flattened.append(y)
+    flattened.append(z)
+    flattened.append(w)
+  }
+
+  return flattened
+}
+
+@inline(never)
+public func run_FlattenListLoop(_ N: Int) {
+  for _ in 0..<5*N {
+    blackHole(flattenLoop(inputArray))
+  }
+}
+
+@inline(never)
+public func run_FlattenListFlatMap(_ N: Int) {
+  for _ in 1...5*N {
+    blackHole(flattenFlatMap(inputArray))
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -72,6 +72,7 @@ import ErrorHandling
 import Exclusivity
 import ExistentialPerformance
 import Fibonacci
+import FlattenList
 import FloatingPointPrinting
 import Hanoi
 import Hash
@@ -239,6 +240,8 @@ registerBenchmark(ErrorHandling)
 registerBenchmark(Exclusivity)
 registerBenchmark(ExistentialPerformance)
 registerBenchmark(Fibonacci)
+registerBenchmark(FlattenListLoop)
+registerBenchmark(FlattenListFlatMap)
 registerBenchmark(FloatingPointPrinting)
 registerBenchmark(Hanoi)
 registerBenchmark(HashTest)


### PR DESCRIPTION
… array.

The first is a naive imperative approach using appends in a loop. The second
uses flatMap. We would like both of these to have equivalent performance.
