### PR TITLE
runtime: silence the compiler warning about const (NFC)

### DIFF
--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -330,15 +330,17 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBox
   static constexpr bool isBitwiseTakable = true;
   static constexpr unsigned numExtraInhabitants =
     swift_getHeapObjectExtraInhabitantCount();
-  
+
   static void storeExtraInhabitant(Container *dest, int index) {
-    swift_storeHeapObjectExtraInhabitant((HeapObject**)&dest->Header.Type,
-                                         index);
+    swift_storeHeapObjectExtraInhabitant(
+        const_cast<HeapObject **>(
+            reinterpret_cast<const HeapObject **>(&dest->Header.Type)),
+        index);
   }
 
   static int getExtraInhabitantIndex(const Container *src) {
-    return swift_getHeapObjectExtraInhabitantIndex(
-                                        (HeapObject* const *)&src->Header.Type);
+    return swift_getHeapObjectExtraInhabitantIndex(const_cast<HeapObject **>(
+        reinterpret_cast<const HeapObject *const *>(&src->Header.Type)));
   }
 };
 


### PR DESCRIPTION
This warning shows up multiple times due to the template specialization.
Explicitly perform the casts with `const_cast` to pacify the compiler.
NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
