### PR TITLE
[benchmark] Refactor Package.swift manifest file

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,2 @@
+# Ignore SwiftPM's default build directory.
+.build


### PR DESCRIPTION
This is a NFC commit which cleans up the SwiftPM manifest file used for
benchmark testing. The manifest can be further improved by removing the
side-effects in the future.
