### PR TITLE
Conform Float80 to CVarArgs when available.

### DIFF
--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -383,6 +383,25 @@ extension Double : _CVarArgPassedAsDouble, _CVarArgAligned {
   }
 }
 
+#if !os(Windows) && (arch(i386) || arch(x86_64))
+extension Float80 : CVarArg, _CVarArgAligned {
+  /// Transform `self` into a series of machine words that can be
+  /// appropriately interpreted by C varargs.
+  @inlinable // FIXME(sil-serialize-all)
+  public var _cVarArgEncoding: [Int] {
+    return _encodeBitsAsWords(self)
+  }
+  
+  /// Returns the required alignment in bytes of
+  /// the value returned by `_cVarArgEncoding`.
+  @inlinable // FIXME(sil-serialize-all)
+  public var _cVarArgAlignment: Int {
+    // FIXME: alignof differs from the ABI alignment on some architectures
+    return MemoryLayout.alignment(ofValue: self)
+  }
+}
+#endif
+
 #if arch(x86_64) || arch(s390x)
 
 /// An object that can manage the lifetime of storage backing a

--- a/test/stdlib/VarArgs.swift
+++ b/test/stdlib/VarArgs.swift
@@ -123,6 +123,21 @@ func test_varArgs5() {
 }
 test_varArgs5()
 
+#if !os(Windows) && (arch(i386) || arch(x86_64))
+func test_varArgs6() {
+  // Verify alignment of va_list contents when `Float80` is present.
+  let  i8 = Int8(1)
+  let f32 = Float(1.1)
+  let f64 = Double(2.2)
+  let f80 = Float80(4.5)
+  my_printf("a %g %d %g %d %Lg %d %g a\n",            f32, i8, f64, i8, f80, i8, f32)
+  my_printf("b %d %g %d %g %d %Lg %d %g b\n",     i8, f32, i8, f64, i8, f80, i8, f32)
+  // CHECK: a 1.1 1 2.2 1 4.5 1 1.1 a
+  // CHECK: b 1 1.1 1 2.2 1 4.5 1 1.1 b
+}
+test_varArgs6()
+#endif
+
 
 // CHECK: done.
 print("done.")


### PR DESCRIPTION
When I added support for importing `long double` as `Float80` on Intel, I neglected to conform it to CVarArgs. This patch fixes that, which most importantly lets users use `String(format:)` with `Float80` values.

<rdar://problem/35970369>