### PR TITLE
[benchmark] Reduce unreasonable setup times

### DIFF
--- a/benchmark/single-source/CharacterProperties.swift
+++ b/benchmark/single-source/CharacterProperties.swift
@@ -253,133 +253,57 @@ func setupMemo() {
 }
 
 // Precompute whole scalar set
-var controlCharactersPrecomputed: Set<UInt32> = {
+func precompute(_ charSet: CharacterSet) -> Set<UInt32> {
   var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if controlCharacters.contains(scalar) {
-      result.insert(scalar.value)
+  for plane in 0...0x10 {
+    guard charSet.hasMember(inPlane: UInt8(plane)) else { continue }
+    let offset = plane &* 0x1_0000
+    for codePoint in 0...0xFFFF {
+      guard let scalar = UnicodeScalar(codePoint &+ offset) else { continue }
+      if charSet.contains(scalar) {
+        result.insert(scalar.value)
+      }
     }
   }
   return result
-}()
+}
+var controlCharactersPrecomputed: Set<UInt32> = precompute(controlCharacters)
 func isControlPrecomputed(_ c: Character) -> Bool {
   return controlCharactersPrecomputed.contains(c.firstScalar.value)
 }
-var alphanumericsPrecomputed: Set<UInt32> = {
-  var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if alphanumerics.contains(scalar) {
-      result.insert(scalar.value)
-    }
-  }
-  return result
-}()
+var alphanumericsPrecomputed: Set<UInt32> = precompute(alphanumerics)
 func isAlphanumericPrecomputed(_ c: Character) -> Bool {
   return alphanumericsPrecomputed.contains(c.firstScalar.value)
 }
-var lowercaseLettersPrecomputed: Set<UInt32> = {
-  var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if lowercaseLetters.contains(scalar) {
-      result.insert(scalar.value)
-    }
-  }
-  return result
-}()
+var lowercaseLettersPrecomputed: Set<UInt32> = precompute(lowercaseLetters)
 func isLowercasePrecomputed(_ c: Character) -> Bool {
   return lowercaseLettersPrecomputed.contains(c.firstScalar.value)
 }
-var punctuationCharactersPrecomputed: Set<UInt32> = {
-  var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if punctuationCharacters.contains(scalar) {
-      result.insert(scalar.value)
-    }
-  }
-  return result
-}()
+var punctuationCharactersPrecomputed: Set<UInt32> = precompute(punctuationCharacters)
 func isPunctuationPrecomputed(_ c: Character) -> Bool {
   return punctuationCharactersPrecomputed.contains(c.firstScalar.value)
 }
-var whitespacesPrecomputed: Set<UInt32> = {
-  var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if whitespaces.contains(scalar) {
-      result.insert(scalar.value)
-    }
-  }
-  return result
-}()
+var whitespacesPrecomputed: Set<UInt32> = precompute(whitespaces)
 func isWhitespacePrecomputed(_ c: Character) -> Bool {
   return whitespacesPrecomputed.contains(c.firstScalar.value)
 }
-var lettersPrecomputed: Set<UInt32> = {
-  var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if letters.contains(scalar) {
-      result.insert(scalar.value)
-    }
-  }
-  return result
-}()
+var lettersPrecomputed: Set<UInt32> = precompute(letters)
 func isLetterPrecomputed(_ c: Character) -> Bool {
   return lettersPrecomputed.contains(c.firstScalar.value)
 }
-var uppercaseLettersPrecomputed: Set<UInt32> = {
-  var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if uppercaseLetters.contains(scalar) {
-      result.insert(scalar.value)
-    }
-  }
-  return result
-}()
+var uppercaseLettersPrecomputed: Set<UInt32> = precompute(uppercaseLetters)
 func isUppercasePrecomputed(_ c: Character) -> Bool {
   return uppercaseLettersPrecomputed.contains(c.firstScalar.value)
 }
-var decimalDigitsPrecomputed: Set<UInt32> = {
-  var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if decimalDigits.contains(scalar) {
-      result.insert(scalar.value)
-    }
-  }
-  return result
-}()
+var decimalDigitsPrecomputed: Set<UInt32> = precompute(decimalDigits)
 func isDecimalPrecomputed(_ c: Character) -> Bool {
   return decimalDigitsPrecomputed.contains(c.firstScalar.value)
 }
-var newlinesPrecomputed: Set<UInt32> = {
-  var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if newlines.contains(scalar) {
-      result.insert(scalar.value)
-    }
-  }
-  return result
-}()
+var newlinesPrecomputed: Set<UInt32> = precompute(newlines)
 func isNewlinePrecomputed(_ c: Character) -> Bool {
   return newlinesPrecomputed.contains(c.firstScalar.value)
 }
-var capitalizedLettersPrecomputed: Set<UInt32> = {
-  var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if capitalizedLetters.contains(scalar) {
-      result.insert(scalar.value)
-    }
-  }
-  return result
-}()
+var capitalizedLettersPrecomputed: Set<UInt32> = precompute(capitalizedLetters)
 func isCapitalizedPrecomputed(_ c: Character) -> Bool {
   return capitalizedLettersPrecomputed.contains(c.firstScalar.value)
 }

--- a/benchmark/single-source/CharacterProperties.swift.gyb
+++ b/benchmark/single-source/CharacterProperties.swift.gyb
@@ -104,17 +104,22 @@ func setupMemo() {
 }
 
 // Precompute whole scalar set
-% for Property, Set in Properties.items():
-var ${Set}Precomputed: Set<UInt32> = {
+func precompute(_ charSet: CharacterSet) -> Set<UInt32> {
   var result = Set<UInt32>()
-  for i in 0...0x0010_FFFF {
-    guard let scalar = UnicodeScalar(i) else { continue }
-    if ${Set}.contains(scalar) {
-      result.insert(scalar.value)
+  for plane in 0...0x10 {
+    guard charSet.hasMember(inPlane: UInt8(plane)) else { continue }
+    let offset = plane &* 0x1_0000
+    for codePoint in 0...0xFFFF {
+      guard let scalar = UnicodeScalar(codePoint &+ offset) else { continue }
+      if charSet.contains(scalar) {
+        result.insert(scalar.value)
+      }
     }
   }
   return result
-}()
+}
+% for Property, Set in Properties.items():
+var ${Set}Precomputed: Set<UInt32> = precompute(${Set})
 func is${Property}Precomputed(_ c: Character) -> Bool {
   return ${Set}Precomputed.contains(c.firstScalar.value)
 }

--- a/benchmark/single-source/DictionaryKeysContains.swift
+++ b/benchmark/single-source/DictionaryKeysContains.swift
@@ -21,14 +21,15 @@ public let DictionaryKeysContains = [
     name: "DictionaryKeysContainsNative",
     runFunction: run_DictionaryKeysContains,
     tags: [.validation, .api, .Dictionary],
-    setUpFunction: setup_DictionaryKeysContainsNative,
-    tearDownFunction: teardown_DictionaryKeysContains),
+    setUpFunction: setupNativeDictionary,
+    tearDownFunction: teardownDictionary,
+    unsupportedPlatforms: [.linux]),
   BenchmarkInfo(
     name: "DictionaryKeysContainsCocoa",
     runFunction: run_DictionaryKeysContains,
     tags: [.validation, .api, .Dictionary],
-    setUpFunction: setup_DictionaryKeysContainsCocoa,
-    tearDownFunction: teardown_DictionaryKeysContains),
+    setUpFunction: setupBridgedDictionary,
+    tearDownFunction: teardownDictionary),
 ]
 #else
 public let DictionaryKeysContains = [
@@ -36,38 +37,34 @@ public let DictionaryKeysContains = [
     name: "DictionaryKeysContainsNative",
     runFunction: run_DictionaryKeysContains,
     tags: [.validation, .api, .Dictionary],
-    setUpFunction: setup_DictionaryKeysContainsNative,
-    tearDownFunction: teardown_DictionaryKeysContains,
+    setUpFunction: setupNativeDictionary,
+    tearDownFunction: teardownDictionary,
     unsupportedPlatforms: [.linux]),
 ]
 #endif
 
 private var dictionary: [NSString: NSString]!
 
-private func setup_DictionaryKeysContainsNative() {
+private func setupNativeDictionary() {
 #if os(Linux)
   fatalError("Unsupported benchmark")
 #else
-  let keyValuePairs = (1...1_000_000).map {
-    ("\($0)" as NSString, "\($0)" as NSString)
+  let keyValuePair: (Int) -> (NSString, NSString) = {
+    let n = "\($0)" as NSString; return (n, n)
   }
-  dictionary = [NSString: NSString](uniqueKeysWithValues: keyValuePairs)
+  dictionary = [NSString: NSString](uniqueKeysWithValues:
+    (1...10_000).lazy.map(keyValuePair))
 #endif
 }
 
 #if _runtime(_ObjC)
-private func setup_DictionaryKeysContainsCocoa() {
-  let keyValuePairs = (1...1_000_000).map {
-    ("\($0)" as NSString, "\($0)" as NSString)
-  }
-  let nativeDictionary = [NSString: NSString](
-    uniqueKeysWithValues: keyValuePairs)
-  dictionary = (NSDictionary(dictionary: nativeDictionary)
-    as! [NSString: NSString])
+private func setupBridgedDictionary() {
+  setupNativeDictionary()
+  dictionary = (NSDictionary(dictionary: dictionary) as! [NSString: NSString])
 }
 #endif
 
-private func teardown_DictionaryKeysContains() {
+private func teardownDictionary() {
   dictionary = nil
 }
 
@@ -82,4 +79,3 @@ public func run_DictionaryKeysContains(_ N: Int) {
   }
 #endif
 }
-


### PR DESCRIPTION
This PR reduces setup time of 3 benchmarks that took unreasonably long to prepare their workloads. It brings them in compliance with the new `BenchmarkDoctor` rule: setUpFunction should take [reasonable time (no more than 200ms)](https://github.com/apple/swift/pull/19910/commits/a24d0ff7a50c8c0c48d53e593abcb9321fd5de66). More details in the [individual commit descriptions](https://github.com/apple/swift/pull/20123/commits/bfbff457273430873529d943df188e5c5f071bd7).