### PR TITLE
[Sema] Hide underscored names from typo-correction

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -602,6 +602,12 @@ static unsigned getCallEditDistance(DeclName writtenName,
   StringRef writtenBase = writtenName.getBaseName().userFacingName();
   StringRef correctedBase = correctedName.getBaseName().userFacingName();
 
+  // Don't typo-correct to a name with a leading underscore unless the typed
+  // name also begins with an underscore.
+  if (correctedBase.startswith("_") && !writtenBase.startswith("_")) {
+    return UnreasonableCallEditDistance;
+  }
+
   unsigned distance = writtenBase.edit_distance(correctedBase, maxEditDistance);
 
   // Bound the distance to UnreasonableCallEditDistance.

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -33,7 +33,9 @@ func useContainer() -> () {
   func exists() -> Bool { return true }
 }
 
-func test(a: BadAttributes) -> () { // expected-note * {{did you mean 'test'?}}
+// expected-note @+2 {{did you mean 'test'?}}
+// expected-note @+1 {{'test' declared here}}
+func test(a: BadAttributes) -> () {
   _ = a.exists() // no-warning
 }
 
@@ -617,7 +619,7 @@ func foo1(bar!=baz) {} // expected-note {{did you mean 'foo1'?}}
 func foo2(bar! = baz) {}// expected-note {{did you mean 'foo2'?}}
 
 // rdar://19605567
-// expected-error@+1{{use of unresolved identifier 'esp'}}
+// expected-error@+1{{use of unresolved identifier 'esp'; did you mean 'test'?}}
 switch esp {
 case let (jeb):
   // expected-error@+5{{operator with postfix spacing cannot start a subexpression}}

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typo-correction-limit 20
+// RUN: %target-typecheck-verify-swift -typo-correction-limit 22
 // RUN: not %target-swift-frontend -typecheck -disable-typo-correction %s 2>&1 | %FileCheck %s -check-prefix=DISABLED
 // RUN: not %target-swift-frontend -typecheck -typo-correction-limit 0 %s 2>&1 | %FileCheck %s -check-prefix=DISABLED
 // RUN: not %target-swift-frontend -typecheck -DIMPORT_FAIL %s 2>&1 | %FileCheck %s -check-prefix=DISABLED
@@ -176,4 +176,18 @@ func boo() { // expected-note {{did you mean 'boo'?}}
       booo() // expected-error {{use of unresolved identifier 'booo'}}
     }
   }
+}
+
+// Don't show underscored names as typo corrections unless the typed name also
+// begins with an underscore.
+func test_underscored_no_match() {
+  let _ham = 0
+  _ = ham
+  // expected-error@-1 {{use of unresolved identifier 'ham'}}
+}
+
+func test_underscored_match() {
+  let _eggs = 4 // expected-note {{'_eggs' declared here}}
+  _ = _fggs + 1
+  // expected-error@-1 {{use of unresolved identifier '_fggs'; did you mean '_eggs'?}}
 }


### PR DESCRIPTION
Identifiers with a leading underscore are now hidden from typo-correction unless the typed name also begins with an underscore.

Resolves [SR-9083](https://bugs.swift.org/browse/SR-9083).
