### PR TITLE
LLVM tools infrastructure

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2387,7 +2387,7 @@ endmacro()
 function(add_swift_host_tool executable)
   set(options)
   set(single_parameter_options SWIFT_COMPONENT)
-  set(multiple_parameter_options DEPENDS)
+  set(multiple_parameter_options)
 
   cmake_parse_arguments(ASHT
                         "${options}"
@@ -2395,12 +2395,7 @@ function(add_swift_host_tool executable)
                         "${multiple_parameter_options}"
                         ${ARGN})
 
-  # Create the executable rule.
-  add_swift_executable(
-    ${executable} 
-    ${ASHT_UNPARSED_ARGUMENTS}
-    DEPENDS ${ASHT_DEPENDS}
-  )
+  add_llvm_executable(${executable} ${ASHT_UNPARSED_ARGUMENTS})
 
   # And then create the install rule if we are asked to.
   if (ASHT_SWIFT_COMPONENT)

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2385,16 +2385,15 @@ macro(add_swift_lib_subdirectory name)
 endmacro()
 
 function(add_swift_host_tool executable)
-  set(ASHT_multiple_parameter_options
-        SWIFT_COMPONENT
-        DEPENDS)
+  set(options)
+  set(single_parameter_options SWIFT_COMPONENT)
+  set(multiple_parameter_options DEPENDS)
 
-  cmake_parse_arguments(
-      ASHT # prefix
-      "" # options
-      "" # single-value args
-      "${ASHT_multiple_parameter_options}" # multi-value args
-      ${ARGN})
+  cmake_parse_arguments(ASHT
+                        "${options}"
+                        "${single_parameter_options}"
+                        "${multiple_parameter_options}"
+                        ${ARGN})
 
   # Create the executable rule.
   add_swift_executable(

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2387,7 +2387,6 @@ endmacro()
 function(add_swift_host_tool executable)
   set(ASHT_multiple_parameter_options
         SWIFT_COMPONENT
-        COMPILE_FLAGS
         DEPENDS)
 
   cmake_parse_arguments(
@@ -2402,7 +2401,6 @@ function(add_swift_host_tool executable)
     ${executable} 
     ${ASHT_UNPARSED_ARGUMENTS}
     DEPENDS ${ASHT_DEPENDS}
-    COMPILE_FLAGS ${ASHT_COMPILE_FLAGS}
   )
 
   # And then create the install rule if we are asked to.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2385,43 +2385,43 @@ macro(add_swift_lib_subdirectory name)
 endmacro()
 
 function(add_swift_host_tool executable)
-  set(ADDSWIFTHOSTTOOL_multiple_parameter_options
+  set(ASHT_multiple_parameter_options
         SWIFT_COMPONENT
         COMPILE_FLAGS
         DEPENDS
         SWIFT_MODULE_DEPENDS)
 
   cmake_parse_arguments(
-      ADDSWIFTHOSTTOOL # prefix
+      ASHT # prefix
       "" # options
       "" # single-value args
-      "${ADDSWIFTHOSTTOOL_multiple_parameter_options}" # multi-value args
+      "${ASHT_multiple_parameter_options}" # multi-value args
       ${ARGN})
 
   # Configure variables for this subdirectory.
   set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
   set(MODULE_VARIANT_SUFFIX "-swiftmodule${VARIANT_SUFFIX}")
 
-  foreach(mod ${ADDSWIFTHOSTTOOL_SWIFT_MODULE_DEPENDS})
-    list(APPEND ADDSWIFTHOSTTOOL_DEPENDS "swift${mod}${MODULE_VARIANT_SUFFIX}")
-    list(APPEND ADDSWIFTHOSTTOOL_DEPENDS "swift${mod}${VARIANT_SUFFIX}")
+  foreach(mod ${ASHT_SWIFT_MODULE_DEPENDS})
+    list(APPEND ASHT_DEPENDS "swift${mod}${MODULE_VARIANT_SUFFIX}")
+    list(APPEND ASHT_DEPENDS "swift${mod}${VARIANT_SUFFIX}")
   endforeach()
 
   # Create the executable rule.
   add_swift_executable(
     ${executable} 
-    ${ADDSWIFTHOSTTOOL_UNPARSED_ARGUMENTS}
-    DEPENDS ${ADDSWIFTHOSTTOOL_DEPENDS}
-    COMPILE_FLAGS ${ADDSWIFTHOSTTOOL_COMPILE_FLAGS}
+    ${ASHT_UNPARSED_ARGUMENTS}
+    DEPENDS ${ASHT_DEPENDS}
+    COMPILE_FLAGS ${ASHT_COMPILE_FLAGS}
   )
 
   # And then create the install rule if we are asked to.
-  if (ADDSWIFTHOSTTOOL_SWIFT_COMPONENT)
-    swift_install_in_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
+  if (ASHT_SWIFT_COMPONENT)
+    swift_install_in_component(${ASHT_SWIFT_COMPONENT}
       TARGETS ${executable}
       RUNTIME DESTINATION bin)
 
-    swift_is_installing_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
+    swift_is_installing_component(${ASHT_SWIFT_COMPONENT}
       is_installing)
   
     if(NOT is_installing)

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2388,8 +2388,7 @@ function(add_swift_host_tool executable)
   set(ASHT_multiple_parameter_options
         SWIFT_COMPONENT
         COMPILE_FLAGS
-        DEPENDS
-        SWIFT_MODULE_DEPENDS)
+        DEPENDS)
 
   cmake_parse_arguments(
       ASHT # prefix
@@ -2397,15 +2396,6 @@ function(add_swift_host_tool executable)
       "" # single-value args
       "${ASHT_multiple_parameter_options}" # multi-value args
       ${ARGN})
-
-  # Configure variables for this subdirectory.
-  set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
-  set(MODULE_VARIANT_SUFFIX "-swiftmodule${VARIANT_SUFFIX}")
-
-  foreach(mod ${ASHT_SWIFT_MODULE_DEPENDS})
-    list(APPEND ASHT_DEPENDS "swift${mod}${MODULE_VARIANT_SUFFIX}")
-    list(APPEND ASHT_DEPENDS "swift${mod}${VARIANT_SUFFIX}")
-  endforeach()
 
   # Create the executable rule.
   add_swift_executable(

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -4,8 +4,6 @@ add_swift_host_tool(swift
   autolink_extract_main.cpp
   modulewrap_main.cpp
   swift_format_main.cpp
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT compiler
 )
 target_link_libraries(swift PRIVATE swiftDriver swiftFrontendTool)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -4,13 +4,11 @@ add_swift_host_tool(swift
   autolink_extract_main.cpp
   modulewrap_main.cpp
   swift_format_main.cpp
-  LINK_LIBRARIES
-    swiftDriver
-    swiftFrontendTool
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
   SWIFT_COMPONENT compiler
 )
+target_link_libraries(swift PRIVATE swiftDriver swiftFrontendTool)
 
 if(HAVE_UNICODE_LIBEDIT)
   target_link_libraries(swift PRIVATE edit)

--- a/tools/lldb-moduleimport-test/CMakeLists.txt
+++ b/tools/lldb-moduleimport-test/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_swift_host_tool(lldb-moduleimport-test
   lldb-moduleimport-test.cpp
-  LINK_LIBRARIES
-    swiftASTSectionImporter swiftFrontend swiftClangImporter
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
-
+target_link_libraries(lldb-moduleimport-test
+                      PRIVATE
+                        swiftASTSectionImporter
+                        swiftFrontend
+                        swiftClangImporter)

--- a/tools/lldb-moduleimport-test/CMakeLists.txt
+++ b/tools/lldb-moduleimport-test/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_swift_host_tool(lldb-moduleimport-test
   lldb-moduleimport-test.cpp
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
 target_link_libraries(lldb-moduleimport-test

--- a/tools/sil-func-extractor/CMakeLists.txt
+++ b/tools/sil-func-extractor/CMakeLists.txt
@@ -1,12 +1,13 @@
 add_swift_host_tool(sil-func-extractor
   SILFunctionExtractor.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftSILGen
-    swiftSILOptimizer
-    swiftSerialization
-    swiftClangImporter
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-func-extractor
+                      PRIVATE
+                        swiftFrontend
+                        swiftSILGen
+                        swiftSILOptimizer
+                        swiftSerialization
+                        swiftClangImporter)

--- a/tools/sil-func-extractor/CMakeLists.txt
+++ b/tools/sil-func-extractor/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_swift_host_tool(sil-func-extractor
   SILFunctionExtractor.cpp
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
 target_link_libraries(sil-func-extractor

--- a/tools/sil-llvm-gen/CMakeLists.txt
+++ b/tools/sil-llvm-gen/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_swift_host_tool(sil-llvm-gen
   SILLLVMGen.cpp
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
 target_link_libraries(sil-llvm-gen

--- a/tools/sil-llvm-gen/CMakeLists.txt
+++ b/tools/sil-llvm-gen/CMakeLists.txt
@@ -1,14 +1,15 @@
 add_swift_host_tool(sil-llvm-gen
   SILLLVMGen.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftIRGen
-    swiftSILGen
-    swiftSILOptimizer
-    # Clang libraries included to appease the linker on linux.
-    clangBasic
-    clangCodeGen
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-llvm-gen
+                      PRIVATE
+                        swiftFrontend
+                        swiftIRGen
+                        swiftSILGen
+                        swiftSILOptimizer
+                        # Clang libraries included to appease the linker on linux.
+                        clangBasic
+                        clangCodeGen)

--- a/tools/sil-nm/CMakeLists.txt
+++ b/tools/sil-nm/CMakeLists.txt
@@ -1,12 +1,13 @@
 add_swift_host_tool(sil-nm
   SILNM.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftSILGen
-    swiftSILOptimizer
-    swiftSerialization
-    swiftClangImporter
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-nm
+                      PRIVATE
+                        swiftFrontend
+                        swiftSILGen
+                        swiftSILOptimizer
+                        swiftSerialization
+                        swiftClangImporter)

--- a/tools/sil-nm/CMakeLists.txt
+++ b/tools/sil-nm/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_swift_host_tool(sil-nm
   SILNM.cpp
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
 target_link_libraries(sil-nm

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -1,14 +1,16 @@
 add_swift_host_tool(sil-opt
   SILOpt.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftIRGen
-    swiftSILGen
-    swiftSILOptimizer
-    # Clang libraries included to appease the linker on linux.
-    clangBasic
-    clangCodeGen
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-opt
+                      PRIVATE
+                        swiftFrontend
+                        swiftIRGen
+                        swiftSILGen
+                        swiftSILOptimizer
+                        # Clang libraries included to appease the linker on linux.
+                        clangBasic
+                        clangCodeGen)
+

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_swift_host_tool(sil-opt
   SILOpt.cpp
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
 target_link_libraries(sil-opt

--- a/tools/sil-passpipeline-dumper/CMakeLists.txt
+++ b/tools/sil-passpipeline-dumper/CMakeLists.txt
@@ -1,15 +1,16 @@
 add_swift_host_tool(sil-passpipeline-dumper
   SILPassPipelineDumper.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftSILGen
-    swiftSILOptimizer
-    swiftSerialization
-    swiftClangImporter
-    # FIXME: Circular dependencies require re-listing these libraries.
-    swiftSema
-    swiftAST
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-passpipeline-dumper
+                      PRIVATE
+                        swiftFrontend
+                        swiftSILGen
+                        swiftSILOptimizer
+                        swiftSerialization
+                        swiftClangImporter
+                        # FIXME: Circular dependencies require re-listing these libraries.
+                        swiftSema
+                        swiftAST)

--- a/tools/sil-passpipeline-dumper/CMakeLists.txt
+++ b/tools/sil-passpipeline-dumper/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_swift_host_tool(sil-passpipeline-dumper
   SILPassPipelineDumper.cpp
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
 target_link_libraries(sil-passpipeline-dumper

--- a/tools/swift-api-digester/CMakeLists.txt
+++ b/tools/swift-api-digester/CMakeLists.txt
@@ -2,6 +2,9 @@ add_swift_host_tool(swift-api-digester
   swift-api-digester.cpp
   ModuleAnalyzerNodes.cpp
   ModuleDiagsConsumer.cpp
-  LINK_LIBRARIES swiftFrontend swiftIDE
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-api-digester
+                      PRIVATE
+                        swiftFrontend
+                        swiftIDE)

--- a/tools/swift-demangle-yamldump/CMakeLists.txt
+++ b/tools/swift-demangle-yamldump/CMakeLists.txt
@@ -1,6 +1,6 @@
+set(LLVM_LINK_COMPONENTS Support)
 add_swift_host_tool(swift-demangle-yamldump
   swift-demangle-yamldump.cpp
-  LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT tools
   )
 target_link_libraries(swift-demangle-yamldump

--- a/tools/swift-demangle-yamldump/CMakeLists.txt
+++ b/tools/swift-demangle-yamldump/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_swift_host_tool(swift-demangle-yamldump
   swift-demangle-yamldump.cpp
-  LINK_LIBRARIES swiftDemangling
   LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT tools
   )
+target_link_libraries(swift-demangle-yamldump
+                      PRIVATE
+                        swiftDemangling)

--- a/tools/swift-demangle/CMakeLists.txt
+++ b/tools/swift-demangle/CMakeLists.txt
@@ -1,6 +1,6 @@
+set(LLVM_LINK_COMPONENTS Support)
 add_swift_host_tool(swift-demangle
   swift-demangle.cpp
-  LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT compiler
   )
 target_link_libraries(swift-demangle

--- a/tools/swift-demangle/CMakeLists.txt
+++ b/tools/swift-demangle/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_swift_host_tool(swift-demangle
   swift-demangle.cpp
-  LINK_LIBRARIES swiftDemangling
   LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT compiler
   )
+target_link_libraries(swift-demangle
+                      PRIVATE
+                        swiftDemangling)

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -2,8 +2,6 @@ add_swift_host_tool(swift-ide-test
   swift-ide-test.cpp
   ModuleAPIDiff.cpp
   XMLValidator.cpp
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
 target_link_libraries(swift-ide-test

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -2,14 +2,15 @@ add_swift_host_tool(swift-ide-test
   swift-ide-test.cpp
   ModuleAPIDiff.cpp
   XMLValidator.cpp
-  LINK_LIBRARIES
-    swiftDriver
-    swiftFrontend
-    swiftIDE
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-ide-test
+                      PRIVATE
+                        swiftDriver
+                        swiftFrontend
+                        swiftIDE)
 
 # If libxml2 is available, make it available for swift-ide-test.
 if(SWIFT_HAVE_LIBXML)

--- a/tools/swift-llvm-opt/CMakeLists.txt
+++ b/tools/swift-llvm-opt/CMakeLists.txt
@@ -1,8 +1,5 @@
 add_swift_host_tool(swift-llvm-opt
   LLVMOpt.cpp
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
-
   SWIFT_COMPONENT tools
 )
 target_link_libraries(swift-llvm-opt

--- a/tools/swift-llvm-opt/CMakeLists.txt
+++ b/tools/swift-llvm-opt/CMakeLists.txt
@@ -1,18 +1,18 @@
 add_swift_host_tool(swift-llvm-opt
   LLVMOpt.cpp
-  LINK_LIBRARIES
-  swiftIRGen
-
-  # Swift libraries included to appease the linker on linux.
-  swiftSema
-  swiftAST
-
-  # Clang libraries included to appease the linker on linux.
-  clangBasic
-  clangCodeGen
-
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
 
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-llvm-opt
+                      PRIVATE
+                        swiftIRGen
+
+                        # Swift libraries included to appease the linker on linux.
+                        swiftSema
+                        swiftAST
+
+                        # Clang libraries included to appease the linker on linux.
+                        clangBasic
+                        clangCodeGen)

--- a/tools/swift-refactor/CMakeLists.txt
+++ b/tools/swift-refactor/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_swift_host_tool(swift-refactor
   swift-refactor.cpp
-  LINK_LIBRARIES swiftDriver swiftFrontend swiftIDE
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-refactor
+                      PRIVATE
+                        swiftDriver
+                        swiftFrontend
+                        swiftIDE)

--- a/tools/swift-reflection-dump/CMakeLists.txt
+++ b/tools/swift-reflection-dump/CMakeLists.txt
@@ -1,6 +1,6 @@
+set(LLVM_LINK_COMPONENTS Support Object)
 add_swift_host_tool(swift-reflection-dump
   swift-reflection-dump.cpp
-  LLVM_COMPONENT_DEPENDS object support
   SWIFT_COMPONENT tools
 )
 target_link_libraries(swift-reflection-dump

--- a/tools/swift-reflection-dump/CMakeLists.txt
+++ b/tools/swift-reflection-dump/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_swift_host_tool(swift-reflection-dump
   swift-reflection-dump.cpp
-  LINK_FAT_LIBRARIES
-    swiftReflection
   LLVM_COMPONENT_DEPENDS object support
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-reflection-dump
+                      PRIVATE
+                        swiftReflection-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -1,10 +1,11 @@
 add_swift_host_tool(swift-remoteast-test
   swift-remoteast-test.cpp
-  LINK_LIBRARIES
-    swiftFrontendTool
-    swiftRemoteAST
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-remoteast-test
+                      PRIVATE
+                        swiftFrontendTool
+                        swiftRemoteAST)
 
 set_target_properties(swift-remoteast-test PROPERTIES ENABLE_EXPORTS 1)
 if(HAVE_UNICODE_LIBEDIT)

--- a/tools/swift-syntax-test/CMakeLists.txt
+++ b/tools/swift-syntax-test/CMakeLists.txt
@@ -1,12 +1,13 @@
 add_swift_host_tool(swift-syntax-test
   swift-syntax-test.cpp
-  LINK_LIBRARIES
-    swiftAST
-    swiftDriver
-    swiftFrontend
-    swiftSema
-    swiftSyntax
   LLVM_COMPONENT_DEPENDS
     Support
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-syntax-test
+                      PRIVATE
+                        swiftAST
+                        swiftDriver
+                        swiftFrontend
+                        swiftSema
+                        swiftSyntax)

--- a/tools/swift-syntax-test/CMakeLists.txt
+++ b/tools/swift-syntax-test/CMakeLists.txt
@@ -1,7 +1,6 @@
+set(LLVM_LINK_COMPONENTS Support)
 add_swift_host_tool(swift-syntax-test
   swift-syntax-test.cpp
-  LLVM_COMPONENT_DEPENDS
-    Support
   SWIFT_COMPONENT tools
 )
 target_link_libraries(swift-syntax-test


### PR DESCRIPTION
Change the way that swift build it's tools to be handled more similarly to the way that clang and LLVM build their tools.  This primarily has two missing pieces at this point: the integration into LLVM distribution infrastructure and the exclude from all handling which should be done similar to clang (`SWIFT_BUILD_TOOLS`).
