### PR TITLE
swift-stdlib-tool: switch to add_swift_host_tool

### DIFF
--- a/tools/swift-stdlib-tool/CMakeLists.txt
+++ b/tools/swift-stdlib-tool/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_swift_executable(swift-stdlib-tool
+add_swift_host_tool(swift-stdlib-tool
   swift-stdlib-tool.mm)
 
 find_library(FOUNDATION NAMES Foundation)


### PR DESCRIPTION
This tool is only built for the host.  Use the add_swift_host_tool
function instead.  NFCI.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
