### PR TITLE
[ObjectiveC] Make NSObject.hashValue non-overridable

### DIFF
--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -216,34 +216,34 @@ extension NSObject : Equatable, Hashable {
 
   /// The hash value.
   ///
-  /// `NSObject` implements this by returning `self.hash`. Subclasses can
-  /// customize hashing by overriding the `hash` property.
+  /// `NSObject` implements this by returning `self.hash`.
+  ///
+  /// `NSObject.hashValue` is not overridable; subclasses can customize hashing
+  /// by overriding the `hash` property.
   ///
   /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
   ///
   /// - Note: the hash value is not guaranteed to be stable across
   ///   different invocations of the same program.  Do not persist the
   ///   hash value across program runs.
-  @objc open // FIXME: Should be @nonobjc public. rdar://problem/42623458
-  var hashValue: Int {
+  @nonobjc
+  public var hashValue: Int {
     return hash
   }
 
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
   ///
-  /// NSObject implements this by feeding `self.hash` to the hasher. Subclasses
-  /// can customize hashing by overriding the `hash` property.
+  /// NSObject implements this by feeding `self.hash` to the hasher.
+  ///
+  /// `NSObject.hash(into:)` is not overridable; subclasses can customize
+  /// hashing by overriding the `hash` property.
   public func hash(into hasher: inout Hasher) {
-    // FIXME: We should combine self.hash here, but hashValue is currently
-    // overridable.
-    hasher.combine(hashValue)
+    hasher.combine(self.hash)
   }
 
   public func _rawHashValue(seed: Int) -> Int {
-    // FIXME: We should use self.hash here, but hashValue is currently
-    // overridable.
-    return self.hashValue._rawHashValue(seed: seed)
+    return self.hash._rawHashValue(seed: seed)
   }
 }
 

--- a/test/stdlib/NSObject-hashing.swift
+++ b/test/stdlib/NSObject-hashing.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -c -verify -verify-ignore-unknown %s -o /dev/null
+
+// REQUIRES: objc_interop
+
+import ObjectiveC
+
+class Foo: NSObject {
+  override var hashValue: Int { // expected-error {{overriding non-open property outside of its defining module}} expected-error {{overriding non-@objc declarations from extensions is not supported}}
+    return 0
+  }
+
+  override func hash(into hasher: inout Hasher) { // expected-error {{overriding non-open instance method outside of its defining module}} expected-error {{overriding declarations in extensions is not supported}}
+  }
+}


### PR DESCRIPTION
Swift 4.2 deprecated overriding `NSObject.hashValue`, by way of a custom compiler warning. This PR removes the ability to override it entirely.

The correct way to customize hashing for `NSObject` subclasses is to override the `hash` property. Classes that override `hashValue` instead break `NSObject` expectations, and will not work correctly in Foundation's `NSSet`, `NSDictionary` and similar hashed collections.

Note: This PR does not remove the compiler warning, as swift-corelibs-foundation still defines `NSObject.hashValue` as open.

rdar://problem/42623458