### PR TITLE
remove skippedByDeabstraction flag

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -345,16 +345,6 @@ private:
          const SILDebugScope *DebugScope = nullptr);
 
 public:
-  // SWIFT_ENABLE_TENSORFLOW
-  /// Whether TFDeabstraction specifically decided to not to deabstract this
-  /// function.
-  ///
-  /// This is a temporary flag that IRGen uses to determine if the graph_ops in
-  /// this function are safe to lower. Once IRGen is powerful enough to lower
-  /// every graph_op that it receives, we should remove this flag.
-  /// TODO: Remove this flag.
-  bool skippedByDeabstraction = false;
-
   ~SILFunction();
 
   SILModule &getModule() const { return Module; }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1983,12 +1983,13 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
       astCtx.getProtocol(KnownProtocolKind::TensorGroup);
   assert(tensorGroupProto && "could not find TensorGroup protocol");
 
-  if (CurSILFn->skippedByDeabstraction) {
-    // graph_ops do make it here when building functions that don't get
-    // deabstracted (e.g. TensorFlow stdlib functions).
-    // IRGen is currently not powerful enough to handle graph_ops in functions
-    // that don't get deabstractd. For these cases, we abort here with an error
-    // message.
+  if (!llvm::TFDynamicCompilation) {
+    // If we are not in dynamic compilation mode, then deabstraction may not
+    // have transformed the graph_ops into a form that we can lower, so do not
+    // try to lower the graph_ops.
+    // TODO(marcrasi): Once we make deabstraction unnecessary for IRGen, we
+    // should be able to lower everything no matter what the mode is, so remove
+    // this check.
     const std::string errMessage = "!!! Compiler bug -- graph_op " +
                               opInfo.getOperationName().str() +
                               " cannot be lowered to LLVM IR !!!\n";

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2880,11 +2880,8 @@ void TFDeabstractionPass::run() {
   // TODO: Rework the heuristics in inlineCalls() to be smarter.  In an ideal
   // world, we would be lazy about inlining, and only inline calls due to actual
   // inter-op value uses.
-  if (module->getSwiftModule() == tfModule) {
-    for (auto &fn : *module)
-      fn.skippedByDeabstraction = true;
+  if (module->getSwiftModule() == tfModule)
     return;
-  }
 
   TensorFunctionClassifier tfc;
   ConstExprEvaluator constantEvaluator(*module);
@@ -2897,10 +2894,8 @@ void TFDeabstractionPass::run() {
   for (auto &fn : *module) {
     // There's no point in deabstracting things defined in other modules,
     // because we won't lower them.
-    if (fn.isAvailableExternally()) {
-      fn.skippedByDeabstraction = true;
+    if (fn.isAvailableExternally())
       continue;
-    }
 
     // If this function is a building block of larger tensor programs (e.g.
     // the ops defined in the TensorFlow module), then don't transform it in
@@ -2913,10 +2908,8 @@ void TFDeabstractionPass::run() {
     // Once it can handle non-deabstracted code, turn deabstraction off entirely
     // in dynamic compilation mode.
     if (!tfc.shouldBePartitioned(&fn, /*forceTFFunctions*/false) &&
-        !llvm::TFDynamicCompilation) {
-      fn.skippedByDeabstraction = true;
+        !llvm::TFDynamicCompilation)
       continue;
-    }
 
     // If something crashes, make sure the pretty stack trace says what we
     // were doing.


### PR DESCRIPTION
The original reason I added this flag was that IRGen could only deal with deabstracted functions, and TFDeabstraction wasn't deabstracting everything. Now that TFDeabstraction is deabstracting everything (https://github.com/apple/swift/pull/20105) in dynamic compilation mode, this flag is no longer necessary!