### PR TITLE
[build-script] When building packages install libIndexStore from clang

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -726,7 +726,7 @@ install-swiftpm
 install-xctest
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;license;sourcekit-inproc
-llvm-install-components=llvm-cov;llvm-profdata;install-IndexStore
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
@@ -1062,7 +1062,7 @@ test-installable-package
 reconfigure
 
 swift-install-components=compiler;clang-builtin-headers;stdlib;swift-syntax;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata;install-IndexStore
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore
 
 # Path to the .tar.gz package we would create.
 installable-package=%(installable_package)s

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -726,7 +726,7 @@ install-swiftpm
 install-xctest
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;license;sourcekit-inproc
-llvm-install-components=llvm-cov;llvm-profdata
+llvm-install-components=llvm-cov;llvm-profdata;install-IndexStore
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
@@ -1062,7 +1062,7 @@ test-installable-package
 reconfigure
 
 swift-install-components=compiler;clang-builtin-headers;stdlib;swift-syntax;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata
+llvm-install-components=llvm-cov;llvm-profdata;install-IndexStore
 
 # Path to the .tar.gz package we would create.
 installable-package=%(installable_package)s


### PR DESCRIPTION
This is needed for the LSP service.