### PR TITLE
[silgen] Rather than adding enable-sil-ownership to all SILGen tests …

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1210,8 +1210,8 @@ config.substitutions.append(('%target-runtime', config.target_runtime))
 
 config.substitutions.append(('%target-typecheck-verify-swift', config.target_parse_verify_swift))
 
-config.substitutions.append(('%target-swift-emit-silgen\(mock-sdk:([^)]+)\)', '%target-swift-frontend(mock-sdk:\\1) -emit-silgen -verify-syntax-tree'))
-config.substitutions.append(('%target-swift-emit-silgen', '%target-swift-frontend -emit-silgen -verify-syntax-tree'))
+config.substitutions.append(('%target-swift-emit-silgen\(mock-sdk:([^)]+)\)', '%target-swift-frontend(mock-sdk:\\1) -emit-silgen -verify-syntax-tree -enable-sil-ownership'))
+config.substitutions.append(('%target-swift-emit-silgen', '%target-swift-frontend -emit-silgen -verify-syntax-tree -enable-sil-ownership'))
 config.substitutions.append(('%target-swift-emit-sil\(mock-sdk:([^)]+)\)', '%target-swift-frontend(mock-sdk:\\1) -emit-sil -verify-syntax-tree'))
 config.substitutions.append(('%target-swift-emit-sil', '%target-swift-frontend -emit-sil -verify-syntax-tree'))
 config.substitutions.append(('%target-swift-emit-ir\(mock-sdk:([^)]+)\)', '%target-swift-frontend(mock-sdk:\\1) -emit-ir -verify-syntax-tree'))


### PR DESCRIPTION
…individually, just use the lit pattern.

This will ensure that new SILGen tests that are added have ownership
verification enabled.

rdar://43398898

