### PR TITLE
add flag for disabling deabstraction

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -55,6 +55,18 @@ static llvm::cl::opt<bool> TFPromoteGlobalVariables(
         "If enabled, promote global variables into SSA with a best "
         "effort to minimize sends/recvs. This is a performance optimization."));
 
+// TODO(marcrasi): This is a very temporary option allowing us to
+// incrementally add IRGen support for non-deabstracted functions. As soon as
+// IRGen fully supports non-deabstracted functions, remove this flag and make
+// TFDeabstraction always be off for non-graph-only functions in dynamic
+// compilation mode.
+static llvm::cl::opt<bool>
+TFDisableDeabstraction(
+    "tf-disable-deabstraction", llvm::cl::init(false),
+    llvm::cl::desc(
+        "Disables deabstraction for everything except graph-only functions. "
+        "-tf-dynamic-compilation must also be enabled when this is on."));
+
 template<typename...T, typename...U>
 static InFlightDiagnostic
 diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag, U &&...args) {
@@ -2865,6 +2877,9 @@ void TFDeabstractionPass::run() {
   SILModule *module = getModule();
   auto &ctx = module->getASTContext();
 
+  assert(llvm::TFDynamicCompilation || !TFDisableDeabstraction &&
+         "If deabstraction is disabled, dynamic compilation must be enabled.");
+
   // If the TensorFlow module hasn't been imported by the program, don't do
   // anything.  This avoids impacting compile time for non-TensorFlow using
   // Swift programs by doing extraneous analysis.
@@ -2892,6 +2907,9 @@ void TFDeabstractionPass::run() {
   // iff they look like they could be the top level of a deabstraction
   // context.
   for (auto &fn : *module) {
+    if (TFDisableDeabstraction && !isAcceleratorOnly(fn))
+      continue;
+
     // There's no point in deabstracting things defined in other modules,
     // because we won't lower them.
     if (fn.isAvailableExternally())
@@ -2951,6 +2969,9 @@ void TFDeabstractionPass::run() {
   // of the functions would be dead after the first round, but some stragglers
   // remain as in the example above.
   for (auto &fn : *module) {
+    if (TFDisableDeabstraction && !isAcceleratorOnly(fn))
+      continue;
+
     // Skip if it is already partitioned, or if it was ignored only because it
     // operated on tensor values.
     if (partitionedFunctions.count(&fn) > 0 ||

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2877,7 +2877,7 @@ void TFDeabstractionPass::run() {
   SILModule *module = getModule();
   auto &ctx = module->getASTContext();
 
-  assert(llvm::TFDynamicCompilation || !TFDisableDeabstraction &&
+  assert((llvm::TFDynamicCompilation || !TFDisableDeabstraction) &&
          "If deabstraction is disabled, dynamic compilation must be enabled.");
 
   // If the TensorFlow module hasn't been imported by the program, don't do

--- a/test/TensorFlowRuntime/gpu_negative_tests.swift
+++ b/test/TensorFlowRuntime/gpu_negative_tests.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // XFAIL: *

--- a/test/TensorFlowRuntime/hangers.swift
+++ b/test/TensorFlowRuntime/hangers.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow

--- a/test/TensorFlowRuntime/random.swift
+++ b/test/TensorFlowRuntime/random.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sync_runtime.swift
+++ b/test/TensorFlowRuntime/sync_runtime.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
 //
 // TODO(SR-9110): Make this pass in dynamic compilation mode.
-// %target-run-dynamic-compilation-swift
+// %target-run-disable-deabstraction-swift
 //
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/top_level_2.swift
+++ b/test/TensorFlowRuntime/top_level_2.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1143,6 +1143,12 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
+    config.target_run_swift_disable_deabstraction = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -Xllvm -tf-dynamic-compilation -DTF_DYNAMIC_COMPILATION -Xllvm -tf-disable-deabstraction -o %%t/a.out -module-name main %s && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_simple_swift_sese_loops = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -Xllvm -tf-ensure-single-loop-exit -o %%t/a.out -module-name main %s && '
@@ -1288,6 +1294,7 @@ config.substitutions.append(('%target-run-simple-swift', config.target_run_simpl
 # SWIFT_ENABLE_TENSORFLOW
 config.substitutions.append(('%target-run-send-recv-handle-swift', config.target_run_simple_swift_send_recv_handle))
 config.substitutions.append(('%target-run-dynamic-compilation-swift', config.target_run_swift_dynamic_compilation))
+config.substitutions.append(('%target-run-disable-deabstraction-swift', config.target_run_swift_disable_deabstraction))
 config.substitutions.append(('%target-run-sese-loops-swift', config.target_run_simple_swift_sese_loops))
 config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))
 config.substitutions.append(('%target-run-simple-opt-Osize-swift', config.target_run_simple_opt_Osize_swift))


### PR DESCRIPTION
This flag will let me incrementally disable deabstraction in our runtime tests.

This profusion of flags is really bad, but I'm pretty sure that I will be able to remove this flag within a week.