### PR TITLE
Enable DWARF Debug info on Windows

### DIFF
--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -71,7 +71,7 @@ toolchains::Windows::constructInvocation(const LinkJobAction &job,
   if (!Linker.empty())
     Arguments.push_back(context.Args.MakeArgString("-fuse-ld=" + Linker));
 
-  if (context.OI.DebugInfoFormat == IRGenDebugInfoFormat::CodeView)
+  if (context.OI.DebugInfoFormat != IRGenDebugInfoFormat::None)
       Arguments.push_back("-Wl,/DEBUG");
 
   // Configure the toolchain.


### PR DESCRIPTION
Passing swift just `-g` on Windows didn't pass the debug flag to the
linker unless CodeView is requested, so the final executable doesn't have
DWARF debug information. This now allows -g to create DWARF on Windows
with lld-link.

Previously (with some elisions) :
```
> .\swiftc -g C:\Users\jmittertreiner\test.swift -use-ld=lld -o C:\Users\jmittertreiner\test.exe -###
"C:\\...\\swiftc.exe" <..> -g <...>\\AppData\\Local\\Temp\\test-5a83c7.o"
"C:\\...\\swiftc.exe" <...> -g <...>\\AppData\\Local\\Temp\\test-9d7cf3.swiftmodule"
"C:\\Program Files\\LLVM\\bin\\clang++.exe" -fuse-ld=lld -target x86_64-pc-win32 -L "C:\\Users\\jmittertreiner\\localswift\\build\\Ninja-ReleaseAssert\\swift-windows-amd64\\lib\\swift\\windows/x86_64" "C:\\Users\\jmittertreiner\\localswift\\build\\Ninja-ReleaseAssert\\swift-windows-amd64\\lib\\swift\\windows\\x86_64\\swiftrt.o" "C:\\Users\\JMITTE~1\\AppData\\Local\\Temp\\test-5a83c7.o" -o "C:\\Users\\jmittertreiner\\test.exe"
```
```
PS C:\Users\jmittertreiner\localswift\build\Ninja-ReleaseAssert\swift-windows-amd64\bin> ..\..\llvm-windows-amd64\bin\llvm-dwarfdump.exe C:\Users\jmittertreiner\test.exe
C:\Users\jmittertreiner\test.exe:       file format COFF-x86-64

.debug_info contents:
```
Now:
```
> .\swiftc -g C:\Users\jmittertreiner\test.swift -use-ld=lld -o C:\Users\jmittertreiner\test.exe -###
"C:\\...\\swiftc.exe" <..> -g <...>\\AppData\\Local\\Temp\\test-5a83c7.o"
"C:\\...\\swiftc.exe" <...> -g <...>\\AppData\\Local\\Temp\\test-9d7cf3.swiftmodule"
"C:\\Program Files\\LLVM\\bin\\clang++.exe" -fuse-ld=lld -Wl,/DEBUG -target x86_64-pc-win32 -L "C:\\Users\\jmittertreiner\\localswift\\build\\Ninja-ReleaseAssert\\swift-windows-amd64\\lib\\swift\\windows/x86_64" "C:\\Users\\jmittertreiner\\localswift\\build\\Ninja-ReleaseAssert\\swift-windows-amd64\\lib\\swift\\windows\\x86_64\\swiftrt.o" "C:\\Users\\JMITTE~1\\AppData\\Local\\Temp\\test-5a83c7.o" -o "C:\\Users\\jmittertreiner\\test.exe"
```
```
PS C:\Users\jmittertreiner\localswift\build\Ninja-ReleaseAssert\swift-windows-amd64\bin> ..\..\llvm-windows-amd64\bin\llvm-dwarfdump.exe C:\Users\jmittertreiner\test.exe
C:\Users\jmittertreiner\test.exe:       file format COFF-x86-64

.debug_info contents:
0x00000000: Compile Unit: length = 0x00000102 version = 0x0004 abbr_offset = 0x0000 addr_size = 0x08 (next unit at 0x00000106)

0x0000000b: DW_TAG_compile_unit
              DW_AT_producer    ("Swift version 4.2-dev (LLVM 80f624ef0e, Clang 002f229821, Swift 1446952521)")
              DW_AT_language    (DW_LANG_Swift)
              DW_AT_name        ("C:\\Users\\jmittertreiner\\test.swift")
              DW_AT_stmt_list   (0x00000000)
              DW_AT_comp_dir    ("C:\\Users\\jmittertreiner\\localswift\\build\\Ninja-ReleaseAssert\\swift-windows-amd64\\bin")
              DW_AT_APPLE_major_runtime_vers    (0x04)
              DW_AT_low_pc      (0x000000014001e190)
              DW_AT_high_pc     (0x000000014001e306)
<...More debug info...>
```
