### PR TITLE
Fixed a SILVerifier failure, where a synthesized host inst for switch_case based control flow handling has its SILLocation set to ReturnKind in the LocationKind field

### DIFF
--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -243,6 +243,11 @@ private:
   friend class CleanupLocation;
 
   void setLocationKind(LocationKind K) { KindData |= (K & LocationKindMask); }
+  // SWIFT_ENABLE_TENSORFLOW
+  // TODO: Assess if this API can be unified with the one above.
+  void setAndOverwriteLocationKind(LocationKind K) {
+    KindData = (K & LocationKindMask);
+  }
   void setStorageKind(StorageKind K) { KindData |= (K & StorageKindMask); }
   unsigned getSpecialFlags() const { return KindData & SpecialFlagsMask; }
   void setSpecialFlags(unsigned Flags) {
@@ -432,6 +437,18 @@ public:
   SILLocation getAsRegularLocation() {
     SILLocation RegularLoc = *this;
     RegularLoc.setLocationKind(RegularKind);
+    return RegularLoc;
+  }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Convert a specialized location kind into a regular location, by completely
+  /// overwriting the existing location kind in `RegularLoc`. In contrast, the
+  /// above function does a bitwise OR on the existing location kind and
+  /// RegularKind.
+  // TODO: Assess if these two APIs can be unified.
+  SILLocation getAsRegularLocationWithOverwrite() {
+    SILLocation RegularLoc = *this;
+    RegularLoc.setAndOverwriteLocationKind(RegularKind);
     return RegularLoc;
   }
 

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -3001,7 +3001,12 @@ void PartitionCloner::handleSendRecvForTerminator(TermInst *inst) {
 
     // The send is at the beginning of each caseBB.
     BH.setInsertionPoint(&caseBB->front());
-    auto loc = caseBB->front().getLoc();
+    // The first inst of `caseBB` could originate from a return statement of a
+    // function that's been inlined here, in which case its LocationKind can be
+    // ReturnKind. But SILVerifier requires that we use a RegularKind
+    // for the SILLocation of the synthesized host code here (such as
+    // `caseIdInst`). This is achieved via getAsRegularLocationWithOverwrite().
+    auto loc = caseBB->front().getLoc().getAsRegularLocationWithOverwrite();
     // `caseId` must be of a type conforming to `AccelerableByTensorFlow`, so we
     // chose Int32 here.
     auto caseIdInst = createSomeIntegerValue(caseId /*caseEntry.index()*/, BH,

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -401,3 +401,29 @@ public func deabstractedCallee(_ t: Tensor<Float>) -> Tensor<Float> {
 public func inlineDeabstracted_b() -> Tensor<Float> {
   return deabstractedCallee([1, 2, 3])
 }
+
+// b/118507040: The SIL location of a synthesized host instruction for
+// switch_case based control flow handling cannot be ReturnKind.
+@inline(never)
+func foo() -> Int32? {
+  return 0
+}
+
+func getLogpLex() {
+  if let _ = foo() {
+    _ = Tensor<Float>(1.0)
+    return
+  } else {
+    // For the SILLocation associated with this return stmt/inst,
+    // The LocationKind is ReturnKind.
+    //
+    // When we synthesize host code to send case id #1 to the accelerator, make
+    // sure the host inst will NOT use ReturnKind as the LocationKind.
+    return
+  }
+}
+
+public func b118507040() {
+  getLogpLex()
+  _ = Tensor<Float>(1.0)
+}


### PR DESCRIPTION
This is because its SILLocation came from the first instruction of the BasicBlock to which we are adding host code for "sending case ID to tensorflow".

When that instruction came from a return statement originally, its SILLocation is ReturnKind. The fix is to overwrite that location kind to be RegularKind.

We will also start a thread with Swift core team / community on the background of
LocationKind, and whether the fix can be made simpler.
