### PR TITLE
[Build] Relax CMAKE_C_COMPILER_ID "Clang" check to match AppleClang

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -120,7 +120,8 @@ function(_add_variant_c_compile_link_flags)
   endif()
 
   # MSVC, clang-cl, gcc don't understand -target.
-  if(CMAKE_C_COMPILER_ID STREQUAL Clang AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+  if(CMAKE_C_COMPILER_ID MATCHES "^Clang|AppleClang$" AND
+      NOT SWIFT_COMPILER_IS_MSVC_LIKE)
     list(APPEND result "-target" "${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_TRIPLE}${DEPLOYMENT_VERSION}")
   endif()
 


### PR DESCRIPTION
In https://github.com/apple/swift/pull/19973 the logic that adds "-target" when
building the C parts of the Standard Library and overlays was changed to use
CMAKE_C_COMPILER_ID to only do so when the compiler ID is "Clang". However,
on Apple toolchains the compiler ID is "AppleClang", so the target was no
longer being explicitly set.

Update the logic to relax the explicit check for "Clang" to also allow
"AppleClang".

rdar://problem/45579667