### PR TITLE
[android] Do  not link library absolute path.

### DIFF
--- a/test/attr/attr_implements_serial.swift
+++ b/test/attr/attr_implements_serial.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'client()' >%t/main.swift
-// RUN: %target-build-swift-dylib(%t/library.%target-dylib-extension) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift
-// RUN: %target-build-swift -I %t -o %t/a.out %s %t/main.swift %t/library.%target-dylib-extension
+// RUN: %target-build-swift-dylib(%t/libAttrImplFP.%target-dylib-extension) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift
+// RUN: %target-build-swift -I %t -o %t/a.out %s %t/main.swift -L %t -Xlinker -rpath -Xlinker %t -lAttrImplFP
 // RUN: %target-codesign %t/a.out
-// RUN: %target-codesign %t/library.%target-dylib-extension
-// RUN: %target-run %t/a.out %t/library.%target-dylib-extension | %FileCheck %s
+// RUN: %target-codesign %t/libAttrImplFP.%target-dylib-extension
+// RUN: %target-run %t/a.out %t/libAttrImplFP.%target-dylib-extension | %FileCheck %s
 // REQUIRES: executable_test
 
 // This test just checks that the lookup-table entries for @_implements are


### PR DESCRIPTION
Avoid using the full path of the shared library to avoid including
the absolute path of the library in the executable, which will not
work once the library is moved to the host machine (like an
Android device).

To avoid doing a confussing `-lrary`, I changed the name of the
library to `libAttrImplFP.so` instead.

Depends on #19949 for correctly working on Android.
