### PR TITLE
make IRGen handle abstract inputs and attrs

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -164,6 +164,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   Int32PtrTy = Int32Ty->getPointerTo();
   Int64Ty = llvm::Type::getInt64Ty(getLLVMContext());
   // SWIFT_ENABLE_TENSORFLOW
+  DoubleTy = llvm::Type::getDoubleTy(getLLVMContext());
   FloatTy = llvm::Type::getFloatTy(getLLVMContext());
 
   Int8PtrTy = llvm::Type::getInt8PtrTy(getLLVMContext());

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -527,6 +527,7 @@ public:
   };
   llvm::IntegerType *Int64Ty;          /// i64
   // SWIFT_ENABLE_TENSORFLOW
+  llvm::Type *DoubleTy;                /// double
   llvm::Type *FloatTy;                 /// float
 
   union {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2067,6 +2067,9 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
     LLVM_DEBUG(llvm::dbgs()
                << " Adding input of type " << opInput->getType() << ".\n");
 
+    // If this is a known TensorFlow value, add it directly.
+    // TODO: We could also handle concrete structs of known TensorFlow values
+    // here, to avoid falling through to the slower TensorGroup case.
     if (tf::isTensorFlowValue(opInput->getType())) {
       auto *tensorHandleValue = getLoweredSingletonExplosion(opInput);
       auto *opAddInputFromTensorHandleFn =
@@ -2079,6 +2082,9 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
       return llvm::ConstantInt::get(IGM.Int32Ty, 1);
     }
 
+    // Otherwise, this must conform to TensorGroup so we can add it using
+    // TFCOpAddInputFromTensorGroup.
+
     auto canType = opInput->getType().getASTType()->getCanonicalType();
     auto conformance = tfModule->lookupConformance(canType,
                                                    tensorGroupProto);
@@ -2086,15 +2092,27 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
     auto *typeMetadata = emitTypeMetadataRef(canType);
     auto *wtable = emitWitnessTableRef(*this, canType, *conformance);
 
-    auto *tensorHandleValue = getLoweredAddress(opInput).getAddress();
-    auto *tensorHandleValueUntyped =
-        Builder.CreateBitCast(tensorHandleValue, IGM.Int8PtrTy);
+    llvm::Value *opInputAddr;
+    if (opInput->getType().isAddress()) {
+      opInputAddr = getLoweredAddress(opInput).getAddress();
+    } else {
+      // It is a value, so we must store it to the stack to get an address.
+      Explosion value = getLoweredExplosion(opInput);
+      auto &typeInfo =
+          cast<LoadableTypeInfo>(getTypeInfo(opInput->getType()));
+      auto stackAddr = typeInfo.allocateStack(*this, opInput->getType(),
+                                              StringRef());
+      typeInfo.initialize(*this, value, stackAddr.getAddress(),
+                          false);
+      opInputAddr = stackAddr.getAddress().getAddress();
+    }
+    opInputAddr = Builder.CreateBitCast(opInputAddr, IGM.Int8PtrTy);
 
     auto *opAddInputFromTensorGroupFn =
         IGM.getTFC_OpAddInputFromTensorGroupFn();
     auto *numInputs = Builder.CreateCall(
         opAddInputFromTensorGroupFn,
-        {op, tensorHandleValueUntyped, status, typeMetadata, wtable});
+        {op, opInputAddr, status, typeMetadata, wtable});
     checkOk(status);
     return numInputs;
   };
@@ -2226,37 +2244,46 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
 
       auto *attrNameValAddr = IGM.getAddrOfGlobalString(argumentName.c_str());
 
-      // Deabstraction extracts builtin types out of stdlib types, so we match
-      // on builtin types. If we remove that part of deabstraction, we should
-      // change this to match on stdlib types.
+      // Handle basic scalar types by looking at the underlying llvm scalar
+      // type. This is independent of all the Swift abstractions around the
+      // type, so we can handle basic scalar types without worrying about Swift
+      // abstractions (e.g. Int64 vs Builtin.Int64).
+      ExplosionSchema schema = getTypeInfo(silType).getSchema();
+      llvm::Type *singleScalarType = nullptr;
+      if (schema.size() == 1 && schema[0].isScalar())
+        singleScalarType = schema[0].getScalarType();
 
-      if (astType->isBuiltinIntegerType(1)) {
+      if (singleScalarType == IGM.Int1Ty) {
         auto *fn = IGM.getTFE_OpSetAttrBoolFn();
         auto *attrValue = getLoweredSingletonExplosion(silValue);
         Builder.CreateCall(fn, {op, attrNameValAddr, attrValue});
         break;
       }
 
-      if (astType->isBuiltinIntegerType(64)) {
+      if (singleScalarType == IGM.Int64Ty) {
         auto *fn = IGM.getTFE_OpSetAttrIntFn();
         auto *attrValue = getLoweredSingletonExplosion(silValue);
         Builder.CreateCall(fn, {op, attrNameValAddr, attrValue});
         break;
       }
 
-      if (auto floatType = dyn_cast<BuiltinFloatType>(astType)) {
+      if (singleScalarType == IGM.DoubleTy) {
         auto *fn = IGM.getTFE_OpSetAttrFloatFn();
         auto *attrValue = getLoweredSingletonExplosion(silValue);
-        if (floatType->getFPKind() == BuiltinFloatType::IEEE32) {
-          Builder.CreateCall(fn, {op, attrNameValAddr, attrValue});
-          break;
-        }
-        if (floatType->getFPKind() == BuiltinFloatType::IEEE64) {
-          auto *truncValue = Builder.CreateFPTrunc(attrValue, IGM.FloatTy);
-          Builder.CreateCall(fn, {op, attrNameValAddr, truncValue});
-          break;
-        }
+        auto *truncValue = Builder.CreateFPTrunc(attrValue, IGM.FloatTy);
+        Builder.CreateCall(fn, {op, attrNameValAddr, truncValue});
+        break;
       }
+
+      if (singleScalarType == IGM.FloatTy) {
+        auto *fn = IGM.getTFE_OpSetAttrFloatFn();
+        auto *attrValue = getLoweredSingletonExplosion(silValue);
+        Builder.CreateCall(fn, {op, attrNameValAddr, attrValue});
+        break;
+      }
+
+      // It is not a basic scalar type. Inspect the astType to figure out how
+      // to handle it.
 
       if (astType->isEqual(
           astCtx.getStringDecl()->getDeclaredInterfaceType())) {
@@ -2362,14 +2389,24 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
 
       auto *attrNameValAddr = IGM.getAddrOfGlobalString(argumentName.c_str());
 
-      // Deabstraction extracts the Builtin.Int32 that's inside the
-      // TensorDataType.
-      if (astType->isBuiltinIntegerType(32)) {
+      // Handle basic scalar types by looking at the underlying llvm scalar
+      // type. This is independent of all the Swift abstractions around the
+      // type, so we can handle basic scalar types without worrying about Swift
+      // abstractions (e.g. Int64 vs Builtin.Int64).
+      ExplosionSchema schema = getTypeInfo(silType).getSchema();
+      llvm::Type *singleScalarType = nullptr;
+      if (schema.size() == 1 && schema[0].isScalar())
+        singleScalarType = schema[0].getScalarType();
+
+      if (singleScalarType == IGM.Int32Ty) {
         auto *fn = IGM.getTFE_OpSetAttrTypeFn();
         auto *attrValue = getLoweredSingletonExplosion(silValue);
         Builder.CreateCall(fn, {op, attrNameValAddr, attrValue});
         break;
       }
+
+      // It is not a basic scalar type. Inspect the astType to figure out how
+      // to handle it.
 
       if (astType->isEqual(getArrayType(
           astCtx,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2083,7 +2083,7 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
     }
 
     // Otherwise, this must conform to TensorGroup so we can add it using
-    // TFCOpAddInputFromTensorGroup.
+    // TFC_OpAddInputFromTensorGroup.
 
     auto canType = opInput->getType().getASTType()->getCanonicalType();
     auto conformance = tfModule->lookupConformance(canType,

--- a/stdlib/public/TensorFlow/TensorGroup.swift
+++ b/stdlib/public/TensorFlow/TensorGroup.swift
@@ -56,7 +56,7 @@ public extension TensorGroup {
 // Conform standard TensorFlow types to TensorGroup
 //===----------------------------------------------------------------------===//
 
-extension TensorHandle : TensorGroup where Scalar : AccelerableByTensorFlow {
+extension TensorHandle : TensorGroup {
   public static var _typeList: [TensorDataType] {
     return [Scalar.tensorFlowDataType]
   }
@@ -101,7 +101,7 @@ extension VariantHandle : TensorGroup {
   }
 }
 
-extension Tensor : TensorGroup where Scalar : AccelerableByTensorFlow {
+extension Tensor : TensorGroup {
   public static var _typeList: [TensorDataType] {
     return [Scalar.tensorFlowDataType]
   }
@@ -116,7 +116,7 @@ extension Tensor : TensorGroup where Scalar : AccelerableByTensorFlow {
   }
 }
 
-extension TensorElementLiteral : TensorGroup where Scalar : AccelerableByTensorFlow {
+extension TensorElementLiteral : TensorGroup {
   public static var _typeList: [TensorDataType] {
     return [Scalar.tensorFlowDataType]
   }

--- a/stdlib/public/TensorFlow/TensorGroup.swift
+++ b/stdlib/public/TensorFlow/TensorGroup.swift
@@ -14,6 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CTensorFlow
+
 /// A protocol for types that can be used as tensor operation inputs and
 /// outputs. When a TensorGroup is used as an input, it gets passed to the
 /// tensor operation as an input list whose elements are the tensor fields of
@@ -47,5 +49,84 @@ public extension TensorGroup {
   /// represents unknown shape.
   static var _unknownShapeList: [TensorShape?] {
     return Array(repeating: nil, count: Int(_tensorHandleCount))
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Conform standard TensorFlow types to TensorGroup
+//===----------------------------------------------------------------------===//
+
+extension TensorHandle : TensorGroup where Scalar : AccelerableByTensorFlow {
+  public static var _typeList: [TensorDataType] {
+    return [Scalar.tensorFlowDataType]
+  }
+
+  public func _unpackTensorHandles(
+      into address: UnsafeMutablePointer<CTensorHandle>?) {
+    address!.initialize(to: _cTensorHandle)
+  }
+
+  public convenience init(_owning tensorHandles: UnsafePointer<CTensorHandle>?) {
+    self.init(_owning: tensorHandles!.pointee)
+  }
+}
+
+extension ResourceHandle : TensorGroup {
+  public static var _typeList: [TensorDataType] {
+    return [TensorDataType(TF_RESOURCE)]
+  }
+
+  public func _unpackTensorHandles(
+      into address: UnsafeMutablePointer<CTensorHandle>?) {
+    address!.initialize(to: _cTensorHandle)
+  }
+
+  public convenience init(_owning tensorHandles: UnsafePointer<CTensorHandle>?) {
+    self.init(owning: tensorHandles!.pointee)
+  }
+}
+
+extension VariantHandle : TensorGroup {
+  public static var _typeList: [TensorDataType] {
+    return [TensorDataType(TF_VARIANT)]
+  }
+
+  public func _unpackTensorHandles(
+      into address: UnsafeMutablePointer<CTensorHandle>?) {
+    address!.initialize(to: _cTensorHandle)
+  }
+
+  public convenience init(_owning tensorHandles: UnsafePointer<CTensorHandle>?) {
+    self.init(owning: tensorHandles!.pointee)
+  }
+}
+
+extension Tensor : TensorGroup where Scalar : AccelerableByTensorFlow {
+  public static var _typeList: [TensorDataType] {
+    return [Scalar.tensorFlowDataType]
+  }
+
+  public func _unpackTensorHandles(
+      into address: UnsafeMutablePointer<CTensorHandle>?) {
+    address!.initialize(to: handle._cTensorHandle)
+  }
+
+  public init(_owning tensorHandles: UnsafePointer<CTensorHandle>?) {
+    self.init(handle: TensorHandle(_owning: tensorHandles!.pointee))
+  }
+}
+
+extension TensorElementLiteral : TensorGroup where Scalar : AccelerableByTensorFlow {
+  public static var _typeList: [TensorDataType] {
+    return [Scalar.tensorFlowDataType]
+  }
+
+  public func _unpackTensorHandles(
+      into address: UnsafeMutablePointer<CTensorHandle>?) {
+    address!.initialize(to: handle._cTensorHandle)
+  }
+
+  public init(_owning tensorHandles: UnsafePointer<CTensorHandle>?) {
+    self.init(handle: TensorHandle(_owning: tensorHandles!.pointee))
   }
 }

--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/raw_ops.swift
+++ b/test/TensorFlowRuntime/raw_ops.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow_swift_bindings

--- a/test/TensorFlowRuntime/retain_release_1.swift
+++ b/test/TensorFlowRuntime/retain_release_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-sese-loops-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/top_level_1.swift
+++ b/test/TensorFlowRuntime/top_level_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 


### PR DESCRIPTION
This makes IRGen able to handle abstract (i.e. non-deabstracted) inputs and attrs. I needed to do three things to achieve this:
1. Conform all our stdlib types to TensorGroup so that the TensorGroup case in `unpackAndAddInput` can handle them.
2. `unpackAndAddInput` had a bug where it didn't handle loadable types correctly in the TensorGroup case, so I fixed that and added a test that explicitly exercises loadable types in the TensorGroup case.
3. Make the attr cases use the underlying llvm type to determine the attr type, rather than the AST type, so that they "see through" all the Swift abstractions and just do the right thing based on the underlying value.

An alternative to (1) would have been to teach IRGen to extract the underlying TF values from all our stdlib types. I think we should do this eventually because it will generate faster code. But (1) is the easier thing to do right now, and the conformances are good to keep even after we implement the faster thing.