### PR TITLE
[stdlib] Switch Zip2Sequence.init to be internal

### DIFF
--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -45,7 +45,7 @@
 public func zip<Sequence1, Sequence2>(
   _ sequence1: Sequence1, _ sequence2: Sequence2
 ) -> Zip2Sequence<Sequence1, Sequence2> {
-  return Zip2Sequence(_sequence1: sequence1, _sequence2: sequence2)
+  return Zip2Sequence(sequence1, sequence2)
 }
 
 /// A sequence of pairs built out of two underlying sequences.
@@ -77,8 +77,7 @@ public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence> {
   /// Creates an instance that makes pairs of elements from `sequence1` and
   /// `sequence2`.
   @inlinable // generic-performance
-  public // @testable
-  init(_sequence1 sequence1: Sequence1, _sequence2 sequence2: Sequence2) {
+  internal init(_ sequence1: Sequence1, _ sequence2: Sequence2) {
     (_sequence1, _sequence2) = (sequence1, sequence2)
   }
 }

--- a/test/Interpreter/protocol_extensions.swift
+++ b/test/Interpreter/protocol_extensions.swift
@@ -65,7 +65,7 @@ extension Sequence {
 
 extension Sequence {
   public func myZip<S : Sequence>(_ s: S) -> Zip2Sequence<Self, S> {
-    return Zip2Sequence(_sequence1: self, _sequence2: s)
+    return zip(self, s)
   }
 }
 

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -7,6 +7,7 @@
 Constructor AnyHashable.init(_box:) has been removed
 Constructor AnyHashable.init(_usingDefaultRepresentationOf:) has been removed
 Constructor ManagedBufferPointer.init(_:_:_:) has been removed
+Constructor Zip2Sequence.init(_sequence1:_sequence2:) has been removed
 Constructor _BridgeableMetatype.init(value:) has been removed
 Func AnyHashable._downCastConditional(into:) has been removed
 Func _CocoaDictionary.Index.copy() has been removed


### PR DESCRIPTION
It's marked with an `@testable` comment but that doesn't seem legit.