### PR TITLE
Markup: add CMARK_STATIC_DEFINE to CFLAGS

### DIFF
--- a/lib/Markup/CMakeLists.txt
+++ b/lib/Markup/CMakeLists.txt
@@ -5,4 +5,7 @@ add_swift_host_library(swiftMarkup STATIC
   
   LINK_LIBRARIES
     libcmark_static)
+target_compile_definitions(swiftMarkup
+                           PRIVATE
+                             CMARK_STATIC_DEFINE)
 


### PR DESCRIPTION
This is needed to link against cmark properly for Windows.  Without this CMark
behaves as a shared library and cannot be linked to statically.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
