### PR TITLE
[CodeCompletion] Propagate completion status in 'let' pattern

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5254,8 +5254,9 @@ namespace  {
                      ChildExpr(ChildExpr), Predicate(Predicate) {}
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-      // Finish if we found the target.
-      if (E == ChildExpr)
+      // Finish if we found the target. 'ChildExpr' might have been replaced
+      // with typechecked expression. In that case, match the position.
+      if (E == ChildExpr || arePositionsSame(E, ChildExpr))
         return { false, nullptr };
 
       if (Predicate(E, Parent))
@@ -5266,13 +5267,6 @@ namespace  {
     Expr *walkToExprPost(Expr *E) override {
       if (Predicate(E, Parent))
         Ancestors.pop_back();
-
-      // 'ChildExpr' might have been replaced with typechecked expression. In
-      // that case, find deepest expression that position is the same as the
-      // target.
-      if (arePositionsSame(E, ChildExpr))
-        return nullptr;
-
       return E;
     }
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1192,7 +1192,7 @@ ParserResult<Pattern> Parser::parseMatchingPatternAsLetOrVar(bool isLet,
   if (subPattern.isNull())
     return nullptr;
   auto *varP = new (Context) VarPattern(varLoc, isLet, subPattern.get());
-  return makeParserResult(varP);
+  return makeParserResult(ParserStatus(subPattern), varP);
 }
 
 

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -65,6 +65,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_1 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_2 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_3 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_U
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_4 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STATIC_CLOSURE_1 | %FileCheck %s -check-prefix=STATIC_CLOSURE_1
 
@@ -477,6 +478,10 @@ func testGeneric() {
   }
   takeGenericInt(.#^GENERIC_2^#)
   takeGenericU(.#^GENERIC_3^#)
+}
+
+switch Generic<Int>.empty {
+case let .#^GENERIC_4^#
 }
 // GENERIC_1: Begin completions
 // GENERIC_1:     Decl[EnumElement]/ExprSpecific:     contains({#content: T#})[#(T) -> Generic<T>#];


### PR DESCRIPTION
Preserve completion status in `let` pattern. This enables code completion like:
```swift
switch enumVal {
case let .<HERE>
}
```
Also, stop context type analysis at outer most expression that matches
the position. It seems that that produces more appropriate results.

rdar://problem/30103287