### PR TITLE
[AutoDiff] Add result index selection to ReverseAutoDiffExpr

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1637,6 +1637,8 @@ ERROR(expr_expected_label,none,
       "expected label '%1' in '%0' expression", (StringRef, StringRef))
 ERROR(expr_expected_function_to_differentiate,none,
       "expected a function to be differentiated", ())
+ERROR(gradient_expr_expected_result_index,none,
+      "expected a result index with a leading dot", ())
 ERROR(gradient_expr_expected_parameter,none,
       "expected a parameter, which must be the index of a function parameter "
       "with a leading dot (e.g. '.0')", ())

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3826,6 +3826,10 @@ public:
   MutableArrayRef<AutoDiffIndexParameter> getParameters() {
     return { getParametersData(), NumParameters };
   }
+  
+  unsigned getResultIndex() const {
+    return ResultIndex;
+  }
 
   SourceRange getSourceRange() const {
     return SourceRange(Loc, RParenLoc);
@@ -3845,6 +3849,8 @@ private:
   Expr *OriginalExpr;
   /// The number of parameters in the parameter list.
   unsigned NumParameters;
+  /// The index of the result to differentiate from.
+  unsigned ResultIndex;
   /// The location of ')'.
   SourceLoc RParenLoc;
 
@@ -3853,7 +3859,7 @@ protected:
                                SourceLoc lParenLoc,
                                Expr *originalExpr,
                                ArrayRef<AutoDiffIndexParameter> parameters,
-                               SourceLoc rParenLoc);
+                               unsigned resultIndex, SourceLoc rParenLoc);
 };
 
 /// Gradient expression - An expression that produces the automatically
@@ -3869,7 +3875,7 @@ public:
   static GradientExpr *create(ASTContext &ctx, SourceLoc loc,
                               SourceLoc lParenLoc, Expr *originalExpr,
                               ArrayRef<AutoDiffIndexParameter> parameters,
-                              SourceLoc rParenLoc);
+                              unsigned resultIndex, SourceLoc rParenLoc);
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Gradient;
@@ -3878,9 +3884,9 @@ public:
 private:
   explicit GradientExpr(SourceLoc loc, SourceLoc lParenLoc, Expr *originalExpr,
                         ArrayRef<AutoDiffIndexParameter> params,
-                        SourceLoc rParenLoc)
+                        unsigned resultIndex, SourceLoc rParenLoc)
     : ReverseAutoDiffExpr(ExprKind::Gradient, loc, lParenLoc, originalExpr,
-                          params, rParenLoc) {}
+                          params, resultIndex, rParenLoc) {}
 };
   
 /// Chainable gradient expression - An expression that produces the
@@ -3898,6 +3904,7 @@ public:
   static ChainableGradientExpr *create(ASTContext &ctx, SourceLoc loc,
                                        SourceLoc lParenLoc, Expr *originalExpr,
                                    ArrayRef<AutoDiffIndexParameter> parameters,
+                                       unsigned resultIndex,
                                        SourceLoc rParenLoc);
   
   static bool classof(const Expr *E) {
@@ -3908,9 +3915,9 @@ private:
   explicit ChainableGradientExpr(SourceLoc loc, SourceLoc lParenLoc,
                                  Expr *originalExpr,
                                  ArrayRef<AutoDiffIndexParameter> params,
-                                 SourceLoc rParenLoc)
+                                 unsigned resultIndex, SourceLoc rParenLoc)
   : ReverseAutoDiffExpr(ExprKind::ChainableGradient, loc, lParenLoc,
-                        originalExpr, params, rParenLoc) {}
+                        originalExpr, params, resultIndex, rParenLoc) {}
 };
 
 /// ValueAndGradient expression - An expression that produces an automatically
@@ -3927,6 +3934,7 @@ public:
   static ValueAndGradientExpr *create(ASTContext &ctx, SourceLoc loc,
                                       SourceLoc lParenLoc, Expr *originalExpr,
                                       ArrayRef<AutoDiffIndexParameter> params,
+                                      unsigned resultIndex,
                                       SourceLoc rParenLoc);
 
   static bool classof(const Expr *E) {
@@ -3937,9 +3945,9 @@ private:
   explicit ValueAndGradientExpr(SourceLoc loc, SourceLoc lParenLoc,
                                 Expr *originalExpr,
                                 ArrayRef<AutoDiffIndexParameter> params,
-                                SourceLoc rParenLoc)
+                                unsigned resultIndex, SourceLoc rParenLoc)
     : ReverseAutoDiffExpr(ExprKind::ValueAndGradient, loc, lParenLoc,
-                          originalExpr, params, rParenLoc) {}
+                          originalExpr, params, resultIndex, rParenLoc) {}
 };
 
 /// The `#adjoint(...)` expression returns the declared adjoint of functions

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1131,23 +1131,24 @@ packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc, ArrayRef<Expr *> args,
 // SWIFT_ENABLE_TENSORFLOW
 ReverseAutoDiffExpr::ReverseAutoDiffExpr(
     ExprKind kind, SourceLoc loc, SourceLoc lParenLoc, Expr *originalExpr,
-    ArrayRef<AutoDiffIndexParameter> parameters, SourceLoc rParenLoc)
+    ArrayRef<AutoDiffIndexParameter> parameters, unsigned resultIndex,
+    SourceLoc rParenLoc)
   : Expr(kind, /*Implicit=*/false), Loc(loc), LParenLoc(lParenLoc),
     OriginalExpr(originalExpr), NumParameters(parameters.size()),
-    RParenLoc(rParenLoc) {
+    ResultIndex(resultIndex), RParenLoc(rParenLoc) {
   std::copy(parameters.begin(), parameters.end(), getParametersData());
 }
 
 GradientExpr *GradientExpr::create(ASTContext &ctx, SourceLoc loc,
                                    SourceLoc lParenLoc, Expr *originalExpr,
                                    ArrayRef<AutoDiffIndexParameter> parameters,
-                                   SourceLoc rParenLoc) {
+                                   unsigned resultIndex, SourceLoc rParenLoc) {
   unsigned numParams = parameters.size();
   unsigned size =
       sizeof(GradientExpr) + numParams * sizeof(AutoDiffIndexParameter);
   void *memory = ctx.Allocate(size, alignof(GradientExpr));
   return new (memory) GradientExpr(loc, lParenLoc, originalExpr, parameters,
-                                   rParenLoc);
+                                   resultIndex, rParenLoc);
 }
 
 
@@ -1155,26 +1156,26 @@ ChainableGradientExpr *
 ChainableGradientExpr::create(ASTContext &ctx, SourceLoc loc,
                               SourceLoc lParenLoc, Expr *originalExpr,
                               ArrayRef<AutoDiffIndexParameter> parameters,
-                              SourceLoc rParenLoc) {
+                              unsigned resultIndex, SourceLoc rParenLoc) {
   unsigned numParams = parameters.size();
   unsigned size = sizeof(ChainableGradientExpr)
       + numParams * sizeof(AutoDiffIndexParameter);
   void *memory = ctx.Allocate(size, alignof(ChainableGradientExpr));
   return new (memory) ChainableGradientExpr(loc, lParenLoc, originalExpr,
-                                            parameters, rParenLoc);
+                                            parameters, resultIndex, rParenLoc);
 }
 
 ValueAndGradientExpr *
 ValueAndGradientExpr::create(ASTContext &ctx, SourceLoc loc,
                              SourceLoc lParenLoc, Expr *originalExpr,
                              ArrayRef<AutoDiffIndexParameter> parameters,
-                             SourceLoc rParenLoc) {
+                             unsigned resultIndex, SourceLoc rParenLoc) {
   unsigned numParams = parameters.size();
   unsigned size =
       sizeof(ValueAndGradientExpr) + numParams * sizeof(AutoDiffIndexParameter);
   void *memory = ctx.Allocate(size, alignof(ValueAndGradientExpr));
   return new (memory) ValueAndGradientExpr(loc, lParenLoc, originalExpr,
-                                           parameters, rParenLoc);
+                                           parameters, resultIndex, rParenLoc);
 }
 
 AdjointExpr *

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3509,6 +3509,7 @@ Parser::parsePlatformVersionConstraintSpec() {
 ///   expr-gradient-body:
 ///     '('
 ///       expr
+///       (',' 'result' ':' expr-gradient-param-index)?
 ///       (',' 'wrt' ':' expr-gradient-param-list)?
 ///     ')'
 ///   expr-gradient-param-list:
@@ -3560,6 +3561,23 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
     return makeParserCodeCompletionResult<Expr>();
   if (originalFnParseResult.isParseError())
     return errorAndSkipToEnd();
+  // If found comma, parse 'result:'.
+  unsigned resultIndex = 0;
+  if (Tok.is(tok::comma) && peekToken().is(tok::identifier) &&
+      peekToken().getText() == "result") {
+    consumeToken(tok::comma);
+    consumeToken(tok::identifier);
+    // Parse 'result' ':'.
+    if (parseToken(tok::colon, diag::expected_parameter_colon))
+      return errorAndSkipToEnd();
+    // Parse '.' '<index>'.
+    SourceLoc indexLoc;
+    if (parseToken(tok::period_prefix,
+                   diag::gradient_expr_expected_result_index) ||
+        parseUnsignedInteger(resultIndex, indexLoc,
+                             diag::gradient_expr_expected_result_index))
+      return errorAndSkipToEnd();
+  }
   // If found comma, parse 'wrt:'.
   SmallVector<AutoDiffIndexParameter, 8> params;
   if (consumeIf(tok::comma)) {
@@ -3624,17 +3642,17 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
   case ExprKind::Gradient:
     result = GradientExpr::create(Context, poundGradLoc, lParenLoc,
                                   originalFnParseResult.get(), params,
-                                  rParenLoc);
+                                  resultIndex, rParenLoc);
     break;
   case ExprKind::ChainableGradient:
     result = ChainableGradientExpr::create(Context, poundGradLoc, lParenLoc,
                                            originalFnParseResult.get(), params,
-                                           rParenLoc);
+                                           resultIndex, rParenLoc);
     break;
   case ExprKind::ValueAndGradient:
     result = ValueAndGradientExpr::create(Context, poundGradLoc, lParenLoc,
                                           originalFnParseResult.get(), params,
-                                          rParenLoc);
+                                          resultIndex, rParenLoc);
     break;
   default:
     llvm_unreachable("Not a reverse AD expression");

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2849,7 +2849,7 @@ static RValue emitGradientInst(RValueEmitter &RVE, const SGFContext &C,
     loweredParamIndices.append(silParamIndices.begin(), silParamIndices.end());
   }
   SILReverseAutoDiffConfig config(
-    {/*sourceIndex*/ 0, loweredParamIndices}, options);
+      {E->getResultIndex(), loweredParamIndices}, options);
   auto gradInst =
     RVE.SGF.B.createGradient(loc, origVal.forward(RVE.SGF), config);
   ManagedValue v = RVE.SGF.emitManagedRValueWithCleanup(gradInst);

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -4160,7 +4160,7 @@ static SILFunction *lookupOrSynthesizeGradient(ADContext &context,
       args.push_back(arg);
     // If it's not seedable, we need to create a default seed.
     if (!config.isSeedable()) {
-      auto seedTy = origTy->getSingleResult().getType();
+      auto seedTy = origTy->getResults()[config.getSourceIndex()].getType();
       auto seedSILTy = SILType::getPrimitiveObjectType(seedTy);
       // Call `<seed type>.init(1)` to create a default
       // seed to feed into the canonical gradient.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7435,7 +7435,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         auto replacement =
           GradientExpr::create(tc.Context, apply->getFn()->getLoc(),
                                apply->getArg()->getStartLoc(), arg, {},
-                               apply->getArg()->getEndLoc());
+                               /*resultIndex*/ 0, apply->getArg()->getEndLoc());
         cs.setType(replacement, simplifyType(openedType));
         return replacement;
       }
@@ -7444,9 +7444,10 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         auto *tup = cast<TupleExpr>(apply->getArg());
         auto arg = tup->getElement(0);
         auto replacement =
-        ValueAndGradientExpr::create(tc.Context, apply->getFn()->getLoc(),
-                                     apply->getArg()->getStartLoc(), arg, {},
-                                     apply->getArg()->getEndLoc());
+          ValueAndGradientExpr::create(tc.Context, apply->getFn()->getLoc(),
+                                       apply->getArg()->getStartLoc(), arg, {},
+                                       /*resultIndex*/ 0,
+                                       apply->getArg()->getEndLoc());
         cs.setType(replacement, simplifyType(openedType));
         return replacement;
       }

--- a/test/AutoDiff/gradient_expr_silgen.swift
+++ b/test/AutoDiff/gradient_expr_silgen.swift
@@ -32,6 +32,11 @@ public func foo(_ x: Float, _ y: Float) -> Float {
   return x * y
 }
 
+@_silgen_name("foo2")
+public func foo2(_ x: Float, _ y: Float) -> (Float, Float) {
+  return (x, y)
+}
+
 @_silgen_name("foo_indir_ret")
 public func foo_indir_ret<T>(x: Float, y: Float, t: T) -> (T, T) {
   return (t, t)
@@ -48,7 +53,9 @@ public func foo_generic_vector_and_scalar<T : FloatingPoint, U : VectorNumeric>(
 let _ = #gradient(foo)
 let _ = #gradient(foo, wrt: .0)
 let _ = #valueAndGradient(foo)
+let _ = #gradient(foo2, result: .1)
 let _: (Float, Float, [Int]) -> (Float, Float) = #gradient(foo_indir_ret, wrt: .0, .1)
+let _: (Float, Float, [Int]) -> (Float, Float) = #gradient(foo_indir_ret, result: .1, wrt: .0, .1)
 let _: (Vector, Vector) -> (Vector, Vector) = #gradient(foo_generic_vector)
 let _: (Float, Vector) -> (Float, Vector) = #gradient(foo_generic_vector_and_scalar)
 
@@ -65,8 +72,15 @@ let _: (Float, Vector) -> (Float, Vector) = #gradient(foo_generic_vector_and_sca
 // CHECK: [[FOO_3_THICK:%.*]] = thin_to_thick_function [[FOO_3]]
 // CHECK: gradient [source 0] [wrt 0, 1] [preserving_result] [[FOO_3_THICK]] : $@callee_guaranteed (Float, Float) -> Float
 
+// CHECK: [[FOO2:%.*]] = function_ref @foo2
+// CHECK: [[FOO2_THICK:%.*]] = thin_to_thick_function [[FOO2]]
+// CHECK: gradient [source 1] [wrt 0, 1] [[FOO2_THICK]] : $@callee_guaranteed (Float, Float) -> (Float, Float)
+
 // CHECK: [[FOO_INDIR_RET:%.*]] = function_ref @foo_indir_ret
 // CHECK: gradient [source 0] [wrt 0, 1] {{%.*}} : $@callee_guaranteed (Float, Float, @guaranteed Array<Int>) -> (@owned Array<Int>, @owned Array<Int>)
+
+// CHECK: [[FOO_INDIR_RET:%.*]] = function_ref @foo_indir_ret
+// CHECK: gradient [source 1] [wrt 0, 1] {{%.*}} : $@callee_guaranteed (Float, Float, @guaranteed Array<Int>) -> (@owned Array<Int>, @owned Array<Int>)
 
 // CHECK: [[FOO_GENERIC_VECTOR:%.*]] = function_ref @foo_generic_vector
 // CHECK: gradient [source 0] [wrt 0, 1] {{%.*}} : $@callee_guaranteed (Vector, Vector) -> Vector

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -48,4 +48,12 @@ SimpleMathTests.test("FunctionCall") {
   expectEqual(3, #gradient(foo, wrt: .0)(3, 4))
 }
 
+SimpleMathTests.test("ResultSelection") {
+  func foo(_ x: Float, _ y: Float) -> (Float, Float) {
+    return (x + 1, y + 2)
+  }
+  expectEqual((1, 0), #gradient(foo, result: .0)(3, 3))
+  expectEqual((0, 1), #gradient(foo, result: .1)(3, 3))
+}
+
 runAllTests()


### PR DESCRIPTION
Update `#gradient` and `#chainableGradient` to support result selection. This unblocks some ML model development.

```swift
func foo(_ x: Float, _ y: Float) -> (Float, Float) {
  return (x + 1, y + 2)
}
_ = #gradient(foo, result: .1) // (Float, Float) -> (Float, Float)
_ = #gradient(foo, result: .0, wrt: .1) // (Float, Float) -> Float
_ = #chainableGradient(foo, result: .0, wrt: .1) // (Float, Float, Float) -> Float
```

Note: `#gradient` and related differential operators will be deprecated after [Generalized Differentiability](https://gist.github.com/rxwei/30ba75ce092ab3b0dce4bde1fc2c9f1d#part-4-generalized-differentiability).