### PR TITLE
build: split out host and target library builds fully

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -598,7 +598,6 @@ endfunction()
 #     [FORCE_BUILD_OPTIMIZED]
 #     [IS_STDLIB_CORE]
 #     [IS_SDK_OVERLAY]
-#     [FORCE_BUILD_FOR_HOST_SDK]
 #     INSTALL_IN_COMPONENT comp
 #     source1 [source2 source3 ...])
 #
@@ -668,16 +667,12 @@ endfunction()
 # INSTALL_IN_COMPONENT comp
 #   The Swift installation component that this library belongs to.
 #
-# FORCE_BUILD_FOR_HOST_SDK
-#   Regardless of the defaults, also build this library for the host SDK.
-#
 # source1 ...
 #   Sources to add into this library
 function(_add_swift_library_single target name)
   set(SWIFTLIB_SINGLE_options
         API_NOTES_NON_OVERLAY
         DONT_EMBED_BITCODE
-        FORCE_BUILD_FOR_HOST_SDK
         FORCE_BUILD_OPTIMIZED
         IS_SDK_OVERLAY
         IS_STDLIB
@@ -1457,7 +1452,6 @@ endfunction()
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]
 #     [TARGET_LIBRARY]
-#     [FORCE_BUILD_FOR_HOST_SDK]
 #     INSTALL_IN_COMPONENT comp
 #     DEPLOYMENT_VERSION_OSX version
 #     DEPLOYMENT_VERSION_IOS version
@@ -1567,16 +1561,12 @@ endfunction()
 # DEPLOYMENT_VERSION_WATCHOS
 #   The minimum deployment version to build for if this is an WATCHOS library.
 #
-# FORCE_BUILD_FOR_HOST_SDK
-#   Regardless of the defaults, also build this library for the host SDK.
-#
 # source1 ...
 #   Sources to add into this library.
 function(add_swift_target_library name)
   set(SWIFTLIB_options
         API_NOTES_NON_OVERLAY
         DONT_EMBED_BITCODE
-        FORCE_BUILD_FOR_HOST_SDK
         FORCE_BUILD_OPTIMIZED
         HAS_SWIFT_CONTENT
         IS_SDK_OVERLAY
@@ -1710,11 +1700,6 @@ function(add_swift_target_library name)
   # SDKs building the variants of this library.
   list_intersect(
       "${SWIFTLIB_TARGET_SDKS}" "${SWIFT_SDKS}" SWIFTLIB_TARGET_SDKS)
-  if(SWIFTLIB_FORCE_BUILD_FOR_HOST_SDK)
-    list_union(
-        "${SWIFTLIB_TARGET_SDKS}" "${SWIFT_HOST_VARIANT_SDK}"
-        SWIFTLIB_TARGET_SDKS)
-  endif()
 
   foreach(sdk ${SWIFTLIB_TARGET_SDKS})
     if(NOT SWIFT_SDK_${sdk}_ARCHITECTURES)
@@ -1907,7 +1892,6 @@ function(add_swift_target_library name)
         ${SWIFTLIB_IS_STDLIB_CORE_keyword}
         ${SWIFTLIB_IS_SDK_OVERLAY_keyword}
         ${SWIFTLIB_TARGET_LIBRARY_keyword}
-        ${SWIFTLIB_FORCE_BUILD_FOR_HOST_SDK_keyword}
         ${SWIFTLIB_FORCE_BUILD_OPTIMIZED_keyword}
         ${SWIFTLIB_NOSWIFTRT_keyword}
         INSTALL_IN_COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -1,5 +1,9 @@
 # Create convenience targets for the Swift standard library.
 
+# NOTE(compnerd) save the original compiler for the host swiftReflection that
+# we build
+set(HOST_CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+set(HOST_CMAKE_C_COMPILER_INITIAL ${CMAKE_C_COMPILER})
 
 if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
   if((NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang") AND
@@ -18,7 +22,7 @@ else()
     set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang++")
     set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
   endif()
-  
+
   set(CMAKE_CXX_COMPILER_ARG1 "")
   set(CMAKE_C_COMPILER_ARG1 "")
   # The sanitizers require using the same version of the compiler for

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -1,13 +1,4 @@
-set(swift_extra_sources)
-
-# When we're building with assertions, include the demangle node dumper to aid
-# in debugging.
-if (LLVM_ENABLE_ASSERTIONS)
-  list(APPEND swift_extra_sources "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
-endif(LLVM_ENABLE_ASSERTIONS)
-
-
-add_swift_target_library(swiftReflection STATIC TARGET_LIBRARY FORCE_BUILD_FOR_HOST_SDK
+set(swiftReflection_SOURCES
   MetadataSource.cpp
   TypeLowering.cpp
   TypeRef.cpp
@@ -19,9 +10,33 @@ add_swift_target_library(swiftReflection STATIC TARGET_LIBRARY FORCE_BUILD_FOR_H
   "${SWIFT_SOURCE_DIR}/lib/Demangling/ManglingUtils.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
-  "${SWIFT_SOURCE_DIR}/lib/Demangling/TypeDecoder.cpp"
-  ${swift_extra_sources}
+  "${SWIFT_SOURCE_DIR}/lib/Demangling/TypeDecoder.cpp")
+
+# When we're building with assertions, include the demangle node dumper to aid
+# in debugging.
+if (LLVM_ENABLE_ASSERTIONS)
+  list(APPEND swiftReflection_SOURCES
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
+endif(LLVM_ENABLE_ASSERTIONS)
+
+add_swift_target_library(swiftReflection STATIC TARGET_LIBRARY
+  ${swiftReflection_SOURCES}
   C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}
   LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
   INSTALL_IN_COMPONENT dev)
+
+# Build a specific version for the host with the host toolchain.  This is going
+# to be used by tools (e.g. lldb)
+
+if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
+  set(CMAKE_C_COMPILER ${HOST_CMAKE_C_COMPILER})
+  set(CMAKE_CXX_COMPILER ${HOST_CMAKE_CXX_COMPILER})
+endif()
+
+add_swift_host_library(swiftReflection STATIC
+  ${swiftReflection_SOURCES})
+target_compile_options(swiftReflection PRIVATE
+  ${SWIFT_RUNTIME_CXX_FLAGS})
+set_property(TARGET swiftReflection
+  APPEND_STRING PROPERTY LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS})
 

--- a/tools/swift-reflection-dump/CMakeLists.txt
+++ b/tools/swift-reflection-dump/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_swift_host_tool(swift-reflection-dump
   swift-reflection-dump.cpp
-  LINK_FAT_LIBRARIES
-    swiftReflection
   LLVM_COMPONENT_DEPENDS object support
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-reflection-dump
+                      PRIVATE
+                        swiftReflection)


### PR DESCRIPTION
Remove this special case handling for building a host library as a target
library.  This is the last piece needed to support cross-compiling lldb.  As a
bonus, it cleans up some of the logic in our special build system.

The way that CMake works with this is that it builds with the concept of the
target being the host.  You can invoke a sub-cmake to cross-compile the library
with the just built compiler.  Unfortunately, we do not do that and are fighting
CMake which breaks horribly with cross-compilation and platforms that are
sufficiently different.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
