### PR TITLE
Parse: Remove the fixit for curried parameter lists, its wrong anyway

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -868,7 +868,7 @@ ERROR(parameter_unnamed,none,
       "unnamed parameters must be written with the empty name '_'", ())
 
 ERROR(parameter_curry_syntax_removed,none,
-      "curried function declaration syntax has been removed; use a single parameter list", ())
+      "cannot have more than one parameter list", ())
 
 ERROR(initializer_as_typed_pattern,none,
       "unexpected initializer in pattern; did you mean to use '='?", ())

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -665,15 +665,9 @@ Parser::parseSingleParameterClause(ParameterContextKind paramContext,
 }
 
 /// Parse function arguments.
-///   func-arguments:
-///     curried-arguments | selector-arguments
-///   curried-arguments:
-///     parameter-clause+
-///   selector-arguments:
-///     '(' selector-element ')' (identifier '(' selector-element ')')+
-///   selector-element:
-///      identifier '(' pattern-atom (':' type)? ('=' expr)? ')'
 ///
+/// Emits a special diagnostic if there are multiple parameter lists,
+/// but otherwise is identical to parseSingleParameterClause().
 ParserStatus
 Parser::parseFunctionArguments(SmallVectorImpl<Identifier> &NamePieces,
                                ParameterList *&BodyParams,
@@ -687,40 +681,18 @@ Parser::parseFunctionArguments(SmallVectorImpl<Identifier> &NamePieces,
   status |= FirstParameterClause;
   BodyParams = FirstParameterClause.get();
 
-  SmallVector<ParameterList *, 2> AllParams;
-  AllParams.push_back(BodyParams);
+  bool MultipleParameterLists = false;
   while (Tok.is(tok::l_paren)) {
+    MultipleParameterLists = true;
     auto CurriedParameterClause
       = parseSingleParameterClause(ParameterContextKind::Curried);
     status |= CurriedParameterClause;
-    AllParams.push_back(CurriedParameterClause.get());
   }
 
   // If the decl uses currying syntax, complain that that syntax has gone away.
-  if (AllParams.size() > 1) {
-    SourceRange allPatternsRange(
-      BodyParams->getStartLoc(),
-      AllParams.back()->getEndLoc());
-    auto diag = diagnose(allPatternsRange.Start,
-                         diag::parameter_curry_syntax_removed);
-    diag.highlight(allPatternsRange);
-    bool seenArg = false;
-    for (unsigned i = 0; i < AllParams.size() - 1; i++) {
-      // Replace ")(" with ", ", so "(x: Int)(y: Int)" becomes
-      // "(x: Int, y: Int)". But just delete them if they're not actually
-      // separating any arguments, e.g. in "()(y: Int)".
-      StringRef replacement(", ");
-      auto *leftParamList = AllParams[i];
-      auto *rightParamList = AllParams[i + 1];
-      if (leftParamList->size() != 0)
-        seenArg = true;
-      if (!seenArg || rightParamList->size() == 0)
-        replacement = "";
-    
-      diag.fixItReplace(SourceRange(leftParamList->getEndLoc(),
-                                    rightParamList->getStartLoc()),
-                        replacement);
-    }
+  if (MultipleParameterLists) {
+    diagnose(BodyParams->getStartLoc(),
+             diag::parameter_curry_syntax_removed);
   }
 
   return status;

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -153,15 +153,15 @@ func bareTypeWithAttr(@convention(c) () -> Void) {} // expected-error{{attribute
 
 // Test fixits on curried functions.
 func testCurryFixits() {
-  func f1(_ x: Int)(y: Int) {} // expected-error{{curried function declaration syntax has been removed; use a single parameter list}} {{19-21=, }}
+  func f1(_ x: Int)(y: Int) {} // expected-error{{cannot have more than one parameter list}}
   func f1a(_ x: Int, y: Int) {}
-  func f2(_ x: Int)(y: Int)(z: Int) {} // expected-error{{curried function declaration syntax has been removed; use a single parameter list}} {{19-21=, }} {{27-29=, }}
+  func f2(_ x: Int)(y: Int)(z: Int) {} // expected-error{{cannot have more than one parameter list}}
   func f2a(_ x: Int, y: Int, z: Int) {}
-  func f3(_ x: Int)() {} // expected-error{{curried function declaration syntax has been removed; use a single parameter list}} {{19-21=}}
+  func f3(_ x: Int)() {} // expected-error{{cannot have more than one parameter list}}
   func f3a(_ x: Int) {}
-  func f4()(x: Int) {} // expected-error{{curried function declaration syntax has been removed; use a single parameter list}} {{11-13=}}
+  func f4()(x: Int) {} // expected-error{{cannot have more than one parameter list}}
   func f4a(_ x: Int) {}
-  func f5(_ x: Int)()(y: Int) {} // expected-error{{curried function declaration syntax has been removed; use a single parameter list}} {{19-21=}} {{21-23=, }}
+  func f5(_ x: Int)()(y: Int) {} // expected-error{{cannot have more than one parameter list}}
   func f5a(_ x: Int, y: Int) {}
 }
 


### PR DESCRIPTION
Fixes <rdar://problem/45274153>.