### PR TITLE
[DNM] hoist wrapping arithmetic

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -690,7 +690,7 @@ public protocol BinaryInteger :
   /// the operation.
   ///
   /// For arbitrary-width integer types where the result can never overflow,
-  /// the `overflow` field of the result should always be `false`.
+  /// the `overflow` field of the result is always `false`.
   ///
   /// - Parameter rhs: The value to subtract from this value.
   /// - Returns: A tuple containing the result of the subtraction along with a
@@ -707,7 +707,7 @@ public protocol BinaryInteger :
   /// Boolean value indicating whether overflow occurred in the operation.
   ///
   /// For arbitrary-width integer types where the result can never overflow,
-  /// the `overflow` field of the result should always be `false`.
+  /// the `overflow` field of the result is always `false`.
   ///
   /// - Parameter rhs: The value to multiply by this value.
   /// - Returns: A tuple containing the result of the multiplication along with
@@ -728,8 +728,8 @@ public protocol BinaryInteger :
   /// the result of `x.dividedReportingOverflow(by: 0)` is `(x, true)`.
   ///
   /// For arbitrary-width integer types where the result can never overflow,
-  /// the `overflow` field of the result should always be `false`, except in
-  /// the case of division by zero.
+  /// the `overflow` field of the result is always `false`, except in the case
+  /// of division by zero.
   ///
   /// - Parameter rhs: The value to divide this value by.
   /// - Returns: A tuple containing the result of the division along with a
@@ -750,8 +750,8 @@ public protocol BinaryInteger :
   /// `(x, true)`.
   ///
   /// For arbitrary-width integer types where the result can never overflow,
-  /// the `overflow` field of the result should always be `false`, except in
-  /// the case of division by zero.
+  /// the `overflow` field of the result is always `false`, except in the case
+  /// of division by zero.
   ///
   /// - Parameter rhs: The value to divide this value by.
   /// - Returns: A tuple containing the result of the operation along with a
@@ -1352,28 +1352,33 @@ extension BinaryInteger {
 //  Default implementations, which make sense only for arbitrary-size integers.
 //  These are then made unavailable on FixedWidthInteger, and concrete fixed-
 //  width types should implement them.
-  @inlinable
+  @available(*, deprecated, message:
+  "Types conforming to BinaryInteger should provide an implementation of this operation.")
   public func addingReportingOverflow(_ rhs: Self) -> (partialValue: Self, overflow: Bool) {
     return (self + rhs, false)
   }
   
-  @inlinable
+  @available(*, deprecated, message:
+  "Types conforming to BinaryInteger should provide an implementation of this operation.")
   public func subtractingReportingOverflow(_ rhs: Self) -> (partialValue: Self, overflow: Bool) {
     return (self - rhs, false)
   }
   
-  @inlinable
+  @available(*, deprecated, message:
+  "Types conforming to BinaryInteger should provide an implementation of this operation.")
   public func multipliedReportingOverflow(by rhs: Self) -> (partialValue: Self, overflow: Bool) {
     return (self * rhs, false)
   }
   
-  @inlinable
+  @available(*, deprecated, message:
+  "Types conforming to BinaryInteger should provide an implementation of this operation.")
   public func dividedReportingOverflow(by rhs: Self) -> (partialValue: Self, overflow: Bool) {
     guard rhs != 0 else { return (self, true) }
     return (self / rhs, false)
   }
   
-  @inlinable
+  @available(*, deprecated, message:
+  "Types conforming to BinaryInteger should provide an implementation of this operation.")
   public func remainderReportingOverflow(dividingBy rhs: Self) -> (partialValue: Self, overflow: Bool) {
     guard rhs != 0 else { return (self, true) }
     return (self % rhs, false)

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -671,6 +671,9 @@ public protocol BinaryInteger :
   /// Returns the sum of this value and the given value, along with a Boolean
   /// value indicating whether overflow occurred in the operation.
   ///
+  /// For arbitrary-width integer types where the result can never overflow,
+  /// the `overflow` field of the result should always be `false`.
+  ///
   /// - Parameter rhs: The value to add to this value.
   /// - Returns: A tuple containing the result of the addition along with a
   ///   Boolean value indicating whether overflow occurred. If the `overflow`
@@ -686,6 +689,9 @@ public protocol BinaryInteger :
   /// value, along with a Boolean value indicating whether overflow occurred in
   /// the operation.
   ///
+  /// For arbitrary-width integer types where the result can never overflow,
+  /// the `overflow` field of the result should always be `false`.
+  ///
   /// - Parameter rhs: The value to subtract from this value.
   /// - Returns: A tuple containing the result of the subtraction along with a
   ///   Boolean value indicating whether overflow occurred. If the `overflow`
@@ -699,6 +705,9 @@ public protocol BinaryInteger :
 
   /// Returns the product of this value and the given value, along with a
   /// Boolean value indicating whether overflow occurred in the operation.
+  ///
+  /// For arbitrary-width integer types where the result can never overflow,
+  /// the `overflow` field of the result should always be `false`.
   ///
   /// - Parameter rhs: The value to multiply by this value.
   /// - Returns: A tuple containing the result of the multiplication along with
@@ -718,6 +727,10 @@ public protocol BinaryInteger :
   /// Dividing by zero is not an error when using this method. For a value `x`,
   /// the result of `x.dividedReportingOverflow(by: 0)` is `(x, true)`.
   ///
+  /// For arbitrary-width integer types where the result can never overflow,
+  /// the `overflow` field of the result should always be `false`, except in
+  /// the case of division by zero.
+  ///
   /// - Parameter rhs: The value to divide this value by.
   /// - Returns: A tuple containing the result of the division along with a
   ///   Boolean value indicating whether overflow occurred. If the `overflow`
@@ -735,6 +748,10 @@ public protocol BinaryInteger :
   /// Dividing by zero is not an error when using this method. For a value `x`,
   /// the result of `x.remainderReportingOverflow(dividingBy: 0)` is
   /// `(x, true)`.
+  ///
+  /// For arbitrary-width integer types where the result can never overflow,
+  /// the `overflow` field of the result should always be `false`, except in
+  /// the case of division by zero.
   ///
   /// - Parameter rhs: The value to divide this value by.
   /// - Returns: A tuple containing the result of the operation along with a
@@ -1352,11 +1369,13 @@ extension BinaryInteger {
   
   @inlinable
   public func dividedReportingOverflow(by rhs: Self) -> (partialValue: Self, overflow: Bool) {
+    guard rhs != 0 else { return (self, true) }
     return (self / rhs, false)
   }
   
   @inlinable
   public func remainderReportingOverflow(dividingBy rhs: Self) -> (partialValue: Self, overflow: Bool) {
+    guard rhs != 0 else { return (self, true) }
     return (self % rhs, false)
   }
 

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1349,39 +1349,43 @@ extension BinaryInteger {
 //===--- Wrapping operators -----------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
-//  Default implementations, which make sense only for arbitrary-size integers.
-//  These are then made unavailable on FixedWidthInteger, and concrete fixed-
-//  width types should implement them.
+  //  Default implementations of overflow arithmetic functions to preserve
+  //  source-compatability. These simply fatalError() because it's impossible
+  //  to provide an implementation that's always correct with the semantics of
+  //  BinaryInteger.
+  //
+  //  If called concretely, these will produce a warning at compile-time and an
+  //  error at run-time. If called from code generic on BinaryInteger, they will
+  //  only produce a run-time error.
+  
   @available(*, deprecated, message:
-  "Types conforming to BinaryInteger should provide an implementation of this operation.")
+  "Types conforming to BinaryInteger should implement addingReportingOverflow(_:Self).")
   public func addingReportingOverflow(_ rhs: Self) -> (partialValue: Self, overflow: Bool) {
-    return (self + rhs, false)
+    fatalError("Types conforming to BinaryInteger should implement addingReportingOverflow(_:Self).")
   }
   
   @available(*, deprecated, message:
-  "Types conforming to BinaryInteger should provide an implementation of this operation.")
+  "Types conforming to BinaryInteger should implement subtractingReportingOverflow(_:Self).")
   public func subtractingReportingOverflow(_ rhs: Self) -> (partialValue: Self, overflow: Bool) {
-    return (self - rhs, false)
+    fatalError("Types conforming to BinaryInteger should implement subtractingReportingOverflow(_:Self).")
   }
   
   @available(*, deprecated, message:
-  "Types conforming to BinaryInteger should provide an implementation of this operation.")
+  "Types conforming to BinaryInteger should implement multipliedReportingOverflow(by:Self).")
   public func multipliedReportingOverflow(by rhs: Self) -> (partialValue: Self, overflow: Bool) {
-    return (self * rhs, false)
+    fatalError("Types conforming to BinaryInteger should implement multipliedReportingOverflow(by:Self).")
   }
   
   @available(*, deprecated, message:
-  "Types conforming to BinaryInteger should provide an implementation of this operation.")
+  "Types conforming to BinaryInteger should implement dividedReportingOverflow(by:Self).")
   public func dividedReportingOverflow(by rhs: Self) -> (partialValue: Self, overflow: Bool) {
-    guard rhs != 0 else { return (self, true) }
-    return (self / rhs, false)
+    fatalError("Types conforming to BinaryInteger should implement dividedReportingOverflow(by:Self).")
   }
   
   @available(*, deprecated, message:
-  "Types conforming to BinaryInteger should provide an implementation of this operation.")
+  "Types conforming to BinaryInteger should implement remainderReportingOverflow(dividingBy:Self).")
   public func remainderReportingOverflow(dividingBy rhs: Self) -> (partialValue: Self, overflow: Bool) {
-    guard rhs != 0 else { return (self, true) }
-    return (self % rhs, false)
+    fatalError("Types conforming to BinaryInteger should implement remainderReportingOverflow(dividingBy:Self).")
   }
 
   /// Returns the sum of the two given values, wrapping the result in case of

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3294,29 +3294,36 @@ extension FixedWidthInteger {
   }
   
   //  Default implementations, which override the BinaryInteger implementations
-  //  and make them unavailable, because they would be incorrect for any
-  //  FixedWidthInteger type. Concrete types must implement these operations.
-  @available(*, unavailable, message: "Concrete types must implement this operation.")
+  //  and make them unavailable; we can do this because these operations have
+  //  always been requirements of FixedWidthInteger, but they were added to
+  //  BinaryInteger after source stability was declared.
+  
+  @available(*, unavailable, message:
+  "Types conforming to FixedWidthInteger must implement addingReportingOverflow(_:Self).")
   public func addingReportingOverflow(_ rhs: Self) -> (partialValue: Self, overflow: Bool) {
     fatalError()
   }
   
-  @available(*, unavailable, message: "Concrete types must implement this operation.")
+  @available(*, unavailable, message:
+  "Types conforming to FixedWidthInteger must implement subtractingReportingOverflow(_:Self).")
   public func subtractingReportingOverflow(_ rhs: Self) -> (partialValue: Self, overflow: Bool) {
     fatalError()
   }
   
-  @available(*, unavailable, message: "Concrete types must implement this operation.")
+  @available(*, unavailable, message:
+  "Types conforming to FixedWidthInteger must implement multipliedReportingOverflow(by:Self).")
   public func multipliedReportingOverflow(by rhs: Self) -> (partialValue: Self, overflow: Bool) {
     fatalError()
   }
   
-  @available(*, unavailable, message: "Concrete types must implement this operation.")
+  @available(*, unavailable, message:
+  "Types conforming to FixedWidthInteger must implement dividedReportingOverflow(by:Self).")
   public func dividedReportingOverflow(by rhs: Self) -> (partialValue: Self, overflow: Bool) {
     fatalError()
   }
   
-  @available(*, unavailable, message: "Concrete types must implement this operation.")
+  @available(*, unavailable, message:
+  "Types conforming to FixedWidthInteger must implement remainderReportingOverflow(dividingBy:Self).")
   public func remainderReportingOverflow(dividingBy rhs: Self) -> (partialValue: Self, overflow: Bool) {
     fatalError()
   }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -14,9 +14,19 @@ Func AnyHashable._downCastConditional(into:) has been removed
 Func Collection.prefix(through:) has been removed
 Func Collection.prefix(upTo:) has been removed
 Func Collection.suffix(from:) has been removed
+Func FixedWidthInteger.&*(_:_:) has been removed
+Func FixedWidthInteger.&*=(_:_:) has been removed
+Func FixedWidthInteger.&+(_:_:) has been removed
+Func FixedWidthInteger.&+=(_:_:) has been removed
+Func FixedWidthInteger.&-(_:_:) has been removed
+Func FixedWidthInteger.&-=(_:_:) has been removed
 Func Sequence.filter(_:) has been removed
 Func Sequence.forEach(_:) has been removed
 Func Sequence.map(_:) has been removed
+Func SignedInteger.&+(_:_:) has been removed
+Func SignedInteger.&-(_:_:) has been removed
+Func SignedInteger._maskingAdd(_:_:) has been removed
+Func SignedInteger._maskingSubtract(_:_:) has been removed
 Func _BridgeStorage.isNativeWithClearedSpareBits(_:) has been removed
 Func _BridgeStorage.isUniquelyReferenced_native_noSpareBits() has been removed
 Func _CocoaDictionary.Index.copy() has been removed
@@ -90,3 +100,8 @@ Var _CocoaSet.Index._storage in a non-resilient type changes position from 1 to 
 /* Decl Attribute changes */
 
 /* Protocol Requirement Changes */
+Func BinaryInteger.addingReportingOverflow(_:) has been added as a protocol requirement
+Func BinaryInteger.dividedReportingOverflow(by:) has been added as a protocol requirement
+Func BinaryInteger.multipliedReportingOverflow(by:) has been added as a protocol requirement
+Func BinaryInteger.remainderReportingOverflow(dividingBy:) has been added as a protocol requirement
+Func BinaryInteger.subtractingReportingOverflow(_:) has been added as a protocol requirement

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -7,9 +7,22 @@
 Func Collection.prefix(through:) has been removed
 Func Collection.prefix(upTo:) has been removed
 Func Collection.suffix(from:) has been removed
+Func FixedWidthInteger.&*(_:_:) has been removed
+Func FixedWidthInteger.&*=(_:_:) has been removed
+Func FixedWidthInteger.&+(_:_:) has been removed
+Func FixedWidthInteger.&+=(_:_:) has been removed
+Func FixedWidthInteger.&-(_:_:) has been removed
+Func FixedWidthInteger.&-=(_:_:) has been removed
+Func FixedWidthInteger.addingReportingOverflow(_:) has been removed
+Func FixedWidthInteger.dividedReportingOverflow(by:) has been removed
+Func FixedWidthInteger.multipliedReportingOverflow(by:) has been removed
+Func FixedWidthInteger.remainderReportingOverflow(dividingBy:) has been removed
+Func FixedWidthInteger.subtractingReportingOverflow(_:) has been removed
 Func Sequence.filter(_:) has been removed
 Func Sequence.forEach(_:) has been removed
 Func Sequence.map(_:) has been removed
+Func SignedInteger.&+(_:_:) has been removed
+Func SignedInteger.&-(_:_:) has been removed
 Func _SequenceWrapper.filter(_:) has been removed
 Func _SequenceWrapper.forEach(_:) has been removed
 Func _SequenceWrapper.map(_:) has been removed
@@ -36,3 +49,8 @@ Var Set.first has been removed
 /* Decl Attribute changes */
 
 /* Protocol Requirement Changes */
+Func BinaryInteger.addingReportingOverflow(_:) has been added as a protocol requirement
+Func BinaryInteger.dividedReportingOverflow(by:) has been added as a protocol requirement
+Func BinaryInteger.multipliedReportingOverflow(by:) has been added as a protocol requirement
+Func BinaryInteger.remainderReportingOverflow(dividingBy:) has been added as a protocol requirement
+Func BinaryInteger.subtractingReportingOverflow(_:) has been added as a protocol requirement

--- a/test/stdlib/IntegerRenames4.swift
+++ b/test/stdlib/IntegerRenames4.swift
@@ -30,8 +30,3 @@ func _signedInteger<T : _SignedInteger>(x: T) {} // expected-error {{'_SignedInt
 func absolutaValuable<T : SignedNumeric & Comparable>(x: T) {
   _ = T.abs(x) // expected-error {{use the 'abs(_:)' free function}}
 }
-
-func signedIntegerMaskingArithmetics<T : SignedInteger>(x: T) {
-  _ = x &+ x // expected-error {{use 'FixedWidthInteger' instead of 'SignedInteger' to get '&+' in generic code}}
-  _ = x &- x // expected-error {{use 'FixedWidthInteger' instead of 'SignedInteger' to get '&-' in generic code}}
-}


### PR DESCRIPTION
It turns out that some generic code is nicer to write if the "wrapping" arithmetic operations are available on `BinaryInteger` and not just `FixedWidthInteger` (even though some types conforming to `BinaryInteger` will never actually overflow or wrap).

Requires evolution proposal, so DNM. Annoyingly has to be done before ABI stability, because while it's possible to *add* requirements with defaults, you cannot *move* a requirement up the hierarchy while maintaining stability.

https://bugs.swift.org/browse/SR-4924