### PR TITLE
fix crasher when passing LValue to #tfop

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2405,11 +2405,9 @@ namespace {
     }
 
     // SWIFT_ENABLE_TENSORFLOW
-    /// When we've type checked a #tfop expression, we do some adjustment to the
-    /// argument types.  Specifically, if an argument type conforms to
-    /// TensorProtocol (like Tensor or TensorElementLiteral), we use the
-    /// TensorHandle that they contain instead.
     Expr *visitTFOp(ObjectLiteralExpr *expr) {
+      // All #tfop operands are RValues.
+      expr->setArg(cs.coerceToRValue(expr->getArg()));
       return expr;
     }
 

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -427,3 +427,10 @@ public func b118507040() {
   getLogpLex()
   _ = Tensor<Float>(1.0)
 }
+
+// Make sure that #tfop can deal with operands that are LValues.
+func tfopLValueOperand() -> Tensor<Float> {
+  var t = Tensor<Float>(0)
+  t = #tfop("Add", t, Tensor<Float>(1), T$dtype: Float.tensorFlowDataType)
+  return t
+}


### PR DESCRIPTION
`#tfop` SILGen expects all operands to be RValues. But it's possible to write code passing an LValue to a `#tfop`. This PR adds a `coerceToRValue` in CSApply, which seems to be the standard way that other expressions make sure their arguments are RValues.

Also I removed an outdated comment that I noticed.