### PR TITLE
[ParseableInterface] Add module arguments if using supplemental output maps

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -284,7 +284,7 @@ def module_name_EQ : Joined<["-"], "module-name=">, Flags<[FrontendOption]>,
   Alias<module_name>;
 
 def module_link_name : Separate<["-"], "module-link-name">,
-  Flags<[FrontendOption]>,
+  Flags<[FrontendOption, ParseableInterfaceOption]>,
   HelpText<"Library to link against when using this module">;
 def module_link_name_EQ : Joined<["-"], "module-link-name=">,
   Flags<[FrontendOption]>, Alias<module_link_name>;

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -507,14 +507,16 @@ createFromTypeToPathMap(const TypeToPathMap *map) {
 
 Optional<std::vector<SupplementaryOutputPaths>>
 SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
-  if (Arg *A = Args.getLastArg(options::OPT_emit_objc_header_path,
-                               options::OPT_emit_module_path,
-                               options::OPT_emit_module_doc_path,
-                               options::OPT_emit_dependencies_path,
-                               options::OPT_emit_reference_dependencies_path,
-                               options::OPT_serialize_diagnostics_path,
-                               options::OPT_emit_loaded_module_trace_path,
-                               options::OPT_emit_tbd_path)) {
+  if (Arg *A = Args.getLastArg(
+        options::OPT_emit_objc_header_path,
+        options::OPT_emit_module_path,
+        options::OPT_emit_module_doc_path,
+        options::OPT_emit_dependencies_path,
+        options::OPT_emit_reference_dependencies_path,
+        options::OPT_serialize_diagnostics_path,
+        options::OPT_emit_loaded_module_trace_path,
+        options::OPT_emit_parseable_module_interface_path,
+        options::OPT_emit_tbd_path)) {
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_have_supplementary_outputs,
                    A->getSpelling(), "-supplementary-output-file-map");

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -159,9 +159,9 @@ static void PrintArg(raw_ostream &OS, const char *Arg, StringRef TempDir) {
 /// Save a copy of any flags marked as ParseableInterfaceOption, if running
 /// in a mode that is going to emit a .swiftinterface file.
 static void SaveParseableInterfaceArgs(ParseableInterfaceOptions &Opts,
+                                       FrontendOptions &FOpts,
                                        ArgList &Args, DiagnosticEngine &Diags) {
-  if (!Args.hasArg(options::OPT_emit_interface_path) &&
-      !Args.hasArg(options::OPT_emit_parseable_module_interface_path))
+  if (!FOpts.InputsAndOutputs.hasParseableInterfaceOutputPath())
     return;
   ArgStringList RenderedArgs;
   for (auto A : Args) {
@@ -1188,12 +1188,13 @@ bool CompilerInvocation::parseArgs(
     return true;
   }
 
-  SaveParseableInterfaceArgs(ParseableInterfaceOpts, ParsedArgs, Diags);
-
   if (ParseFrontendArgs(FrontendOpts, ParsedArgs, Diags,
                         ConfigurationFileBuffers)) {
     return true;
   }
+
+  SaveParseableInterfaceArgs(ParseableInterfaceOpts, FrontendOpts,
+                             ParsedArgs, Diags);
 
   if (ParseLangArgs(LangOpts, ParsedArgs, Diags, FrontendOpts)) {
     return true;

--- a/test/Driver/emit-interface.swift
+++ b/test/Driver/emit-interface.swift
@@ -19,3 +19,21 @@
 // CHECK-EXPLICIT-PATH: swift -frontend
 // CHECK-EXPLICIT-PATH-SAME: emit-interface.swift
 // CHECK-EXPLICIT-PATH-SAME: -emit-parseable-module-interface-path {{.+}}/unrelated.swiftinterface
+
+// Ensure that we emit arguments when we force filelists as well
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-parseable-module-interface -o %t/foo -module-name foo -force-single-frontend-invocation -driver-filelist-threshold=0 2>&1 | %FileCheck -check-prefix=CHECK-FILELIST %s
+
+// CHECK-FILELIST: swift -frontend
+// CHECK-FILELIST-SAME: -supplementary-output-file-map
+// CHECK-FILELIST-NOT: emit-interface.swift{{ }}
+
+
+// Actually run this and make sure the flags show up in the interface
+
+// RUN: %swiftc_driver -target x86_64-apple-macosx10.9 %s -emit-parseable-module-interface -o %t/foo -module-name foo -force-single-frontend-invocation -driver-filelist-threshold=0 2>&1
+// RUN: %FileCheck %s < %t/foo.swiftinterface --check-prefix CHECK-FILELIST-INTERFACE
+
+// CHECK-FILELIST-INTERFACE: swift-module-flags:
+// CHECK-FILELIST-INTERFACE-SAME: -target x86_64-apple-macosx10.9
+// CHECK-FILELIST-INTERFACE-SAME: -module-name foo
+

--- a/test/Driver/emit-interface.swift
+++ b/test/Driver/emit-interface.swift
@@ -26,14 +26,3 @@
 // CHECK-FILELIST: swift -frontend
 // CHECK-FILELIST-SAME: -supplementary-output-file-map
 // CHECK-FILELIST-NOT: emit-interface.swift{{ }}
-
-
-// Actually run this and make sure the flags show up in the interface
-
-// RUN: %swiftc_driver -target x86_64-apple-macosx10.9 %s -emit-parseable-module-interface -o %t/foo -module-name foo -force-single-frontend-invocation -driver-filelist-threshold=0 2>&1
-// RUN: %FileCheck %s < %t/foo.swiftinterface --check-prefix CHECK-FILELIST-INTERFACE
-
-// CHECK-FILELIST-INTERFACE: swift-module-flags:
-// CHECK-FILELIST-INTERFACE-SAME: -target x86_64-apple-macosx10.9
-// CHECK-FILELIST-INTERFACE-SAME: -module-name foo
-

--- a/test/ParseableInterface/option-preservation.swift
+++ b/test/ParseableInterface/option-preservation.swift
@@ -1,6 +1,18 @@
+// RUN: %empty-directory(%t)
+
 // RUN: %target-swift-frontend -enable-resilience -emit-parseable-module-interface-path %t.swiftinterface -module-name t %s -emit-module -o /dev/null
 // RUN: %FileCheck %s < %t.swiftinterface -check-prefix=CHECK-SWIFTINTERFACE
 //
 // CHECK-SWIFTINTERFACE: {{swift-module-flags:.* -enable-resilience}}
+
+// Make sure flags show up when filelists are enabled
+
+// RUN: %target-build-swift %s -driver-filelist-threshold=0 -emit-parseable-module-interface -o %t/foo -module-name foo -module-link-name fooCore -force-single-frontend-invocation 2>&1
+// RUN: %FileCheck %s < %t/foo.swiftinterface --check-prefix CHECK-FILELIST-INTERFACE
+
+// CHECK-FILELIST-INTERFACE: swift-module-flags:
+// CHECK-FILELIST-INTERFACE-SAME: -target
+// CHECK-FILELIST-INTERFACE-SAME: -module-link-name fooCore
+// CHECK-FILELIST-INTERFACE-SAME: -module-name foo
 
 public func foo() { }


### PR DESCRIPTION
Currently, the check for whether to serialize parseable interface
arguments doesn't handle the case where a supplementary output file map
is used, preferring only to check if the frontend is passed
`-emit*interface`. Instead, check if the frontend inputs and outputs
contains a parseable interface, and use that to determine if we need to
save args.

This also puts `-module-link-name` in the parseable interface arg list.

Needs tests.