### PR TITLE
IRGen: Use @_weakLinked to test backward deployment of resilient protocols

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -359,9 +359,8 @@ DECL_ATTR(_clangImporterSynthesizedType, ClangImporterSynthesizedType,
   LongAttribute | RejectByParser | UserInaccessible |
   NotSerialized, 74)
 SIMPLE_DECL_ATTR(_weakLinked, WeakLinked,
-  OnNominalType | OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor |
-  OnEnumElement |
-  UserInaccessible,
+  OnNominalType | OnAssociatedType | OnFunc | OnAccessor | OnVar |
+  OnSubscript | OnConstructor | OnEnumElement | UserInaccessible,
   75)
 SIMPLE_DECL_ATTR(_frozen, Frozen,
   OnEnum |

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -919,23 +919,7 @@ public:
   }
 
   /// Determine whether this entity will be weak-imported.
-  bool isWeakImported(ModuleDecl *module) const {
-    if (getKind() == Kind::SILGlobalVariable &&
-        getSILGlobalVariable()->getDecl())
-      return getSILGlobalVariable()->getDecl()->isWeakImported(module);
-
-    if (getKind() == Kind::SILFunction) {
-      if (auto clangOwner = getSILFunction()->getClangNodeOwner())
-        return clangOwner->isWeakImported(module);
-      if (getSILFunction()->isWeakLinked())
-        return getSILFunction()->isAvailableExternally();
-    }
-
-    if (!isDeclKind(getKind()))
-      return false;
-
-    return getDecl()->isWeakImported(module);
-  }
+  bool isWeakImported(ModuleDecl *module) const;
   
   /// Return the source file whose codegen should trigger emission of this
   /// link entity, if one can be identified.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -551,6 +551,12 @@ bool Decl::isWeakImported(ModuleDecl *fromModule) const {
   if (getAttrs().hasAttribute<WeakLinkedAttr>())
     return true;
 
+  if (auto *accessor = dyn_cast<AccessorDecl>(this))
+    return accessor->getStorage()->isWeakImported(fromModule);
+
+  if (auto *dtor = dyn_cast<DestructorDecl>(this))
+    return cast<ClassDecl>(dtor->getDeclContext())->isWeakImported(fromModule);
+
   // FIXME: Also check availability when containingModule is resilient.
   return false;
 }

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -57,9 +57,6 @@ static void addFunctionAttributes(SILFunction *F, DeclAttributes &Attrs,
   // @_silgen_name and @_cdecl functions may be called from C code somewhere.
   if (Attrs.hasAttribute<SILGenNameAttr>() || Attrs.hasAttribute<CDeclAttr>())
     F->setHasCReferences(true);
-
-  if (Attrs.hasAttribute<WeakLinkedAttr>())
-    F->setWeakLinked();
 }
 
 SILFunction *
@@ -114,6 +111,9 @@ SILFunctionBuilder::getOrCreateFunction(SILLocation loc, SILDeclRef constant,
 
     if (constant.isForeign && decl->hasClangNode())
       F->setClangNodeOwner(decl);
+
+    if (decl->isWeakImported(/*fromModule=*/nullptr))
+      F->setWeakLinked();
 
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
       auto *storage = accessor->getStorage();

--- a/test/IRGen/Inputs/weak_import_native_helper.swift
+++ b/test/IRGen/Inputs/weak_import_native_helper.swift
@@ -103,3 +103,15 @@ public enum GenericE<T> {}
 
 @_weakLinked
 open class GenericC<T> {}
+
+public protocol OtherProtocol {}
+public struct ConcreteType : OtherProtocol {}
+
+public protocol ProtocolWithWeakMembers {
+  @_weakLinked associatedtype T : OtherProtocol = ConcreteType
+  @_weakLinked func f()
+}
+
+extension ProtocolWithWeakMembers {
+  @_weakLinked public func f() {}
+}

--- a/test/IRGen/weak_import_native.swift
+++ b/test/IRGen/weak_import_native.swift
@@ -5,6 +5,12 @@
 
 import weak_import_native_helper
 
+// CHECK-DAG: @"$s25weak_import_native_helper23ProtocolWithWeakMembersP1TAC_AA05OtherE0Tn" = extern_weak global %swift.protocol_requirement
+// CHECK-DAG: @"$s1T25weak_import_native_helper23ProtocolWithWeakMembersPTl" = extern_weak global %swift.protocol_requirement
+// CHECK-DAG: @"$s25weak_import_native_helper23ProtocolWithWeakMembersP1fyyFTq" = extern_weak global %swift.method_descriptor
+// CHECK-DAG: declare extern_weak swiftcc void @"$s25weak_import_native_helper23ProtocolWithWeakMembersPAAE1fyyF"(%swift.type*, i8**, %swift.opaque* noalias nocapture swiftself)
+struct ConformsToProtocolWithWeakMembers : ProtocolWithWeakMembers {}
+
 func testTopLevel() {
   // CHECK-DAG: declare extern_weak {{.+}} @"$s25weak_import_native_helper2fnyyF"()
   fn()
@@ -52,10 +58,16 @@ func testStruct() {
 }
 
 func testEnum() {
-  // FIXME: We're still referencing tags directly.
+  // CHECK-DAG: @"$s25weak_import_native_helper1EO6strongyA2CmFWC" = external constant i32
   _ = E.strong
+
+  // CHECK-DAG: @"$s25weak_import_native_helper1EO0A0yA2CmFWC" = extern_weak constant i32
   _ = E.weak
+
+  // CHECK-DAG: @"$s25weak_import_native_helper1EO11strongAssocyACSicACmFWC" = external constant i32
   _ = E.strongAssoc(0)
+
+  // CHECK-DAG: @"$s25weak_import_native_helper1EO0A5AssocyACSicACmFWC" = extern_weak constant i32
   _ = E.weakAssoc(0)
 }
 
@@ -66,25 +78,23 @@ func testClass() {
   // CHECK-DAG: declare extern_weak {{.+}} @"$s25weak_import_native_helper1CC2fnyyFTj"
   c.fn()
 
-  // FIXME: vtable dispatch functions for accessors should also be weak
-
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1CC10storedPropSivgTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1CC10storedPropSivsTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1CC10storedPropSivMTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1CC10storedPropSivgTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1CC10storedPropSivsTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1CC10storedPropSivMTj"
   let x = c.storedProp
   c.storedProp = x
   c.storedProp += 1
 
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1CC12computedPropSivgTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1CC12computedPropSivsTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1CC12computedPropSivMTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1CC12computedPropSivgTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1CC12computedPropSivsTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1CC12computedPropSivMTj"
   let y = c.computedProp
   c.computedProp = y
   c.computedProp += 1
 
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1CCyS2icigTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1CCyS2icisTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1CCyS2iciMTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1CCyS2icigTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1CCyS2icisTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1CCyS2iciMTj"
   let z = c[0]
   c[0] = z
   c[0] += 1
@@ -104,18 +114,16 @@ func testProtocolExistential(_ p: P) {
   // CHECK-DAG: declare extern_weak {{.+}} @"$s25weak_import_native_helper1PP2fnyyFTj"
   p.fn()
 
-  // FIXME: witness table dispatch functions for accessors should also be weak
-
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1PP4propSivgTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1PP4propSivsTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1PP4propSivMTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1PP4propSivgTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1PP4propSivsTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1PP4propSivMTj"
   let x = p.prop
   mutP.prop = x
   mutP.prop += 1
 
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1PPyS2icigTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1PPyS2icisTj"
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper1PPyS2iciMTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1PPyS2icigTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1PPyS2icisTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper1PPyS2iciMTj"
   let z = p[0]
   mutP[0] = z
   mutP[0] += 1
@@ -137,27 +145,24 @@ func testProtocolGeneric<Impl: P>(_ type: Impl.Type) {
 }
 
 func testWeakTypes() -> [Any.Type] {
-  // FIXME: These should be weak.
-  // CHECK-DAG: declare swiftcc %swift.metadata_response @"$s25weak_import_native_helper5WeakSVMa"
-  // CHECK-DAG: declare swiftcc %swift.metadata_response @"$s25weak_import_native_helper5WeakEOMa"
-  // CHECK-DAG: declare swiftcc %swift.metadata_response @"$s25weak_import_native_helper5WeakCCMa"
+  // CHECK-DAG: declare extern_weak swiftcc %swift.metadata_response @"$s25weak_import_native_helper5WeakSVMa"
+  // CHECK-DAG: declare extern_weak swiftcc %swift.metadata_response @"$s25weak_import_native_helper5WeakEOMa"
+  // CHECK-DAG: declare extern_weak swiftcc %swift.metadata_response @"$s25weak_import_native_helper5WeakCCMa"
   // CHECK-DAG: @"$s25weak_import_native_helper5WeakPMp" = extern_weak global %swift.protocol
-  // CHECK-DAG: declare swiftcc %swift.metadata_response @"$s25weak_import_native_helper8GenericSVMa"
-  // CHECK-DAG: declare swiftcc %swift.metadata_response @"$s25weak_import_native_helper8GenericEOMa"
-  // CHECK-DAG: declare swiftcc %swift.metadata_response @"$s25weak_import_native_helper8GenericCCMa"
+  // CHECK-DAG: declare extern_weak swiftcc %swift.metadata_response @"$s25weak_import_native_helper8GenericSVMa"
+  // CHECK-DAG: declare extern_weak swiftcc %swift.metadata_response @"$s25weak_import_native_helper8GenericEOMa"
+  // CHECK-DAG: declare extern_weak swiftcc %swift.metadata_response @"$s25weak_import_native_helper8GenericCCMa"
   return [WeakS.self, WeakE.self, WeakC.self, WeakP.self, GenericS<Int>.self, GenericE<Int>.self, GenericC<Int>.self]
 }
 
 class WeakSub: WeakC {
   deinit {
-    // FIXME: This should be weak.
-    // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper5WeakCCfd"
+    // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper5WeakCCfd"
   }
 }
 
 class WeakGenericSub: GenericC<Int> {
   deinit {
-    // FIXME: This should be weak.
-    // CHECK-DAG: declare swiftcc {{.+}} @"$s25weak_import_native_helper8GenericCCfd"
+    // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s25weak_import_native_helper8GenericCCfd"
   }
 }

--- a/validation-test/Evolution/Inputs/protocol_add_requirements.swift
+++ b/validation-test/Evolution/Inputs/protocol_add_requirements.swift
@@ -19,7 +19,7 @@ public protocol AddMethodsProtocol {
   func unimportantOperation() -> Element
 
 #if AFTER
-  func uselessOperation() -> Element
+  @_weakLinked func uselessOperation() -> Element
 #endif
 }
 
@@ -29,7 +29,7 @@ extension AddMethodsProtocol {
   }
 
 #if AFTER
-  public func uselessOperation() -> Element {
+  @_weakLinked public func uselessOperation() -> Element {
     return unimportantOperation().increment()
   }
 #endif
@@ -56,12 +56,12 @@ public protocol AddConstructorsProtocol {
   init(name: String)
 
 #if AFTER
-  init?(nickname: String)
+  @_weakLinked init?(nickname: String)
 #endif
 }
 
 extension AddConstructorsProtocol {
-  public init?(nickname: String) {
+  @_weakLinked public init?(nickname: String) {
     if nickname == "" {
       return nil
     }
@@ -85,15 +85,15 @@ public protocol AddPropertiesProtocol {
   var maxRPM: Int { get set }
 
 #if AFTER
-  var maxSafeSpeed: Int { get set }
-  var minSafeSpeed: Int { get nonmutating set }
-  var redLine: Int { mutating get set }
+  @_weakLinked var maxSafeSpeed: Int { get set }
+  @_weakLinked var minSafeSpeed: Int { get nonmutating set }
+  @_weakLinked var redLine: Int { mutating get set }
 #endif
 }
 
 extension AddPropertiesProtocol {
 #if AFTER
-  public var maxSafeSpeed: Int {
+  @_weakLinked public var maxSafeSpeed: Int {
     get {
       return topSpeed / 2
     }
@@ -102,7 +102,7 @@ extension AddPropertiesProtocol {
     }
   }
 
-  public var minSafeSpeed: Int {
+  @_weakLinked public var minSafeSpeed: Int {
     get {
       return topSpeed / 4
     }
@@ -111,7 +111,7 @@ extension AddPropertiesProtocol {
     }
   }
 
-  public var redLine: Int {
+  @_weakLinked public var redLine: Int {
     get {
       return maxRPM - 2000
     }
@@ -153,12 +153,12 @@ public protocol AddSubscriptProtocol {
   mutating func set(key key: Key, value: Value)
 
 #if AFTER
-  subscript(key: Key) -> Value { get set }
+  @_weakLinked subscript(key: Key) -> Value { get set }
 #endif
 }
 
 extension AddSubscriptProtocol {
-  public subscript(key: Key) -> Value {
+  @_weakLinked public subscript(key: Key) -> Value {
     get {
       return get(key: key)
     }
@@ -188,8 +188,8 @@ public struct Wrapper<T>: SimpleProtocol {
 
 public protocol AddAssocTypesProtocol {
 #if AFTER
-  associatedtype AssocType = Self
-  associatedtype AssocType2: SimpleProtocol = Wrapper<AssocType>
+  @_weakLinked associatedtype AssocType = Self
+  @_weakLinked associatedtype AssocType2: SimpleProtocol = Wrapper<AssocType>
 #endif
 }
 

--- a/validation-test/Evolution/test_protocol_add_requirements.swift
+++ b/validation-test/Evolution/test_protocol_add_requirements.swift
@@ -1,4 +1,4 @@
-// RUN: %target-resilience-test --no-backward-deployment
+// RUN: %target-resilience-test
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/Evolution/test_protocol_reorder_requirements.swift
+++ b/validation-test/Evolution/test_protocol_reorder_requirements.swift
@@ -1,4 +1,4 @@
-// RUN: %target-resilience-test --no-backward-deployment
+// RUN: %target-resilience-test
 // REQUIRES: executable_test
 
 import StdlibUnittest


### PR DESCRIPTION
Get the attribute working for more link entity kinds, which addresses
all the FIXME:s in the original test case.

Now the protocol resilience tests can be updated to use @_weakLinked
for all newly-added protocol requirements and default implementations.

This allows the tests to pass in the backward deployment test scenario
as well.

Eventually this will be based on availability instead of a special
attribute.

This completes <rdar://problem/29888071>.