### PR TITLE
Improve the interfaces for working with integer widths

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -789,10 +789,12 @@ public:
   static IntegerLiteralExpr *
   createFromUnsigned(ASTContext &C, unsigned value);
 
+  /// Returns the value of the literal, appropriately constructed in the
+  /// target type.
   APInt getValue() const;
-  static APInt getValue(StringRef Text, unsigned BitWidth, bool Negative);
 
-  APInt getRawMagnitude() const;
+  /// Returns the raw value of the literal without any truncation.
+  APInt getRawValue() const;
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::IntegerLiteral;

--- a/include/swift/Basic/APIntMap.h
+++ b/include/swift/Basic/APIntMap.h
@@ -1,0 +1,54 @@
+//===--- APIntMap.h - A map with APInts as the keys -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// LLVM does not allow arbitrary APInts to be the keys of a DenseMap because
+// APInts are only comparable if they have the same bit-width.  This map
+// implementation assumes that its keys will always be constrained to their
+// minimum width, so it's not a general-purpose structure, but it does work.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_APINTMAP_H
+#define SWIFT_BASIC_APINTMAP_H
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/DenseMap.h"
+#include "swift/Basic/LLVM.h"
+
+namespace swift {
+
+struct WidthPreservingAPIntDenseMapInfo {
+  // For the special values, we use -1 with a bit-width that isn't minimal
+  // for the value, then use a parser that always produces values with
+  // minimal bit-widths so that we don't get a conflict.
+  static inline APInt getEmptyKey() {
+    return APInt::getAllOnesValue(/*bitwidth*/2);
+  }
+  static inline APInt getTombstoneKey() {
+    return APInt::getAllOnesValue(/*bitwidth*/3);
+  }
+
+  static unsigned getHashValue(const APInt &Key) {
+    return static_cast<unsigned>(hash_value(Key));
+  }
+
+  static bool isEqual(const APInt &LHS, const APInt &RHS) {
+    return LHS.getBitWidth() == RHS.getBitWidth() && LHS == RHS;
+  }
+};
+
+template <class Value>
+using APIntMap = llvm::DenseMap<APInt, Value, WidthPreservingAPIntDenseMapInfo>;
+
+}
+
+#endif

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3032,6 +3032,7 @@ Type ErrorType::get(Type originalType) {
 
 BuiltinIntegerType *BuiltinIntegerType::get(BuiltinIntegerWidth BitWidth,
                                             const ASTContext &C) {
+  assert(!BitWidth.isArbitraryWidth());
   BuiltinIntegerType *&Result = C.getImpl().IntegerTypes[BitWidth];
   if (Result == nullptr)
     Result = new (C, AllocationArena::Permanent) BuiltinIntegerType(BitWidth,C);

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -849,46 +849,81 @@ IntegerLiteralExpr * IntegerLiteralExpr::createFromUnsigned(ASTContext &C, unsig
   return new (C) IntegerLiteralExpr(Text, SourceLoc(), /*implicit*/ true);
 }
 
-/// A wrapper around LLVM::getAsInteger that can be used on Swift interger
-/// literals. It avoids misinterpreting decimal numbers prefixed with 0 as
-/// octal numbers.
-static bool getAsInteger(StringRef Text, llvm::APInt &Value) {
-  // swift encodes octal differently from C
-  bool IsCOctal = Text.size() > 1 && Text[0] == '0' && isdigit(Text[1]);
-  return Text.getAsInteger(IsCOctal ? 10 : 0, Value);
-}
-
-static APInt getIntegerLiteralValue(bool IsNegative, StringRef Text,
-                                    unsigned BitWidth) {
-  llvm::APInt Value(BitWidth, 0);
-  bool Error = getAsInteger(Text, Value);
-  assert(!Error && "Invalid IntegerLiteral formed"); (void)Error;
-  if (IsNegative)
-    Value = -Value;
-  if (Value.getBitWidth() != BitWidth)
-    Value = Value.sextOrTrunc(BitWidth);
-  return Value;
-}
-
-APInt IntegerLiteralExpr::getValue(StringRef Text, unsigned BitWidth, bool Negative) {
-  return getIntegerLiteralValue(Negative, Text, BitWidth);
-}
-
-/// Returns the raw magnitude of the literal text without any truncation.
-APInt IntegerLiteralExpr::getRawMagnitude() const {
-  llvm::APInt Value(64, 0);
-  bool Error = getAsInteger(getDigitsText(), Value);
-  assert(!Error && "Invalid IntegerLiteral formed");
-  (void)Error;
-  return Value;
+APInt IntegerLiteralExpr::getRawValue() const {
+  return BuiltinIntegerWidth::arbitrary().parse(getDigitsText(), /*radix*/0,
+                                                isNegative());
 }
 
 APInt IntegerLiteralExpr::getValue() const {
   assert(!getType().isNull() && "Semantic analysis has not completed");
   assert(!getType()->hasError() && "Should have a valid type");
-  return getIntegerLiteralValue(
-      isNegative(), getDigitsText(),
-      getType()->castTo<BuiltinIntegerType>()->getGreatestWidth());
+  auto width = getType()->castTo<BuiltinIntegerType>()->getWidth();
+  return width.parse(getDigitsText(), /*radix*/ 0, isNegative());
+}
+
+APInt BuiltinIntegerWidth::parse(StringRef text, unsigned radix, bool negate,
+                                 bool *hadError) const {
+  if (hadError) *hadError = false;
+
+  // Parse an unsigned value from the string.
+  APInt value;
+
+  // Swift doesn't treat a leading zero as signifying octal, but
+  // StringRef::getAsInteger does.  Force decimal parsing in this case.
+  if (radix == 0 && text.size() >= 2 && text[0] == '0' && isdigit(text[1]))
+    radix = 10;
+
+  bool error = text.getAsInteger(radix, value);
+  if (error) {
+    if (hadError) *hadError = true;
+    return value;
+  }
+
+  // If we're producing an arbitrary-precision value, we don't need to do
+  // much additional processing.
+  if (isArbitraryWidth()) {
+    // The parser above always produces a non-negative value, so if the sign
+    // bit is set we need to give it some breathing room.
+    if (value.isNegative())
+      value = value.zext(value.getBitWidth() + 1);
+    assert(!value.isNegative());
+
+    // Now we can safely negate.
+    if (negate) {
+      value = -value;
+      assert(value.isNegative() || value.isNullValue());
+    }
+
+    // Truncate down to the minimum number of bits required to express
+    // this value exactly.
+    auto requiredBits = value.getMinSignedBits();
+    if (value.getBitWidth() > requiredBits)
+      value = value.trunc(requiredBits);
+
+  // If we have a fixed-width type (including abstract ones), we need to do
+  // fixed-width transformations, which can overflow.
+  } else {
+    unsigned width = getGreatestWidth();
+
+    // The overflow diagnostics in this case can't be fully correct because
+    // we don't know whether we're supposed to be producing a signed number
+    // or an unsigned one.
+
+    if (hadError && value.getActiveBits() > width)
+      *hadError = true;
+    value = value.zextOrTrunc(width);
+
+    if (negate) {
+      value = -value;
+
+      if (hadError && !value.isNegative())
+        *hadError = true;
+    }
+
+    assert(value.getBitWidth() == width);
+  }
+
+  return value;
 }
 
 static APFloat getFloatLiteralValue(bool IsNegative, StringRef Text,

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1077,9 +1077,9 @@ namespace {
       auto intExpr = cast<IntegerLiteralExpr>(target->getRawValueExpr());
       auto intType = getDiscriminatorType();
 
-      APInt intValue = IntegerLiteralExpr::getValue(intExpr->getDigitsText(),
-                                                    intType->getBitWidth(),
-                                                    intExpr->isNegative());
+      APInt intValue =
+        BuiltinIntegerWidth::fixed(intType->getBitWidth())
+          .parse(intExpr->getDigitsText(), /*radix*/ 0, intExpr->isNegative());
 
       return intValue.getZExtValue();
     }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1220,17 +1220,7 @@ namespace {
         if (IntegerLiteralExpr *intLit = dyn_cast<IntegerLiteralExpr>(expr)) {
           unsigned maxWidth =
               maxIntType->castTo<BuiltinIntegerType>()->getGreatestWidth();
-          APInt magnitude = intLit->getRawMagnitude();
-          unsigned magWidth = magnitude.getActiveBits();
-          bool isNegative = intLit->isNegative();
-
-          // Compute the literal bit width in the signed two's complement form.
-          // This is generally one more than the magnitude width, but is the
-          // same when the literal is of the form -2^i (for some Nat `i`).
-          unsigned signedLitWidth =
-              (isNegative && (magnitude.countTrailingZeros() == magWidth - 1))
-                  ? magWidth
-                  : (magWidth + 1);
+          unsigned signedLitWidth = intLit->getRawValue().getMinSignedBits();
 
           if (signedLitWidth > maxWidth) { // overflow?
             CS.TC.diagnose(expr->getLoc(),

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -870,12 +870,8 @@ namespace {
         return !cacheVal.second;
       }
       case ExprKind::IntegerLiteral: {
-        // FIXME: The magic number 128 is bad and we should actually figure out
-        // the bitwidth.  But it's too early in Sema to get it.
         auto *ILE = cast<IntegerLiteralExpr>(EL);
-        auto cacheVal =
-            IntLiteralCache.insert(
-                {ILE->getValue(ILE->getDigitsText(), 128, ILE->isNegative()), ILE});
+        auto cacheVal = IntLiteralCache.insert({ILE->getRawValue(), ILE});
         PrevPattern = (cacheVal.first != IntLiteralCache.end())
                     ? cacheVal.first->getSecond()
                     : nullptr;

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -20,7 +20,7 @@
 #include "swift/AST/Pattern.h"
 #include "swift/Basic/STLExtras.h"
 
-#include <llvm/ADT/APInt.h>
+#include "swift/Basic/APIntMap.h"
 #include <llvm/ADT/APFloat.h>
 
 #include <numeric>
@@ -31,22 +31,6 @@ using namespace swift;
 #define DEBUG_TYPE "TypeCheckSwitchStmt"
 
 namespace {
-  struct DenseMapAPIntKeyInfo {
-    static inline APInt getEmptyKey() { return APInt(); }
-
-    static inline APInt getTombstoneKey() {
-      return APInt::getAllOnesValue(/*bitwidth*/1);
-    }
-
-    static unsigned getHashValue(const APInt &Key) {
-      return static_cast<unsigned>(hash_value(Key));
-    }
-
-    static bool isEqual(const APInt &LHS, const APInt &RHS) {
-      return LHS.getBitWidth() == RHS.getBitWidth() && LHS == RHS;
-    }
-  };
-
   struct DenseMapAPFloatKeyInfo {
     static inline APFloat getEmptyKey() { return APFloat(APFloat::Bogus(), 1); }
     static inline APFloat getTombstoneKey() { return APFloat(APFloat::Bogus(), 2); }
@@ -858,7 +842,7 @@ namespace {
     TypeChecker &TC;
     const SwitchStmt *Switch;
     const DeclContext *DC;
-    llvm::DenseMap<APInt, Expr *, ::DenseMapAPIntKeyInfo> IntLiteralCache;
+    APIntMap<Expr *> IntLiteralCache;
     llvm::DenseMap<APFloat, Expr *, ::DenseMapAPFloatKeyInfo> FloatLiteralCache;
     llvm::DenseMap<StringRef, Expr *> StringLiteralCache;
     


### PR DESCRIPTION
Preparation for `Builtin.IntegerLiteral`.  Builds on top of https://github.com/apple/swift/pull/20177