### PR TITLE
[AutoDiff] Adopt AdditiveArithmetic protocol for AD

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -68,6 +68,7 @@ PROTOCOL(Encodable)
 PROTOCOL(Decodable)
 // SWIFT_ENABLE_TENSORFLOW
 PROTOCOL(AccelerableByTensorFlow)
+PROTOCOL(AdditiveArithmetic)
 PROTOCOL(Numeric)
 PROTOCOL(FloatingPoint)
 PROTOCOL(ParameterGroup)

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4051,6 +4051,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   // SWIFT_ENABLE_TENSORFLOW
   case KnownProtocolKind::AccelerableByTensorFlow:
   case KnownProtocolKind::FloatingPoint:
+  case KnownProtocolKind::AdditiveArithmetic:
   case KnownProtocolKind::Numeric:
   case KnownProtocolKind::ParameterGroup:
   case KnownProtocolKind::Parameterized:

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -57,16 +57,12 @@ public extension Tensor where Scalar : Numeric {
 }
 
 //===----------------------------------------------------------------------===//
-// Vector numeric properties and element-wise arithmetics
+// Additive group
 //===----------------------------------------------------------------------===//
 
-extension Tensor : VectorNumeric where Scalar : Numeric {
-  public typealias ScalarElement = Scalar
-  public typealias Dimensionality = TensorShape
-
-  @inlinable @inline(__always)
-  public init(dimensionality: TensorShape, repeating repeatedValue: Scalar) {
-    self.init(shape: dimensionality, repeating: repeatedValue)
+extension Tensor : AdditiveArithmetic where Scalar : Numeric {
+  public static var zero: Tensor {
+    return Tensor(zeros: [])
   }
 
   /// Adds two tensors and produces their sum.
@@ -84,53 +80,18 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
   public static func - (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.sub(lhs, rhs)
   }
+}
 
-  /// Multiplies two tensors and produces their product.
-  /// - Note: `*` supports broadcasting.
-  @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointMultiply(_:_:originalValue:seed:))
-  public static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
-    return Raw.mul(lhs, rhs)
-  }
+//===----------------------------------------------------------------------===//
+// Vector space
+//===----------------------------------------------------------------------===//
 
-  /// Adds the scalar to every scalar of the tensor and produces the sum.
-  @inlinable @inline(__always)
-  public static func + (lhs: Scalar, rhs: Tensor) -> Tensor {
-    return Tensor(lhs) + rhs
-  }
-
-  /// Adds the scalar to every scalar of the tensor and produces the sum.
-  @inlinable @inline(__always)
-  public static func + (lhs: Tensor, rhs: Scalar) -> Tensor {
-    return lhs + Tensor(rhs)
-  }
-
-  /// Subtracts the scalar from every scalar of the tensor and produces the
-  /// difference.
-  @inlinable @inline(__always)
-  public static func - (lhs: Scalar, rhs: Tensor) -> Tensor {
-    return Tensor(lhs) - rhs
-  }
-
-  /// Subtracts the scalar from every scalar of the tensor and produces the
-  /// difference.
-  @inlinable @inline(__always)
-  public static func - (lhs: Tensor, rhs: Scalar) -> Tensor {
-    return lhs - Tensor(rhs)
-  }
-
+extension Tensor : VectorNumeric where Scalar : Numeric {
   /// Multiplies the scalar with every scalar of the tensor and produces the
   /// product.
   @inlinable @inline(__always)
   public static func * (lhs: Scalar, rhs: Tensor) -> Tensor {
     return Tensor(lhs) * rhs
-  }
-
-  /// Multiplies the scalar with every scalar of the tensor and produces the
-  /// product.
-  @inlinable @inline(__always)
-  public static func * (lhs: Tensor, rhs: Scalar) -> Tensor {
-    return lhs * Tensor(rhs)
   }
 }
 
@@ -139,7 +100,37 @@ extension Tensor : Differentiable where Scalar : FloatingPoint {
   public typealias CotangentVector = Tensor
 }
 
+//===----------------------------------------------------------------------===//
+// Additional element-wise operators
+//===----------------------------------------------------------------------===//
+
 public extension Tensor where Scalar : Numeric {
+  /// Adds the scalar to every scalar of the tensor and produces the sum.
+  @inlinable @inline(__always)
+  static func + (lhs: Scalar, rhs: Tensor) -> Tensor {
+    return Tensor(lhs) + rhs
+  }
+
+  /// Adds the scalar to every scalar of the tensor and produces the sum.
+  @inlinable @inline(__always)
+  static func + (lhs: Tensor, rhs: Scalar) -> Tensor {
+    return lhs + Tensor(rhs)
+  }
+
+  /// Subtracts the scalar from every scalar of the tensor and produces the
+  /// difference.
+  @inlinable @inline(__always)
+  static func - (lhs: Scalar, rhs: Tensor) -> Tensor {
+    return Tensor(lhs) - rhs
+  }
+
+  /// Subtracts the scalar from every scalar of the tensor and produces the
+  /// difference.
+  @inlinable @inline(__always)
+  static func - (lhs: Tensor, rhs: Scalar) -> Tensor {
+    return lhs - Tensor(rhs)
+  }
+
   /// Adds two tensors and stores the result in the left-hand-side variable.
   /// - Note: `+=` supports broadcasting.
   @inlinable @inline(__always)
@@ -169,6 +160,21 @@ public extension Tensor where Scalar : Numeric {
     lhs = lhs - rhs
   }
 
+  /// Multiplies two tensors and produces their product.
+  /// - Note: `*` supports broadcasting.
+  @inlinable @inline(__always)
+  @differentiable(reverse, adjoint: _adjointMultiply(_:_:originalValue:seed:))
+  static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
+    return Raw.mul(lhs, rhs)
+  }
+
+  /// Multiplies the scalar with every scalar of the tensor and produces the
+  /// product.
+  @inlinable @inline(__always)
+  static func * (lhs: Tensor, rhs: Scalar) -> Tensor {
+    return lhs * Tensor(rhs)
+  }
+
   /// Multiplies two tensors and stores the result in the left-hand-side
   /// variable.
   /// - Note: `*=` supports broadcasting.
@@ -177,8 +183,6 @@ public extension Tensor where Scalar : Numeric {
     lhs = lhs * rhs
   }
 
-  /// Multiplies the scalar with every scalar of the tensor and stores the
-  /// result in the left-hand-side variable.
   @inlinable @inline(__always)
   static func *= (lhs: inout Tensor, rhs: Scalar) {
     lhs = lhs * rhs

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -329,10 +329,16 @@ public extension Tensor {
   ///   - shape: The dimensions of the tensor.
   ///   - repeatedValue: The scalar value to repeat.
   ///
+  // TODO: Deprecate this in favor of `init(repeating:shape:)`.
   @inlinable @inline(__always)
   init(shape: TensorShape, repeating repeatedValue: Scalar) {
-    self = Raw.fill(
-      dims: Tensor<Int32>(shape.dimensions), value: Tensor(repeatedValue))
+    self.init(repeating: repeatedValue, shape: shape)
+  }
+
+  @inlinable @inline(__always)
+  init(repeating repeatedValue: Scalar, shape: TensorShape) {
+    self = Raw.fill(dims: Tensor<Int32>(shape.dimensions),
+                    value: Tensor(repeatedValue))
   }
 
   /// Creates a tensor by broadcasting the given scalar to a given rank with

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -21,40 +21,38 @@
 //===----------------------------------------------------------------------===//
 
 /// A type that represents an unranked vector space. Values of this type are
-/// elements in this vector space and with a specific dimensionality.
-public protocol VectorNumeric {
-  /// The type of scalars in the real vector space.
-  associatedtype ScalarElement
+/// elements in this vector space and with a specific shape.
+public protocol VectorNumeric : AdditiveArithmetic {
+  /// The type of scalars in the vector space.
+  associatedtype Scalar : AdditiveArithmetic
 
   /// The type whose values specifies the dimensionality of an object in the
-  /// real vector space.
-  associatedtype Dimensionality
+  /// vector space.
+  associatedtype Shape
 
-  /// Create a scalar in the real vector space that the type represents.
-  ///
-  /// - Parameter scalar: the scalar
-  init(_ scalar: ScalarElement)
+  // TODO: This is a degenerate API. To be removed.
+  init(_ scalar: Scalar)
 
-  /// Create an object in the real vector space with the specified
-  /// dimensionality by repeatedly filling the object with the specified
-  /// value.
+  /// Create an object in the vector space with the specified shape by
+  /// repeatedly filling the object with the specified scalar value.
   ///
   /// - Parameters:
-  ///   - dimensionality: the dimensionality
-  ///   - repeatedValue: the value repeat for the specified dimensionality
-  init(dimensionality: Dimensionality, repeating repeatedValue: ScalarElement)
+  ///   - shape: the shape
+  ///   - repeatedValue: the value repeat for the specified shape
+  init(repeating repeatedValue: Scalar, shape: Shape)
 
-  static func + (lhs: Self, rhs: Self) -> Self
-  static func + (lhs: Self, rhs: ScalarElement) -> Self
-  static func + (lhs: ScalarElement, rhs: Self) -> Self
+  static func * (lhs: Scalar, rhs: Self) -> Self
+  static func *= (lhs: inout Self, rhs: Scalar)
+}
 
-  static func - (lhs: Self, rhs: Self) -> Self
-  static func - (lhs: Self, rhs: ScalarElement) -> Self
-  static func - (lhs: ScalarElement, rhs: Self) -> Self
+public extension VectorNumeric {
+  static func * (lhs: Self, rhs: Scalar) -> Self {
+    return rhs * lhs
+  }
 
-  static func * (lhs: Self, rhs: Self) -> Self
-  static func * (lhs: Self, rhs: ScalarElement) -> Self
-  static func * (lhs: ScalarElement, rhs: Self) -> Self
+  static func *= (lhs: inout Self, rhs: Scalar) {
+    lhs = rhs * lhs
+  }
 }
 
 /// A type that mathematically represents a differentiable manifold whose
@@ -64,17 +62,17 @@ public protocol VectorNumeric {
 /// elements are of `Tangent` type.
 public protocol Differentiable {
   /// The tangent vector space of this differentiable manifold.
-  associatedtype TangentVector : VectorNumeric
-    where TangentVector.ScalarElement : FloatingPoint
+  associatedtype TangentVector : Differentiable
+    where TangentVector.TangentVector == TangentVector
   /// The cotangent space of this differentiable manifold.
-  associatedtype CotangentVector : VectorNumeric
-    where TangentVector.ScalarElement : FloatingPoint
+  associatedtype CotangentVector : Differentiable
+    where CotangentVector.CotangentVector == CotangentVector
 
   /// Returns `self` moved along the value space towards the given tangent
   /// vector. In Riemannian geometry (mathematics), this represents an
   /// exponential map.
   func moved(toward direction: TangentVector) -> Self
-  
+
   /// Convert a cotangent vector to its corresponding tangent vector.
   func tangentVector(from cotangent: CotangentVector) -> TangentVector
 }
@@ -89,32 +87,6 @@ public extension Differentiable
 public extension Differentiable where TangentVector == CotangentVector {
   func tangentVector(from cotangent: CotangentVector) -> TangentVector {
     return cotangent
-  }
-}
-
-public extension VectorNumeric {
-  static func + (lhs: Self, rhs: ScalarElement) -> Self {
-    return lhs + Self(rhs)
-  }
-
-  static func + (lhs: ScalarElement, rhs: Self) -> Self {
-    return Self(lhs) + rhs
-  }
-
-  static func - (lhs: Self, rhs: ScalarElement) -> Self {
-    return lhs - Self(rhs)
-  }
-
-  static func - (lhs: ScalarElement, rhs: Self) -> Self {
-    return Self(lhs) - rhs
-  }
-
-  static func * (lhs: Self, rhs: ScalarElement) -> Self {
-    return lhs * Self(rhs)
-  }
-
-  static func * (lhs: ScalarElement, rhs: Self) -> Self {
-    return Self(lhs) * rhs
   }
 }
 

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -23,6 +23,7 @@ extension ExpressibleByIntegerLiteral
   }
 }
 
+// SWIFT_ENABLE_TENSORFLOW
 //===----------------------------------------------------------------------===//
 //===--- AdditiveArithmetic -----------------------------------------------===//
 //===----------------------------------------------------------------------===//
@@ -146,6 +147,7 @@ public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
 /// the required mutating methods. Extensions to `Numeric` provide default
 /// implementations for the protocol's nonmutating methods based on the
 /// mutating variants.
+// SWIFT_ENABLE_TENSORFLOW
 public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
   /// Creates a new instance from the given integer, if it can be represented
   /// exactly.

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -24,81 +24,13 @@ extension ExpressibleByIntegerLiteral
 }
 
 //===----------------------------------------------------------------------===//
-//===--- Numeric ----------------------------------------------------------===//
+//===--- AdditiveArithmetic -----------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
-/// Declares methods backing binary arithmetic operators--such as `+`, `-` and
-/// `*`--and their mutating counterparts.
-///
-/// The `Numeric` protocol provides a suitable basis for arithmetic on
-/// scalar values, such as integers and floating-point numbers. You can write
-/// generic methods that operate on any numeric type in the standard library
-/// by using the `Numeric` protocol as a generic constraint.
-///
-/// The following example declares a method that calculates the total of any
-/// sequence with `Numeric` elements.
-///
-///     extension Sequence where Element: Numeric {
-///         func sum() -> Element {
-///             return reduce(0, +)
-///         }
-///     }
-///
-/// The `sum()` method is now available on any sequence or collection with
-/// numeric values, whether it is an array of `Double` or a countable range of
-/// `Int`.
-///
-///     let arraySum = [1.1, 2.2, 3.3, 4.4, 5.5].sum()
-///     // arraySum == 16.5
-///
-///     let rangeSum = (1..<10).sum()
-///     // rangeSum == 45
-///
-/// Conforming to the Numeric Protocol
-/// =====================================
-///
-/// To add `Numeric` protocol conformance to your own custom type, implement
-/// the required mutating methods. Extensions to `Numeric` provide default
-/// implementations for the protocol's nonmutating methods based on the
-/// mutating variants.
-public protocol Numeric : Equatable, ExpressibleByIntegerLiteral {
-  /// Creates a new instance from the given integer, if it can be represented
-  /// exactly.
-  ///
-  /// If the value passed as `source` is not representable exactly, the result
-  /// is `nil`. In the following example, the constant `x` is successfully
-  /// created from a value of `100`, while the attempt to initialize the
-  /// constant `y` from `1_000` fails because the `Int8` type can represent
-  /// `127` at maximum:
-  ///
-  ///     let x = Int8(exactly: 100)
-  ///     // x == Optional(100)
-  ///     let y = Int8(exactly: 1_000)
-  ///     // y == nil
-  ///
-  /// - Parameter source: A value to convert to this type.
-  init?<T : BinaryInteger>(exactly source: T)
-
-  /// A type that can represent the absolute value of any possible value of the
-  /// conforming type.
-  associatedtype Magnitude : Comparable, Numeric
-
-  /// The magnitude of this value.
-  ///
-  /// For any numeric value `x`, `x.magnitude` is the absolute value of `x`.
-  /// You can use the `magnitude` property in operations that are simpler to
-  /// implement in terms of unsigned values, such as printing the value of an
-  /// integer, which is just printing a '-' character in front of an absolute
-  /// value.
-  ///
-  ///     let x = -200
-  ///     // x.magnitude == 200
-  ///
-  /// The global `abs(_:)` function provides more familiar syntax when you need
-  /// to find an absolute value. In addition, because `abs(_:)` always returns
-  /// a value of the same type, even in a generic context, using the function
-  /// instead of the `magnitude` property is encouraged.
-  var magnitude: Magnitude { get }
+// TODO: Add stdlib-style documentation.
+public protocol AdditiveArithmetic : Equatable {
+  // TODO: Add stdlib-style documentation.
+  static var zero: Self { get }
 
   /// Adds two values and produces their sum.
   ///
@@ -158,6 +90,100 @@ public protocol Numeric : Equatable, ExpressibleByIntegerLiteral {
   ///   - lhs: A numeric value.
   ///   - rhs: The value to subtract from `lhs`.
   static func -=(lhs: inout Self, rhs: Self)
+}
+
+public extension AdditiveArithmetic {
+  static func +=(lhs: inout Self, rhs: Self) {
+    lhs = lhs + rhs
+  }
+
+  static func -=(lhs: inout Self, rhs: Self) {
+    lhs = lhs - rhs
+  }
+}
+
+public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
+  static var zero: Self {
+    return 0
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//===--- Numeric ----------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+/// Declares methods backing binary arithmetic operators--such as `+`, `-` and
+/// `*`--and their mutating counterparts.
+///
+/// The `Numeric` protocol provides a suitable basis for arithmetic on
+/// scalar values, such as integers and floating-point numbers. You can write
+/// generic methods that operate on any numeric type in the standard library
+/// by using the `Numeric` protocol as a generic constraint.
+///
+/// The following example declares a method that calculates the total of any
+/// sequence with `Numeric` elements.
+///
+///     extension Sequence where Element: Numeric {
+///         func sum() -> Element {
+///             return reduce(0, +)
+///         }
+///     }
+///
+/// The `sum()` method is now available on any sequence or collection with
+/// numeric values, whether it is an array of `Double` or a countable range of
+/// `Int`.
+///
+///     let arraySum = [1.1, 2.2, 3.3, 4.4, 5.5].sum()
+///     // arraySum == 16.5
+///
+///     let rangeSum = (1..<10).sum()
+///     // rangeSum == 45
+///
+/// Conforming to the Numeric Protocol
+/// =====================================
+///
+/// To add `Numeric` protocol conformance to your own custom type, implement
+/// the required mutating methods. Extensions to `Numeric` provide default
+/// implementations for the protocol's nonmutating methods based on the
+/// mutating variants.
+public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
+  /// Creates a new instance from the given integer, if it can be represented
+  /// exactly.
+  ///
+  /// If the value passed as `source` is not representable exactly, the result
+  /// is `nil`. In the following example, the constant `x` is successfully
+  /// created from a value of `100`, while the attempt to initialize the
+  /// constant `y` from `1_000` fails because the `Int8` type can represent
+  /// `127` at maximum:
+  ///
+  ///     let x = Int8(exactly: 100)
+  ///     // x == Optional(100)
+  ///     let y = Int8(exactly: 1_000)
+  ///     // y == nil
+  ///
+  /// - Parameter source: A value to convert to this type.
+  init?<T : BinaryInteger>(exactly source: T)
+
+  /// A type that can represent the absolute value of any possible value of the
+  /// conforming type.
+  associatedtype Magnitude : Comparable, Numeric
+
+  /// The magnitude of this value.
+  ///
+  /// For any numeric value `x`, `x.magnitude` is the absolute value of `x`.
+  /// You can use the `magnitude` property in operations that are simpler to
+  /// implement in terms of unsigned values, such as printing the value of an
+  /// integer, which is just printing a '-' character in front of an absolute
+  /// value.
+  ///
+  ///     let x = -200
+  ///     // x.magnitude == 200
+  ///
+  /// The global `abs(_:)` function provides more familiar syntax when you need
+  /// to find an absolute value. In addition, because `abs(_:)` always returns
+  /// a value of the same type, even in a generic context, using the function
+  /// instead of the `magnitude` property is encouraged.
+  var magnitude: Magnitude { get }
 
   /// Multiplies two values and produces their product.
   ///
@@ -327,7 +353,7 @@ public func abs<T : SignedNumeric & Comparable>(_ x: T) -> T {
   return x < (0 as T) ? -x : x
 }
 
-extension Numeric {
+extension AdditiveArithmetic {
   /// Returns the given number unchanged.
   ///
   /// You can use the unary plus operator (`+`) to provide symmetry in your

--- a/test/AutoDiff/gradient_expr_silgen.swift
+++ b/test/AutoDiff/gradient_expr_silgen.swift
@@ -7,13 +7,16 @@ struct Vector {
 }
 
 extension Vector : VectorNumeric {
-  typealias ScalarElement = Float
-  typealias Dimensionality = Int
-  init(_ scalar: ScalarElement) {
+  typealias Scalar = Float
+  typealias Shape = Int
+  init(_ scalar: Scalar) {
     self.init(x: scalar, y: scalar)
   }
-  init(dimensionality: Int, repeating value: ScalarElement) {
-    precondition(dimensionality == 2)
+  static var zero: Vector {
+    return Vector(0)
+  }
+  init(repeating value: Scalar, shape: Int) {
+    precondition(shape == 2)
     self.init(value)
   }
   static func + (a: Vector, b: Vector) -> Vector {
@@ -22,8 +25,8 @@ extension Vector : VectorNumeric {
   static func - (a: Vector, b: Vector) -> Vector {
     return Vector(x: a.x-b.x, y: a.y-b.y)
   }
-  static func * (a: Vector, b: Vector) -> Vector {
-    return Vector(x: a.x*b.x, y: a.y*b.y)
+  static func * (a: Scalar, b: Vector) -> Vector {
+    return Vector(x: a*b.x, y: a*b.y)
   }
 }
 
@@ -43,12 +46,12 @@ public func foo_indir_ret<T>(x: Float, y: Float, t: T) -> (T, T) {
 }
 
 @_silgen_name("foo_generic_vector")
-public func foo_generic_vector<T : VectorNumeric>(x: T, y: T) -> T where T.ScalarElement : FloatingPoint {
+public func foo_generic_vector<T : VectorNumeric>(x: T, y: T) -> T where T.Scalar : FloatingPoint {
   return x
 }
 
 @_silgen_name("foo_generic_vector_and_scalar")
-public func foo_generic_vector_and_scalar<T : FloatingPoint, U : VectorNumeric>(x: T, y: U) -> U where U.ScalarElement : FloatingPoint { return y }
+public func foo_generic_vector_and_scalar<T : FloatingPoint, U : VectorNumeric>(x: T, y: U) -> U where U.Scalar : FloatingPoint { return y }
 
 let _ = #gradient(foo)
 let _ = #gradient(foo, wrt: .0)

--- a/test/AutoDiff/simple_real_vector.swift
+++ b/test/AutoDiff/simple_real_vector.swift
@@ -1,15 +1,19 @@
 // RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
 
 @_fixed_layout
-public struct Vector : VectorNumeric, Differentiable {
+public struct Vector : AdditiveArithmetic, VectorNumeric, Differentiable {
   public var x: Float
   public var y: Float
 
   public typealias TangentVector = Vector
-  public typealias ScalarElement = Float
-  public typealias Dimensionality = ()
+  public typealias Scalar = Float
+  public typealias Shape = ()
 
-  public init(dimensionality: (), repeating repeatedValue: Float) {
+  public static var zero: Vector {
+    return Vector(0)
+  }
+
+  public init(repeating repeatedValue: Float, shape: ()) {
     self.init(repeatedValue)
   }
 
@@ -17,27 +21,28 @@ public struct Vector : VectorNumeric, Differentiable {
     self.x = scalar
     self.y = scalar
   }
+
+  @differentiable(reverse, adjoint: fakeAdj)
+  public static func + (lhs: Vector, rhs: Vector) -> Vector {
+    abort()
+  }
+
+  @differentiable(reverse, adjoint: fakeAdj)
+  public static func - (lhs: Vector, rhs: Vector) -> Vector {
+    abort()
+  }
+
+  public static func * (lhs: Float, rhs: Vector) -> Vector {
+    abort()
+  }
+
+  public static func fakeAdj(lhs: Vector, rhs: Vector, y: Vector, seed: Vector) -> (Vector, Vector) {
+    abort()
+  }
 }
 
 // This exists to minimize generated SIL.
 @inline(never) func abort() -> Never { fatalError() }
-
-@differentiable(reverse, adjoint: fakeAdj)
-public func + (lhs: Vector, rhs: Vector) -> Vector {
-  abort()
-}
-@differentiable(reverse, adjoint: fakeAdj)
-public func - (lhs: Vector, rhs: Vector) -> Vector {
-  abort()
-}
-@differentiable(reverse, adjoint: fakeAdj)
-public func * (lhs: Vector, rhs: Vector) -> Vector {
-  abort()
-}
-
-public func fakeAdj(lhs: Vector, rhs: Vector, y: Vector, seed: Vector) -> (Vector, Vector) {
-  abort()
-}
 
 public func test1() -> Vector {
   func foo(_ x: Vector) -> Vector {
@@ -52,51 +57,6 @@ public func test1() -> Vector {
 // CHECK:   [[SCALAR_INIT_METHOD:%.*]] = witness_method $Float, #ExpressibleByIntegerLiteral.init!allocator.1
 // CHECK:   apply [[SCALAR_INIT_METHOD]]<Float>({{%.*}}, {{%.*}}, {{%.*}})
 // CHECK:   [[VECTOR_INIT_METHOD:%.*]] = witness_method $Vector, #VectorNumeric.init!allocator.1
-// CHECK:   apply [[VECTOR_INIT_METHOD]]<Vector>(%1, %16, %15) : $@convention(witness_method: VectorNumeric) <τ_0_0 where τ_0_0 : VectorNumeric> (@in τ_0_0.ScalarElement, @thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   apply [[VECTOR_INIT_METHOD]]<Vector>(%1, %16, %15) : $@convention(witness_method: VectorNumeric) <τ_0_0 where τ_0_0 : VectorNumeric> (@in τ_0_0.Scalar, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   [[CAN_GRAD:%.*]] = function_ref @{{.*}}test1{{.*}}foo{{.*}}__grad_src_0_wrt_0_s_p : $@convention(thin) (Vector, Vector) -> (Vector, Vector)
 // CHECK:   apply [[CAN_GRAD]]({{.*}}, {{.*}})
-
-// CHECK-LABEL: sil private @{{.*}}test1{{.*}}foo{{.*}}__adjoint_src_0_wrt_0
-// CHECK: bb0(%0 : $Vector, %1 : ${{.*}}test1{{.*}}foo{{.*}}__Type{{.*}}, %2 : $Vector, %3 : $Vector):
-// CHECK:   %4 = struct_extract %1 : ${{.*}}test1{{.*}}foo{{.*}}__Type{{.*}}, #{{.*}}.pv_0
-// CHECK:   %5 = struct_extract %1 : ${{.*}}test1{{.*}}foo{{.*}}__Type{{.*}}, #{{.*}}.v_0
-// CHECK:   %6 = alloc_stack $Vector
-// CHECK:   %7 = begin_access [init] [static] [no_nested_conflict] %6 : $*Vector
-// CHECK:   %8 = begin_access [init] [static] [no_nested_conflict] %7 : $*Vector
-// CHECK:   store %3 to %8 : $*Vector
-// CHECK:   end_access %8 : $*Vector
-// CHECK:   end_access %7 : $*Vector
-// CHECK:   %12 = begin_access [read] [static] [no_nested_conflict] %6 : $*Vector
-// CHECK:   %13 = load %12 : $*Vector
-// CHECK:   end_access %12 : $*Vector
-// CHECK:   %15 = function_ref @{{.*}}fakeAdj{{.*}} : $@convention(thin) (Vector, Vector, Vector, Vector) -> (Vector, Vector)
-// CHECK:   %16 = apply %15(%0, %0, %5, %13) : $@convention(thin) (Vector, Vector, Vector, Vector) -> (Vector, Vector)
-// CHECK:   dealloc_stack %6 : $*Vector
-// CHECK:   %18 = tuple_extract %16 : $(Vector, Vector), 0
-// CHECK:   %19 = tuple_extract %16 : $(Vector, Vector), 1
-// CHECK:   %20 = alloc_stack $Vector
-// CHECK:   %21 = alloc_stack $Vector
-// CHECK:   %22 = alloc_stack $Vector
-// CHECK:   %23 = begin_access [init] [static] [no_nested_conflict] %21 : $*Vector
-// CHECK:   %24 = begin_access [init] [static] [no_nested_conflict] %22 : $*Vector
-// CHECK:   store %18 to %23 : $*Vector
-// CHECK:   store %19 to %24 : $*Vector
-// CHECK:   end_access %23 : $*Vector
-// CHECK:   end_access %24 : $*Vector
-// CHECK:   %29 = begin_access [init] [static] [no_nested_conflict] %20 : $*Vector
-// CHECK:   %30 = begin_access [read] [static] [no_nested_conflict] %21 : $*Vector
-// CHECK:   %31 = begin_access [read] [static] [no_nested_conflict] %22 : $*Vector
-// CHECK:   %32 = witness_method $Vector, #VectorNumeric."+"!1 : <Self where Self : VectorNumeric> (Self.Type) -> (Self, Self) -> @dynamic_self Self : $@convention(witness_method: VectorNumeric) <τ_0_0 where τ_0_0 : VectorNumeric> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
-// CHECK:   %33 = metatype $@thick Vector.Type
-// CHECK:   %34 = apply %32<Vector>(%29, %31, %30, %33) : $@convention(witness_method: VectorNumeric) <τ_0_0 where τ_0_0 : VectorNumeric> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
-// CHECK:   end_access %29 : $*Vector
-// CHECK:   end_access %31 : $*Vector
-// CHECK:   end_access %30 : $*Vector
-// CHECK:   dealloc_stack %22 : $*Vector
-// CHECK:   dealloc_stack %21 : $*Vector
-// CHECK:   %40 = begin_access [read] [static] [no_nested_conflict] %20 : $*Vector
-// CHECK:   %41 = load %40 : $*Vector
-// CHECK:   end_access %40 : $*Vector
-// CHECK:   dealloc_stack %20 : $*Vector
-// CHECK:   return %41 : $Vector
-// CHECK: }

--- a/test/Constraints/fast-operator-typechecking.swift
+++ b/test/Constraints/fast-operator-typechecking.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -solver-enable-operator-designated-types -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// UNSUPPORTED: tensorflow
 
 // rdar://problem/32998180
 func checksum(value: UInt16) -> UInt16 {

--- a/test/Constraints/fast-operator-typechecking.swift
+++ b/test/Constraints/fast-operator-typechecking.swift
@@ -1,5 +1,6 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-enable-operator-designated-types -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// SWIFT_ENABLE_TENSORFLOW
 // UNSUPPORTED: tensorflow
+// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-enable-operator-designated-types -solver-disable-shrink -disable-constraint-solver-performance-hacks
 
 // rdar://problem/32998180
 func checksum(value: UInt16) -> UInt16 {

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -1,3 +1,4 @@
+// SWIFT_ENABLE_TENSORFLOW
 // UNSUPPORTED: tensorflow
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -1,3 +1,4 @@
+// UNSUPPORTED: tensorflow
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)

--- a/test/api-digester/stability-stdlib-abi.swift
+++ b/test/api-digester/stability-stdlib-abi.swift
@@ -1,5 +1,6 @@
-// REQUIRES: OS=macosx
+// SWIFT_ENABLE_TENSORFLOW
 // UNSUPPORTED: tensorflow
+// REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.tmp)
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
 // RUN: %api-digester -dump-sdk -module Swift -o %t.tmp/current-stdlib.json -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -abi

--- a/test/api-digester/stability-stdlib-abi.swift
+++ b/test/api-digester/stability-stdlib-abi.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// UNSUPPORTED: tensorflow
 // RUN: %empty-directory(%t.tmp)
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
 // RUN: %api-digester -dump-sdk -module Swift -o %t.tmp/current-stdlib.json -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -abi

--- a/test/api-digester/stability-stdlib-source.swift
+++ b/test/api-digester/stability-stdlib-source.swift
@@ -1,5 +1,6 @@
-// REQUIRES: OS=macosx
+// SWIFT_ENABLE_TENSORFLOW
 // UNSUPPORTED: tensorflow
+// REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.tmp)
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
 // RUN: %api-digester -dump-sdk -module Swift -o %t.tmp/current-stdlib.json -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk

--- a/test/api-digester/stability-stdlib-source.swift
+++ b/test/api-digester/stability-stdlib-source.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// UNSUPPORTED: tensorflow
 // RUN: %empty-directory(%t.tmp)
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
 // RUN: %api-digester -dump-sdk -module Swift -o %t.tmp/current-stdlib.json -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk

--- a/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
@@ -1,4 +1,5 @@
 // RUN: %scale-test --begin 7 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// UNSUPPORTED: tensorflow
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 let a = [0]

--- a/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19915443.swift.gyb
@@ -1,5 +1,6 @@
+// SWIFT_ENABLE_TENSORFLOW
+// UNSUPPORTED: macosx
 // RUN: %scale-test --begin 7 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
-// UNSUPPORTED: tensorflow
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 let a = [0]

--- a/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
@@ -1,5 +1,6 @@
+// SWIFT_ENABLE_TENSORFLOW
+// UNSUPPORTED: macosx
 // RUN: %scale-test --begin 8 --end 16 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
-// UNSUPPORTED: tensorflow
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
@@ -1,4 +1,5 @@
 // RUN: %scale-test --begin 8 --end 16 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// UNSUPPORTED: tensorflow
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
SE proposal [Make Numeric Refine a new AdditiveArithmetic Protocol](https://forums.swift.org/t/make-numeric-refine-a-new-additivearithmetic-protocol/17269) is currently being considered for a formal review by the core team. This patch adopts the new protocol and switches to unified operator lookup for the automatic differentiation transform. Concretely, this patch includes the following:

1. Apply #19989: Introduce `AdditiveNumeric` and refactor `Numeric`.
2. Make `VectorNumeric` refine `AdditiveNumeric`, sharing additive arithmetic operators.
3. Remove `*(Self, Self)` to make `VectorNumeric` correctly define an abstract vector space (also discussed on the SE thread), keeping only `*(Scalar, Self)` and `*=(inout Self, Scalar)`.
4. Further constrain `Differentiable`'s `TangentVector` and `CotangentVector` to be also differentiable. This limits customization points that won't make sense mathematically.
5. Since we are no longer dealing with `+` defined separately in `VectorNumeric` and `Numeric`, the AD core transform has been refactored to use the unified `+` operator under `AdditiveArithmetic`.

Note: Some ABI stability tests and operator resolution tests have been temporarily disabled to prevent duplicate work: #19989 is going to handle all of this anyway and the TF branch will be patched when #19989 lands in master.

Todo next:
Remove `init(_:)` from `VectorNumeric`. This is a degenerate case because seeding a VJP using a vector of 1s to get a "gradient" is simply incorrect. AD type checking, the core transform, and primitive definitions in the TF module need to be refactored to make this change possible.