### PR TITLE
[5.0]  Don't try to devirtualize methods if the target has no error r…

### DIFF
--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -670,6 +670,15 @@ bool swift::canDevirtualizeClassMethod(FullApplySite AI,
       return false;
   }
 
+  // devirtualizeClassMethod below does not support this case. It currently
+  // assumes it can try_apply call the target.
+  if (!F->getLoweredFunctionType()->hasErrorResult() &&
+      isa<TryApplyInst>(AI.getInstruction())) {
+    LLVM_DEBUG(llvm::dbgs() << "        FAIL: Trying to devirtualize a "
+          "try_apply but vtable entry has no error result.\n");
+    return false;
+  }
+
   return true;
 }
 
@@ -973,6 +982,15 @@ static bool canDevirtualizeWitnessMethod(ApplySite AI) {
     // hidden symbol.
     if (!F->hasValidLinkageForFragileRef())
       return false;
+  }
+
+  // devirtualizeWitnessMethod below does not support this case. It currently
+  // assumes it can try_apply call the target.
+  if (!F->getLoweredFunctionType()->hasErrorResult() &&
+      isa<TryApplyInst>(AI.getInstruction())) {
+    LLVM_DEBUG(llvm::dbgs() << "        FAIL: Trying to devirtualize a "
+          "try_apply but wtable entry has no error result.\n");
+    return false;
   }
 
   return true;

--- a/test/SILOptimizer/devirt_class_witness_method.sil
+++ b/test/SILOptimizer/devirt_class_witness_method.sil
@@ -3,22 +3,30 @@ sil_stage canonical
 // RUN: %FileCheck -check-prefix=YAML -input-file=%t.opt.yaml %s
 
 import Builtin
-
+enum Error {}
 protocol P {
   func f()
+  func g() throws
 }
 
 extension P {
   func f()
+  func g() throws
 }
 
 class C<T, U> : P {}
 
 sil hidden_external [transparent] [thunk] @witness_thunk : $@convention(witness_method: P) <τ_0_0><τ_1_0, τ_1_1 where τ_0_0 : C<τ_1_0, τ_1_1>> (@in_guaranteed τ_0_0) -> ()
+sil hidden_external [transparent] [thunk] @witness_thunk2 : $@convention(witness_method: P) <τ_0_0><τ_1_0, τ_1_1 where τ_0_0 : C<τ_1_0, τ_1_1>> (@in_guaranteed τ_0_0) -> ()
 
 // CHECK-LABEL: sil hidden @caller : $@convention(thin) <T, U> (@owned C<T, U>) -> ()
 // CHECK: [[FN:%.*]] = function_ref @witness_thunk
 // CHECK: apply [[FN]]<C<T, U>, T, U>(
+// CHECK: return
+
+// CHECK-LABEL: sil hidden @caller2
+// CHECK: witness_method
+// CHECK: try_apply
 // CHECK: return
 
 // YAML:      --- !Passed
@@ -26,7 +34,7 @@ sil hidden_external [transparent] [thunk] @witness_thunk : $@convention(witness_
 // YAML-NEXT: Name:            sil.WitnessMethodDevirtualized
 // YAML-NEXT: DebugLoc:
 // YAML-NEXT:   File:            {{.*}}/devirt_class_witness_method.sil
-// YAML-NEXT:   Line:            47
+// YAML-NEXT:   Line:            55
 // YAML-NEXT:   Column:          8
 // YAML-NEXT: Function:        caller
 // YAML-NEXT: Args:
@@ -34,7 +42,7 @@ sil hidden_external [transparent] [thunk] @witness_thunk : $@convention(witness_
 // YAML-NEXT:   - Method:          '"witness_thunk"'
 // YAML-NEXT:     DebugLoc:
 // YAML-NEXT:       File:            {{.*}}/devirt_class_witness_method.sil
-// YAML-NEXT:       Line:            17
+// YAML-NEXT:       Line:            19
 // YAML-NEXT:       Column:          44
 // YAML-NEXT: ...
 
@@ -51,10 +59,31 @@ bb0(%0 : $C<T, U>):
   return %9 : $()
 }
 
+sil hidden @caller2 : $@convention(thin) <T, U> (@owned C<T, U>) -> () {
+bb0(%0 : $C<T, U>):
+  strong_retain %0 : $C<T, U>
+  %4 = alloc_stack $C<T, U>
+  store %0 to %4 : $*C<T, U>
+  %6 = witness_method $C<T, U>, #P.g!1 : <Self where Self : P> (Self) -> () throws -> () : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @error Error
+  try_apply %6<C<T, U>>(%4) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%8 : $()):
+  br bb3
+
+bb2(%11 : $Error):
+  br bb3
+
+bb3:
+  dealloc_stack %4 : $*C<T, U>
+  strong_release %0 : $C<T, U>
+  %9 = tuple ()
+  return %9 : $()
+}
 sil_vtable C {}
 
 sil_witness_table hidden <T, U> C<T, U>: P module clsx {
   method #P.f!1: <Self where Self : P> (Self) -> () -> () : @witness_thunk
+  method #P.g!1: <Self where Self : P> (Self) -> () throws -> () : @witness_thunk2
 }
 
 sil_default_witness_table hidden P {

--- a/test/SILOptimizer/devirt_speculative.sil
+++ b/test/SILOptimizer/devirt_speculative.sil
@@ -154,3 +154,64 @@ bb0(%0 : $Base):
   unreachable
 } 
 
+class Throw {
+  func mayThrow() throws
+}
+
+class S1 : Throw {
+  override func mayThrow()
+}
+
+class S2 : Throw {
+  override func mayThrow() throws
+}
+
+sil hidden [thunk] @$S4main4ThrowC8mayThrowyyKF : $@convention(method) (@guaranteed Throw) -> @error Error {
+bb0(%0 : $Throw):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil hidden @$S4main2S1C8mayThrowyyF : $@convention(method) (@guaranteed S1) -> () {
+bb0(%0 : $S1):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil hidden [thunk] [always_inline] @$S4main2S2C8mayThrowyyKF : $@convention(method) (@guaranteed S2) -> @error Error {
+bb0(%0 : $S2):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil{{.*}} @test_devirt_of_throw_without_error
+// CHECK-NOT: checked_cast_br [exact] %0 : $Throw to $S1
+// CHECK: return
+
+sil hidden [noinline] @test_devirt_of_throw_without_error : $@convention(thin) (@owned Throw) -> () {
+bb0(%0 : $Throw):
+  %80 = class_method %0 : $Throw, #Throw.mayThrow!1 : (Throw) -> () throws -> (), $@convention(method) (@guaranteed Throw) -> @error Error // user: %81
+  try_apply %80(%0) : $@convention(method) (@guaranteed Throw) -> @error Error, normal bb7, error bb6
+
+bb6(%82 : $Error):
+  br bb1
+
+bb7(%84 : $()):
+  br bb1
+
+bb1:
+  %3 = tuple ()
+  return %3 : $()
+}
+
+sil_vtable Throw {
+  #Throw.mayThrow!1: (Throw) -> () throws -> () : @$S4main4ThrowC8mayThrowyyKF
+}
+
+sil_vtable S1 {
+  #Throw.mayThrow!1: (Throw) -> () throws -> () : @$S4main2S1C8mayThrowyyF [override]
+}
+
+sil_vtable S2 {
+  #Throw.mayThrow!1: (Throw) -> () throws -> () : @$S4main2S2C8mayThrowyyKF [override]
+}


### PR DESCRIPTION
…esult but the original class method call was a try_apply

The code handling the devirtualization does not handle this case. We
would call a method without an error result using try_apply which
resulted in an IRGen crash (or SIL verification failure if enabled).

rdar://44710251