### PR TITLE
🚱[DNM][stdlib] Finalize Hasher layout by adding 256 bits of extra state

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -448,7 +448,6 @@ internal var _minASCIICharReprBuiltin: Builtin.Int63 {
 
 extension Character : Equatable {
   @inlinable
-  @inline(__always)
   public static func == (lhs: Character, rhs: Character) -> Bool {
     let l0 = lhs._smallUTF16
     if _fastPath(l0 != nil), let l = l0?._storage {
@@ -467,7 +466,6 @@ extension Character : Equatable {
 
 extension Character : Comparable {
   @inlinable
-  @inline(__always)
   public static func < (lhs: Character, rhs: Character) -> Bool {
     let l0 = lhs._smallUTF16
     if _fastPath(l0 != nil), let l = l0?._storage {

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -235,8 +235,7 @@ extension Hasher { // Combining integers
     self._combine(bytes: UInt64(truncatingIfNeeded: value), count: 1)
   }
 
-  @usableFromInline
-  @_effects(releasenone)
+  @inline(__always)
   internal mutating func _combine(bytes: UInt64, count: Int) {
     _sanityCheck(count >= 0 && count < 8)
     let count = UInt64(truncatingIfNeeded: count)

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -16,21 +16,14 @@
 
 import SwiftShims
 
-// FIXME: Remove @usableFromInline once Hasher is resilient.
-// rdar://problem/38549901
-@usableFromInline
-internal protocol _HasherCore {
-  init(rawSeed: (UInt64, UInt64))
-  mutating func compress(_ value: UInt64)
-  mutating func finalize(tailAndByteCount: UInt64) -> UInt64
-}
-
-extension _HasherCore {
+extension _SipHash13Core {
+  @inlinable
   @inline(__always)
   internal init() {
     self.init(rawSeed: Hasher._executionSeed)
   }
 
+  @inlinable
   @inline(__always)
   internal init(seed: Int) {
     let executionSeed = Hasher._executionSeed
@@ -40,235 +33,6 @@ extension _HasherCore {
     self.init(rawSeed: (
       executionSeed.0 ^ UInt64(truncatingIfNeeded: seed),
       executionSeed.1))
-  }
-}
-
-@inline(__always)
-internal func _loadPartialUnalignedUInt64LE(
-  _ p: UnsafeRawPointer,
-  byteCount: Int
-) -> UInt64 {
-  var result: UInt64 = 0
-  switch byteCount {
-  case 7:
-    result |= UInt64(p.load(fromByteOffset: 6, as: UInt8.self)) &<< 48
-    fallthrough
-  case 6:
-    result |= UInt64(p.load(fromByteOffset: 5, as: UInt8.self)) &<< 40
-    fallthrough
-  case 5:
-    result |= UInt64(p.load(fromByteOffset: 4, as: UInt8.self)) &<< 32
-    fallthrough
-  case 4:
-    result |= UInt64(p.load(fromByteOffset: 3, as: UInt8.self)) &<< 24
-    fallthrough
-  case 3:
-    result |= UInt64(p.load(fromByteOffset: 2, as: UInt8.self)) &<< 16
-    fallthrough
-  case 2:
-    result |= UInt64(p.load(fromByteOffset: 1, as: UInt8.self)) &<< 8
-    fallthrough
-  case 1:
-    result |= UInt64(p.load(fromByteOffset: 0, as: UInt8.self))
-    fallthrough
-  case 0:
-    return result
-  default:
-    _sanityCheckFailure()
-  }
-}
-
-/// This is a buffer for segmenting arbitrary data into 8-byte chunks.  Buffer
-/// storage is represented by a single 64-bit value in the format used by the
-/// finalization step of SipHash. (The least significant 56 bits hold the
-/// trailing bytes, while the most significant 8 bits hold the count of bytes
-/// appended so far, modulo 256. The count of bytes currently stored in the
-/// buffer is in the lower three bits of the byte count.)
-// FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
-// rdar://problem/38549901
-@usableFromInline @_fixed_layout
-internal struct _HasherTailBuffer {
-  // msb                                                             lsb
-  // +---------+-------+-------+-------+-------+-------+-------+-------+
-  // |byteCount|                 tail (<= 56 bits)                     |
-  // +---------+-------+-------+-------+-------+-------+-------+-------+
-  internal var value: UInt64
-
-  @inline(__always)
-  internal init() {
-    self.value = 0
-  }
-
-  @inline(__always)
-  internal init(tail: UInt64, byteCount: UInt64) {
-    // byteCount can be any value, but we only keep the lower 8 bits.  (The
-    // lower three bits specify the count of bytes stored in this buffer.)
-    // FIXME: This should be a single expression, but it causes exponential
-    // behavior in the expression type checker <rdar://problem/42672946>.
-    let shiftedByteCount: UInt64 = ((byteCount & 7) << 3)
-    let mask: UInt64 = (1 << shiftedByteCount - 1)
-    _sanityCheck(tail & ~mask == 0)
-    self.value = (byteCount &<< 56 | tail)
-  }
-
-  @inline(__always)
-  internal init(tail: UInt64, byteCount: Int) {
-    self.init(tail: tail, byteCount: UInt64(truncatingIfNeeded: byteCount))
-  }
-
-  internal var tail: UInt64 {
-    @inline(__always)
-    get { return value & ~(0xFF &<< 56) }
-  }
-
-  internal var byteCount: UInt64 {
-    @inline(__always)
-    get { return value &>> 56 }
-  }
-
-  @inline(__always)
-  internal mutating func append(_ bytes: UInt64) -> UInt64 {
-    let c = byteCount & 7
-    if c == 0 {
-      value = value &+ (8 &<< 56)
-      return bytes
-    }
-    let shift = c &<< 3
-    let chunk = tail | (bytes &<< shift)
-    value = (((value &>> 56) &+ 8) &<< 56) | (bytes &>> (64 - shift))
-    return chunk
-  }
-
-  @inline(__always)
-  internal
-  mutating func append(_ bytes: UInt64, count: UInt64) -> UInt64? {
-    _sanityCheck(count >= 0 && count < 8)
-    _sanityCheck(bytes & ~((1 &<< (count &<< 3)) &- 1) == 0)
-    let c = byteCount & 7
-    let shift = c &<< 3
-    if c + count < 8 {
-      value = (value | (bytes &<< shift)) &+ (count &<< 56)
-      return nil
-    }
-    let chunk = tail | (bytes &<< shift)
-    value = ((value &>> 56) &+ count) &<< 56
-    if c + count > 8 {
-      value |= bytes &>> (64 - shift)
-    }
-    return chunk
-  }
-}
-
-// FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
-// rdar://problem/38549901
-@usableFromInline @_fixed_layout
-internal struct _BufferingHasher<RawCore: _HasherCore> {
-  private var _buffer: _HasherTailBuffer
-  private var _core: RawCore
-
-  @inline(__always)
-  internal init(core: RawCore) {
-    self._buffer = _HasherTailBuffer()
-    self._core = core
-  }
-
-  @inline(__always)
-  internal init() {
-    self.init(core: RawCore())
-  }
-
-  @inline(__always)
-  internal init(seed: Int) {
-    self.init(core: RawCore(seed: seed))
-  }
-
-  @inline(__always)
-  internal mutating func combine(_ value: UInt) {
-#if arch(i386) || arch(arm)
-    combine(UInt32(truncatingIfNeeded: value))
-#else
-    combine(UInt64(truncatingIfNeeded: value))
-#endif
-  }
-
-  @inline(__always)
-  internal mutating func combine(_ value: UInt64) {
-    _core.compress(_buffer.append(value))
-  }
-
-  @inline(__always)
-  internal mutating func combine(_ value: UInt32) {
-    let value = UInt64(truncatingIfNeeded: value)
-    if let chunk = _buffer.append(value, count: 4) {
-      _core.compress(chunk)
-    }
-  }
-
-  @inline(__always)
-  internal mutating func combine(_ value: UInt16) {
-    let value = UInt64(truncatingIfNeeded: value)
-    if let chunk = _buffer.append(value, count: 2) {
-      _core.compress(chunk)
-    }
-  }
-
-  @inline(__always)
-  internal mutating func combine(_ value: UInt8) {
-    let value = UInt64(truncatingIfNeeded: value)
-    if let chunk = _buffer.append(value, count: 1) {
-      _core.compress(chunk)
-    }
-  }
-
-  @inline(__always)
-  internal mutating func combine(bytes: UInt64, count: Int) {
-    _sanityCheck(count >= 0 && count < 8)
-    let count = UInt64(truncatingIfNeeded: count)
-    if let chunk = _buffer.append(bytes, count: count) {
-      _core.compress(chunk)
-    }
-  }
-
-  @inline(__always)
-  internal mutating func combine(bytes: UnsafeRawBufferPointer) {
-    var remaining = bytes.count
-    guard remaining > 0 else { return }
-    var data = bytes.baseAddress!
-
-    // Load first unaligned partial word of data
-    do {
-      let start = UInt(bitPattern: data)
-      let end = _roundUp(start, toAlignment: MemoryLayout<UInt64>.alignment)
-      let c = min(remaining, Int(end - start))
-      if c > 0 {
-        let chunk = _loadPartialUnalignedUInt64LE(data, byteCount: c)
-        combine(bytes: chunk, count: c)
-        data += c
-        remaining -= c
-      }
-    }
-    _sanityCheck(
-      remaining == 0 ||
-      Int(bitPattern: data) & (MemoryLayout<UInt64>.alignment - 1) == 0)
-
-    // Load as many aligned words as there are in the input buffer
-    while remaining >= MemoryLayout<UInt64>.size {
-      combine(UInt64(littleEndian: data.load(as: UInt64.self)))
-      data += MemoryLayout<UInt64>.size
-      remaining -= MemoryLayout<UInt64>.size
-    }
-
-    // Load last partial word of data
-    _sanityCheck(remaining >= 0 && remaining < 8)
-    if remaining > 0 {
-      let chunk = _loadPartialUnalignedUInt64LE(data, byteCount: remaining)
-      combine(bytes: chunk, count: remaining)
-    }
-  }
-
-  @inline(__always)
-  internal mutating func finalize() -> UInt64 {
-    return _core.finalize(tailAndByteCount: _buffer.value)
   }
 }
 
@@ -295,18 +59,14 @@ internal struct _BufferingHasher<RawCore: _HasherCore> {
 ///   different values on every new execution of your program. The hash
 ///   algorithm implemented by `Hasher` may itself change between any two
 ///   versions of the standard library.
-@_fixed_layout // FIXME: Should be resilient (rdar://problem/38549901)
+@_fixed_layout
 public struct Hasher {
-  // FIXME: Remove @usableFromInline once Hasher is resilient.
-  // rdar://problem/38549901
   @usableFromInline
-  internal typealias RawCore = _SipHash13Core
-  // FIXME: Remove @usableFromInline once Hasher is resilient.
-  // rdar://problem/38549901
-  @usableFromInline
-  internal typealias Core = _BufferingHasher<RawCore>
+  internal typealias _Core = _SipHash13Core
 
-  internal var _core: Core
+  internal var _tail: _TailBuffer
+
+  internal var _core: _Core
 
   /// Creates a new hasher.
   ///
@@ -314,7 +74,8 @@ public struct Hasher {
   /// startup, usually from a high-quality random source.
   @_effects(releasenone)
   public init() {
-    self._core = Core()
+    self._tail = _TailBuffer()
+    self._core = _Core()
   }
 
   /// Initialize a new hasher using the specified seed value.
@@ -322,16 +83,103 @@ public struct Hasher {
   @usableFromInline
   @_effects(releasenone)
   internal init(_seed: Int) {
-    self._core = Core(seed: _seed)
+    self._tail = _TailBuffer()
+    self._core = _Core(seed: _seed)
   }
 
   /// Initialize a new hasher using the specified seed value.
-  @usableFromInline // @testable
+  @usableFromInline
   @_effects(releasenone)
   internal init(_rawSeed: (UInt64, UInt64)) {
-    self._core = Core(core: RawCore(rawSeed: _rawSeed))
+    self._tail = _TailBuffer()
+    self._core = _Core(rawSeed: _rawSeed)
   }
+}
 
+extension Hasher {
+  /// This is a buffer for segmenting arbitrary data into 8-byte chunks.  Buffer
+  /// storage is represented by a single 64-bit value in the format used by the
+  /// finalization step of SipHash. (The least significant 56 bits hold the
+  /// trailing bytes, while the most significant 8 bits hold the count of bytes
+  /// appended so far, modulo 256. The count of bytes currently stored in the
+  /// buffer is in the lower three bits of the byte count.)
+  @usableFromInline
+  @_fixed_layout
+  internal struct _TailBuffer {
+    // msb                                                             lsb
+    // +---------+-------+-------+-------+-------+-------+-------+-------+
+    // |byteCount|                 tail (<= 56 bits)                     |
+    // +---------+-------+-------+-------+-------+-------+-------+-------+
+    internal var value: UInt64
+
+    @inline(__always)
+    internal init() {
+      self.value = 0
+    }
+
+    @inline(__always)
+    internal init(tail: UInt64, byteCount: UInt64) {
+      // byteCount can be any value, but we only keep the lower 8 bits.  (The
+      // lower three bits specify the count of bytes stored in this buffer.)
+      // FIXME: This should be a single expression, but it causes exponential
+      // behavior in the expression type checker <rdar://problem/42672946>.
+      let shiftedByteCount: UInt64 = (byteCount & 7) &<< 3
+      let mask: UInt64 = (1 &<< shiftedByteCount) &- 1
+      _sanityCheck(tail & ~mask == 0)
+      self.value = (byteCount &<< 56 | tail)
+    }
+
+    @inline(__always)
+    internal init(tail: UInt64, byteCount: Int) {
+      self.init(tail: tail, byteCount: UInt64(truncatingIfNeeded: byteCount))
+    }
+
+    internal var tail: UInt64 {
+      @inline(__always)
+      get { return value & ~(0xFF &<< 56) }
+    }
+
+    internal var byteCount: UInt64 {
+      @inline(__always)
+      get { return value &>> 56 }
+    }
+
+    @inline(__always)
+    internal mutating func append(_ bytes: UInt64) -> UInt64 {
+      let c = byteCount & 7
+      if c == 0 {
+        value = value &+ (8 &<< 56)
+        return bytes
+      }
+      let shift = c &<< 3
+      let chunk = tail | (bytes &<< shift)
+      value = (((value &>> 56) &+ 8) &<< 56) | (bytes &>> (64 &- shift))
+      return chunk
+    }
+
+    @inline(__always)
+    internal
+    mutating func append(_ bytes: UInt64, count: UInt64) -> UInt64? {
+      _sanityCheck(count >= 0 && count < 8)
+      let inputMask: UInt64 = (1 &<< (count &<< 3)) &- 1
+      _sanityCheck(bytes & ~inputMask == 0)
+      let c = byteCount & 7
+      let shift = c &<< 3
+      if c &+ count < 8 {
+        value = (value | (bytes &<< shift)) &+ (count &<< 56)
+        return nil
+      }
+      let chunk = tail | (bytes &<< shift)
+      value = ((value &>> 56) &+ count) &<< 56
+      if c &+ count > 8 {
+        value |= bytes &>> (64 &- shift)
+      }
+      return chunk
+    }
+  }
+}
+
+extension Hasher { // Runtime settings
   /// Indicates whether we're running in an environment where hashing needs to
   /// be deterministic. If this is true, the hash seed is not random, and hash
   /// tables do not apply per-instance perturbation that is not repeatable.
@@ -348,7 +196,7 @@ public struct Hasher {
 
   /// The 128-bit hash seed used to initialize the hasher state. Initialized
   /// once during process startup.
-  @inlinable // @testable
+  @inlinable
   internal static var _executionSeed: (UInt64, UInt64) {
     @inline(__always)
     get {
@@ -361,7 +209,9 @@ public struct Hasher {
         _swift_stdlib_Hashing_parameters.seed1)
     }
   }
+}
 
+extension Hasher { // Combining arbitrary Hashable values
   /// Adds the given value to this hasher, mixing its essential parts into the
   /// hasher state.
   ///
@@ -371,41 +221,89 @@ public struct Hasher {
   public mutating func combine<H: Hashable>(_ value: H) {
     value.hash(into: &self)
   }
+}
 
-  @_effects(releasenone)
+extension Hasher { // Combining integers
   @usableFromInline
+  @_effects(releasenone)
   internal mutating func _combine(_ value: UInt) {
-    _core.combine(value)
+#if arch(i386) || arch(arm)
+    self._combine(UInt32(truncatingIfNeeded: value))
+#else
+    self._combine(UInt64(truncatingIfNeeded: value))
+#endif
   }
 
-  @_effects(releasenone)
   @usableFromInline
+  @_effects(releasenone)
   internal mutating func _combine(_ value: UInt64) {
-    _core.combine(value)
+    _core.compress(_tail.append(value))
   }
 
-  @_effects(releasenone)
   @usableFromInline
+  @_effects(releasenone)
   internal mutating func _combine(_ value: UInt32) {
-    _core.combine(value)
+    self._combine(bytes: UInt64(truncatingIfNeeded: value), count: 4)
   }
 
-  @_effects(releasenone)
   @usableFromInline
+  @_effects(releasenone)
   internal mutating func _combine(_ value: UInt16) {
-    _core.combine(value)
+    self._combine(bytes: UInt64(truncatingIfNeeded: value), count: 2)
   }
 
-  @_effects(releasenone)
   @usableFromInline
+  @_effects(releasenone)
   internal mutating func _combine(_ value: UInt8) {
-    _core.combine(value)
+    self._combine(bytes: UInt64(truncatingIfNeeded: value), count: 1)
   }
 
-  @_effects(releasenone)
   @usableFromInline
-  internal mutating func _combine(bytes value: UInt64, count: Int) {
-    _core.combine(bytes: value, count: count)
+  @_effects(releasenone)
+  internal mutating func _combine(bytes: UInt64, count: Int) {
+    _sanityCheck(count >= 0 && count < 8)
+    let count = UInt64(truncatingIfNeeded: count)
+    if let chunk = _tail.append(bytes, count: count) {
+      _core.compress(chunk)
+    }
+  }
+}
+
+extension Hasher { // Combining arbitrary byte sequences
+  // Load a partial 64-bit little-endian integer from the specified address.
+  @inline(__always)
+  internal static func _loadPartialUnalignedUInt64LE(
+    _ p: UnsafeRawPointer,
+    byteCount: Int
+  ) -> UInt64 {
+    var result: UInt64 = 0
+    switch byteCount {
+    case 7:
+      result |= UInt64(p.load(fromByteOffset: 6, as: UInt8.self)) &<< 48
+      fallthrough
+    case 6:
+      result |= UInt64(p.load(fromByteOffset: 5, as: UInt8.self)) &<< 40
+      fallthrough
+    case 5:
+      result |= UInt64(p.load(fromByteOffset: 4, as: UInt8.self)) &<< 32
+      fallthrough
+    case 4:
+      result |= UInt64(p.load(fromByteOffset: 3, as: UInt8.self)) &<< 24
+      fallthrough
+    case 3:
+      result |= UInt64(p.load(fromByteOffset: 2, as: UInt8.self)) &<< 16
+      fallthrough
+    case 2:
+      result |= UInt64(p.load(fromByteOffset: 1, as: UInt8.self)) &<< 8
+      fallthrough
+    case 1:
+      result |= UInt64(p.load(fromByteOffset: 0, as: UInt8.self))
+      fallthrough
+    case 0:
+      return result
+    default:
+      _sanityCheckFailure()
+    }
   }
 
   /// Adds the contents of the given buffer to this hasher, mixing it into the
@@ -414,16 +312,53 @@ public struct Hasher {
   /// - Parameter bytes: A raw memory buffer.
   @_effects(releasenone)
   public mutating func combine(bytes: UnsafeRawBufferPointer) {
-    _core.combine(bytes: bytes)
-  }
+    var remaining = bytes.count
+    guard remaining > 0 else { return }
+    var data = bytes.baseAddress!
 
+    // Load first unaligned partial word of data
+    do {
+      let start = UInt(bitPattern: data)
+      let end = _roundUp(start, toAlignment: MemoryLayout<UInt64>.alignment)
+      let c = min(remaining, Int(end - start))
+      if c > 0 {
+        let chunk = Hasher._loadPartialUnalignedUInt64LE(data, byteCount: c)
+        self._combine(bytes: chunk, count: c)
+        data += c
+        remaining -= c
+      }
+    }
+    _sanityCheck(
+      remaining == 0 ||
+      Int(bitPattern: data) & (MemoryLayout<UInt64>.alignment - 1) == 0)
+
+    // Load as many aligned words as there are in the input buffer
+    while remaining >= MemoryLayout<UInt64>.size {
+      self._combine(UInt64(littleEndian: data.load(as: UInt64.self)))
+      data += MemoryLayout<UInt64>.size
+      remaining -= MemoryLayout<UInt64>.size
+    }
+
+    // Load last partial word of data
+    _sanityCheck(remaining >= 0 && remaining < 8)
+    if remaining > 0 {
+      let chunk = Hasher._loadPartialUnalignedUInt64LE(
+        data,
+        byteCount: remaining)
+      self._combine(bytes: chunk, count: remaining)
+    }
+  }
+}
+
+extension Hasher { // Finalization
   /// Finalize the hasher state and return the hash value.
   /// Finalizing invalidates the hasher; additional bits cannot be combined
   /// into it, and it cannot be finalized again.
   @_effects(releasenone)
   @usableFromInline
   internal mutating func _finalize() -> Int {
-    return Int(truncatingIfNeeded: _core.finalize())
+    let value = _core.finalize(tailAndByteCount: _tail.value)
+    return Int(truncatingIfNeeded: value)
   }
 
   /// Finalizes the hasher state and returns the hash value.
@@ -439,31 +374,34 @@ public struct Hasher {
   @_effects(releasenone)
   public __consuming func finalize() -> Int {
     var core = _core
-    return Int(truncatingIfNeeded: core.finalize())
+    let value = core.finalize(tailAndByteCount: _tail.value)
+    return Int(truncatingIfNeeded: value)
   }
+}
 
+extension Hasher { // Helpers for _rawHashValue(seed:)
   @_effects(readnone)
   @usableFromInline
   internal static func _hash(seed: Int, _ value: UInt64) -> Int {
-    var core = RawCore(seed: seed)
+    var core = _Core(seed: seed)
     core.compress(value)
-    let tbc = _HasherTailBuffer(tail: 0, byteCount: 8)
+    let tbc = _TailBuffer(tail: 0, byteCount: 8)
     return Int(truncatingIfNeeded: core.finalize(tailAndByteCount: tbc.value))
   }
 
   @_effects(readnone)
   @usableFromInline
   internal static func _hash(seed: Int, _ value: UInt) -> Int {
-    var core = RawCore(seed: seed)
+    var core = _Core(seed: seed)
 #if arch(i386) || arch(arm)
-    _sanityCheck(UInt.bitWidth < UInt64.bitWidth)
-    let tbc = _HasherTailBuffer(
+    _sanityCheck(UInt.bitWidth == 32)
+    let tbc = _TailBuffer(
       tail: UInt64(truncatingIfNeeded: value),
       byteCount: UInt.bitWidth &>> 3)
 #else
     _sanityCheck(UInt.bitWidth == UInt64.bitWidth)
     core.compress(UInt64(truncatingIfNeeded: value))
-    let tbc = _HasherTailBuffer(tail: 0, byteCount: 8)
+    let tbc = _TailBuffer(tail: 0, byteCount: 8)
 #endif
     return Int(truncatingIfNeeded: core.finalize(tailAndByteCount: tbc.value))
   }
@@ -475,8 +413,8 @@ public struct Hasher {
     bytes value: UInt64,
     count: Int) -> Int {
     _sanityCheck(count >= 0 && count < 8)
-    var core = RawCore(seed: seed)
-    let tbc = _HasherTailBuffer(tail: value, byteCount: count)
+    var core = _Core(seed: seed)
+    let tbc = _TailBuffer(tail: value, byteCount: count)
     return Int(truncatingIfNeeded: core.finalize(tailAndByteCount: tbc.value))
   }
 
@@ -485,8 +423,8 @@ public struct Hasher {
   internal static func _hash(
     seed: Int,
     bytes: UnsafeRawBufferPointer) -> Int {
-    var core = Core(seed: seed)
-    core.combine(bytes: bytes)
-    return Int(truncatingIfNeeded: core.finalize())
+    var hasher = Hasher(_seed: seed)
+    hasher.combine(bytes: bytes)
+    return hasher.finalize()
   }
 }

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -16,26 +16,6 @@
 
 import SwiftShims
 
-extension _SipHash13Core {
-  @inlinable
-  @inline(__always)
-  internal init() {
-    self.init(rawSeed: Hasher._executionSeed)
-  }
-
-  @inlinable
-  @inline(__always)
-  internal init(seed: Int) {
-    let executionSeed = Hasher._executionSeed
-    // Prevent sign-extending the supplied seed; this makes testing slightly
-    // easier.
-    let seed = UInt(bitPattern: seed)
-    self.init(rawSeed: (
-      executionSeed.0 ^ UInt64(truncatingIfNeeded: seed),
-      executionSeed.1))
-  }
-}
-
 /// The universal hash function used by `Set` and `Dictionary`.
 ///
 /// `Hasher` can be used to map an arbitrary sequence of bytes to an integer
@@ -61,9 +41,6 @@ extension _SipHash13Core {
 ///   versions of the standard library.
 @_fixed_layout
 public struct Hasher {
-  @usableFromInline
-  internal typealias _Core = _SipHash13Core
-
   internal var _tail: _TailBuffer
 
   internal var _core: _Core

--- a/stdlib/public/core/SipHash.swift
+++ b/stdlib/public/core/SipHash.swift
@@ -105,12 +105,14 @@ extension Hasher._Core {
       executionSeed.1))
   }
 
+  @inline(__always)
   internal mutating func compress(_ m: UInt64) {
     _state.v3 ^= m
     _state._round()
     _state.v0 ^= m
   }
 
+  @inline(__always)
   internal mutating func finalize(tailAndByteCount: UInt64) -> UInt64 {
     compress(tailAndByteCount)
     _state.v2 ^= 0xff

--- a/stdlib/public/core/SipHash.swift
+++ b/stdlib/public/core/SipHash.swift
@@ -28,11 +28,13 @@ extension Hasher {
     fileprivate var v1: UInt64 = 0x646f72616e646f6d
     fileprivate var v2: UInt64 = 0x6c7967656e657261
     fileprivate var v3: UInt64 = 0x7465646279746573
+#if false // FIXME: Temporarily disabled
     // The fields below are reserved for future use. They aren't currently used.
     fileprivate var v4: UInt64 = 0
     fileprivate var v5: UInt64 = 0
     fileprivate var v6: UInt64 = 0
     fileprivate var v7: UInt64 = 0
+#endif
 
     @inline(__always)
     fileprivate init(rawSeed: (UInt64, UInt64)) {

--- a/stdlib/public/core/SipHash.swift
+++ b/stdlib/public/core/SipHash.swift
@@ -19,28 +19,32 @@
 /// * Daniel J. Bernstein <djb@cr.yp.to>
 //===----------------------------------------------------------------------===//
 
-@_fixed_layout
-@usableFromInline
-internal struct _SipHashState {
-  // "somepseudorandomlygeneratedbytes"
-  fileprivate var v0: UInt64 = 0x736f6d6570736575
-  fileprivate var v1: UInt64 = 0x646f72616e646f6d
-  fileprivate var v2: UInt64 = 0x6c7967656e657261
-  fileprivate var v3: UInt64 = 0x7465646279746573
-  // These fields are reserved for future use.
-  fileprivate var p0: UInt64 = 0
-  fileprivate var p1: UInt64 = 0
-  fileprivate var p2: UInt64 = 0
-  fileprivate var p3: UInt64 = 0
+extension Hasher {
+  @_fixed_layout
+  @usableFromInline
+  internal struct _State {
+    // "somepseudorandomlygeneratedbytes"
+    fileprivate var v0: UInt64 = 0x736f6d6570736575
+    fileprivate var v1: UInt64 = 0x646f72616e646f6d
+    fileprivate var v2: UInt64 = 0x6c7967656e657261
+    fileprivate var v3: UInt64 = 0x7465646279746573
+    // The fields below are reserved for future use. They aren't currently used.
+    fileprivate var v4: UInt64 = 0
+    fileprivate var v5: UInt64 = 0
+    fileprivate var v6: UInt64 = 0
+    fileprivate var v7: UInt64 = 0
 
-  @inline(__always)
-  fileprivate init(rawSeed: (UInt64, UInt64)) {
-    v3 ^= rawSeed.1
-    v2 ^= rawSeed.0
-    v1 ^= rawSeed.1
-    v0 ^= rawSeed.0
+    @inline(__always)
+    fileprivate init(rawSeed: (UInt64, UInt64)) {
+      v3 ^= rawSeed.1
+      v2 ^= rawSeed.0
+      v1 ^= rawSeed.1
+      v0 ^= rawSeed.0
+    }
   }
+}
 
+extension Hasher._State {
   @inline(__always)
   fileprivate
   static func _rotateLeft(_ x: UInt64, by amount: UInt64) -> UInt64 {
@@ -50,19 +54,19 @@ internal struct _SipHashState {
   @inline(__always)
   fileprivate mutating func _round() {
     v0 = v0 &+ v1
-    v1 = _SipHashState._rotateLeft(v1, by: 13)
+    v1 = Hasher._State._rotateLeft(v1, by: 13)
     v1 ^= v0
-    v0 = _SipHashState._rotateLeft(v0, by: 32)
+    v0 = Hasher._State._rotateLeft(v0, by: 32)
     v2 = v2 &+ v3
-    v3 = _SipHashState._rotateLeft(v3, by: 16)
+    v3 = Hasher._State._rotateLeft(v3, by: 16)
     v3 ^= v2
     v0 = v0 &+ v3
-    v3 = _SipHashState._rotateLeft(v3, by: 21)
+    v3 = Hasher._State._rotateLeft(v3, by: 21)
     v3 ^= v0
     v2 = v2 &+ v1
-    v1 = _SipHashState._rotateLeft(v1, by: 17)
+    v1 = Hasher._State._rotateLeft(v1, by: 17)
     v1 ^= v2
-    v2 = _SipHashState._rotateLeft(v2, by: 32)
+    v2 = Hasher._State._rotateLeft(v2, by: 32)
   }
 
   @inline(__always)
@@ -71,27 +75,42 @@ internal struct _SipHashState {
   }
 }
 
-@usableFromInline
-@_fixed_layout
-internal struct _SipHash13Core {
-  private var _state: _SipHashState
-
+extension Hasher {
   @usableFromInline
-  @_effects(releasenone)
-  internal init(rawSeed: (UInt64, UInt64)) {
-    _state = _SipHashState(rawSeed: rawSeed)
+  @_fixed_layout
+  internal struct _Core {
+    private var _state: Hasher._State
+
+    @inline(__always)
+    internal init(rawSeed: (UInt64, UInt64)) {
+      _state = Hasher._State(rawSeed: rawSeed)
+    }
+  }
+}
+
+extension Hasher._Core {
+  @inline(__always)
+  internal init() {
+    self.init(rawSeed: Hasher._executionSeed)
   }
 
-  @usableFromInline
-  @_effects(releasenone)
+  @inline(__always)
+  internal init(seed: Int) {
+    let executionSeed = Hasher._executionSeed
+    // Prevent sign-extending the supplied seed; this makes testing slightly
+    // easier.
+    let seed = UInt(bitPattern: seed)
+    self.init(rawSeed: (
+      executionSeed.0 ^ UInt64(truncatingIfNeeded: seed),
+      executionSeed.1))
+  }
+
   internal mutating func compress(_ m: UInt64) {
     _state.v3 ^= m
     _state._round()
     _state.v0 ^= m
   }
 
-  @usableFromInline
-  @_effects(releasenone)
   internal mutating func finalize(tailAndByteCount: UInt64) -> UInt64 {
     compress(tailAndByteCount)
     _state.v2 ^= 0xff

--- a/stdlib/public/core/SipHash.swift
+++ b/stdlib/public/core/SipHash.swift
@@ -19,15 +19,19 @@
 /// * Daniel J. Bernstein <djb@cr.yp.to>
 //===----------------------------------------------------------------------===//
 
-// FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
-// rdar://problem/38549901
-@usableFromInline @_fixed_layout
+@_fixed_layout
+@usableFromInline
 internal struct _SipHashState {
   // "somepseudorandomlygeneratedbytes"
   fileprivate var v0: UInt64 = 0x736f6d6570736575
   fileprivate var v1: UInt64 = 0x646f72616e646f6d
   fileprivate var v2: UInt64 = 0x6c7967656e657261
   fileprivate var v3: UInt64 = 0x7465646279746573
+  // These fields are reserved for future use.
+  fileprivate var p0: UInt64 = 0
+  fileprivate var p1: UInt64 = 0
+  fileprivate var p2: UInt64 = 0
+  fileprivate var p3: UInt64 = 0
 
   @inline(__always)
   fileprivate init(rawSeed: (UInt64, UInt64)) {
@@ -67,25 +71,27 @@ internal struct _SipHashState {
   }
 }
 
-// FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
-// rdar://problem/38549901
-@usableFromInline @_fixed_layout
-internal struct _SipHash13Core: _HasherCore {
+@usableFromInline
+@_fixed_layout
+internal struct _SipHash13Core {
   private var _state: _SipHashState
 
-  @inline(__always)
+  @usableFromInline
+  @_effects(releasenone)
   internal init(rawSeed: (UInt64, UInt64)) {
     _state = _SipHashState(rawSeed: rawSeed)
   }
 
-  @inline(__always)
+  @usableFromInline
+  @_effects(releasenone)
   internal mutating func compress(_ m: UInt64) {
     _state.v3 ^= m
     _state._round()
     _state.v0 ^= m
   }
 
-  @inline(__always)
+  @usableFromInline
+  @_effects(releasenone)
   internal mutating func finalize(tailAndByteCount: UInt64) -> UInt64 {
     compress(tailAndByteCount)
     _state.v2 ^= 0xff
@@ -93,107 +99,5 @@ internal struct _SipHash13Core: _HasherCore {
       _state._round()
     }
     return _state._extract()
-  }
-}
-
-internal struct _SipHash24Core: _HasherCore {
-  private var _state: _SipHashState
-
-  @inline(__always)
-  internal init(rawSeed: (UInt64, UInt64)) {
-    _state = _SipHashState(rawSeed: rawSeed)
-  }
-
-  @inline(__always)
-  internal mutating func compress(_ m: UInt64) {
-    _state.v3 ^= m
-    _state._round()
-    _state._round()
-    _state.v0 ^= m
-  }
-
-  @inline(__always)
-  internal mutating func finalize(tailAndByteCount: UInt64) -> UInt64 {
-    compress(tailAndByteCount)
-
-    _state.v2 ^= 0xff
-    for _ in 0..<4 {
-      _state._round()
-    }
-    return _state._extract()
-  }
-}
-
-// FIXME: This type only exists to facilitate testing, and should not exist in
-// production builds.
-@usableFromInline // @testable
-internal struct _SipHash13 {
-  internal typealias Core = _SipHash13Core
-
-  internal var _core: _BufferingHasher<Core>
-
-  @usableFromInline // @testable
-  internal init(_rawSeed: (UInt64, UInt64)) {
-    _core = _BufferingHasher(core: Core(rawSeed: _rawSeed))
-  }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt64) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt32) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt16) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt8) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(bytes v: UInt64, count: Int) {
-    _core.combine(bytes: v, count: count)
-  }
-  @usableFromInline // @testable
-  internal mutating func combine(bytes: UnsafeRawBufferPointer) {
-    _core.combine(bytes: bytes)
-  }
-  @usableFromInline // @testable
-  internal __consuming func finalize() -> UInt64 {
-    var core = _core
-    return core.finalize()
-  }
-}
-
-// FIXME: This type only exists to facilitate testing, and should not exist in
-// production builds.
-@usableFromInline // @testable
-internal struct _SipHash24 {
-  internal typealias Core = _SipHash24Core
-
-  internal var _core: _BufferingHasher<Core>
-
-  @usableFromInline // @testable
-  internal init(_rawSeed: (UInt64, UInt64)) {
-    _core = _BufferingHasher(core: Core(rawSeed: _rawSeed))
-  }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt64) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt32) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt16) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(_ v: UInt8) { _core.combine(v) }
-  @usableFromInline // @testable
-  internal mutating func _combine(bytes v: UInt64, count: Int) {
-    _core.combine(bytes: v, count: count)
-  }
-  @usableFromInline // @testable
-  internal mutating func combine(bytes: UnsafeRawBufferPointer) {
-    _core.combine(bytes: bytes)
-  }
-  @usableFromInline // @testable
-  internal __consuming func finalize() -> UInt64 {
-    var core = _core
-    return core.finalize()
   }
 }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -30,7 +30,9 @@ Struct _ConcreteHashableBox has been removed
 Struct _HasherTailBuffer has been removed
 Struct _HeapBufferHeader has been removed
 Struct _SipHash13 has been removed
+Struct _SipHash13Core has been removed
 Struct _SipHash24 has been removed
+Struct _SipHashState has been removed
 Subscript ManagedBufferPointer.subscript(_:) has been removed
 Var ManagedBufferPointer.baseAddress has been removed
 Var ManagedBufferPointer.storage has been removed
@@ -51,7 +53,7 @@ Var __SwiftDeferredNSArray._heapBufferBridgedPtr has been removed
 /* Renamed Decls */
 
 /* Type Changes */
-Var Hasher._core has declared type change from _BufferingHasher<_SipHash13Core> to _SipHash13Core
+Var Hasher._core has declared type change from _BufferingHasher<_SipHash13Core> to Hasher._Core
 Struct _BridgeableMetatype is now without @_fixed_layout
 Func __ContiguousArrayStorageBase._getNonVerbatimBridgingBuffer() is added to a non-resilient type
 Var Hasher._core in a non-resilient type changes position from 0 to 1
@@ -60,11 +62,6 @@ Var _CocoaDictionary.Index._offset is added to a non-resilient type
 Var _CocoaDictionary.Index._storage in a non-resilient type changes position from 1 to 0
 Var _CocoaSet.Index._offset is added to a non-resilient type
 Var _CocoaSet.Index._storage in a non-resilient type changes position from 1 to 0
-Var _SipHashState.p0 is added to a non-resilient type
-Var _SipHashState.p1 is added to a non-resilient type
-Var _SipHashState.p2 is added to a non-resilient type
-Var _SipHashState.p3 is added to a non-resilient type
-Struct _SipHash13Core has removed conformance to _HasherCore
 
 /* Decl Attribute changes */
 

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -23,9 +23,14 @@ Func _getEnumCaseName(_:) has been removed
 Func _opaqueSummary(_:) has been removed
 Func _stdlib_NSDictionary_allKeys(_:) has been removed
 Func _stdlib_NSSet_allObjects(_:) has been removed
+Protocol _HasherCore has been removed
 Protocol _HeapBufferHeader_ has been removed
+Struct _BufferingHasher has been removed
 Struct _ConcreteHashableBox has been removed
+Struct _HasherTailBuffer has been removed
 Struct _HeapBufferHeader has been removed
+Struct _SipHash13 has been removed
+Struct _SipHash24 has been removed
 Subscript ManagedBufferPointer.subscript(_:) has been removed
 Var ManagedBufferPointer.baseAddress has been removed
 Var ManagedBufferPointer.storage has been removed
@@ -46,12 +51,20 @@ Var __SwiftDeferredNSArray._heapBufferBridgedPtr has been removed
 /* Renamed Decls */
 
 /* Type Changes */
+Var Hasher._core has declared type change from _BufferingHasher<_SipHash13Core> to _SipHash13Core
 Struct _BridgeableMetatype is now without @_fixed_layout
 Func __ContiguousArrayStorageBase._getNonVerbatimBridgingBuffer() is added to a non-resilient type
+Var Hasher._core in a non-resilient type changes position from 0 to 1
+Var Hasher._tail is added to a non-resilient type
 Var _CocoaDictionary.Index._offset is added to a non-resilient type
 Var _CocoaDictionary.Index._storage in a non-resilient type changes position from 1 to 0
 Var _CocoaSet.Index._offset is added to a non-resilient type
 Var _CocoaSet.Index._storage in a non-resilient type changes position from 1 to 0
+Var _SipHashState.p0 is added to a non-resilient type
+Var _SipHashState.p1 is added to a non-resilient type
+Var _SipHashState.p2 is added to a non-resilient type
+Var _SipHashState.p3 is added to a non-resilient type
+Struct _SipHash13Core has removed conformance to _HasherCore
 
 /* Decl Attribute changes */
 

--- a/validation-test/stdlib/SipHash.swift
+++ b/validation-test/stdlib/SipHash.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-stdlib-swiftgyb
+// RUN: %target-run-stdlib-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest
@@ -7,12 +7,6 @@ let SipHashTests = TestSuite("SipHashTests")
 
 extension Hasher {
   typealias HashValue = Int
-}
-extension _SipHash13 {
-  typealias HashValue = UInt64
-}
-extension _SipHash24 {
-  typealias HashValue = UInt64
 }
 
 struct SipHashTest {
@@ -46,89 +40,6 @@ struct SipHashTest {
     self.output = output
   }
 }
-
-let sipHash24Tests: [SipHashTest] = [
-  // Test vectors from the reference C implementation, which was released
-  // to public domain by:
-  //
-  // * Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
-  // * Daniel J. Bernstein <djb@cr.yp.to>
-  SipHashTest(referenceVectorIndex: 0, output: 0x726fdb47dd0e0e31),
-  SipHashTest(referenceVectorIndex: 1, output: 0x74f839c593dc67fd),
-  SipHashTest(referenceVectorIndex: 2, output: 0x0d6c8009d9a94f5a),
-  SipHashTest(referenceVectorIndex: 3, output: 0x85676696d7fb7e2d),
-  SipHashTest(referenceVectorIndex: 4, output: 0xcf2794e0277187b7),
-  SipHashTest(referenceVectorIndex: 5, output: 0x18765564cd99a68d),
-  SipHashTest(referenceVectorIndex: 6, output: 0xcbc9466e58fee3ce),
-  SipHashTest(referenceVectorIndex: 7, output: 0xab0200f58b01d137),
-  SipHashTest(referenceVectorIndex: 8, output: 0x93f5f5799a932462),
-  SipHashTest(referenceVectorIndex: 9, output: 0x9e0082df0ba9e4b0),
-  SipHashTest(referenceVectorIndex: 10, output: 0x7a5dbbc594ddb9f3),
-  SipHashTest(referenceVectorIndex: 11, output: 0xf4b32f46226bada7),
-  SipHashTest(referenceVectorIndex: 12, output: 0x751e8fbc860ee5fb),
-  SipHashTest(referenceVectorIndex: 13, output: 0x14ea5627c0843d90),
-  SipHashTest(referenceVectorIndex: 14, output: 0xf723ca908e7af2ee),
-  SipHashTest(referenceVectorIndex: 15, output: 0xa129ca6149be45e5),
-  SipHashTest(referenceVectorIndex: 16, output: 0x3f2acc7f57c29bdb),
-  SipHashTest(referenceVectorIndex: 17, output: 0x699ae9f52cbe4794),
-  SipHashTest(referenceVectorIndex: 18, output: 0x4bc1b3f0968dd39c),
-  SipHashTest(referenceVectorIndex: 19, output: 0xbb6dc91da77961bd),
-  SipHashTest(referenceVectorIndex: 20, output: 0xbed65cf21aa2ee98),
-  SipHashTest(referenceVectorIndex: 21, output: 0xd0f2cbb02e3b67c7),
-  SipHashTest(referenceVectorIndex: 22, output: 0x93536795e3a33e88),
-  SipHashTest(referenceVectorIndex: 23, output: 0xa80c038ccd5ccec8),
-  SipHashTest(referenceVectorIndex: 24, output: 0xb8ad50c6f649af94),
-  SipHashTest(referenceVectorIndex: 25, output: 0xbce192de8a85b8ea),
-  SipHashTest(referenceVectorIndex: 26, output: 0x17d835b85bbb15f3),
-  SipHashTest(referenceVectorIndex: 27, output: 0x2f2e6163076bcfad),
-  SipHashTest(referenceVectorIndex: 28, output: 0xde4daaaca71dc9a5),
-  SipHashTest(referenceVectorIndex: 29, output: 0xa6a2506687956571),
-  SipHashTest(referenceVectorIndex: 30, output: 0xad87a3535c49ef28),
-  SipHashTest(referenceVectorIndex: 31, output: 0x32d892fad841c342),
-  SipHashTest(referenceVectorIndex: 32, output: 0x7127512f72f27cce),
-  SipHashTest(referenceVectorIndex: 33, output: 0xa7f32346f95978e3),
-  SipHashTest(referenceVectorIndex: 34, output: 0x12e0b01abb051238),
-  SipHashTest(referenceVectorIndex: 35, output: 0x15e034d40fa197ae),
-  SipHashTest(referenceVectorIndex: 36, output: 0x314dffbe0815a3b4),
-  SipHashTest(referenceVectorIndex: 37, output: 0x027990f029623981),
-  SipHashTest(referenceVectorIndex: 38, output: 0xcadcd4e59ef40c4d),
-  SipHashTest(referenceVectorIndex: 39, output: 0x9abfd8766a33735c),
-  SipHashTest(referenceVectorIndex: 40, output: 0x0e3ea96b5304a7d0),
-  SipHashTest(referenceVectorIndex: 41, output: 0xad0c42d6fc585992),
-  SipHashTest(referenceVectorIndex: 42, output: 0x187306c89bc215a9),
-  SipHashTest(referenceVectorIndex: 43, output: 0xd4a60abcf3792b95),
-  SipHashTest(referenceVectorIndex: 44, output: 0xf935451de4f21df2),
-  SipHashTest(referenceVectorIndex: 45, output: 0xa9538f0419755787),
-  SipHashTest(referenceVectorIndex: 46, output: 0xdb9acddff56ca510),
-  SipHashTest(referenceVectorIndex: 47, output: 0xd06c98cd5c0975eb),
-  SipHashTest(referenceVectorIndex: 48, output: 0xe612a3cb9ecba951),
-  SipHashTest(referenceVectorIndex: 49, output: 0xc766e62cfcadaf96),
-  SipHashTest(referenceVectorIndex: 50, output: 0xee64435a9752fe72),
-  SipHashTest(referenceVectorIndex: 51, output: 0xa192d576b245165a),
-  SipHashTest(referenceVectorIndex: 52, output: 0x0a8787bf8ecb74b2),
-  SipHashTest(referenceVectorIndex: 53, output: 0x81b3e73d20b49b6f),
-  SipHashTest(referenceVectorIndex: 54, output: 0x7fa8220ba3b2ecea),
-  SipHashTest(referenceVectorIndex: 55, output: 0x245731c13ca42499),
-  SipHashTest(referenceVectorIndex: 56, output: 0xb78dbfaf3a8d83bd),
-  SipHashTest(referenceVectorIndex: 57, output: 0xea1ad565322a1a0b),
-  SipHashTest(referenceVectorIndex: 58, output: 0x60e61c23a3795013),
-  SipHashTest(referenceVectorIndex: 59, output: 0x6606d7e446282b93),
-  SipHashTest(referenceVectorIndex: 60, output: 0x6ca4ecb15c5f91e1),
-  SipHashTest(referenceVectorIndex: 61, output: 0x9f626da15c9625f3),
-  SipHashTest(referenceVectorIndex: 62, output: 0xe51b38608ef25f57),
-  SipHashTest(referenceVectorIndex: 63, output: 0x958a324ceb064572),
-  // End of reference test vectors.
-
-  SipHashTest(
-    input: [
-      0x72, 0xdc, 0xde, 0xd4, 0x6d, 0xb4, 0xc8, 0xa1,
-      0xcf, 0x22, 0xe2, 0x7f, 0xe3, 0xf6, 0xe5, 0x6d,
-      0x8b, 0x66, 0x0b, 0xaf, 0xba, 0x16, 0x25, 0xf3,
-      0x63, 0x8e, 0x69, 0x80, 0xf3, 0x7e, 0xd6, 0xe3,
-    ],
-    seed: (0xa3432fc680796c34, 0x1173946a79aeaae5),
-    output: 0x058b04535972ff2b),
-]
 
 let sipHash13Tests: [SipHashTest] = [
   SipHashTest(referenceVectorIndex: 0, output: 0xabac0158050fc4dc),
@@ -237,25 +148,19 @@ struct Loop<C: Collection>: Sequence, IteratorProtocol {
   }
 }
 
-% for (Self, tests) in [
-%   ('Hasher', 'sipHash13Tests'),
-%   ('_SipHash13', 'sipHash13Tests'),
-%   ('_SipHash24', 'sipHash24Tests')
-% ]:
-
-SipHashTests.test("${Self}/combine(UnsafeRawBufferPointer)")
-  .forEach(in: ${tests}) { test in
-  var hasher = ${Self}(_rawSeed: test.seed)
+SipHashTests.test("Hasher/combine(UnsafeRawBufferPointer)")
+  .forEach(in: sipHash13Tests) { test in
+  var hasher = Hasher(_rawSeed: test.seed)
   test.input.withUnsafeBytes { hasher.combine(bytes: $0) }
   let hash = hasher.finalize()
-  expectEqual(${Self}.HashValue(truncatingIfNeeded: test.output), hash)
+  expectEqual(Hasher.HashValue(truncatingIfNeeded: test.output), hash)
 }
 
-SipHashTests.test("${Self}/combine(UnsafeRawBufferPointer)/pattern")
-  .forEach(in: cartesianProduct(${tests}, incrementalPatterns)) { test_ in
+SipHashTests.test("Hasher/combine(UnsafeRawBufferPointer)/pattern")
+  .forEach(in: cartesianProduct(sipHash13Tests, incrementalPatterns)) { test_ in
   let (test, pattern) = test_
 
-  var hasher = ${Self}(_rawSeed: test.seed)
+  var hasher = Hasher(_rawSeed: test.seed)
   var chunkSizes = Loop(pattern).makeIterator()
   var startIndex = 0
   while startIndex != test.input.endIndex {
@@ -267,43 +172,52 @@ SipHashTests.test("${Self}/combine(UnsafeRawBufferPointer)/pattern")
     startIndex += chunkSize
   }
   let hash = hasher.finalize()
-  expectEqual(${Self}.HashValue(truncatingIfNeeded: test.output), hash)
+  expectEqual(Hasher.HashValue(truncatingIfNeeded: test.output), hash)
 }
 
-% for data_type in ['UInt', 'UInt64', 'UInt32', 'UInt16', 'UInt8']:
-SipHashTests.test("${Self}._combine(${data_type})")
-  .forEach(in: ${tests}) { test in
 
-  var hasher = ${Self}(_rawSeed: test.seed)
+func testIntegerType<I: FixedWidthInteger>(
+  _ type: I.Type,
+  combiner: @escaping (inout Hasher, I) -> Void) {
+  SipHashTests.test("Hasher._combine(\(type.self))")
+    .forEach(in: sipHash13Tests) { test in
 
-  // Load little-endian chunks and combine them into the hasher.
-  let bitWidth = ${data_type}.bitWidth
-  var i = 0
-  var count = 0
-  var chunk: ${data_type} = 0
-  while i < test.input.count {
-    chunk |= ${data_type}(test.input[i]) << (8 * count)
-    i += 1
-    count += 1
-    if 8 * count == bitWidth {
-      hasher._combine(chunk)
-      count = 0
-      chunk = 0
+    var hasher = Hasher(_rawSeed: test.seed)
+
+    // Load little-endian chunks and combine them into the hasher.
+    let bitWidth = I.bitWidth
+    var i = 0
+    var count = 0
+    var chunk: I = 0
+    while i < test.input.count {
+      chunk |= I(test.input[i]) << (8 * count)
+      i += 1
+      count += 1
+      if 8 * count == bitWidth {
+        combiner(&hasher, chunk)
+        count = 0
+        chunk = 0
+      }
     }
-  }
-  // Combine tail bytes.
-  if count > 0 {
-    hasher._combine(bytes: UInt64(truncatingIfNeeded: chunk), count: count)
-  }
+    // Combine tail bytes.
+    if count > 0 {
+      hasher._combine(bytes: UInt64(truncatingIfNeeded: chunk), count: count)
+    }
 
-  let hash = hasher.finalize()
-  expectEqual(${Self}.HashValue(truncatingIfNeeded: test.output), hash)
+    let hash = hasher.finalize()
+    expectEqual(Hasher.HashValue(truncatingIfNeeded: test.output), hash)
+  }
 }
-% end
 
-SipHashTests.test("${Self}/OperationsAfterFinalize") {
+testIntegerType(UInt.self) { $0._combine($1) }
+testIntegerType(UInt64.self) { $0._combine($1) }
+testIntegerType(UInt32.self) { $0._combine($1) }
+testIntegerType(UInt16.self) { $0._combine($1) }
+testIntegerType(UInt8.self) { $0._combine($1) }
+
+SipHashTests.test("Hasher/OperationsAfterFinalize") {
   // Verify that finalize is nonmutating.
-  var hasher1 = ${Self}(_rawSeed: (0, 0))
+  var hasher1 = Hasher(_rawSeed: (0, 0))
   hasher1._combine(1 as UInt8)
   _ = hasher1.finalize()
   // Hasher is now consumed. The operations below are illegal, but this isn't
@@ -314,13 +228,12 @@ SipHashTests.test("${Self}/OperationsAfterFinalize") {
   let hash1b = hasher1.finalize()
   expectEqual(hash1a, hash1b)
 
-  var hasher2 = ${Self}(_rawSeed: (0, 0))
+  var hasher2 = Hasher(_rawSeed: (0, 0))
   hasher2._combine(1 as UInt8)
   hasher2._combine(2 as UInt16)
   let hash2 = hasher2.finalize()
   expectEqual(hash1a, hash2)
 }
-% end
 
 runAllTests()
 


### PR DESCRIPTION
It seems too costly to make Hasher a resilient struct, so leave it `@_fixed_layout`. 

To partially compensate for this, add 256 bits of extra state space, reserved for potential future use.
