### PR TITLE
[AutoDiff] Fix crasher when a closure with context gets differentiated

### DIFF
--- a/test/AutoDiff/autodiff_e2e_basic.swift
+++ b/test/AutoDiff/autodiff_e2e_basic.swift
@@ -11,7 +11,7 @@ func adjointId(_ x: Float, originalValue: Float, seed: Float) -> Float {
 
 _ = #gradient(id)(2)
 
-// CHECK: @{{.*}}id{{.*}}__grad_src_0_wrt_0
+// CHECK-LABEL: @{{.*}}id{{.*}}__grad_src_0_wrt_0
 // CHECK-LABEL: @{{.*}}id{{.*}}__grad_src_0_wrt_0_s_p
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -41,7 +41,7 @@ let x = #gradient(sigmoid)(3)
 let (value: y, gradient: z) = #valueAndGradient(sigmoid)(4)
 print(x * z)
 
-// CHECK: @{{.*}}sigmoid{{.*}}__grad_src_0_wrt_0
+// CHECK-LABEL: @{{.*}}sigmoid{{.*}}__grad_src_0_wrt_0
 // CHECK: @{{.*}}sigmoid{{.*}}__grad_src_0_wrt_0_s_p
 // CHECK: @{{.*}}sigmoid{{.*}}__grad_src_0_wrt_0_p
 
@@ -51,7 +51,6 @@ public func publicFunc(_ x: Float) -> Float {
 }
 _ = #gradient(publicFunc)
 
-// CHECK: sil non_abi @{{.*}}publicFunc{{.*}}__grad_src_0_wrt_0
-// CHECK: sil non_abi @{{.*}}publicFunc{{.*}}__primal_src_0_wrt_0
-// CHECK: sil non_abi @{{.*}}publicFunc{{.*}}__adjoint_src_0_wrt_0
-
+// CHECK-LABEL: @{{.*}}publicFunc{{.*}}__grad_src_0_wrt_0
+// CHECK: @{{.*}}publicFunc{{.*}}__primal_src_0_wrt_0
+// CHECK: @{{.*}}publicFunc{{.*}}__adjoint_src_0_wrt_0

--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+
+public func closureCapture() {
+  let val: Float = 10
+  let clo: (Float) -> Float = { x in
+    val * x
+  }
+  _ = #gradient(clo)
+}
+
+// CHECK-LABEL: @{{.*}}closureCapture{{.*}}
+// CHECK: [[ORIG_FN:%.*]] = function_ref @{{.*}}closureCapture{{.*}}
+// CHECK: [[PARTIAL_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[ORIG_FN]]
+// CHECK: [[GRAD_FN:%.*]] = function_ref @{{.*}}closureCapture{{.*}}___grad
+// CHECK: [[PARTIAL_APPLIED_GRAD:%.*]] = partial_apply [callee_guaranteed] [[GRAD_FN]]

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -56,4 +56,13 @@ SimpleMathTests.test("ResultSelection") {
   expectEqual((0, 1), #gradient(foo, result: .1)(3, 3))
 }
 
+
+SimpleMathTests.test("CaptureGlobal") {
+  let z: Float = 10
+  func foo(_ x: Float) -> Float {
+    return z * x
+  }
+  expectEqual(10, #gradient(foo)(0))
+}
+
 runAllTests()


### PR DESCRIPTION
This patch makes the following self-explanatory case possible.

```swift
  let val: Float = 10
  let clo: (Float) -> Float = { x in
    val * x
  }
  _ = #gradient(clo)
```