### PR TITLE
[test] Re-enable Driver/sdk-link.swift. rdar://42247881

### DIFF
--- a/test/Driver/sdk-link.swift
+++ b/test/Driver/sdk-link.swift
@@ -6,7 +6,6 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
-// REQUIRES: rdar42247881
 
 import Foundation
 


### PR DESCRIPTION
Talked with @jrose-apple offline about this, fixing the root-cause of the flakiness seems to be harder than expected. So we re-enable it to get the coverage back while investigating.