### PR TITLE
swift: update for LLVM SVN r344140

### DIFF
--- a/include/swift/Basic/FileSystem.h
+++ b/include/swift/Basic/FileSystem.h
@@ -23,7 +23,7 @@ namespace llvm {
   class Twine;
 }
 
-namespace clang {
+namespace llvm {
   namespace vfs {
     class FileSystem;
   }
@@ -58,7 +58,7 @@ namespace swift {
 
   namespace vfs {
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
-    getFileOrSTDIN(clang::vfs::FileSystem &FS,
+    getFileOrSTDIN(llvm::vfs::FileSystem &FS,
                    const llvm::Twine &Name, int64_t FileSize = -1,
                    bool RequiresNullTerminator = true, bool IsVolatile = false);
   } // end namespace vfs

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -26,7 +26,7 @@ namespace swift {
 /// \brief This class manages and owns source buffers.
 class SourceManager {
   llvm::SourceMgr LLVMSourceMgr;
-  llvm::IntrusiveRefCntPtr<clang::vfs::FileSystem> FileSystem;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem;
   unsigned CodeCompletionBufferID = 0U;
   unsigned CodeCompletionOffset;
 
@@ -37,7 +37,7 @@ class SourceManager {
   ///
   /// This is as much a hack to prolong the lifetime of status objects as it is
   /// to speed up stats.
-  mutable llvm::DenseMap<StringRef, clang::vfs::Status> StatusCache;
+  mutable llvm::DenseMap<StringRef, llvm::vfs::Status> StatusCache;
 
   // \c #sourceLocation directive handling.
   struct VirtualFile {
@@ -49,8 +49,8 @@ class SourceManager {
   mutable std::pair<const char *, const VirtualFile*> CachedVFile = {nullptr, nullptr};
 
 public:
-  SourceManager(llvm::IntrusiveRefCntPtr<clang::vfs::FileSystem> FS =
-                    clang::vfs::getRealFileSystem())
+  SourceManager(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
+                    llvm::vfs::getRealFileSystem())
     : FileSystem(FS) {}
 
   llvm::SourceMgr &getLLVMSourceMgr() {
@@ -60,11 +60,11 @@ public:
     return LLVMSourceMgr;
   }
 
-  void setFileSystem(llvm::IntrusiveRefCntPtr<clang::vfs::FileSystem> FS) {
+  void setFileSystem(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS) {
     FileSystem = FS;
   }
 
-  llvm::IntrusiveRefCntPtr<clang::vfs::FileSystem> getFileSystem() {
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> getFileSystem() {
     return FileSystem;
   }
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -430,7 +430,7 @@ public:
 
   DiagnosticEngine &getDiags() { return Diagnostics; }
 
-  clang::vfs::FileSystem &getFileSystem() { return *SourceMgr.getFileSystem(); }
+  llvm::vfs::FileSystem &getFileSystem() { return *SourceMgr.getFileSystem(); }
 
   ASTContext &getASTContext() {
     return *Context;

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -20,6 +20,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
+#include "llvm/Support/VirtualFileSystem.h"
 
 using namespace swift;
 
@@ -223,7 +224,7 @@ std::error_code swift::moveFileIfDifferent(const llvm::Twine &source,
 }
 
 llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
-swift::vfs::getFileOrSTDIN(clang::vfs::FileSystem &FS,
+swift::vfs::getFileOrSTDIN(llvm::vfs::FileSystem &FS,
                            const llvm::Twine &Filename,
                            int64_t FileSize,
                            bool RequiresNullTerminator,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -213,8 +213,8 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
 
 static bool loadAndValidateVFSOverlay(
     const std::string &File,
-    const llvm::IntrusiveRefCntPtr<clang::vfs::FileSystem> &BaseFS,
-    const llvm::IntrusiveRefCntPtr<clang::vfs::OverlayFileSystem> &OverlayFS,
+    const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &BaseFS,
+    const llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> &OverlayFS,
     DiagnosticEngine &Diag) {
   // FIXME: It should be possible to allow chained lookup of later VFS overlays
   // through the mapping defined by earlier overlays.
@@ -226,7 +226,7 @@ static bool loadAndValidateVFSOverlay(
     return true;
   }
 
-  auto VFS = clang::vfs::getVFSFromYAML(std::move(Buffer.get()),
+  auto VFS = llvm::vfs::getVFSFromYAML(std::move(Buffer.get()),
                                         nullptr, File);
   if (!VFS) {
     Diag.diagnose(SourceLoc(), diag::invalid_vfs_overlay_file, File);
@@ -237,9 +237,9 @@ static bool loadAndValidateVFSOverlay(
 }
 
 bool CompilerInstance::setUpVirtualFileSystemOverlays() {
-  auto BaseFS = clang::vfs::getRealFileSystem();
-  auto OverlayFS = llvm::IntrusiveRefCntPtr<clang::vfs::OverlayFileSystem>(
-                    new clang::vfs::OverlayFileSystem(BaseFS));
+  auto BaseFS = llvm::vfs::getRealFileSystem();
+  auto OverlayFS = llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>(
+                    new llvm::vfs::OverlayFileSystem(BaseFS));
   bool hadAnyFailure = false;
   for (const auto &File : Invocation.getSearchPathOptions().VFSOverlayFiles) {
     hadAnyFailure |=

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -37,7 +37,7 @@ using namespace swift;
 
 static bool
 extractSwiftInterfaceVersionAndArgs(DiagnosticEngine &Diags,
-                                    clang::vfs::FileSystem &FS,
+                                    llvm::vfs::FileSystem &FS,
                                     StringRef SwiftInterfacePathIn,
                                     swift::version::Version &Vers,
                                     llvm::StringSaver &SubArgSaver,
@@ -160,7 +160,7 @@ static bool writeSwiftInterfaceDeps(DiagnosticEngine &Diags,
 // Check that the output .swiftmodule file is at least as new as all the
 // dependencies it read when it was built last time.
 static bool
-swiftModuleIsUpToDate(clang::vfs::FileSystem &FS,
+swiftModuleIsUpToDate(llvm::vfs::FileSystem &FS,
                       StringRef InPath, StringRef OutPath, StringRef DepPath) {
 
   if (!FS.exists(OutPath) || !FS.exists(DepPath))
@@ -201,7 +201,7 @@ swiftModuleIsUpToDate(clang::vfs::FileSystem &FS,
 }
 
 static bool buildSwiftModuleFromSwiftInterface(
-    clang::vfs::FileSystem &FS, DiagnosticEngine &Diags,
+    llvm::vfs::FileSystem &FS, DiagnosticEngine &Diags,
     CompilerInvocation &SubInvocation, StringRef InPath, StringRef OutPath,
     StringRef DepPath) {
   bool SubError = false;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -50,7 +50,7 @@ std::error_code SerializedModuleLoaderBase::openModuleFiles(
           (!ModuleBuffer && !ModuleDocBuffer)) &&
          "Module and Module Doc buffer must both be initialized or NULL");
 
-  clang::vfs::FileSystem &FS = *Ctx.SourceMgr.getFileSystem();
+  llvm::vfs::FileSystem &FS = *Ctx.SourceMgr.getFileSystem();
 
   // Try to open the module file first.  If we fail, don't even look for the
   // module documentation file.


### PR DESCRIPTION
Update swift's usage of clang::vfs which has been hoisted into LLVM.
(cherry picked from commit ccacfe7a73ccf535184754f21d831059bde2061b)

 Conflicts:
	lib/Frontend/ParseableInterfaceSupport.cpp