### PR TITLE
[LICM] Only add dynamic begin_access checks to the list of access scopes to be analyzed

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -654,7 +654,9 @@ void LoopTreeOptimization::analyzeCurrentLoop(
       case SILInstructionKind::BeginAccessInst: {
         auto *BI = dyn_cast<BeginAccessInst>(&Inst);
         assert(BI && "Expected a Begin Access");
-        BeginAccesses.push_back(BI);
+        if (BI->getEnforcement() == SILAccessEnforcement::Dynamic) {
+          BeginAccesses.push_back(BI);
+        }
         checkSideEffects(Inst, MayWrites);
         break;
       }


### PR DESCRIPTION
This should provide slight compile-time improvement
