### PR TITLE
[CSBindings] Detect situations when type variable bindings could be i…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -423,6 +423,15 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
     case ConstraintKind::ArgumentConversion:
     case ConstraintKind::OperatorArgumentConversion:
     case ConstraintKind::OptionalObject: {
+      // If there is a `bind param` constraint associated with
+      // current type variable, result should be aware of that
+      // fact. Binding set might be incomplete until
+      // this constraint is resolved, because we currently don't
+      // look-through constraints expect to `subtype` to try and
+      // find related bindings.
+      if (constraint->getKind() == ConstraintKind::BindParam)
+        result.PotentiallyIncomplete = true;
+
       auto binding = getPotentialBindingForRelationalConstraint(
           result, constraint, hasDependentMemberRelationalConstraints,
           hasNonDependentMemberRelationalConstraints,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2806,6 +2806,12 @@ private:
     /// Whether the bindings of this type involve other type variables.
     bool InvolvesTypeVariables = false;
 
+    /// Whether the bindings represent (potentially) incomplete set,
+    /// there is no way to say with absolute certainty if that's the
+    /// case, but that could happen when certain constraints like
+    /// `bind param` are present in the system.
+    bool PotentiallyIncomplete = false;
+
     /// Whether this type variable has literal bindings.
     LiteralBindingKind LiteralBinding = LiteralBindingKind::None;
 
@@ -2850,9 +2856,14 @@ private:
       if (formBindingScore(y) < formBindingScore(x))
         return false;
 
-      // If the only difference is default types,
+      // If there is a difference in number of default types,
       // prioritize bindings with fewer of them.
-      return x.NumDefaultableBindings < y.NumDefaultableBindings;
+      if (x.NumDefaultableBindings != y.NumDefaultableBindings)
+        return x.NumDefaultableBindings < y.NumDefaultableBindings;
+
+      // As a last resort, let's check if the bindings are
+      // potentially incomplete, and if so, let's de-prioritize them.
+      return x.PotentiallyIncomplete < y.PotentiallyIncomplete;
     }
 
     void foundLiteralBinding(ProtocolDecl *proto) {
@@ -2885,6 +2896,8 @@ private:
     void dump(llvm::raw_ostream &out,
               unsigned indent = 0) const LLVM_ATTRIBUTE_USED {
       out.indent(indent);
+      if (PotentiallyIncomplete)
+        out << "potentially_incomplete ";
       if (FullyBound)
         out << "fully_bound ";
       if (SubtypeOfExistentialType)

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -797,3 +797,11 @@ func test<Instances : Collection>(
 ) { fatalError() }
 
 test([1]) { _, _ in fatalError(); () }
+
+// rdar://problem/45659733
+func rdar_45659733() {
+  func foo<T : BinaryInteger>(_: AnyHashable, _: T) {}
+  func bar(_ a: Int, _ b: Int) {
+    _ = (a ..< b).map { i in foo(i, i) } // Ok
+  }
+}


### PR DESCRIPTION
…ncomplete

When `bind param` constraint is associated with a given type
variable a set of bindings collected for it is potentially
incomplete, because binding gathering doesn't look through related
type variables. Which means that such type variable has to be
de-prioritized until `bind param` constraint is resolved
or there is just nothing else to try, otherwise there is a
risk that solver would skip some of the valid solutions.

Resolves: rdar://problem/45659733

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
