### PR TITLE
use the &>> operator.

### DIFF
--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -113,16 +113,16 @@ class Hash {
   /// \brief Left-rotate \p x by \p c.
   final
   func rol(_ x: UInt32, _ c: UInt32) -> UInt32 {
-    let a = UInt32(Int64(x) &<< Int64(c))
-    let b = UInt32(Int64(x) &>> (32 - Int64(c)))
+    let a = UInt32(truncatingIfNeeded: Int64(x) &<< Int64(c))
+    let b = UInt32(truncatingIfNeeded: Int64(x) &>> (32 - Int64(c)))
     return a|b
   }
 
   /// \brief Right-rotate \p x by \p c.
   final
   func ror(_ x: UInt32, _ c: UInt32) -> UInt32 {
-    let a = UInt32(Int64(x) &>> Int64(c))
-    let b = UInt32(Int64(x) &<< (32 - Int64(c)))
+    let a = UInt32(truncatingIfNeeded: Int64(x) &>> Int64(c))
+    let b = UInt32(truncatingIfNeeded: Int64(x) &<< (32 - Int64(c)))
     return a|b
   }
 }

--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -113,18 +113,16 @@ class Hash {
   /// \brief Left-rotate \p x by \p c.
   final
   func rol(_ x: UInt32, _ c: UInt32) -> UInt32 {
-    // TODO: use the &>> operator.
-    let a = UInt32(truncatingIfNeeded: Int64(x) << Int64(c))
-    let b = UInt32(truncatingIfNeeded: Int64(x) >> (32 - Int64(c)))
+    let a = UInt32(Int64(x) &<< Int64(c))
+    let b = UInt32(Int64(x) &>> (32 - Int64(c)))
     return a|b
   }
 
   /// \brief Right-rotate \p x by \p c.
   final
   func ror(_ x: UInt32, _ c: UInt32) -> UInt32 {
-    // TODO: use the &>> operator.
-    let a = UInt32(truncatingIfNeeded: Int64(x) >> Int64(c))
-    let b = UInt32(truncatingIfNeeded: Int64(x) << (32 - Int64(c)))
+    let a = UInt32(Int64(x) &>> Int64(c))
+    let b = UInt32(Int64(x) &<< (32 - Int64(c)))
     return a|b
   }
 }

--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -113,17 +113,13 @@ class Hash {
   /// \brief Left-rotate \p x by \p c.
   final
   func rol(_ x: UInt32, _ c: UInt32) -> UInt32 {
-    let a = UInt32(truncatingIfNeeded: Int64(x) &<< Int64(c))
-    let b = UInt32(truncatingIfNeeded: Int64(x) &>> (32 - Int64(c)))
-    return a|b
+    return x &<< c | x &>> (32 &- c)
   }
 
   /// \brief Right-rotate \p x by \p c.
   final
   func ror(_ x: UInt32, _ c: UInt32) -> UInt32 {
-    let a = UInt32(truncatingIfNeeded: Int64(x) &>> Int64(c))
-    let b = UInt32(truncatingIfNeeded: Int64(x) &<< (32 - Int64(c)))
-    return a|b
+    return x &>> c | x &<< (32 &- c)
   }
 }
 


### PR DESCRIPTION
like this:
```
let a = UInt32(truncatingIfNeeded: Int64(x) << Int64(c))
```
chang to use the &>> operator.:
```
let a = UInt32(truncatingIfNeeded: Int64(x) &<< Int64(c))
```
Please review, test and merge, just a small change