### PR TITLE
[stdlib] Don’t force-inline Character.== and .<

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -448,7 +448,6 @@ internal var _minASCIICharReprBuiltin: Builtin.Int63 {
 
 extension Character : Equatable {
   @inlinable
-  @inline(__always)
   public static func == (lhs: Character, rhs: Character) -> Bool {
     let l0 = lhs._smallUTF16
     if _fastPath(l0 != nil), let l = l0?._storage {
@@ -467,7 +466,6 @@ extension Character : Equatable {
 
 extension Character : Comparable {
   @inlinable
-  @inline(__always)
   public static func < (lhs: Character, rhs: Character) -> Bool {
     let l0 = lhs._smallUTF16
     if _fastPath(l0 != nil), let l = l0?._storage {


### PR DESCRIPTION
The code to compare character values can be huge; it doesn’t seem a good idea to forcibly inline it. The `@inline(__always)` here can make unrelated modifications to `Set`'s code trigger a ballooning of the size of specialized `Set<Character>` operations to as much as 10x their usual size. (E.g., `insert` grows from 1.5kB to 15kB.) It also causes ~20% slowdowns in some benchmarks.

The code size bloat doesn’t always happen; I *guess* that _fastPaths inside String.== cause unintuitive inlining decisions in callers.