### PR TITLE
[Runtime] Check for @objc existentials conforming to @objc protocols.

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -362,8 +362,24 @@ bool swift::_conformsToProtocol(const OpaqueValue *value,
 #endif
 
   
-  case MetadataKind::Existential: // FIXME
-  case MetadataKind::ExistentialMetatype: // FIXME
+  case MetadataKind::Existential: {
+#if SWIFT_OBJC_INTEROP
+    // If all protocols are @objc and at least one of them conforms to the
+    // protocol, succeed.
+    auto existential = cast<ExistentialTypeMetadata>(type);
+    if (!existential->isObjC())
+      return false;
+    for (auto existentialProto : existential->getProtocols()) {
+      if (protocol_conformsToProtocol(existentialProto.getObjCProtocol(),
+                                      protocol.getObjCProtocol()))
+        return true;
+    }
+#endif
+
+    return false;
+  }
+
+  case MetadataKind::ExistentialMetatype:
   default:
     return false;
   }

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -14,6 +14,7 @@ let DemangleToMetadataTests = TestSuite("DemangleToMetadataObjC")
 @objc enum E: Int { case a }
 @objc protocol P1 { }
 protocol P2 { }
+@objc protocol P3: P1 { }
 
 DemangleToMetadataTests.test("@objc classes") {
   expectEqual(type(of: C()), _typeByMangledName("4main1CC")!)
@@ -94,6 +95,12 @@ DemangleToMetadataTests.test("members of runtime-only Objective-C classes") {
 DemangleToMetadataTests.test("runtime conformance lookup via foreign superclasses") {
   expectEqual(Set<CFMutableString>.self,
     _typeByMangledName("ShySo18CFMutableStringRefaG")!)
+}
+
+class F<T: P1> { }
+
+DemangleToMetadataTests.test("runtime conformance check for @objc protocol inheritance") {
+  expectEqual(F<P3>.self, _typeByMangledName("4main1FCyAA2P3PG")!)
 }
 
 runAllTests()


### PR DESCRIPTION
When checking conformance requirements against an @objc protocol, also
check for an @objc existential using protocol_conformsToProtocol().
Fixes rdar://problem/45685649.
