### PR TITLE
Add benchmarks for various ObjC NSString operations on bridged Swift Strings

### DIFF
--- a/benchmark/single-source/ObjectiveCBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCBridgingStubs.swift
@@ -27,7 +27,18 @@ public let ObjectiveCBridgingStubs = [
   BenchmarkInfo(name: "ObjectiveCBridgeStubToNSDate2", runFunction: run_ObjectiveCBridgeStubToNSDate, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubToNSString", runFunction: run_ObjectiveCBridgeStubToNSString, tags: [.validation, .bridging]),
   BenchmarkInfo(name: "ObjectiveCBridgeStubURLAppendPath2", runFunction: run_ObjectiveCBridgeStubURLAppendPath, tags: [.validation, .bridging]),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringIsEqual", runFunction: run_ObjectiveCBridgeStringIsEqual, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringIsEqual2", runFunction: run_ObjectiveCBridgeStringIsEqual2, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringIsEqualAllSwift", runFunction: run_ObjectiveCBridgeStringIsEqualAllSwift, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringCompare", runFunction: run_ObjectiveCBridgeStringCompare, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringCompare2", runFunction: run_ObjectiveCBridgeStringCompare2, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringGetCStringPtr", runFunction: run_ObjectiveCBridgeStringGetCStringPtr, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringRangeOfString", runFunction: run_ObjectiveCBridgeStringRangeOfString, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringHash", runFunction: run_ObjectiveCBridgeStringHash, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringUTF8String", runFunction: run_ObjectiveCBridgeStringUTF8String, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
 ]
+
+var b:BridgeTester! = nil
 
 #if _runtime(_ObjC)
 @inline(never)
@@ -256,5 +267,118 @@ public func run_ObjectiveCBridgeStubDataAppend(N: Int) {
       testObjectiveCBridgeStubDataAppend()
     }
   }
+#endif
+}
+
+@inline(never)
+internal func getStringsToBridge() -> [String] {
+  let strings1 = ["hello", "the quick brown fox jumps over the lazy dog", "the quick brown fox jumps over the lazy dög"]
+  return strings1 + strings1.map { $0 + $0 } //mix of literals and non-literals
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringIsEqual(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testIsEqualToString()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringIsEqual2(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testIsEqualToString2()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringIsEqualAllSwift(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testIsEqualToStringAllSwift()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringCompare(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testCompare()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringCompare2(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testCompare2()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringGetCStringPtr(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testGetCStringPtr()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringRangeOfString(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testRangeOfString()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringHash(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testHash()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringUTF8String(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testUTF8String()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func setup_StringBridgeBenchmark() {
+#if _runtime(_ObjC)
+  b = BridgeTester()
+  b.setUpStringTests(getStringsToBridge())
 #endif
 }

--- a/benchmark/utils/ObjectiveCTests/ObjectiveCTests.h
+++ b/benchmark/utils/ObjectiveCTests/ObjectiveCTests.h
@@ -19,9 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
   NSArray<NSString *> *myArrayOfStrings;
   NSDate *myBeginDate;
   NSDate *myEndDate;
+  NSArray<NSString *> *cornucopiaOfStrings;
+  NSArray<NSString *> *bridgedStrings;
 }
 
 - (id)init;
+- (void)setUpStringTests:(NSArray<NSString *> *)bridgedStrings;
 - (void)testFromString:(NSString *) str;
 - (NSString *)testToString;
 - (void)testFromArrayOfStrings:(NSArray<NSString *> *)arr;
@@ -30,6 +33,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDate *)beginDate;
 - (NSDate *)endDate;
 - (void)useDate:(NSDate *)date;
+
+- (void)testIsEqualToString;
+- (void)testIsEqualToString2;
+- (void)testIsEqualToStringAllSwift;
+- (void)testUTF8String;
+- (void)testGetCStringPtr;
+- (void)testRangeOfString;
+- (void)testHash;
+- (void)testCompare;
+- (void)testCompare2;
 
 @end
 

--- a/benchmark/utils/ObjectiveCTests/ObjectiveCTests.m
+++ b/benchmark/utils/ObjectiveCTests/ObjectiveCTests.m
@@ -11,6 +11,92 @@
 //===----------------------------------------------------------------------===//
 
 #import "ObjectiveCTests.h"
+#import <objc/runtime.h>
+
+@interface CustomString : NSString {
+  unichar *_backing;
+  NSUInteger _length;
+}
+
+@end
+
+@implementation CustomString
+
+- (instancetype)initWithCharacters:(const unichar *)characters length:(NSUInteger)length {
+  self = [super init];
+  _backing = malloc(sizeof(unichar) * length);
+  memcpy(_backing, characters, length * sizeof(unichar));
+  _length = length;
+  return self;
+}
+
+- (void)dealloc {
+  free(_backing);
+}
+
+- (unichar)characterAtIndex:(NSUInteger)index {
+  return _backing[index];
+}
+
+- (NSUInteger)length {
+  return _length;
+}
+
+@end
+
+@interface CustomFastASCIIString : NSString {
+  char *_backing;
+  NSUInteger _length;
+}
+
+@end
+
+@implementation CustomFastASCIIString
+
+- (instancetype)initWithCString:(const char *)bytes length:(NSUInteger)length {
+  self = [super init];
+  _backing = strdup(bytes);
+  _length = length;
+  return self;
+}
+
+- (void)dealloc {
+  free(_backing);
+}
+
+- (NSStringEncoding)fastestEncoding {
+  return NSASCIIStringEncoding;
+}
+
+- (NSUInteger)length {
+  return _length;
+}
+
+- (unichar)characterAtIndex:(NSUInteger)index {
+  return _backing[index];
+}
+
+- (const char *)_fastCStringContents:(BOOL)nullTerminationRequired {
+  return _backing;
+}
+
+@end
+
+@interface CustomFastUnicodeString : CustomString
+
+@end
+
+@implementation CustomFastUnicodeString
+
+- (NSStringEncoding)fastestEncoding {
+  return NSUnicodeStringEncoding;
+}
+
+- (const unichar *)_fastCharacterContents {
+  return _backing;
+}
+
+@end
 
 @implementation BridgeTester
 
@@ -44,6 +130,161 @@
                     nanosecond:10];
 
   return self;
+}
+
+- (void)setUpStringTests:(NSArray<NSString *> *)inBridgedStrings {
+  
+  const char *taggedContents = "hello";
+  const char *tagged2Contents = "hella";
+  const char *notTaggedContents = "the quick brown fox jumps over the lazy dog";
+  const char *notTagged2Contents = "the quick brown fox jumps over the lazy dogabc";
+  const char *nonASCIIContents = "the quick brown fox jümps over the lazy dog";
+  const char *nonASCII2Contents = "the quick brown fox jumps over the lazy dög";
+  const char *longNonASCIIContents = "the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy dïgz";
+  const char *longASCIIContents = "the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy the quick brown fox jumps over the lazy dogz";
+  
+  NSString *tagged = [NSString stringWithUTF8String:taggedContents];
+  NSString *tagged2 = [NSString stringWithUTF8String:tagged2Contents];
+  NSString *notTagged = [NSString stringWithUTF8String:notTaggedContents];
+  NSString *notTagged2 = [NSString stringWithUTF8String:notTaggedContents];
+  NSString *notTaggedLonger = [NSString stringWithUTF8String:notTagged2Contents];
+  NSString *nonASCII = [NSString stringWithUTF8String:nonASCIIContents];
+  NSString *nonASCII2 = [NSString stringWithUTF8String:nonASCIIContents];
+  NSString *nonASCIIOther = [NSString stringWithUTF8String:nonASCII2Contents];
+  NSString *longNonASCII = [NSString stringWithUTF8String:longNonASCIIContents];
+  NSString *noCopyLongNonASCII = [[NSString alloc] initWithBytesNoCopy:(void *)longNonASCIIContents length:strlen(longNonASCIIContents) encoding:NSUTF8StringEncoding freeWhenDone:NO];
+  NSString *noCopyLongASCII = [[NSString alloc] initWithBytesNoCopy:(void *)longASCIIContents length:strlen(longASCIIContents) encoding:NSUTF8StringEncoding freeWhenDone:NO];
+  NSString *constantTaggable = @"hello";
+  NSString *constantASCII = @"the quick brown fox jumps over the lazy dog";
+  NSString *constantNonASCII = @"the quick brown fox jümps over the lazy dog";
+  
+  unichar taggableUnichars[] = {
+    'h', 'e', 'l', 'l', 'o'
+  };
+  unichar nonTaggableUnichars[] = {
+    't', 'h', 'e',  'q', 'u', 'i', 'c', 'k',  'b', 'r', 'o', 'w', 'n',  'f', 'o', 'x',  'j', 'u', 'm', 'p', 's',  'o', 'v', 'e', 'r',  't', 'h', 'e',  'l', 'a', 'z', 'y',  'd', 'o', 'g'
+  };
+  NSString *taggableCustom = [[CustomString alloc] initWithCharacters:&taggableUnichars[0] length:sizeof(taggableUnichars) / sizeof(taggableUnichars[0])];
+  NSString *nonTaggableCustom = [[CustomString alloc] initWithCharacters:&nonTaggableUnichars[0] length:sizeof(nonTaggableUnichars) / sizeof(nonTaggableUnichars[0])];
+  NSString *taggableFastCustom = [[CustomFastASCIIString alloc] initWithCString:taggedContents length:strlen(taggedContents)];
+  NSString *nonTaggableFastCustom = [[CustomFastASCIIString alloc] initWithCString:notTaggedContents length:strlen(notTaggedContents)];
+  NSString *taggableUnicodeCustom = [[CustomFastUnicodeString alloc] initWithCharacters:&taggableUnichars[0] length:sizeof(taggableUnichars) / sizeof(taggableUnichars[0])];
+  NSString *nonTaggableUnicodeCustom = [[CustomFastUnicodeString alloc] initWithCharacters:&nonTaggableUnichars[0] length:sizeof(nonTaggableUnichars) / sizeof(nonTaggableUnichars[0])];
+  
+  cornucopiaOfStrings = [NSArray arrayWithObjects: tagged, tagged2, notTagged, notTagged2, notTaggedLonger, nonASCII, nonASCII2, nonASCIIOther, longNonASCII, noCopyLongASCII, noCopyLongNonASCII, constantASCII, constantNonASCII
+                         , taggableCustom, nonTaggableCustom, taggableFastCustom, nonTaggableFastCustom, taggableUnicodeCustom, nonTaggableUnicodeCustom, nil];
+  bridgedStrings = inBridgedStrings;
+}
+
+- (void)testIsEqualToString {
+  for (NSString *str1 in cornucopiaOfStrings) {
+    for (NSString *str2 in bridgedStrings) {
+      @autoreleasepool {
+        for (int i = 0; i < 10; i++) {
+          [str1 isEqualToString: str2];
+        }
+      }
+    }
+  }
+}
+
+- (void)testIsEqualToString2 {
+  for (NSString *str1 in bridgedStrings) {
+    for (NSString *str2 in cornucopiaOfStrings) {
+      @autoreleasepool {
+        for (int i = 0; i < 20; i++) {
+          [str1 isEqualToString: str2];
+        }
+      }
+    }
+  }
+}
+
+- (void)testIsEqualToStringAllSwift {
+  for (NSString *str1 in bridgedStrings) {
+    for (NSString *str2 in bridgedStrings) {
+      @autoreleasepool {
+        for (int i = 0; i < 50; i++) {
+          [str1 isEqualToString: str2];
+        }
+      }
+    }
+  }
+}
+
+- (void)testCompare {
+  for (NSString *str1 in cornucopiaOfStrings) {
+    for (NSString *str2 in bridgedStrings) {
+      @autoreleasepool {
+        for (int i = 0; i < 20; i++) {
+          (void)[str1 compare: str2];
+        }
+      }
+    }
+  }
+}
+
+- (void)testCompare2 {
+  for (NSString *str1 in bridgedStrings) {
+    for (NSString *str2 in cornucopiaOfStrings) {
+      @autoreleasepool {
+        for (int i = 0; i < 20; i++) {
+          (void)[str1 compare: str2];
+        }
+      }
+    }
+  }
+}
+
+
+- (void)testUTF8String {
+  for (NSString *str1 in bridgedStrings) {
+    @autoreleasepool {
+      for (int i = 0; i < 100; i++) {
+        (void)[str1 UTF8String];
+      }
+    }
+  }
+}
+
+- (void)testGetCStringPtr {
+  for (NSString *str1 in bridgedStrings) {
+    for (int i = 0; i < 20000; i++) {
+      (void)CFStringGetCStringPtr((CFStringRef)str1, kCFStringEncodingASCII);
+    }
+  }
+}
+
+- (void)testRangeOfString {
+  for (NSString *str1 in bridgedStrings) {
+    @autoreleasepool {
+      for (int i = 0; i < 300; i++) {
+        (void)[str1 rangeOfString:@"z"];
+      }
+    }
+  };
+}
+
+- (void) testHash {
+  for (NSString *str1 in bridgedStrings) {
+    @autoreleasepool {
+      for (int i = 0; i < 100; i++) {
+        [str1 hash];
+      }
+    }
+  }
+}
+
+- (void)testGetCharactersRange {
+  unichar *buffer = malloc(10000);
+  for (NSString *str1 in bridgedStrings) {
+    @autoreleasepool {
+      for (int i = 0; i < 100; i++) {
+        (void)[str1 getCharacters:buffer range:NSMakeRange(0, [str1 length])];
+      }
+    }
+  };
+  free(buffer);
 }
 
 - (NSString *)testToString {


### PR DESCRIPTION
This is an adaptation of some of NSString's microbenchmark suite. I'm using it to guide work on _AbstractStringStorage, but it should be generally useful too.