### PR TITLE
IRGen: always use runtime initialized VWT on PE/COFF

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -3319,6 +3319,10 @@ struct TargetResilientClassMetadataPattern {
 using ResilientClassMetadataPattern =
   TargetResilientClassMetadataPattern<InProcess>;
 
+extern "C" {
+  extern const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bo);
+}
+
 /// The control structure for performing non-trivial initialization of
 /// singleton value metadata, which is required when e.g. a non-generic
 /// value type has a resilient component type.
@@ -3362,6 +3366,7 @@ struct TargetSingletonMetadataInitialization {
       return ResilientPattern->RelocationFunction(description,
                                                   ResilientPattern.get());
     }
+    IncompleteMetadata.get()->setValueWitnesses(&VALUE_WITNESS_SYM(Bo));
     return IncompleteMetadata.get();
   }
 };

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2699,6 +2699,11 @@ namespace {
       }
     }
 
+    void addValueWitnessTable() {
+      // Filled in at runtime.
+      B.addNullPointer(IGM.WitnessTableTy);
+    }
+
     void addGenericArgument(ClassDecl *forClass) {
       // Filled in at runtime.
       B.addNullPointer(IGM.TypeMetadataPtrTy);


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
