### PR TITLE
Remove imported reflection field descriptors

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -386,11 +386,11 @@ public:
 };
 
 class ProtocolCompositionTypeRef final : public TypeRef {
-  std::vector<const NominalTypeRef *> Protocols;
+  std::vector<const TypeRef *> Protocols;
   const TypeRef *Superclass;
   bool HasExplicitAnyObject;
 
-  static TypeRefID Profile(std::vector<const NominalTypeRef *> Protocols,
+  static TypeRefID Profile(std::vector<const TypeRef *> Protocols,
                            const TypeRef *Superclass,
                            bool HasExplicitAnyObject) {
     TypeRefID ID;
@@ -403,7 +403,7 @@ class ProtocolCompositionTypeRef final : public TypeRef {
   }
 
 public:
-  ProtocolCompositionTypeRef(std::vector<const NominalTypeRef *> Protocols,
+  ProtocolCompositionTypeRef(std::vector<const TypeRef *> Protocols,
                              const TypeRef *Superclass,
                              bool HasExplicitAnyObject)
     : TypeRef(TypeRefKind::ProtocolComposition),
@@ -412,13 +412,14 @@ public:
 
   template <typename Allocator>
   static const ProtocolCompositionTypeRef *
-  create(Allocator &A, std::vector<const NominalTypeRef *> Protocols,
+  create(Allocator &A, std::vector<const TypeRef *> Protocols,
          const TypeRef *Superclass, bool HasExplicitAnyObject) {
     FIND_OR_CREATE_TYPEREF(A, ProtocolCompositionTypeRef, Protocols,
                            Superclass, HasExplicitAnyObject);
   }
 
-  const std::vector<const NominalTypeRef *> &getProtocols() const {
+  // These are either NominalTypeRef or ObjCProtocolTypeRef.
+  const std::vector<const TypeRef *> &getProtocols() const {
     return Protocols;
   }
 
@@ -630,6 +631,36 @@ public:
 
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::ObjCClass;
+  }
+};
+
+class ObjCProtocolTypeRef final : public TypeRef {
+  std::string Name;
+  static const ObjCProtocolTypeRef *UnnamedSingleton;
+
+  static TypeRefID Profile(const std::string &Name) {
+    TypeRefID ID;
+    ID.addString(Name);
+    return ID;
+  }
+public:
+  ObjCProtocolTypeRef(const std::string &Name)
+    : TypeRef(TypeRefKind::ObjCProtocol), Name(Name) {}
+
+  static const ObjCProtocolTypeRef *getUnnamed();
+
+  template <typename Allocator>
+  static const ObjCProtocolTypeRef *create(Allocator &A,
+                                           const std::string &Name) {
+    FIND_OR_CREATE_TYPEREF(A, ObjCProtocolTypeRef, Name);
+  }
+
+  const std::string &getName() const {
+    return Name;
+  }
+
+  static bool classof(const TypeRef *TR) {
+    return TR->getKind() == TypeRefKind::ObjCProtocol;
   }
 };
 

--- a/include/swift/Reflection/TypeRefs.def
+++ b/include/swift/Reflection/TypeRefs.def
@@ -28,6 +28,7 @@ TYPEREF(GenericTypeParameter, TypeRef)
 TYPEREF(DependentMember, TypeRef)
 TYPEREF(ForeignClass, TypeRef)
 TYPEREF(ObjCClass, TypeRef)
+TYPEREF(ObjCProtocol, TypeRef)
 TYPEREF(Opaque, TypeRef)
 #define REF_STORAGE(Name, ...) \
   TYPEREF(Name##Storage, TypeRef)

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -498,20 +498,39 @@ public:
 #if SWIFT_OBJC_INTEROP
         // Check whether we have an Objective-C protocol.
         if (ProtocolAddress.isObjC()) {
-          auto MangledNameStr =
+          auto Name =
             readObjCProtocolName(ProtocolAddress.getObjCProtocol());
+          StringRef NameStr(Name);
 
-          StringRef MangledName =
-            Demangle::dropSwiftManglingPrefix(MangledNameStr);
+          // If this is a Swift-defined protocol, demangle it.
+          if (NameStr.startswith("_TtP")) {
+            Demangle::Context DCtx;
+            auto Demangled = DCtx.demangleSymbolAsNode(NameStr);
+            if (!Demangled)
+              return BuiltType();
 
-          Demangle::Context DCtx;
-          auto Demangled = DCtx.demangleTypeAsNode(MangledName);
-          if (!Demangled)
-            return BuiltType();
+            // FIXME: This appears in _swift_buildDemanglingForMetadata().
+            while (Demangled->getKind() == Node::Kind::Global ||
+                   Demangled->getKind() == Node::Kind::TypeMangling ||
+                   Demangled->getKind() == Node::Kind::Type ||
+                   Demangled->getKind() == Node::Kind::ProtocolList ||
+                   Demangled->getKind() == Node::Kind::TypeList ||
+                   Demangled->getKind() == Node::Kind::Type) {
+              if (Demangled->getNumChildren() != 1)
+                return BuiltType();
+              Demangled = Demangled->getFirstChild();
+            }
 
-          // FIXME: Imported protocols?
+            auto Protocol = Builder.createProtocolDecl(Demangled);
+            if (!Protocol)
+              return BuiltType();
 
-          auto Protocol = Builder.createProtocolDecl(Demangled);
+            Protocols.push_back(Protocol);
+            continue;
+          }
+
+          // Otherwise, this is an imported protocol.
+          auto Protocol = Builder.createObjCProtocolDecl(NameStr);
           if (!Protocol)
             return BuiltType();
 
@@ -520,6 +539,7 @@ public:
         }
 #endif
 
+        // Swift-native protocol.
         Demangle::Demangler Dem;
         auto Demangled = readDemanglingForContextDescriptor(
             ProtocolAddress.getSwiftProtocol(), Dem);

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -509,6 +509,8 @@ public:
           if (!Demangled)
             return BuiltType();
 
+          // FIXME: Imported protocols?
+
           auto Protocol = Builder.createProtocolDecl(Demangled);
           if (!Protocol)
             return BuiltType();

--- a/include/swift/RemoteAST/RemoteAST.h
+++ b/include/swift/RemoteAST/RemoteAST.h
@@ -221,6 +221,9 @@ public:
                                          Type staticType);
 };
 
+Type getTypeForMangling(ASTContext &ctx,
+                        StringRef mangling);
+
 } // end namespace remoteAST
 } // end namespace swift
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1045,12 +1045,6 @@ public:
   /// without knowledge of their contents. This includes imported structs
   /// and fixed-size multi-payload enums.
   llvm::SetVector<const NominalTypeDecl *> OpaqueTypes;
-  /// Imported classes referenced by types in this module when emitting
-  /// reflection metadata.
-  llvm::SetVector<const ClassDecl *> ImportedClasses;
-  /// Imported protocols referenced by types in this module when emitting
-  /// reflection metadata.
-  llvm::SetVector<const ProtocolDecl *> ImportedProtocols;
   /// Imported structs referenced by types in this module when emitting
   /// reflection metadata.
   llvm::SetVector<const StructDecl *> ImportedStructs;

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/TypeRepr.h"
 #include "swift/Basic/Mangler.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/Demangling/Demangler.h"
 #include "llvm/ADT/StringSwitch.h"
 
 // TODO: Develop a proper interface for this.
@@ -1341,4 +1342,15 @@ RemoteASTContext::getDynamicTypeAndAddressForExistential(
     remote::RemoteAddress address, Type staticType) {
   return asImpl(Impl)->getDynamicTypeAndAddressForExistential(address,
                                                               staticType);
+}
+
+Type swift::remoteAST::getTypeForMangling(ASTContext &ctx,
+                                          StringRef mangling) {
+  Demangle::Context Dem;
+  auto node = Dem.demangleSymbolAsNode(mangling);
+  if (!node)
+    return Type();
+
+  RemoteASTTypeBuilder builder(ctx);
+  return swift::Demangle::decodeMangledType(builder, node);
 }

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -438,6 +438,16 @@ public:
     return createNominalType(typeDecl, /*parent*/ Type());
   }
 
+  ProtocolDecl *createObjCProtocolDecl(StringRef name) {
+    auto typeDecl =
+        findForeignNominalTypeDecl(name, /*relatedEntityKind*/{},
+                                   ForeignModuleKind::Imported,
+                                   Demangle::Node::Kind::Protocol);
+    if (auto *protocolDecl = dyn_cast_or_null<ProtocolDecl>(typeDecl))
+      return protocolDecl;
+    return nullptr;
+  }
+
   Type createForeignClassType(StringRef mangledName) {
     auto typeDecl = createNominalTypeDecl(mangledName);
     if (!typeDecl) return Type();

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -307,6 +307,8 @@ _buildDemanglingForNominalType(const Metadata *type, Demangle::Demangler &Dem) {
 }
 
 // Build a demangled type tree for a type.
+//
+// FIXME: This should use MetadataReader.h.
 Demangle::NodePointer
 swift::_swift_buildDemanglingForMetadata(const Metadata *type,
                                          Demangle::Demangler &Dem) {

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -11,10 +11,10 @@
 // CHECK: TypesToReflect.OC
 // CHECK: -----------------
 // CHECK: nsObject: __C.NSObject
-// CHECK: (class __C.NSObject)
+// CHECK: (objective_c_class name=NSObject)
 
 // CHECK: nsString: __C.NSString
-// CHECK: (class __C.NSString)
+// CHECK: (objective_c_class name=NSString)
 
 // CHECK: cfString: __C.CFStringRef
 // CHECK: (alias __C.CFStringRef)
@@ -25,7 +25,7 @@
 
 // CHECK: ocnss: TypesToReflect.GenericOC<__C.NSString>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
-// CHECK:   (class __C.NSString))
+// CHECK:   (objective_c_class name=NSString))
 
 // CHECK: occfs: TypesToReflect.GenericOC<__C.CFStringRef>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
@@ -37,7 +37,7 @@
 // CHECK: TypesToReflect.HasObjCClasses
 // CHECK: -----------------------------
 // CHECK: url: __C.NSURL
-// CHECK: (class __C.NSURL)
+// CHECK: (objective_c_class name=NSURL)
 
 // CHECK: integer: Swift.Int
 // CHECK: (struct Swift.Int)
@@ -47,13 +47,6 @@
 
 // CHECK: TypesToReflect.OP
 // CHECK: -----------------
-
-// CHECK: __C.NSBundle
-// CHECK: ----------
-// CHECK: __C.NSURL
-// CHECK: ---------
-// CHECK: __C.NSCoding
-// CHECK: ------------
 
 // CHECK: ASSOCIATED TYPES:
 // CHECK: =================
@@ -77,7 +70,7 @@
 // CHECK-NEXT: ====================
 
 // CHECK:      - Capture types:
-// CHECK-NEXT: (class __C.NSBundle)
+// CHECK-NEXT: (objective_c_class name=NSBundle)
 // CHECK-NEXT: (protocol_composition
-// CHECK-NEXT:   (protocol __C.NSCoding))
+// CHECK-NEXT:   (objective_c_protocol name=NSCoding))
 // CHECK-NEXT: - Metadata sources:

--- a/test/RemoteAST/objc_classes.swift
+++ b/test/RemoteAST/objc_classes.swift
@@ -26,3 +26,19 @@ let observer = NSObject()
 a.addObserver(observer, forKeyPath: "property", options: [], context: nil)
 printDynamicType(a)
 // CHECK: A<Int>
+
+// FIXME: The ... & AnyObject is redundant here:
+
+printType(NSFastEnumeration.self)
+// CHECK: NSFastEnumeration & AnyObject
+
+printType(Optional<NSFastEnumeration>.self)
+// CHECK: Optional<NSFastEnumeration & AnyObject>
+
+@objc protocol OurObjCProtocol {}
+
+printType(OurObjCProtocol.self)
+// CHECK: OurObjCProtocol & AnyObject
+
+printType(Optional<OurObjCProtocol>.self)
+// CHECK: Optional<OurObjCProtocol & AnyObject>

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -215,10 +215,10 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 TEST(TypeRefTest, UniqueProtocolTypeRef) {
   TypeRefBuilder Builder;
 
-  Optional<std::string> P1 = ABC;
-  Optional<std::string> P2 = ABC;
-  Optional<std::string> P3 = ABCD;
-  Optional<std::string> P4 = XYZ;
+  TypeRefBuilder::BuiltProtocolDecl P1 = std::make_pair(ABC, false);
+  TypeRefBuilder::BuiltProtocolDecl P2 = std::make_pair(ABC, false);
+  TypeRefBuilder::BuiltProtocolDecl P3 = std::make_pair(ABCD, false);
+  TypeRefBuilder::BuiltProtocolDecl P4 = std::make_pair(XYZ, false);
 
   EXPECT_EQ(P1, P2);
   EXPECT_NE(P2, P3);
@@ -280,8 +280,8 @@ TEST(TypeRefTest, UniqueDependentMemberTypeRef) {
 
   auto N1 = Builder.createNominalType(ABC, nullptr);
   auto N2 = Builder.createNominalType(XYZ, nullptr);
-  Optional<std::string> P1 = ABC;
-  Optional<std::string> P2 = ABCD;
+  TypeRefBuilder::BuiltProtocolDecl P1 = std::make_pair(ABC, false);
+  TypeRefBuilder::BuiltProtocolDecl P2 = std::make_pair(ABCD, false);
 
   auto DM1 = Builder.createDependentMemberType("Index", N1, P1);
   auto DM2 = Builder.createDependentMemberType("Index", N1, P1);


### PR DESCRIPTION
Right now we expect that every class and protocol has a field
descriptor that tells us if the entity is @objc or not.

For imported types, the descriptor will not exist if we did not
directly emit a field whose concrete type contains the imported
type. For example, in lldb, we might have a generic type whose
runtime substituted type includes an imported type.

In this case, TypeLowering would fail to produce a layout because
it did not find a field descriptor for the imported type.

A better approach is to have the TypeDecoder call a different
factory method for imported types, and handle them specially in
TypeLowering, bypassing the field type metadata altogether.