### PR TITLE
[Lexer] Micro optimization for getTokenAt()

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -267,9 +267,7 @@ Token Lexer::getTokenAt(SourceLoc Loc) {
           HashbangMode::Allowed, CommentRetentionMode::None,
           TriviaRetentionMode::WithoutTrivia);
   L.restoreState(State(Loc));
-  Token Result;
-  L.lex(Result);
-  return Result;
+  return L.peekNextToken();
 }
 
 void Lexer::formToken(tok Kind, const char *TokStart) {


### PR DESCRIPTION
`lex()` invokes `lexImpl()`. Since it doesn't need to lex next token, `peekNextToken()` is sufficient.
