### PR TITLE
ClangImporter: Update Swift for changes in clang (PCH + Modules issues)

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1025,6 +1025,7 @@ ClangImporter::create(ASTContext &ctx,
   if (importerOpts.Mode == ClangImporterOptions::Modes::EmbedBitcode)
     return importer;
 
+  instance.getLangOpts().NeededByPCHOrCompilationUsesPCH = true;
   bool canBegin = action->BeginSourceFile(instance,
                                           instance.getFrontendOpts().Inputs[0]);
   if (!canBegin)
@@ -1405,6 +1406,7 @@ ClangImporter::emitBridgingPCH(StringRef headerPath,
   invocation->getFrontendOpts().OutputFile = outputPCHPath;
   invocation->getFrontendOpts().ProgramAction = clang::frontend::GeneratePCH;
   invocation->getPreprocessorOpts().resetNonModularOptions();
+  invocation->getLangOpts()->NeededByPCHOrCompilationUsesPCH = true;
 
   clang::CompilerInstance emitInstance(
     Impl.Instance->getPCHContainerOperations());


### PR DESCRIPTION
This sets the NeededByPCHOrCompilationUsesPCH language option when
emitting a brigding PCH.

rdar://problem/35056912
rdar://problem/30384801

Initial patch by Adrian Prantl

(cherry picked from commit 5d5f542fe47668f80a4661ccccdb0048c9629a39)
(cherry picked from commit fa2a5779b17f50260aeaad5d9c3c0062e99f07d2)
