### PR TITLE
Fix Runtime.swift.gyb failure on s390x.

### DIFF
--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -672,7 +672,7 @@ var BitTwiddlingTestSuite = TestSuite("BitTwiddling")
 BitTwiddlingTestSuite.test("_pointerSize") {
 #if arch(i386) || arch(arm)
   expectEqual(4, MemoryLayout<Optional<AnyObject>>.size)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le)
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
   expectEqual(8, MemoryLayout<Optional<AnyObject>>.size)
 #else
   fatalError("implement")


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adding s390x arch support on `_pointerSize` test under `stdlib/Runtime.swift.gyb` test.