### PR TITLE
Add a test for synthesized get-only properties in swiftinterfaces

### DIFF
--- a/test/ParseableInterface/synthesized.swift
+++ b/test/ParseableInterface/synthesized.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
+
+// CHECK-LABEL: public enum HasRawValue : Int {
+public enum HasRawValue: Int {
+  // CHECK-NEXT: case a, b, c
+  case a, b = 5, c
+  // CHECK-NEXT: public typealias RawValue = Swift.Int
+  // CHECK-NEXT: public var hashValue: Swift.Int {
+  // CHECK-NEXT:   get{{$}}
+  // CHECK-NEXT: }
+  // CHECK-NEXT: public func hash(into hasher: inout Swift.Hasher)
+  // CHECK-NEXT: @inlinable public init?(rawValue: Swift.Int)
+  // CHECK-NEXT: public var rawValue: Swift.Int {
+  // CHECK-NEXT:   @inlinable get{{$}}
+  // CHECK-NEXT: }
+} // CHECK-NEXT: {{^}$}}
+
+// CHECK-LABEL: @objc public enum ObjCEnum : Int {
+@objc public enum ObjCEnum: Int {
+  // CHECK-NEXT: case a, b, c
+  case a, b = 5, c
+  // CHECK-NEXT: public typealias RawValue = Swift.Int
+  // CHECK-NEXT: public var hashValue: Swift.Int {
+  // CHECK-NEXT:   get{{$}}
+  // CHECK-NEXT: }
+  // CHECK-NEXT: public func hash(into hasher: inout Swift.Hasher)
+  // CHECK-NEXT: @inlinable public init?(rawValue: Swift.Int)
+  // CHECK-NEXT: public var rawValue: Swift.Int {
+  // CHECK-NEXT:   @inlinable get{{$}}
+  // CHECK-NEXT: }
+} // CHECK-NEXT: {{^}$}}


### PR DESCRIPTION
Probably superfluous with all the other tests @harlanhaskins has been adding, but I wrote it and it was sitting around on my machine, so we might as well use it.