### PR TITLE
[test] Make sure we don't try to autolink the framework we're building

### DIFF
--- a/test/ClangImporter/MixedSource/Inputs/AutolinkingTest.framework/Headers/AutolinkingTest.h
+++ b/test/ClangImporter/MixedSource/Inputs/AutolinkingTest.framework/Headers/AutolinkingTest.h
@@ -1,0 +1,3 @@
+struct Test {
+  int value;
+};

--- a/test/ClangImporter/MixedSource/Inputs/AutolinkingTest.framework/Modules/module.modulemap
+++ b/test/ClangImporter/MixedSource/Inputs/AutolinkingTest.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module AutolinkingTest {
+  umbrella header "AutolinkingTest.h"
+  export *
+  module * { export * }
+}

--- a/test/ClangImporter/MixedSource/autolinking.swift
+++ b/test/ClangImporter/MixedSource/autolinking.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend %s -module-name AutolinkingTest -F %S/Inputs -import-underlying-module -emit-ir | %FileCheck %s
+
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
+// UNSUPPORTED: OS=linux-androideabi
+
+// Use a type declared in the Clang part of the module.
+public let y = Test()
+
+// CHECK: !llvm.linker.options
+// CHECK-NOT: !{!"-framework", !"AutolinkingTest"}
+// CHECK: !{!"-lswiftCore"}
+// CHECK-NOT: !{!"-framework", !"AutolinkingTest"}


### PR DESCRIPTION
...even the Clang part of it. (We did this on the 4.2 branch by accident, but @slavapestov removed the offending code entirely in #16147.)

rdar://problem/42604464