### PR TITLE
[RemoteAST] Fix typo in existential payload calculation.

### DIFF
--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -1183,7 +1183,7 @@ public:
     if (!typeResult)
       return getFailure<std::pair<Type, RemoteAddress>>();
     return std::make_pair<Type, RemoteAddress>(std::move(typeResult),
-                                               std::move(object));
+                                               RemoteAddress(*pointerval));
   }
 
   Result<std::pair<Type, RemoteAddress>>


### PR DESCRIPTION
This only shows up in lldb, so I'm adding a test there and
test the two commits together.

(cherry picked from commit b25953e0ea0fc0140e2253928a00695809bdf947)
