### PR TITLE
IRGen the TensorFlow stdlib

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1298,7 +1298,7 @@ FUNCTION(TF_NewStatus, TF_NewStatus, C_CC,
          ATTRS(NoUnwind))
 
 FUNCTION(TF_DeleteStatus, TF_DeleteStatus, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
 
@@ -1308,47 +1308,47 @@ FUNCTION(TFE_NewOp, TFE_NewOp, C_CC,
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_DeleteOp, TFE_DeleteOp, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_OpAddInput, TFE_OpAddInput, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_OpSetDevice, TFE_OpSetDevice, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_OpSetAttrType, TFE_OpSetAttrType, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_OpSetAttrFunctionName, TFE_OpSetAttrFunctionName, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, SizeTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_OpSetAttrInt, TFE_OpSetAttrInt, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int64Ty),
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_OpSetAttrFloat, TFE_OpSetAttrFloat, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, FloatTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_OpSetAttrBool, TFE_OpSetAttrBool, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int1Ty),
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_OpSetAttrString, TFE_OpSetAttrString, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, SizeTy),
          ATTRS(NoUnwind))
 
@@ -1362,32 +1362,32 @@ FUNCTION(TFE_OpSetAttrString, TFE_OpSetAttrString, C_CC,
 //                           const int64_t* values,
 //                           int num_values);
 FUNCTION(TFE_OpSetAttrIntList, TFE_OpSetAttrIntList, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
 // Similar situation with the final int param as described above on
 // TFE_OpSetAttrIntList.
 FUNCTION(TFE_OpSetAttrTypeList, TFE_OpSetAttrTypeList, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
 // Similar situation with the final int param as described above on
 // TFE_OpSetAttrIntList.
 FUNCTION(TFE_OpSetAttrShapeList, TFE_OpSetAttrShapeList, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrPtrTy, Int8PtrTy, Int32Ty,
 	      Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_OpSetAttrTensor, TFE_OpSetAttrTensor, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TF_DeleteTensor, TF_DeleteTensor, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
 
@@ -1403,7 +1403,7 @@ FUNCTION(TFC_CreateFloatTensor, swift_tfc_CreateFloatTensor, C_CC,
          ATTRS(NoUnwind))
 
 FUNCTION(TFE_Execute, swift_tfc_TFE_Execute, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrPtrTy, Int32PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
@@ -1433,7 +1433,7 @@ FUNCTION(TFC_AllocateCHandleBuffer,
 
 FUNCTION(TFC_DeallocateCHandleBuffer,
          _swift_tfc_DeallocateCHandleBuffer, SwiftCC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
 
@@ -1454,43 +1454,43 @@ FUNCTION(TFC_CreateTensorHandleFromC, _swift_tfc_CreateTensorHandleFromC, C_CC,
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_OpSetAttrBoolArray, _swift_tfc_OpSetAttrBoolArray, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_OpSetAttrInt32Array, _swift_tfc_OpSetAttrInt32Array, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_OpSetAttrInt64Array, _swift_tfc_OpSetAttrInt64Array, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_OpSetAttrDoubleArray, _swift_tfc_OpSetAttrDoubleArray, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_OpSetAttrFloatArray, _swift_tfc_OpSetAttrFloatArray, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_OpSetAttrTypeArray, _swift_tfc_OpSetAttrTypeArray, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_OpSetAttrTensorShapeArray, _swift_tfc_OpSetAttrTensorShapeArray,
-         C_CC, RETURNS(),
+         C_CC, RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_OpSetAttrOptionalTensorShapeArray,
 	 _swift_tfc_OpSetAttrOptionalTensorShapeArray,
-         C_CC, RETURNS(),
+         C_CC, RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
@@ -1498,12 +1498,12 @@ FUNCTION(TFC_OpSetAttrOptionalTensorShapeArray,
 // In LLVM IR, the String gets exploded to (BridgeObjectPtrTy, Int64Ty), so
 // IRGen passes those two values in place of the Swift String.
 FUNCTION(TFC_OpSetAttrString, _swift_tfc_OpSetAttrString, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, BridgeObjectPtrTy, Int64Ty),
          ATTRS(NoUnwind))
 
 FUNCTION(TFC_CheckOk, _swift_tfc_CheckOk, C_CC,
-         RETURNS(),
+         RETURNS(VoidTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
 

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow
 
 import TensorFlow

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -1,11 +1,6 @@
-// RUN: %target-run-simple-swift
 // TODO: Revert to %target-run-simple-swift once we fold dynamic compilation into -Onone.
 // RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize
-
-// This file contains testing over a dataset as a global variable. This requires
-// sends/recvs support for variant handles.
 
 import CTensorFlow
 import TensorFlow

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-disable-deabstraction-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 
@@ -10,8 +11,7 @@ import StdlibUnittest
 var RuntimeEntryPointTests = TestSuite("RuntimeEntryPoint")
 
 RuntimeEntryPointTests.testCPUOrGPU("RoundTrip_CTensorHandle_AnyTensorHandle") {
-  let zero: TensorHandle<Float> =
-    #tfop("Const", dtype$dtype: Float.tensorFlowDataType, value$tensor: Float(0.0))
+  let zero: TensorHandle<Float> = Tensor<Float>(0.0).handle
   var cHandle = zero._cTensorHandle
   let status = TF_NewStatus()
   // We must do a copy, i.e. a retain on the tensor handle, to make sure it won't

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -219,7 +219,7 @@
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-10-22-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
                 "tensorflow": "01bcaa9336724e80541aa7d3dcb14d6f9fd6b2b4",
-                "tensorflow-swift-bindings": "1c70c0b4094b95461769f9e5839e3f364a0fc895"
+                "tensorflow-swift-bindings": "15ed58b7cb21fe7ce1781fb1e97f9144c0eeb03b"
             }
         }
     }

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -219,7 +219,7 @@
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-10-22-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
                 "tensorflow": "01bcaa9336724e80541aa7d3dcb14d6f9fd6b2b4",
-                "tensorflow-swift-bindings": "15ed58b7cb21fe7ce1781fb1e97f9144c0eeb03b"
+                "tensorflow-swift-bindings": "a00181af8f0abac830d3197a5e375900973438d5"
             }
         }
     }


### PR DESCRIPTION
This PR makes IRGen run on the TensorFlow stdlib. This allows non-inlined calls to TensorFlow stdlib functions, which makes it possible to compile with `-Onone -Xllvm -tf-dynamic-compilation -Xllvm -tf-disable-deabstraction`. I remove the "REQUIRES: swift_test_mode_optimize" from some of the dynamic compilation tests to exercise this new ability.

The things that I had to fix were:
* https://github.com/tensorflow/swift-bindings/pull/9
* Turn a few IRGen compile-time assertion failures into runtime errors, so that the compiler doesn't die when it compiles stdlib functions that it doesn't support. (Specifically, Dataset map and filter).
* Bail out earlier on `GraphFunctionDeviceInfo::isConfigOp`, for the reason explained in the comment.
* Fix the function signature of some TF functions in RuntimeFunctions.def. The compiler was caching those signatures, which were slightly wrong, and then dieing when it tried to compile calls to those functions in CompilerRuntime.swift.