### PR TITLE
Allow Resource/Variant handles to be arguments when we use TFEager API.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -3840,7 +3840,9 @@ void TFFunctionPartition::insertTensorComputationStartEndTerminate(
     // closed over.  If it is a TensorHandle<T>, load the CTensorHandle out of
     // it.  If it is a scalar, then we need to box the scalar in a
     // CTensorHandle.
-    if (isTensorHandle(tensorValue->getType().getASTType())) {
+    if ((TFSendRecvOpaqueHandle &&
+         isTensorFlowValue(tensorValue->getType().getASTType())) ||
+        isTensorHandle(tensorValue->getType().getASTType())) {
       // Upcast to _AnyTensorHandle.
       tensorValue = B.createUpcast(loc, tensorValue, anyTensorHandleSILTy);
       auto fieldAddress =

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -23,14 +23,11 @@ let scalars = Tensor<Float>([0, 1, 2])
 let dataset = Dataset(elements: scalars)
 var iterator = dataset.makeIterator()
 
-DatasetGlobalTests.testCPUOrGPU("DatasetAsGlobalVar") {
-  // This stmt makes sure the load inst from the global var `dataset` does not
-  // make dataset an input arg tensor.
-  //
-  // It can be removed when we convert arg tensors to Swift->TF tensor
-  // transfers.
-  _ = scalars + scalars
+DatasetGlobalTests.testCPUOrGPU("RuntimeConfigTest") {
+  expectTrue(_RuntimeConfig.usesTFEagerAPI)
+}
 
+DatasetGlobalTests.testCPUOrGPU("DatasetAsGlobalVar") {
   var expectedVal: Float = 0.0
   for item in dataset {
     _hostOp(item)
@@ -40,13 +37,6 @@ DatasetGlobalTests.testCPUOrGPU("DatasetAsGlobalVar") {
 }
 
 DatasetGlobalTests.testCPUOrGPU("IteratorAsGlobalVar") {
-  // This stmt makes sure the load inst from the global var `iterator` does not
-  // make iterator an input arg tensor.
-  //
-  // It can be removed when we convert arg tensors to Swift->TF tensor
-  // transfers.
-  _ = scalars + scalars
-
   var expectedVal: Float = 0.0
 	while let item = iterator.next() {
     _hostOp(item)


### PR DESCRIPTION
This PR simply makes the check for determining supported argument types to be more inclusive.

This change also enables the remaining workaround in TensorFlowRuntime/dataset_global.swift test. 