### PR TITLE
Assert that tap vars are in the current DeclContext

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3086,6 +3086,11 @@ namespace {
     }
 
     Type visitTapExpr(TapExpr *expr) {
+      DeclContext *varDC = expr->getVar()->getDeclContext();
+      assert(varDC == CS.DC || (varDC && isa<AbstractClosureExpr>(varDC) &&
+              cast<AbstractClosureExpr>(varDC)->hasSingleExpressionBody()) &&
+             "TapExpr var should be in the same DeclContext we're checking it in!");
+      
       auto locator = CS.getConstraintLocator(expr);
       auto tv = CS.createTypeVariable(locator);
 


### PR DESCRIPTION
This assertion would have caught the last-minute bug in the string interpolation rework, but I'm not sure it actually holds in all cases—I've already found one exception (single-expression closures) and there may be others.

I'm running it against more code to see if there are other special cases I need to account for, or if this is not a general rule I can rely on.