### PR TITLE
Runtime: add UnknownObject on non-ObjC builds

### DIFF
--- a/include/swift/Runtime/BuiltinTypes.def
+++ b/include/swift/Runtime/BuiltinTypes.def
@@ -55,9 +55,7 @@ BUILTIN_POINTER_TYPE(Bb, "Builtin.BridgeObject")
 BUILTIN_POINTER_TYPE(Bp, "Builtin.RawPointer")
 BUILTIN_TYPE(BB, "Builtin.UnsafeValueBuffer")
 
-#if SWIFT_OBJC_INTEROP
 BUILTIN_POINTER_TYPE(BO, "Builtin.UnknownObject")
-#endif
 
 // Int8 vector types
 BUILTIN_VECTOR_TYPE(Bi8_, Int8, 2)

--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -101,6 +101,8 @@ namespace pointer_types {
 
     /// The basic value-witness table for ObjC object pointers.
     using BO = ObjCRetainableBox;
+#else
+    using BO = UnknownObjectRetainableBox;
 #endif
 
   }


### PR DESCRIPTION
The UnknownObject type is used for the block convention block pointers.
This is used in libdispatch and we cannot build for Windows without it.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
