### PR TITLE
build: handle directories for unified build

### DIFF
--- a/cmake/modules/SwiftWindowsSupport.cmake
+++ b/cmake/modules/SwiftWindowsSupport.cmake
@@ -76,12 +76,12 @@ function(swift_windows_generate_sdk_vfs_overlay flags)
   set(UCRTVersion $ENV{UCRTVersion})
 
   # TODO(compnerd) use a target to avoid re-creating this file all the time
-  configure_file("${CMAKE_SOURCE_DIR}/utils/WindowsSDKVFSOverlay.yaml.in"
-                 "${CMAKE_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
+  configure_file("${SWIFT_SOURCE_DIR}/utils/WindowsSDKVFSOverlay.yaml.in"
+                 "${CMAKE_CURRENT_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
                  @ONLY)
 
   set(${flags}
-      -Xclang;-ivfsoverlay;-Xclang;"${CMAKE_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
+        -Xclang;-ivfsoverlay;-Xclang;"${CMAKE_CURRENT_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
       PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
The directory paths would collide with a cross-compiled unified build of
LLVM and swift.  Adjust the directories to work in that environment.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
