### PR TITLE
Runtime: silence some warnings

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -583,12 +583,13 @@ static bool isNonNative_unTagged_bridgeObject(void *object) {
   return (uintptr_t(object) & objectPointerIsObjCBit) != 0
       && (uintptr_t(object) & heap_object_abi::BridgeObjectTagBitsMask) == 0;
 }
-#endif
 
 /// Return true iff the given BridgeObject is a tagged value.
 static bool isBridgeObjectTaggedPointer(void *object) {
-	return (uintptr_t(object) & heap_object_abi::BridgeObjectTagBitsMask) != 0;
+  return (uintptr_t(object) & heap_object_abi::BridgeObjectTagBitsMask) != 0;
 }
+
+#endif
 
 // Mask out the spare bits in a bridgeObject, returning the object it
 // encodes.

--- a/stdlib/public/runtime/WeakReference.h
+++ b/stdlib/public/runtime/WeakReference.h
@@ -189,7 +189,7 @@ class WeakReference {
 
  public:
   
-  WeakReference() = default;
+  WeakReference() : nativeValue() {}
 
   WeakReference(std::nullptr_t)
     : nativeValue(WeakReferenceBits(nullptr)) { }


### PR DESCRIPTION
Silence warnings about deleted defaulted constructors due to the
non-trivial constructor for the atomic type.  Guard a conditionally used
function with the appropriate guard.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
