### PR TITLE
[5.0][sourcekitd] Make sure to put '-resource-dir' argument in front to allow overriding it by the passed in arguments

### DIFF
--- a/test/SourceKit/Misc/Inputs/custom-resource-stdlib.swift
+++ b/test/SourceKit/Misc/Inputs/custom-resource-stdlib.swift
@@ -1,0 +1,1 @@
+public struct CoolInt {}

--- a/test/SourceKit/Misc/resource-dir-handling.swift
+++ b/test/SourceKit/Misc/resource-dir-handling.swift
@@ -1,0 +1,10 @@
+// REQUIRES: OS=macosx
+
+var p: CoolInt
+
+// RUN: mkdir -p %t/custom-resource-dir/macosx/x86_64
+// RUN: %target-swift-frontend -emit-module -module-name Swift -parse-stdlib -target x86_64-apple-macosx10.12 %S/Inputs/custom-resource-stdlib.swift -o %t/custom-resource-dir/macosx/x86_64
+// RUN: %sourcekitd-test -req=cursor -pos=3:8 %s -- -resource-dir %t/custom-resource-dir -target x86_64-apple-macosx10.12 %s | %FileCheck %s
+
+// CHECK: source.lang.swift.ref.struct
+// CHECK-NEXT: CoolInt

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -431,9 +431,12 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
                                              DiagnosticEngine &Diags,
                                              StringRef UnresolvedPrimaryFile,
                                              std::string &Error) {
-  SmallVector<const char *, 16> Args(OrigArgs.begin(), OrigArgs.end());
+  SmallVector<const char *, 16> Args;
+  // Make sure to put '-resource-dir' at the top to allow overriding it by
+  // the passed in arguments.
   Args.push_back("-resource-dir");
   Args.push_back(Impl.RuntimeResourcePath.c_str());
+  Args.append(OrigArgs.begin(), OrigArgs.end());
 
   bool HadError = driver::getSingleFrontendInvocationFromDriverArguments(
       Args, Diags, [&](ArrayRef<const char *> FrontendArgs) {


### PR DESCRIPTION
Otherwise, passing a custom '-resource-dir' option will be ignored.
rdar://45764554

master: https://github.com/apple/swift/pull/20312