### PR TITLE
build: always build swift-reflection-dump

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -50,8 +50,4 @@ if(SWIFT_HOST_VARIANT STREQUAL "macosx")
   add_swift_tool_subdirectory(swift-stdlib-tool)
 endif()
 
-
-is_sdk_requested("${SWIFT_HOST_VARIANT_SDK}" SWIFT_HOST_SDK_REQUESTED)
-if(SWIFT_BUILD_STDLIB AND SWIFT_HOST_SDK_REQUESTED)
-  add_swift_tool_subdirectory(swift-reflection-dump)
-endif()
+add_swift_tool_subdirectory(swift-reflection-dump)


### PR DESCRIPTION
We always build swiftReflection now for the tools which allows us to
always build this tool.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
