### PR TITLE
Dead interpolation elimination improvements

### DIFF
--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -80,4 +80,6 @@ KNOWN_STDLIB_TYPE_DECL(KeyedEncodingContainer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(KeyedDecodingContainer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(RangeReplaceableCollection, ProtocolDecl, 1)
 
+KNOWN_STDLIB_TYPE_DECL(DefaultStringInterpolation, NominalTypeDecl, 0)
+
 #undef KNOWN_STDLIB_TYPE_DECL

--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -81,5 +81,7 @@ KNOWN_STDLIB_TYPE_DECL(KeyedDecodingContainer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(RangeReplaceableCollection, ProtocolDecl, 1)
 
 KNOWN_STDLIB_TYPE_DECL(DefaultStringInterpolation, NominalTypeDecl, 0)
+KNOWN_STDLIB_TYPE_DECL(_StringGuts, NominalTypeDecl, 0)
+KNOWN_STDLIB_TYPE_DECL(_StringObject, NominalTypeDecl, 0)
 
 #undef KNOWN_STDLIB_TYPE_DECL

--- a/include/swift/SILOptimizer/Utils/IndexTrie.h
+++ b/include/swift/SILOptimizer/Utils/IndexTrie.h
@@ -77,7 +77,31 @@ public:
 
     return false;
   }
+
+  void dumpRef(llvm::raw_ostream &out, bool last = true) const {
+    if (Parent) {
+      Parent->dumpRef(out, false);
+      out << ", ";
+      out << Index;
+    } else {
+      out << "(Root";
+    }
+
+    if (last)
+      out << ")";
+  }
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dumpRef() const LLVM_ATTRIBUTE_USED,
+                            "Only meant for use in the debugger") {
+    dumpRef(llvm::errs());
+  }
 };
+
+static inline
+llvm::raw_ostream &operator<<(llvm::raw_ostream &out, IndexTrieNode *ITN) {
+  ITN->dumpRef(out);
+  return out;
+}
 
 } // end namespace swift
 

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -612,7 +612,7 @@ static bool shouldSkipApplyDuringEarlyInlining(FullApplySite AI) {
 
   if (Callee->hasSemanticsAttr("self_no_escaping_closure") ||
       Callee->hasSemanticsAttr("pair_no_escaping_closure") ||
-      Callee->hasSemanticsAttr("interpolation.selfEffectsOnly"))
+      Callee->hasSemanticsAttr("interpolation.append"))
     return true;
 
   // Add here the checks for any specific @_effects attributes that need

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -611,7 +611,8 @@ static bool shouldSkipApplyDuringEarlyInlining(FullApplySite AI) {
     return false;
 
   if (Callee->hasSemanticsAttr("self_no_escaping_closure") ||
-      Callee->hasSemanticsAttr("pair_no_escaping_closure"))
+      Callee->hasSemanticsAttr("pair_no_escaping_closure") ||
+      Callee->hasSemanticsAttr("interpolation.selfEffectsOnly"))
     return true;
 
   // Add here the checks for any specific @_effects attributes that need

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -73,6 +73,7 @@ extension _StringGuts {
 
   // Grow to accomodate at least `n` code units
   @usableFromInline
+  @_semantics("interpolation.append")
   internal mutating func grow(_ n: Int) {
     defer { self._invariantCheck() }
 

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -83,7 +83,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   /// Do not call this method directly. It is used by the compiler when
   /// interpreting string interpolations.
   @inlinable
-  @_semantics("interpolation.selfEffectsOnly")
+  @_semantics("interpolation.append")
   public mutating func appendLiteral(_ literal: String) {
     literal.write(to: &self)
   }
@@ -106,7 +106,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  @_semantics("interpolation.selfEffectsOnly")
+  @_semantics("interpolation.append")
   public mutating func appendInterpolation<T>(_ value: T)
     where T: TextOutputStreamable, T: CustomStringConvertible
   {
@@ -129,7 +129,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  @_semantics("interpolation.selfEffectsOnly")
+  @_semantics("interpolation.append")
   public mutating func appendInterpolation<T>(_ value: T)
     where T: TextOutputStreamable
   {
@@ -154,7 +154,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  @_semantics("interpolation.selfEffectsOnly")
+  @_semantics("interpolation.append")
   public mutating func appendInterpolation<T>(_ value: T)
     where T: CustomStringConvertible
   {
@@ -179,7 +179,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  @_semantics("interpolation.selfEffectsOnly")
+  @_semantics("interpolation.append")
   public mutating func appendInterpolation<T>(_ value: T) {
     _print_unlocked(value, &self)
   }

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -71,6 +71,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   /// Do not call this initializer directly. It is used by the compiler when
   /// interpreting string interpolations.
   @inlinable
+  @_effects(readonly)
   public init(literalCapacity: Int, interpolationCount: Int) {
     let capacityPerInterpolation = 2
     let initialCapacity = literalCapacity +

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -83,6 +83,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   /// Do not call this method directly. It is used by the compiler when
   /// interpreting string interpolations.
   @inlinable
+  @_semantics("interpolation.selfEffectsOnly")
   public mutating func appendLiteral(_ literal: String) {
     literal.write(to: &self)
   }
@@ -105,6 +106,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
+  @_semantics("interpolation.selfEffectsOnly")
   public mutating func appendInterpolation<T>(_ value: T)
     where T: TextOutputStreamable, T: CustomStringConvertible
   {
@@ -127,6 +129,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
+  @_semantics("interpolation.selfEffectsOnly")
   public mutating func appendInterpolation<T>(_ value: T)
     where T: TextOutputStreamable
   {
@@ -151,6 +154,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
+  @_semantics("interpolation.selfEffectsOnly")
   public mutating func appendInterpolation<T>(_ value: T)
     where T: CustomStringConvertible
   {
@@ -175,6 +179,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
+  @_semantics("interpolation.selfEffectsOnly")
   public mutating func appendInterpolation<T>(_ value: T) {
     _print_unlocked(value, &self)
   }

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -71,7 +71,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol {
   /// Do not call this initializer directly. It is used by the compiler when
   /// interpreting string interpolations.
   @inlinable
-  @_effects(readonly)
+  @inline(__always)
   public init(literalCapacity: Int, interpolationCount: Int) {
     let capacityPerInterpolation = 2
     let initialCapacity = literalCapacity +

--- a/test/SILOptimizer/unused_containers.swift
+++ b/test/SILOptimizer/unused_containers.swift
@@ -74,6 +74,14 @@ func string_interpolation2() {
   "\(false) \(true)"
 }
 
+//CHECK-LABEL: string_interpolation_non_small
+//CHECK: bb0:
+//CHECK-NEXT: tuple
+//CHECK-NEXT: return
+func string_interpolation_non_small() {
+  "The quick brown fox jumped over the lazy \("animal")."
+}
+
 //CHECK-LABEL: string_plus
 //CHECK: bb0:
 //CHECK-NEXT: tuple

--- a/test/SILOptimizer/unused_containers.swift
+++ b/test/SILOptimizer/unused_containers.swift
@@ -4,7 +4,6 @@
 
 // FIXME: https://bugs.swift.org/browse/SR-7806
 // REQUIRES: CPU=arm64 || CPU=x86_64
-// REQUIRES: rdar45797168
 
 // FIXME: https://bugs.swift.org/browse/SR-9008
 


### PR DESCRIPTION
The optimizer doesn't understand the effects of `appendLiteral(_:)` and `appendInterpolation(_:)` calls, which only modify `self`. Because of this, it can't tell that an interpolation can be eliminated if the resulting string is unused, which causes a (no-assertions-only) test failure and some code size regressions.

This is an attempt to help DeadCodeElimination along. The first revision benchmarked poorly when I tried it a few days ago; I'm just pushing it now to get a baseline, and then I'll experiment a little more from there. Currently pretty hacky, too.

This could be a dead end. If it isn't, it should resolve [SR-9008](https://bugs.swift.org/browse/SR-9008), rdar://45294605, and rdar://45788348.