### PR TITLE
[test] disable SILOptimizer/unused_containers.swift to unblock CI. rdar://45797168

### DIFF
--- a/test/SILOptimizer/unused_containers.swift
+++ b/test/SILOptimizer/unused_containers.swift
@@ -4,9 +4,9 @@
 
 // FIXME: https://bugs.swift.org/browse/SR-7806
 // REQUIRES: CPU=arm64 || CPU=x86_64
+// REQUIRES: rdar45797168
 
 // FIXME: https://bugs.swift.org/browse/SR-9008
-// XFAIL: linux
 
 //CHECK-LABEL: @$s17unused_containers16empty_array_testyyF
 //CHECK: bb0:


### PR DESCRIPTION
We've seen the failure in OS X bots too:
https://ci.swift.org/view/Dashboard/job/oss-swift_tools-RA_stdlib-RD_test-simulator/