### PR TITLE
[QoI][stdlib] Improve some random call sites

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -929,7 +929,7 @@ extension Collection {
     using generator: inout T
   ) -> Element? {
     guard !isEmpty else { return nil }
-    let random = Int.random(in: 0 ..< count)
+    let random = Int.random(in: 0 ..< count, using: &generator)
     let idx = index(
       startIndex,
       offsetBy: random

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -929,12 +929,12 @@ extension Collection {
     using generator: inout T
   ) -> Element? {
     guard !isEmpty else { return nil }
-    let random = generator.next(upperBound: UInt(count))
-    let index = self.index(
+    let random = Int.random(in: 0 ..< count)
+    let idx = index(
       startIndex,
-      offsetBy: numericCast(random)
+      offsetBy: random
     )
-    return self[index]
+    return self[idx]
   }
 
   /// Returns a random element of the collection.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -930,10 +930,7 @@ extension Collection {
   ) -> Element? {
     guard !isEmpty else { return nil }
     let random = Int.random(in: 0 ..< count, using: &generator)
-    let idx = index(
-      startIndex,
-      offsetBy: random
-    )
+    let idx = index(startIndex, offsetBy: random)
     return self[idx]
   }
 

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -449,7 +449,7 @@ extension MutableCollection where Self : RandomAccessCollection {
     var amount = count
     var currentIndex = startIndex
     while amount > 1 {
-      let random = Int.random(in: 0 ..< amount)
+      let random = Int.random(in: 0 ..< amount, using: &generator)
       amount -= 1
       swapAt(
         currentIndex,

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -445,16 +445,15 @@ extension MutableCollection where Self : RandomAccessCollection {
   public mutating func shuffle<T: RandomNumberGenerator>(
     using generator: inout T
   ) {
-    let count = self.count
     guard count > 1 else { return }
     var amount = count
     var currentIndex = startIndex
     while amount > 1 {
-      let random = generator.next(upperBound: UInt(amount))
+      let random = Int.random(in: 0 ..< amount)
       amount -= 1
       swapAt(
         currentIndex,
-        index(currentIndex, offsetBy: numericCast(random))
+        index(currentIndex, offsetBy: random)
       )
       formIndex(after: &currentIndex)
     }


### PR DESCRIPTION
Instead of using generator directly, use `Int.random(in:)` to improve clarity of these call sites.

cc: @lorentey 

Can you also kick off benchmarks as well?