### PR TITLE
[incrParse] Fix SyntaxParsingCache::translateToPreEditPosition()

### DIFF
--- a/include/swift/Parse/SyntaxParsingCache.h
+++ b/include/swift/Parse/SyntaxParsingCache.h
@@ -34,8 +34,11 @@ struct SourceEdit {
   /// The length of the string that replaced the range described above.
   size_t ReplacementLength;
 
+  SourceEdit(size_t Start, size_t End, size_t ReplacementLength)
+      : Start(Start), End(End), ReplacementLength(ReplacementLength){};
+
   /// The length of the range that has been replaced
-  size_t originalLength() { return End - Start; }
+  size_t originalLength() const { return End - Start; }
 
   /// Check if the characters replaced by this edit fall into the given range
   /// or are directly adjacent to it
@@ -65,12 +68,16 @@ public:
       : OldSyntaxTree(OldSyntaxTree) {}
 
   /// Add an edit that transformed the source file which created this cache into
-  /// the source file that is now being parsed incrementally. The order in which
-  /// the edits are added using this method needs to be the same order in which
-  /// the edits were applied to the source file.
-  void addEdit(size_t Start, size_t End, size_t ReplacementLength) {
-    Edits.push_back({Start, End, ReplacementLength});
-  }
+  /// the source file that is now being parsed incrementally. \c Start must be a
+  /// position from the *original* source file, and it must not overlap any
+  /// other edits previously added. For instance, given:
+  ///   (aaa, bbb)
+  ///   0123456789
+  /// When you want to turn this into:
+  ///   (c, dddd)
+  ///   0123456789
+  /// edits should be: { 1, 4, 1 } and { 6, 9, 4 }.
+  void addEdit(size_t Start, size_t End, size_t ReplacementLength);
 
   /// Check if a syntax node of the given kind at the given position can be
   /// reused for a new syntax tree.
@@ -86,11 +93,13 @@ public:
   getReusedRegions(const SourceFileSyntax &SyntaxTree) const;
 
   /// Translates a post-edit position to a pre-edit position by undoing the
-  /// specified edits.
+  /// specified edits. Returns \c None if no pre-edit position exists because
+  /// the post-edit position has been inserted by an edit.
+  /// 
   /// Should not be invoked externally. Only public for testing purposes.
-  static size_t
+  static Optional<size_t>
   translateToPreEditPosition(size_t PostEditPosition,
-                             llvm::SmallVector<SourceEdit, 4> Edits);
+                             ArrayRef<SourceEdit> Edits);
 
 private:
   llvm::Optional<Syntax> lookUpFrom(const Syntax &Node, size_t NodeStart,

--- a/test/incrParse/inserted_text_starts_identifier.swift
+++ b/test/incrParse/inserted_text_starts_identifier.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %validate-incrparse %s --test-case STRING
+
+// SR-8995 rdar://problem/45259469
+
+self = <<STRING<|||_                            _>>>foo(1)[object1, object2] + o bar(1)


### PR DESCRIPTION
If the position is in the region that is inserted by the edits, "pre-edit" position shouldn't exist. So we cannot reuse the node at the position.

rdar://problem/45259469
https://bugs.swift.org/browse/SR-8995

CC: @ahoppen 