### PR TITLE
[Runtime] Diagnose multiple retroactive conformances for X: P.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2292,11 +2292,17 @@ public:
     return TypeRef.getTypeContextDescriptor(getTypeKind());
   }
 
+  /// Whether this is a retroactive conformance.
+  bool isRetroactive() const {
+    return Flags.isRetroactive();
+  }
+
   /// Retrieve the context of a retroactive conformance.
-  const TargetContextDescriptor<Runtime> *getRetroactiveContext() const {
+  ConstTargetPointer<Runtime, TargetContextDescriptor<Runtime>>
+  getRetroactiveContext() const {
     if (!Flags.isRetroactive()) return nullptr;
 
-    return this->template getTrailingObjects<RelativeContextPointer<Runtime>>();
+    return *this->template getTrailingObjects<RelativeContextPointer<Runtime>>();
   }
 
   /// Whether this conformance is non-unique because it has been synthesized

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -452,6 +452,12 @@ public:
                            ProtocolDescriptorRef protocol,
                            const WitnessTable **conformance);
 
+  /// Determine whether the given type conforms to the given Swift protocol.
+  const WitnessTable *
+  _conformsToSwiftProtocol(const Metadata * const type,
+                           const ProtocolDescriptor *protocol,
+                           const char *module);
+
   /// Given a type that we know conforms to the given protocol, find the
   /// superclass that introduced the conformance.
   const Metadata *findConformingSuperclass(const Metadata *type,

--- a/test/Runtime/Inputs/RetroactiveA.swift
+++ b/test/Runtime/Inputs/RetroactiveA.swift
@@ -1,0 +1,9 @@
+import RetroactiveCommon
+
+extension CommonStruct : CommonP1 {
+  public typealias AssocType = Int
+}
+
+public func getCommonRequiresP1_Struct() -> Any.Type {
+  return CommonRequiresP1<CommonStruct>.self
+}

--- a/test/Runtime/Inputs/RetroactiveB.swift
+++ b/test/Runtime/Inputs/RetroactiveB.swift
@@ -1,0 +1,9 @@
+import RetroactiveCommon
+
+extension CommonStruct : CommonP1 {
+  public typealias AssocType = String
+}
+
+public func getCommonRequiresP1_Struct() -> Any.Type {
+  return CommonRequiresP1<CommonStruct>.self
+}

--- a/test/Runtime/Inputs/RetroactiveCommon.swift
+++ b/test/Runtime/Inputs/RetroactiveCommon.swift
@@ -1,0 +1,9 @@
+public struct CommonStruct { }
+
+public protocol CommonP1 {
+  associatedtype AssocType
+}
+
+public struct CommonRequiresP1<T: CommonP1> {
+  public init() { }
+}

--- a/test/Runtime/multiple_conformances.swift
+++ b/test/Runtime/multiple_conformances.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation %S/Inputs/RetroactiveCommon.swift -emit-module-path %t/RetroactiveCommon.swiftmodule -emit-object -o %t/RetroactiveCommon.o
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveA.swift -emit-module-path %t/RetroactiveA.swiftmodule -emit-object -o %t/RetroactiveA.o
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveB.swift -emit-module-path %t/RetroactiveB.swiftmodule -emit-object -o %t/RetroactiveB.o
+// RUN: %target-build-swift -I %t %s %t/RetroactiveCommon.o %t/RetroactiveA.o %t/RetroactiveB.o -module-name main -o %t/a.out 
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out > %t.log 2>&1
+// RUN: %FileCheck %s < %t.log
+
+// REQUIRES: executable_test
+
+import RetroactiveCommon
+import RetroactiveA
+import RetroactiveB
+
+// CHECK: Swift runtime warning: multiple conformances for 'RetroactiveCommon.CommonStruct: CommonP1' found in modules 'RetroactiveA' and 'RetroactiveB'. Arbitrarily selecting conformance from module 'RetroactiveA'
+let demangled1 = _typeByMangledName("17RetroactiveCommon16CommonRequiresP1Vy17RetroactiveCommon12CommonStructVG")!


### PR DESCRIPTION
Thread a module name into the protocol conformance lookup function
(e.g., the function implementing swift_conformsToProtocol), and compare that
against the module context of retroactive conformances. When we don’t care
where we find the resulting conformance (e.g., the module name is NULL),
and more than one retroactive conformance found, produce a warning like this:

    ***Swift runtime warning: multiple conformances for 
    'RetroactiveCommon.CommonStruct: CommonP1' found in modules
    'RetroactiveA' and 'RetroactiveB'. Arbitrarily selecting conformance 
    from module 'RetroactiveA'

This code will also be used to select specific conformances.
