### PR TITLE
[SR-8617] Index explicit types in enum cases

### DIFF
--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1592,6 +1592,10 @@ Pattern *Traversal::visitIsPattern(IsPattern *P) {
 }
 
 Pattern *Traversal::visitEnumElementPattern(EnumElementPattern *P) {
+  if (!P->isParentTypeImplicit())
+    if (doIt(P->getParentType()))
+      return nullptr;
+
   if (!P->hasSubPattern())
     return P;
 

--- a/test/Index/patterns.swift
+++ b/test/Index/patterns.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+struct Foo {
+  enum Inner {
+    case bar
+  }
+}
+
+let a: Foo.Inner = .bar
+
+if case .bar = a {}
+// CHECK: [[@LINE-1]]:10 | {{.*}} | bar
+if case Foo.Inner.bar = a {}
+// CHECK: [[@LINE-1]]:19 | {{.*}} | bar
+// CHECK: [[@LINE-2]]:9 | {{.*}} | Foo
+// CHECK: [[@LINE-3]]:13 | {{.*}} | Inner
+switch a {
+case .bar:
+// CHECK: [[@LINE-1]]:7 | {{.*}} | bar
+    break
+case Foo.Inner.bar:
+// CHECK: [[@LINE-1]]:16 | {{.*}} | bar
+// CHECK: [[@LINE-2]]:6 | {{.*}} | Foo
+// CHECK: [[@LINE-3]]:10 | {{.*}} | Inner
+    break
+default:
+    break
+}


### PR DESCRIPTION
Similar to https://github.com/apple/swift/pull/19938, explicitly defining a type in enum patterns such as `if case Foo.bar = x {}` was resulting in the type portion not being indexed. This is somewhat common if you have an enum inside a nested type, so this checks the existence of an explicit parent and walks it as well.

Resolves [SR-8617](https://bugs.swift.org/browse/SR-8617).