### PR TITLE
IRGen/Runtime: Make key path pattern format true-const.

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -917,6 +917,9 @@ public:
   bool isObjCClassRef() const {
     return getKind() == Kind::ObjCClassRef;
   }
+  bool isSILFunction() const {
+    return getKind() == Kind::SILFunction;
+  }
 
   /// Determine whether this entity will be weak-imported.
   bool isWeakImported(ModuleDecl *module) const;

--- a/lib/IRGen/ConstantBuilder.h
+++ b/lib/IRGen/ConstantBuilder.h
@@ -81,6 +81,7 @@ public:
   }
 
   void addRelativeAddress(llvm::Constant *target) {
+    assert(!isa<llvm::ConstantPointerNull>(target));
     addRelativeOffset(IGM().RelativeAddressTy, target);
   }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -929,6 +929,9 @@ private:
                               StringRef funcName,
                               CopyAddrHelperGenerator generator);
 
+  llvm::Constant *getOrCreateGOTEquivalent(llvm::Constant *global,
+                                           LinkEntity entity);
+                                           
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalVars;
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalGOTEquivalents;
   llvm::DenseMap<LinkEntity, llvm::Function*> GlobalFuncs;

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -519,6 +519,11 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   llvm_unreachable("bad link entity kind");
 }
 
+static bool isAvailableExternally(IRGenModule &IGM, SILFunction *F) {
+  // TODO
+  return true;
+}
+
 static bool isAvailableExternally(IRGenModule &IGM, const DeclContext *dc) {
   dc = dc->getModuleScopeContext();
   if (isa<ClangModuleUnit>(dc) ||
@@ -619,16 +624,24 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
   case Kind::DefaultAssociatedConformanceAccessor:
     return false;
 
+  case Kind::SILFunction:
+    return ::isAvailableExternally(IGM, getSILFunction());
+
+  case Kind::FieldOffset: {
+    return ::isAvailableExternally(IGM,
+                                   cast<VarDecl>(getDecl())
+                                     ->getDeclContext()
+                                     ->getInnermostTypeContext());
+  }
+  
   case Kind::ObjCMetadataUpdateFunction:
   case Kind::ValueWitness:
   case Kind::TypeMetadataAccessFunction:
   case Kind::TypeMetadataLazyCacheVariable:
-  case Kind::FieldOffset:
   case Kind::ProtocolWitnessTableLazyAccessFunction:
   case Kind::ProtocolWitnessTableLazyCacheVariable:
   case Kind::AssociatedTypeWitnessTableAccessFunction:
   case Kind::GenericProtocolWitnessTableInstantiationFunction:
-  case Kind::SILFunction:
   case Kind::SILGlobalVariable:
   case Kind::ReflectionBuiltinDescriptor:
   case Kind::ReflectionFieldDescriptor:

--- a/stdlib/public/SwiftShims/KeyPath.h
+++ b/stdlib/public/SwiftShims/KeyPath.h
@@ -107,9 +107,9 @@ static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDResolved
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
   = 0x00000002U;
 
-extern void *(swift_keyPathGenericWitnessTable[]);
+extern const void *_Nonnull (swift_keyPathGenericWitnessTable[]);
 
-static inline void *__swift_keyPathGenericWitnessTable_addr(void) {
+static inline const void *_Nonnull __swift_keyPathGenericWitnessTable_addr(void) {
   return swift_keyPathGenericWitnessTable;
 }
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -433,28 +433,19 @@ internal enum KeyPathComponentKind {
 }
 
 internal struct ComputedPropertyID: Hashable {
-  internal init(value: Int, isStoredProperty: Bool, isTableOffset: Bool) {
-    self.value = value
-    self.isStoredProperty = isStoredProperty
-    self.isTableOffset = isTableOffset
-  }
-
   internal var value: Int
-  internal var isStoredProperty: Bool
-  internal var isTableOffset: Bool
+  internal var kind: KeyPathComputedIDKind
 
   internal static func ==(
     x: ComputedPropertyID, y: ComputedPropertyID
   ) -> Bool {
     return x.value == y.value
-      && x.isStoredProperty == y.isStoredProperty
-      && x.isTableOffset == x.isTableOffset
+      && x.kind == y.kind
   }
 
   internal func hash(into hasher: inout Hasher) {
     hasher.combine(value)
-    hasher.combine(isStoredProperty)
-    hasher.combine(isTableOffset)
+    hasher.combine(kind)
   }
 }
 
@@ -731,6 +722,18 @@ internal final class NonmutatingWritebackBuffer<CurValue, NewValue> {
   }
 }
 
+internal typealias KeyPathComputedArgumentLayoutFn = @convention(thin)
+  (_ patternArguments: UnsafeRawPointer) -> (size: Int, alignmentMask: Int)
+internal typealias KeyPathComputedArgumentInitializerFn = @convention(thin)
+  (_ patternArguments: UnsafeRawPointer,
+   _ instanceArguments: UnsafeMutableRawPointer) -> ()
+
+internal enum KeyPathComputedIDKind {
+  case pointer
+  case storedPropertyIndex
+  case vtableOffset
+}
+
 internal struct RawKeyPathComponent {
   internal init(header: Header, body: UnsafeRawBufferPointer) {
     self.header = header
@@ -824,6 +827,21 @@ internal struct RawKeyPathComponent {
     internal static var computedIDByVTableOffsetFlag: UInt32 {
       return _SwiftKeyPathComponentHeader_ComputedIDByVTableOffsetFlag
     }
+    internal var computedIDKind: KeyPathComputedIDKind {
+      let storedProperty = _value & Header.computedIDByStoredPropertyFlag != 0
+      let vtableOffset = _value & Header.computedIDByVTableOffsetFlag != 0
+
+      switch (storedProperty, vtableOffset) {
+      case (true, true):
+        _sanityCheckFailure("not allowed")
+      case (true, false):
+        return .storedPropertyIndex
+      case (false, true):
+        return .vtableOffset
+      case (false, false):
+        return .pointer
+      }
+    }
 
     internal static var computedHasArgumentsFlag: UInt32 {
       return _SwiftKeyPathComponentHeader_ComputedHasArgumentsFlag
@@ -867,11 +885,23 @@ internal struct RawKeyPathComponent {
     internal static var computedIDUnresolvedIndirectPointer: UInt32 {
       return _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
     }
+    internal var isComputedIDResolved: Bool {
+      return
+        payload & Header.computedIDResolutionMask == Header.computedIDResolved
+    }
     
     internal var _value: UInt32
     
     internal var discriminator: UInt32 {
-      return (_value & Header.discriminatorMask) >> Header.discriminatorShift
+      get {
+        return (_value & Header.discriminatorMask) >> Header.discriminatorShift
+      }
+      set {
+        let shifted = newValue << Header.discriminatorShift
+        _sanityCheck(shifted & Header.discriminatorMask == shifted,
+                     "discriminator doesn't fit")
+        _value = _value & ~Header.discriminatorMask | shifted
+      }
     }
     internal var payload: UInt32 {
       get {
@@ -959,44 +989,116 @@ internal struct RawKeyPathComponent {
       switch kind {
       case .struct, .class:
         if storedOffsetPayload == Header.unresolvedFieldOffsetPayload
-           || storedOffsetPayload == Header.outOfLineOffsetPayload {
+           || storedOffsetPayload == Header.outOfLineOffsetPayload
+           || storedOffsetPayload == Header.unresolvedIndirectOffsetPayload {
           // A 32-bit offset is stored in the body.
           return MemoryLayout<UInt32>.size
         }
-        if storedOffsetPayload == Header.unresolvedIndirectOffsetPayload {
-          // A pointer-aligned, pointer-sized pointer is stored in the body.
-          return Header.pointerAlignmentSkew + MemoryLayout<Int>.size
-        }
         // Otherwise, there's no body.
-        return Header.pointerAlignmentSkew
+        return 0
 
       case .external:
         // The body holds a pointer to the external property descriptor,
         // and some number of substitution arguments, the count of which is
         // in the payload.
-        return Header.pointerAlignmentSkew
-          + MemoryLayout<Int>.size * (1 + Int(payload))
+        return 4 * (1 + Int(payload))
 
       case .computed:
         // The body holds at minimum the id and getter.
-        var size = Header.pointerAlignmentSkew + MemoryLayout<Int>.size * 2
+        var size = 8
         // If settable, it also holds the setter.
         if isComputedSettable {
-          size += MemoryLayout<Int>.size
+          size += 4
         }
         // If there are arguments, there's also a layout function,
         // witness table, and initializer function.
         // Property descriptors never carry argument information, though.
         if !forPropertyDescriptor && hasComputedArguments {
-          size += MemoryLayout<Int>.size * 3
+          size += 12
         }
 
         return size
 
       case .optionalForce, .optionalChain, .optionalWrap:
         // Otherwise, there's no body.
-        return Header.pointerAlignmentSkew
+        return 0
       }
+    }
+
+    init(discriminator: UInt32, payload: UInt32) {
+      _value = 0
+      self.discriminator = discriminator
+      self.payload = payload
+    }
+
+    init(optionalForce: ()) {
+      self.init(discriminator: Header.optionalTag,
+                payload: Header.optionalForcePayload)
+    }
+
+    init(optionalWrap: ()) {
+      self.init(discriminator: Header.optionalTag,
+                payload: Header.optionalWrapPayload)
+    }
+
+    init(optionalChain: ()) {
+      self.init(discriminator: Header.optionalTag,
+                payload: Header.optionalChainPayload)
+    }
+
+    init(stored kind: KeyPathStructOrClass,
+         mutable: Bool,
+         inlineOffset: UInt32) {
+      let discriminator: UInt32
+      switch kind {
+      case .struct: discriminator = Header.structTag
+      case .class: discriminator = Header.classTag
+      }
+
+      _sanityCheck(inlineOffset <= Header.maximumOffsetPayload)
+      let payload = inlineOffset
+        | (mutable ? Header.storedMutableFlag : 0)
+      self.init(discriminator: discriminator,
+                payload: payload)
+    }
+
+    init(storedWithOutOfLineOffset kind: KeyPathStructOrClass,
+         mutable: Bool) {
+      let discriminator: UInt32
+      switch kind {
+      case .struct: discriminator = Header.structTag
+      case .class: discriminator = Header.classTag
+      }
+
+      let payload = Header.outOfLineOffsetPayload
+        | (mutable ? Header.storedMutableFlag : 0)
+
+      self.init(discriminator: discriminator,
+                payload: payload)
+    }
+
+    init(computedWithIDKind kind: KeyPathComputedIDKind,
+         mutating: Bool,
+         settable: Bool,
+         hasArguments: Bool,
+         instantiatedFromExternalWithArguments: Bool) {
+      let discriminator = Header.computedTag
+      var payload =
+          (mutating ? Header.computedMutatingFlag : 0)
+        | (settable ? Header.computedSettableFlag : 0)
+        | (hasArguments ? Header.computedHasArgumentsFlag : 0)
+        | (instantiatedFromExternalWithArguments
+             ? Header.computedInstantiatedFromExternalWithArgumentsFlag : 0)
+      switch kind {
+      case .pointer:
+        break
+      case .storedPropertyIndex:
+        payload |= Header.computedIDByStoredPropertyFlag
+      case .vtableOffset:
+        payload |= Header.computedIDByVTableOffsetFlag
+      }
+      self.init(discriminator: discriminator,
+                payload: payload)
     }
   }
 
@@ -1009,9 +1111,7 @@ internal struct RawKeyPathComponent {
       }
       return 0
     case .external:
-      // align to pointer + pointer to external descriptor
-      // + N generic argument accessors (N in payload)
-      return Header.pointerAlignmentSkew + ptrSize * (1 + Int(header.payload))
+      _sanityCheckFailure("should be instantiated away")
     case .optionalChain, .optionalForce, .optionalWrap:
       return 0
     case .computed:
@@ -1057,11 +1157,12 @@ internal struct RawKeyPathComponent {
   }
 
   internal var _computedID: ComputedPropertyID {
-    let payload = header.payload
+    _sanityCheck(header.kind == .computed,
+                 "not a computed property")
+
     return ComputedPropertyID(
       value: _computedIDValue,
-      isStoredProperty: payload & Header.computedIDByStoredPropertyFlag != 0,
-      isTableOffset: payload & Header.computedIDByVTableOffsetFlag != 0)
+      kind: header.computedIDKind)
   }
 
   internal var _computedGetter: UnsafeRawPointer {
@@ -1081,12 +1182,6 @@ internal struct RawKeyPathComponent {
       fromByteOffset: Header.pointerAlignmentSkew + MemoryLayout<Int>.size * 2,
       as: UnsafeRawPointer.self)
   }
-
-  internal typealias ComputedArgumentLayoutFn = @convention(thin)
-    (_ patternArguments: UnsafeRawPointer) -> (size: Int, alignmentMask: Int)
-  internal typealias ComputedArgumentInitializerFn = @convention(thin)
-    (_ patternArguments: UnsafeRawPointer,
-     _ instanceArguments: UnsafeMutableRawPointer) -> ()
 
   internal var _computedArgumentHeaderPointer: UnsafeRawPointer {
     _sanityCheck(header.hasComputedArguments, "no arguments")
@@ -1474,6 +1569,27 @@ internal struct RawKeyPathComponent {
   }
 }
 
+internal func _pop<T>(from: inout UnsafeRawBufferPointer,
+                      as type: T.Type) -> T {
+  let buffer = _pop(from: &from, as: type, count: 1)
+  return buffer.baseAddress.unsafelyUnwrapped.pointee
+}
+internal func _pop<T>(from: inout UnsafeRawBufferPointer,
+                      as: T.Type,
+                      count: Int) -> UnsafeBufferPointer<T> {
+  _sanityCheck(_isPOD(T.self), "should be POD")
+  from = MemoryLayout<T>._roundingUpBaseToAlignment(from)
+  let byteCount = MemoryLayout<T>.stride * count
+  let result = UnsafeBufferPointer(
+    start: from.baseAddress.unsafelyUnwrapped.assumingMemoryBound(to: T.self),
+    count: count)
+
+  from = UnsafeRawBufferPointer(
+    start: from.baseAddress.unsafelyUnwrapped + byteCount,
+    count: from.count - byteCount)
+  return result
+}
+  
 internal struct KeyPathBuffer {
   internal var data: UnsafeRawBufferPointer
   internal var trivial: Bool
@@ -1563,7 +1679,7 @@ internal struct KeyPathBuffer {
   }
   
   internal mutating func next() -> (RawKeyPathComponent, Any.Type?) {
-    let header = pop(RawKeyPathComponent.Header.self)
+    let header = _pop(from: &data, as: RawKeyPathComponent.Header.self)
     // Track if this is the last component of the reference prefix.
     if header.endOfReferencePrefix {
       _sanityCheck(self.hasReferencePrefix,
@@ -1576,39 +1692,16 @@ internal struct KeyPathBuffer {
     let size = component.bodySize
     component.body = UnsafeRawBufferPointer(start: component.body.baseAddress,
                                             count: size)
-    _ = popRaw(size: size, alignment: Int8.self)
+    _ = _pop(from: &data, as: Int8.self, count: size)
 
     // fetch type, which is in the buffer unless it's the final component
     let nextType: Any.Type?
     if data.count == 0 {
       nextType = nil
     } else {
-      nextType = pop(Any.Type.self)
+      nextType = _pop(from: &data, as: Any.Type.self)
     }
     return (component, nextType)
-  }
-  
-  internal mutating func pop<T>(_ type: T.Type) -> T {
-    _sanityCheck(_isPOD(T.self), "should be POD")
-    let raw = popRaw(size: MemoryLayout<T>.size,
-                     alignment: T.self)
-    let resultBuf = UnsafeMutablePointer<T>.allocate(capacity: 1)
-    _memcpy(dest: resultBuf,
-            src: raw.baseAddress.unsafelyUnwrapped,
-            size: UInt(MemoryLayout<T>.size))
-    let result = resultBuf.pointee
-    resultBuf.deallocate()
-    return result
-  }
-  internal mutating func popRaw<Alignment>(
-    size: Int, alignment: Alignment.Type
-  ) -> UnsafeRawBufferPointer {
-    data = MemoryLayout<Alignment>._roundingUpBaseToAlignment(data)
-    let result = UnsafeRawBufferPointer(start: data.baseAddress, count: size)
-    data = UnsafeRawBufferPointer(
-      start: data.baseAddress.unsafelyUnwrapped + size,
-      count: data.count - size)
-    return result
   }
 }
 
@@ -2133,6 +2226,10 @@ internal var keyPathObjectHeaderSize: Int {
   return MemoryLayout<HeapObject>.size + MemoryLayout<Int>.size
 }
 
+internal var keyPathPatternHeaderSize: Int {
+  return 12
+}
+
 // Runtime entry point to instantiate a key path object.
 // Note that this has a compatibility override shim in the runtime so that
 // future compilers can backward-deploy support for instantiating new key path
@@ -2143,149 +2240,623 @@ public func _swift_getKeyPath(pattern: UnsafeMutableRawPointer,
     -> UnsafeRawPointer {
   // The key path pattern is laid out like a key path object, with a few
   // modifications:
+  // - Pointers in the instantiated object are compressed into 32-bit
+  //   relative offsets in the pattern.
+  // - The pattern begins with a field that's either zero, for a pattern that
+  //   depends on instantiation arguments, or that's a relative reference to
+  //   a global mutable pointer variable, which can be initialized to a single
+  //   shared instantiation of this pattern.
   // - Instead of the two-word object header with isa and refcount, two
   //   pointers to metadata accessors are provided for the root and leaf
   //   value types of the key path.
-  // - The header reuses the "trivial" bit to mean "instantiable in-line",
-  //   meaning that the key path described by this pattern has no contextually
-  //   dependent parts (no dependence on generic parameters, subscript indexes,
-  //   etc.), so it can be set up as a global object once. (The resulting
-  //   global object will itself always have the "trivial" bit set, since it
-  //   never needs to be destroyed.)
   // - Components may have unresolved forms that require instantiation.
-  // - Type metadata pointers are unresolved, and instead
-  //   point to accessor functions that instantiate the metadata.
+  // - Type metadata and protocol conformance pointers are replaced with
+  //   relative-referenced accessor functions that instantiate the
+  //   needed generic argument when called.
   //
   // The pattern never precomputes the capabilities of the key path (readonly/
   // writable/reference-writable), nor does it encode the reference prefix.
   // These are resolved dynamically, so that they always reflect the dynamic
   // capability of the properties involved.
-  let oncePtr = pattern
-  let patternPtr = pattern.advanced(by: MemoryLayout<Int>.size)
-  let bufferPtr = patternPtr.advanced(by: keyPathObjectHeaderSize)
 
-  // If the pattern is instantiable in-line, do a dispatch_once to
-  // initialize it. (The resulting object will still have the
-  // "trivial" bit set, since a global object never needs destruction.)
-  let bufferHeader = bufferPtr.load(as: KeyPathBuffer.Header.self)
+  let oncePtrPtr = pattern
+  let patternPtr = pattern.advanced(by: 4)
+
+  let bufferHeader = patternPtr.load(fromByteOffset: keyPathPatternHeaderSize,
+                                     as: KeyPathBuffer.Header.self)
   bufferHeader.validateReservedBits()
 
-  if bufferHeader.instantiableInLine {
-    Builtin.onceWithContext(oncePtr._rawValue, _getKeyPath_instantiateInline,
-                            patternPtr._rawValue)
+  // If the first word is nonzero, it relative-references a cache variable
+  // we can use to reference a single shared instantiation of this key path.
+  let oncePtrOffset = oncePtrPtr.load(as: Int32.self)
+  let oncePtr: UnsafeRawPointer?
+  if oncePtrOffset != 0 {
+    let theOncePtr = _resolveRelativeAddress(oncePtrPtr, oncePtrOffset)
+    oncePtr = theOncePtr
 
-    // Return the instantiated object at +1.
-    let objectPtr: UnsafeRawPointer
-
-    // If in-place instantiation failed, then the first word of the pattern
-    // buffer will be null, and the second word will contain the out-of-line
-    // object that was instantiated instead.
-    let firstWord = patternPtr.load(as: UnsafeRawPointer?.self)
-    if firstWord == nil {
-      objectPtr = patternPtr.load(fromByteOffset: MemoryLayout<Int>.size,
-                                  as: UnsafeRawPointer.self)
-    } else {
-      objectPtr = UnsafeRawPointer(patternPtr)
+    // See whether we already instantiated this key path.
+    // This is a non-atomic load because the instantiated pointer will be
+    // written with a release barrier, and loads of the instantiated key path
+    // ought to carry a dependency through this loaded pointer.
+    let existingInstance = theOncePtr.load(as: UnsafeRawPointer?.self)
+    
+    if let existingInstance = existingInstance {
+      // Return the instantiated object at +1.
+      let object = Unmanaged<AnyKeyPath>.fromOpaque(existingInstance)
+      // TODO: This retain will be unnecessary once we support global objects
+      // with inert refcounting.
+      _ = object.retain()
+      return existingInstance
     }
-
-    let object = Unmanaged<AnyKeyPath>.fromOpaque(objectPtr)
-    // TODO: This retain will be unnecessary once we support global objects
-    // with inert refcounting.
-    _ = object.retain()
-    return objectPtr
+  } else {
+    oncePtr = nil
   }
 
-  // Otherwise, instantiate a new key path object modeled on the pattern.
+  // Instantiate a new key path object modeled on the pattern.
   // Do a pass to determine the class of the key path we'll be instantiating
   // and how much space we'll need for it.
-  let (keyPathClass, rootType, size, alignmentMask)
+  let (keyPathClass, rootType, size, _)
     = _getKeyPathClassAndInstanceSizeFromPattern(patternPtr, arguments)
-  return _getKeyPath_instantiateOutOfLine(
-    pattern: patternPtr,
-    arguments: arguments,
-    keyPathClass: keyPathClass,
-    rootType: rootType,
-    size: size,
-    alignmentMask: alignmentMask)
-}
 
-internal func _getKeyPath_instantiateOutOfLine(
-  pattern: UnsafeRawPointer,
-  arguments: UnsafeRawPointer,
-  keyPathClass: AnyKeyPath.Type,
-  rootType: Any.Type,
-  size: Int,
-  alignmentMask: Int)
-    -> UnsafeRawPointer {
   // Allocate the instance.
   let instance = keyPathClass._create(capacityInBytes: size) { instanceData in
     // Instantiate the pattern into the instance.
-    let patternBufferPtr = pattern.advanced(by: keyPathObjectHeaderSize)
-    let patternBuffer = KeyPathBuffer(base: patternBufferPtr)
-
-    _instantiateKeyPathBuffer(patternBuffer, instanceData, rootType, arguments)
+    _instantiateKeyPathBuffer(patternPtr, instanceData, rootType, arguments)
   }
-  // Take the KVC string from the pattern.
-  let kvcStringPtr = pattern.advanced(by: MemoryLayout<HeapObject>.size)
-  instance._kvcKeyPathStringPtr = kvcStringPtr
-    .load(as: Optional<UnsafePointer<CChar>>.self)
 
-  // Hand it off at +1.
-  return UnsafeRawPointer(Unmanaged.passRetained(instance).toOpaque())
-}
+  // Adopt the KVC string from the pattern.
+  let kvcStringBase = patternPtr.advanced(by: 8)
+  let kvcStringOffset = kvcStringBase.load(as: Int32.self)
 
-internal func _getKeyPath_instantiateInline(
-  _ objectRawPtr: Builtin.RawPointer
-) {
-  let objectPtr = UnsafeMutableRawPointer(objectRawPtr)
-
-  // Do a pass to determine the class of the key path we'll be instantiating
-  // and how much space we'll need for it.
-  // The pattern argument doesn't matter since an in-place pattern should never
-  // have arguments.
-  let (keyPathClass, rootType, instantiatedSize, alignmentMask)
-    = _getKeyPathClassAndInstanceSizeFromPattern(objectPtr, objectPtr)
-  _sanityCheck(alignmentMask < MemoryLayout<Int>.alignment,
-               "overalignment not implemented")
-
-  let bufferPtr = objectPtr.advanced(by: keyPathObjectHeaderSize)
-  let buffer = KeyPathBuffer(base: bufferPtr)
-  let totalSize = buffer.data.count + MemoryLayout<Int>.size
-  let bufferData = UnsafeMutableRawBufferPointer(
-    start: bufferPtr,
-    count: instantiatedSize)
-
-  // Do the instantiation in place if the final object fits.
-  if instantiatedSize <= totalSize {
-    _instantiateKeyPathBuffer(buffer, bufferData, rootType, bufferPtr)
-
-    _swift_instantiateInertHeapObject(objectPtr,
-      unsafeBitCast(keyPathClass, to: OpaquePointer.self))
+  if kvcStringOffset == 0 {
+    // Null pointer.
+    instance._kvcKeyPathStringPtr = nil
   } else {
-    // Otherwise, we'll need to instantiate out-of-place.
-    let object = _getKeyPath_instantiateOutOfLine(
-      pattern: objectPtr,
-      arguments: objectPtr,
-      keyPathClass: keyPathClass,
-      rootType: rootType,
-      size: instantiatedSize,
-      alignmentMask: alignmentMask)
-
-    // Write a null pointer to the first word of the in-place buffer as
-    // a signal that this isn't a valid object.
-    // We rely on the heap object header size being >=2 words to get away with
-    // this.
-    assert(keyPathObjectHeaderSize >= MemoryLayout<Int>.size * 2)
-    objectPtr.storeBytes(of: nil, as: UnsafeRawPointer?.self)
-
-    // Put the pointer to the out-of-line object in the second word.
-    objectPtr.storeBytes(of: object, toByteOffset: MemoryLayout<Int>.size,
-                         as: UnsafeRawPointer.self)
+    let kvcStringPtr = _resolveRelativeAddress(kvcStringBase, kvcStringOffset)
+    instance._kvcKeyPathStringPtr =
+      kvcStringPtr.assumingMemoryBound(to: CChar.self)
   }
+
+  // If we can cache this instance as a shared instance, do so.
+  if let oncePtr = oncePtr {
+    // Try to replace a null pointer in the cache variable with the instance
+    // pointer.
+    let instancePtr = Unmanaged.passRetained(instance)
+
+    while true {
+      let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
+        oncePtr._rawValue,
+        0._builtinWordValue,
+        UInt(bitPattern: instancePtr.toOpaque())._builtinWordValue)
+
+      // If the exchange succeeds, then the instance we formed is the canonical
+      // one.
+      if Bool(won) {
+        break
+      }
+
+      // Otherwise, someone raced with us to instantiate the key path pattern
+      // and won. Their instance should be just as good as ours, so we can take
+      // that one and let ours get deallocated.
+      if let existingInstance = UnsafeRawPointer(bitPattern: Int(oldValue)) {
+        // Return the instantiated object at +1.
+        let object = Unmanaged<AnyKeyPath>.fromOpaque(existingInstance)
+        // TODO: This retain will be unnecessary once we support global objects
+        // with inert refcounting.
+        _ = object.retain()
+        // Release the instance we created.
+        instancePtr.release()
+        return existingInstance
+      } else {
+        // Try the cmpxchg again if it spuriously failed.
+        continue
+      }
+    }
+  }
+
+  return UnsafeRawPointer(Unmanaged.passRetained(instance).toOpaque())
 }
 
 internal typealias MetadataAccessor =
   @convention(c) (UnsafeRawPointer) -> UnsafeRawPointer
+
+internal enum KeyPathStructOrClass {
+  case `struct`, `class`
+}
+internal enum KeyPathPatternStoredOffset {
+  case inline(UInt32)
+  case outOfLine(UInt32)
+  case unresolvedFieldOffset(UInt32)
+  case unresolvedIndirectOffset(UnsafePointer<UInt32>)
+}
+internal struct KeyPathPatternComputedArguments {
+  var getLayout: KeyPathComputedArgumentLayoutFn
+  var witnesses: UnsafePointer<ComputedArgumentWitnesses>
+  var initializer: KeyPathComputedArgumentInitializerFn
+}
+
+internal protocol KeyPathPatternVisitor {
+  mutating func visitHeader(rootAccessor: MetadataAccessor,
+                            leafAccessor: MetadataAccessor,
+                            kvcCompatibilityString: UnsafeRawPointer)
+  mutating func visitStoredComponent(kind: KeyPathStructOrClass,
+                                     mutable: Bool,
+                                     offset: KeyPathPatternStoredOffset)
+  mutating func visitComputedComponent(mutating: Bool,
+                                       idKind: KeyPathComputedIDKind,
+                                       idResolved: Bool,
+                                       idValueBase: UnsafeRawPointer,
+                                       idValue: Int32,
+                                       getter: UnsafeRawPointer,
+                                       setter: UnsafeRawPointer?,
+                                       arguments: KeyPathPatternComputedArguments?,
+                                       externalArgs: UnsafeBufferPointer<Int32>?)
+  mutating func visitOptionalChainComponent()
+  mutating func visitOptionalForceComponent()
+  mutating func visitOptionalWrapComponent()
+
+  mutating func visitIntermediateComponentType(accessor: MetadataAccessor)
+
+  mutating func finish()
+}
+
+internal func _resolveRelativeAddress(_ base: UnsafeRawPointer,
+                                      _ offset: Int32) -> UnsafeRawPointer {
+  // Sign-extend the offset to pointer width and add with wrap on overflow.
+  return UnsafeRawPointer(bitPattern: Int(bitPattern: base) &+ Int(offset))
+    .unsafelyUnwrapped
+}
+internal func _resolveRelativeIndirectableAddress(_ base: UnsafeRawPointer,
+                                                  _ offset: Int32)
+    -> UnsafeRawPointer {
+  // Low bit indicates whether the reference is indirected or not.
+  if offset & 1 != 0 {
+    let ptrToPtr = _resolveRelativeAddress(base, offset - 1)
+    return ptrToPtr.load(as: UnsafeRawPointer.self)
+  }
+  return _resolveRelativeAddress(base, offset)
+}
+internal func _loadRelativeAddress<T>(at: UnsafeRawPointer,
+                                      fromByteOffset: Int = 0,
+                                      as: T.Type) -> T {
+  let offset = at.load(fromByteOffset: fromByteOffset, as: Int32.self)
+  return unsafeBitCast(_resolveRelativeAddress(at + fromByteOffset, offset),
+                       to: T.self)
+}
+
+internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
+                                  _ pattern: UnsafeRawPointer,
+                                  walker: inout W) {
+  // Visit the header.
+  let rootAccessor = _loadRelativeAddress(at: pattern,
+                                          as: MetadataAccessor.self)
+  let leafAccessor = _loadRelativeAddress(at: pattern, fromByteOffset: 4,
+                                          as: MetadataAccessor.self)
+  let kvcString = _loadRelativeAddress(at: pattern, fromByteOffset: 8,
+                                       as: UnsafeRawPointer.self)
+
+  walker.visitHeader(rootAccessor: rootAccessor,
+                     leafAccessor: leafAccessor,
+                     kvcCompatibilityString: kvcString)
+
+  let bufferPtr = pattern.advanced(by: keyPathPatternHeaderSize)
+  let bufferHeader = bufferPtr.load(as: KeyPathBuffer.Header.self)
+  var buffer = UnsafeRawBufferPointer(start: bufferPtr + 4,
+                                      count: bufferHeader.size)
+
+  func visitStored(header: RawKeyPathComponent.Header,
+                   componentBuffer: inout UnsafeRawBufferPointer) {
+    // Decode a stored property. A small offset may be stored inline in the
+    // header word, or else be stored out-of-line, or need instantiation of some
+    // kind.
+    let offset: KeyPathPatternStoredOffset
+    switch header.storedOffsetPayload {
+    case RawKeyPathComponent.Header.outOfLineOffsetPayload:
+      offset = .outOfLine(_pop(from: &componentBuffer,
+                               as: UInt32.self))
+    case RawKeyPathComponent.Header.unresolvedFieldOffsetPayload:
+      offset = .unresolvedFieldOffset(_pop(from: &componentBuffer,
+                                           as: UInt32.self))
+    case RawKeyPathComponent.Header.unresolvedIndirectOffsetPayload:
+      let base = buffer.baseAddress.unsafelyUnwrapped
+      let relativeOffset = _pop(from: &componentBuffer,
+                                as: Int32.self)
+      let ptr = _resolveRelativeIndirectableAddress(base, relativeOffset)
+      offset = .unresolvedIndirectOffset(
+                                       ptr.assumingMemoryBound(to: UInt32.self))
+    default:
+      offset = .inline(header.storedOffsetPayload)
+    }
+    let kind: KeyPathStructOrClass = header.kind == .struct 
+      ? .struct : .class
+    walker.visitStoredComponent(kind: kind,
+                                mutable: header.isStoredMutable,
+                                offset: offset)
+  }
+
+  func popComputedAccessors(header: RawKeyPathComponent.Header,
+                            componentBuffer: inout UnsafeRawBufferPointer)
+      -> (idValueBase: UnsafeRawPointer,
+          idValue: Int32,
+          getter: UnsafeRawPointer,
+          setter: UnsafeRawPointer?) {
+    let idValueBase = componentBuffer.baseAddress.unsafelyUnwrapped
+    let idValue = _pop(from: &componentBuffer, as: Int32.self)
+    let getterBase = componentBuffer.baseAddress.unsafelyUnwrapped
+    let getterRef = _pop(from: &componentBuffer, as: Int32.self)
+    let getter = _resolveRelativeAddress(getterBase, getterRef)
+    let setter: UnsafeRawPointer?
+    if header.isComputedSettable {
+      let setterBase = componentBuffer.baseAddress.unsafelyUnwrapped
+      let setterRef = _pop(from: &componentBuffer, as: Int32.self)
+      setter = _resolveRelativeAddress(setterBase, setterRef)
+    } else {
+      setter = nil
+    }
+    return (idValueBase: idValueBase, idValue: idValue,
+            getter: getter, setter: setter)
+  }
+
+  func popComputedArguments(header: RawKeyPathComponent.Header,
+                            componentBuffer: inout UnsafeRawBufferPointer)
+      -> KeyPathPatternComputedArguments? {
+    if header.hasComputedArguments {
+      let getLayoutBase = componentBuffer.baseAddress.unsafelyUnwrapped
+      let getLayoutRef = _pop(from: &componentBuffer, as: Int32.self)
+      let getLayoutRaw = _resolveRelativeAddress(getLayoutBase, getLayoutRef)
+      let getLayout = unsafeBitCast(getLayoutRaw,
+                                    to: KeyPathComputedArgumentLayoutFn.self)
+
+      let witnessesBase = componentBuffer.baseAddress.unsafelyUnwrapped
+      let witnessesRef = _pop(from: &componentBuffer, as: Int32.self)
+      let witnesses: UnsafeRawPointer
+      if witnessesRef == 0 {
+        witnesses = __swift_keyPathGenericWitnessTable_addr()
+      } else {
+        witnesses = _resolveRelativeAddress(witnessesBase, witnessesRef)
+      }
+
+      let initializerBase = componentBuffer.baseAddress.unsafelyUnwrapped
+      let initializerRef = _pop(from: &componentBuffer, as: Int32.self)
+      let initializerRaw = _resolveRelativeAddress(initializerBase,
+                                                   initializerRef)
+      let initializer = unsafeBitCast(initializerRaw,
+                                  to: KeyPathComputedArgumentInitializerFn.self)
+
+      return KeyPathPatternComputedArguments(getLayout: getLayout,
+        witnesses:
+              witnesses.assumingMemoryBound(to: ComputedArgumentWitnesses.self),
+        initializer: initializer)
+    } else {
+      return nil
+    }
+  }
+
+  while !buffer.isEmpty {
+    let header = _pop(from: &buffer,
+                      as: RawKeyPathComponent.Header.self)
+
+    // Ensure that we pop an amount of data consistent with what
+    // RawKeyPathComponent.Header.patternComponentBodySize computes.
+    var bufferSizeBefore = 0
+    var expectedPop = 0
+
+    _sanityCheck({
+      bufferSizeBefore = buffer.count
+      expectedPop = header.patternComponentBodySize
+      return true
+    }())
+
+    switch header.kind {
+    case .class, .struct:
+      visitStored(header: header, componentBuffer: &buffer)
+    case .computed:
+      let (idValueBase, idValue, getter, setter)
+        = popComputedAccessors(header: header,
+                               componentBuffer: &buffer)
+
+      // If there are arguments, gather those too.
+      let arguments = popComputedArguments(header: header,
+                                           componentBuffer: &buffer)
+
+      walker.visitComputedComponent(mutating: header.isComputedMutating,
+                                    idKind: header.computedIDKind,
+                                    idResolved: header.isComputedIDResolved,
+                                    idValueBase: idValueBase,
+                                    idValue: idValue,
+                                    getter: getter,
+                                    setter: setter,
+                                    arguments: arguments,
+                                    externalArgs: nil)
+
+    case .optionalChain:
+      walker.visitOptionalChainComponent()
+    case .optionalWrap:
+      walker.visitOptionalWrapComponent()
+    case .optionalForce:
+      walker.visitOptionalForceComponent()
+    case .external:
+      // Look at the external property descriptor to see if we should take it
+      // over the component given in the pattern.
+      let genericParamCount = Int(header.payload)
+      let descriptorBase = buffer.baseAddress.unsafelyUnwrapped
+      let descriptorOffset = _pop(from: &buffer,
+                                  as: Int32.self)
+      let descriptor =
+        _resolveRelativeIndirectableAddress(descriptorBase, descriptorOffset)
+      let descriptorHeader =
+        descriptor.load(as: RawKeyPathComponent.Header.self)
+      if descriptorHeader.isTrivialPropertyDescriptor {
+        // If the descriptor is trivial, then use the local candidate.
+        // Skip the external generic parameter accessors to get to it.
+        _ = _pop(from: &buffer, as: Int32.self, count: genericParamCount)
+        continue
+      }
+      
+      // Grab the generic parameter accessors to pass to the external component.
+      let externalArgs = _pop(from: &buffer, as: Int32.self,
+                              count: genericParamCount)
+
+      // Grab the header for the local candidate in case we need it for
+      // a computed property.
+      let localCandidateHeader = _pop(from: &buffer,
+                                      as: RawKeyPathComponent.Header.self)
+      let localCandidateSize = localCandidateHeader.patternComponentBodySize
+      _sanityCheck({
+        expectedPop += localCandidateSize + 4
+        return true
+      }())
+
+      let descriptorSize = descriptorHeader.propertyDescriptorBodySize
+      var descriptorBuffer = UnsafeRawBufferPointer(start: descriptor + 4,
+                                                    count: descriptorSize)
+
+      // Look at what kind of component the external property has.
+      switch descriptorHeader.kind {
+      case .struct, .class:
+        // A stored component. We can instantiate it
+        // without help from the local candidate.
+        _ = _pop(from: &buffer, as: UInt8.self, count: localCandidateSize)
+
+        visitStored(header: descriptorHeader,
+                    componentBuffer: &descriptorBuffer)
+        
+      case .computed:
+        // A computed component. The accessors come from the descriptor.
+        let (idValueBase, idValue, getter, setter)
+          = popComputedAccessors(header: descriptorHeader,
+                                 componentBuffer: &descriptorBuffer)
+        
+        // Get the arguments from the external descriptor and/or local candidate
+        // component.
+        let arguments: KeyPathPatternComputedArguments?
+        if localCandidateHeader.kind == .computed
+            && localCandidateHeader.hasComputedArguments {
+          // If both have arguments, then we have to build a bit of a chimera.
+          // The canonical identity and accessors come from the descriptor,
+          // but the argument equality/hash handling is still as described
+          // in the local candidate.
+          // We don't need the local candidate's accessors.
+          _ = popComputedAccessors(header: localCandidateHeader,
+                                   componentBuffer: &buffer)
+          // We do need the local arguments.
+          arguments = popComputedArguments(header: localCandidateHeader,
+                                           componentBuffer: &buffer)
+        } else {
+          // If the local candidate doesn't have arguments, we don't need
+          // anything from it at all.
+          _ = _pop(from: &buffer, as: UInt8.self, count: localCandidateSize)
+          arguments = nil
+        }
+
+        walker.visitComputedComponent(
+          mutating: descriptorHeader.isComputedMutating,
+          idKind: descriptorHeader.computedIDKind,
+          idResolved: descriptorHeader.isComputedIDResolved,
+          idValueBase: idValueBase,
+          idValue: idValue,
+          getter: getter,
+          setter: setter,
+          arguments: arguments,
+          externalArgs: genericParamCount > 0 ? externalArgs : nil)
+      case .optionalChain, .optionalWrap, .optionalForce, .external:
+        _sanityCheckFailure("not possible for property descriptor")
+      }
+    }
+
+    // Check that we consumed the expected amount of data from the pattern.
+    _sanityCheck(
+      {
+        // Round the amount of data we read up to alignment.
+        let popped = MemoryLayout<Int32>._roundingUpToAlignment(
+           bufferSizeBefore - buffer.count)
+        return expectedPop == popped
+      }(),
+      """
+      component size consumed during pattern walk does not match \
+      component size returned by patternComponentBodySize
+      """)
+
+    // Break if this is the last component.
+    if buffer.isEmpty { break }
+
+    // Otherwise, pop the intermediate component type accessor and
+    // go around again.
+    let componentTypeBase = buffer.baseAddress.unsafelyUnwrapped
+    let componentTypeOffset = _pop(from: &buffer, as: Int32.self)
+    let componentTypeAccessorRaw = _resolveRelativeAddress(componentTypeBase,
+                                                         componentTypeOffset)
+    let componentTypeAccessor = unsafeBitCast(componentTypeAccessorRaw,
+                                              to: MetadataAccessor.self)
+    walker.visitIntermediateComponentType(accessor: componentTypeAccessor)
+    _sanityCheck(!buffer.isEmpty)
+  }
+
+  // We should have walked the entire pattern.
+  _sanityCheck(buffer.isEmpty, "did not walk entire pattern buffer")
+  walker.finish()
+}
+
+internal struct GetKeyPathClassAndInstanceSizeFromPattern
+    : KeyPathPatternVisitor {
+  var size: Int = MemoryLayout<Int>.size // start with one word for the header
+  var capability: KeyPathKind = .value
+  var didChain: Bool = false
+  var root: Any.Type!
+  var leaf: Any.Type!
+  let patternArgs: UnsafeRawPointer
+
+  init(patternArgs: UnsafeRawPointer) {
+    self.patternArgs = patternArgs
+  }
+
+  mutating func roundUpToPointerAlignment() {
+    size = MemoryLayout<Int>._roundingUpToAlignment(size)
+  }
+
+  mutating func visitHeader(rootAccessor: MetadataAccessor,
+                            leafAccessor: MetadataAccessor,
+                            kvcCompatibilityString: UnsafeRawPointer) {
+    // Get the root and leaf type metadata so we can form the class type
+    // for the entire key path.
+    root = unsafeBitCast(rootAccessor(patternArgs), to: Any.Type.self)
+    leaf = unsafeBitCast(leafAccessor(patternArgs), to: Any.Type.self)
+  }
+
+  mutating func visitStoredComponent(kind: KeyPathStructOrClass,
+                                     mutable: Bool,
+                                     offset: KeyPathPatternStoredOffset) {
+    // Mutable class properties can be the root of a reference mutation.
+    // Mutable struct properties pass through the existing capability.
+    if mutable {
+      switch kind {
+      case .class:
+        capability = .reference
+      case .struct:
+        break
+      }
+    } else {
+      // Immutable properties can only be read.
+      capability = .readOnly
+    }
+
+    // The size of the instantiated component depends on whether we can fit
+    // the offset inline.
+    switch offset {
+    case .inline:
+      size += 4
+
+    case .outOfLine, .unresolvedFieldOffset, .unresolvedIndirectOffset:
+      size += 8
+    }
+  }
+
+  mutating func visitComputedComponent(mutating: Bool,
+                                   idKind: KeyPathComputedIDKind,
+                                   idResolved: Bool,
+                                   idValueBase: UnsafeRawPointer,
+                                   idValue: Int32,
+                                   getter: UnsafeRawPointer,
+                                   setter: UnsafeRawPointer?,
+                                   arguments: KeyPathPatternComputedArguments?,
+                                   externalArgs: UnsafeBufferPointer<Int32>?) {
+    let settable = setter != nil
+
+    switch (settable, mutating) {
+    case (false, false):
+      // If the property is get-only, the capability becomes read-only, unless
+      // we get another reference-writable component.
+      capability = .readOnly
+    case (true, false):
+      capability = .reference
+    case (true, true):
+      // Writable if the base is. No effect.
+      break
+    case (false, true):
+      _sanityCheckFailure("unpossible")
+    }
+
+    // Save space for the header...
+    size += 4
+    roundUpToPointerAlignment()
+    // ...id, getter, and maybe setter...
+    size += MemoryLayout<Int>.size * 2
+    if settable {
+      size += MemoryLayout<Int>.size
+    }
+    
+    // ...and the arguments, if any.
+    let argumentHeaderSize = MemoryLayout<Int>.size * 2
+    switch (arguments, externalArgs) {
+    case (nil, nil):
+      break
+    case (let arguments?, nil):
+      size += argumentHeaderSize
+      // If we have arguments, calculate how much space they need by invoking
+      // the layout function.
+      let (addedSize, addedAlignmentMask) = arguments.getLayout(patternArgs)
+      // TODO: Handle over-aligned values
+      _sanityCheck(addedAlignmentMask < MemoryLayout<Int>.alignment,
+                   "overaligned computed property element not supported")
+      size += addedSize
+    
+    case (let arguments?, let externalArgs?):
+      // If we're referencing an external declaration, and it takes captured
+      // arguments, then we have to build a bit of a chimera. The canonical
+      // identity and accessors come from the descriptor, but the argument
+      // handling is still as described in the local candidate.
+      size += argumentHeaderSize
+      let (addedSize, addedAlignmentMask) = arguments.getLayout(patternArgs)
+      // TODO: Handle over-aligned values
+      _sanityCheck(addedAlignmentMask < MemoryLayout<Int>.alignment,
+                   "overaligned computed property element not supported")
+      size += addedSize
+      // We also need to store the size of the local arguments so we can
+      // find the external component arguments.
+      roundUpToPointerAlignment()
+      size += RawKeyPathComponent.Header.externalWithArgumentsExtraSize
+      size += MemoryLayout<Int>.size * externalArgs.count
+
+    case (nil, let externalArgs?):
+      // If we're instantiating an external property with a local
+      // candidate that has no arguments, then things are a little
+      // easier. We only need to instantiate the generic
+      // arguments for the external component's accessors.
+      size += argumentHeaderSize
+      size += MemoryLayout<Int>.size * externalArgs.count
+    }
+  }
+
+  mutating func visitOptionalChainComponent() {
+    // Optional chaining forces the entire keypath to be read-only, even if
+    // there are further reference-writable components.
+    didChain = true
+    capability = .readOnly
+    size += 4
+  }
+  mutating func visitOptionalWrapComponent() {
+    // Optional chaining forces the entire keypath to be read-only, even if
+    // there are further reference-writable components.
+    didChain = true
+    capability = .readOnly
+    size += 4
+  }
+
+  mutating func visitOptionalForceComponent() {
+    // Force-unwrapping passes through the mutability of the preceding keypath.
+    size += 4
+  }
+
+  mutating func visitIntermediateComponentType(accessor _: MetadataAccessor) {
+    // The instantiated component type will be stored in the instantiated
+    // object.
+    roundUpToPointerAlignment()
+    size += MemoryLayout<Int>.size
+  }
+
+  mutating func finish() {
+  }
+}
 
 internal func _getKeyPathClassAndInstanceSizeFromPattern(
   _ pattern: UnsafeRawPointer,
@@ -2296,315 +2867,18 @@ internal func _getKeyPathClassAndInstanceSizeFromPattern(
   size: Int,
   alignmentMask: Int
 ) {
-  // Resolve the root and leaf types.
-  let rootAccessor = pattern.load(as: MetadataAccessor.self)
-  let leafAccessor = pattern.load(fromByteOffset: MemoryLayout<Int>.size,
-                                    as: MetadataAccessor.self)
-
-  let root = unsafeBitCast(rootAccessor(arguments), to: Any.Type.self)
-  let leaf = unsafeBitCast(leafAccessor(arguments), to: Any.Type.self)
-
-  // Scan the pattern to figure out the dynamic capability of the key path.
-  // Start off assuming the key path is writable.
-  var capability: KeyPathKind = .value
-  var didChain = false
-
-  let bufferPtr = pattern.advanced(by: keyPathObjectHeaderSize)
-  var buffer = KeyPathBuffer(base: bufferPtr)
-  var size = buffer.data.count + MemoryLayout<Int>.size
-
-  if !buffer.data.isEmpty {
-   while true {
-    let header = buffer.pop(RawKeyPathComponent.Header.self)
-
-    // Ensure that we pop an amount of data consistent with what
-    // RawKeyPathComponent.Header.patternComponentBodySize computes.
-    var bufferSizeBefore = 0
-    var expectedPop = 0
-
-    _sanityCheck({
-      bufferSizeBefore = buffer.data.count
-      expectedPop = header.patternComponentBodySize
-      return true
-    }())
-
-    func setStoredCapability(for header: RawKeyPathComponent.Header) {
-      // Mutable class properties can be the root of a reference mutation.
-      // Mutable struct properties pass through the existing capability.
-      if header.isStoredMutable {
-        if header.kind == .class { capability = .reference }
-      } else {
-        // Immutable properties can only be read.
-        capability = .readOnly
-      }
-    }
-
-    func setComputedCapability(for header: RawKeyPathComponent.Header) {
-      let settable = header.isComputedSettable
-      let mutating = header.isComputedMutating
-
-      switch (settable, mutating) {
-      case (false, false):
-        // If the property is get-only, the capability becomes read-only, unless
-        // we get another reference-writable component.
-        capability = .readOnly
-      case (true, false):
-        capability = .reference
-      case (true, true):
-        // Writable if the base is. No effect.
-        break
-      case (false, true):
-        _sanityCheckFailure("unpossible")
-      }
-    }
-
-    switch header.kind {
-    case .class, .struct:
-      setStoredCapability(for: header)
-
-      // Check the final instantiated size of the offset.
-      if header.storedOffsetPayload == RawKeyPathComponent.Header.unresolvedFieldOffsetPayload
-        || header.storedOffsetPayload == RawKeyPathComponent.Header.outOfLineOffsetPayload {
-        _ = buffer.pop(UInt32.self)
-      }
-      if header.storedOffsetPayload == RawKeyPathComponent.Header.unresolvedIndirectOffsetPayload {
-        _ = buffer.pop(Int.self)
-        // On 64-bit systems the pointer to the ivar offset variable is
-        // pointer-sized and -aligned, but the resulting offset ought to be
-        // 32 bits only and fit into padding between the 4-byte header and
-        // pointer-aligned type word. We don't need this space after
-        // instantiation.
-        if MemoryLayout<Int>.size == 8 {
-          size -= MemoryLayout<UnsafeRawPointer>.size
-        }
-      }
-
-    case .external:
-      // Look at the external property descriptor to see if we should take it
-      // over the component given in the pattern.
-      let genericParamCount = Int(header.payload)
-      let descriptor = buffer.pop(UnsafeRawPointer.self)
-      let descriptorHeader = descriptor.load(as: RawKeyPathComponent.Header.self)
-      if descriptorHeader.isTrivialPropertyDescriptor {
-        // If the descriptor is trivial, then use the local candidate.
-        // Leave this external reference out of the final object size.
-        size -= (2 + genericParamCount) * MemoryLayout<Int>.size
-        // Skip the generic parameter accessors to get to the local candidate.
-        _ = buffer.popRaw(size: MemoryLayout<Int>.size * genericParamCount,
-                          alignment: Int.self)
-        continue
-      }
-
-      // Drop this external reference...
-      size -= (header.patternComponentBodySize
-               + MemoryLayout<RawKeyPathComponent.Header>.size)
-      _ = buffer.popRaw(size: MemoryLayout<Int>.size * genericParamCount,
-                        alignment: Int.self)
-      // ...and the local candidate, which is the component following this
-      // one.
-      let localCandidateHeader = buffer.pop(RawKeyPathComponent.Header.self)
-      let localCandidateSize = localCandidateHeader.patternComponentBodySize
-      size -= (localCandidateSize
-               + MemoryLayout<RawKeyPathComponent.Header>.size)
-
-      // (Note that we don't pop the local candidate from the pattern buffer
-      // just yet, since we may need parts of it to instantiate the final
-      // component in some cases below. It still ought to be consumed
-      // in the computation below.)
-      _sanityCheck({
-        expectedPop += localCandidateSize
-                    +  MemoryLayout<RawKeyPathComponent.Header>.size
-        return true
-      }())
-
-      // Measure the instantiated size of the external component.
-      let newComponentSize: Int
-      switch descriptorHeader.kind {
-      case .class, .struct:
-        setStoredCapability(for: descriptorHeader)
-
-        // Discard the local candidate.
-        _ = buffer.popRaw(size: localCandidateSize,
-                          alignment: Int32.self)
-
-        // The final component will be a stored component with just an offset.
-        // If the offset requires resolution, then it'll be stored out of
-        // line after the header.
-        if descriptorHeader.storedOffsetPayload
-            > RawKeyPathComponent.Header.maximumOffsetPayload {
-          newComponentSize = MemoryLayout<RawKeyPathComponent.Header>.size
-                           + MemoryLayout<UInt32>.size
-        } else {
-          newComponentSize = MemoryLayout<RawKeyPathComponent.Header>.size
-        }
-
-      case .computed:
-        // The final component will be an instantiation of the computed
-        // component.
-        setComputedCapability(for: descriptorHeader)
-
-        // If the external declaration is computed, and it takes captured
-        // arguments, then we have to build a bit of a chimera. The canonical
-        // identity and accessors come from the descriptor, but the argument
-        // handling is still as described in the local candidate.
-        if descriptorHeader.hasComputedArguments {
-          // We always start with the buffer size and witnesses.
-          var argumentBufferSize = MemoryLayout<Int>.size * 2
-
-          if localCandidateHeader.kind == .computed
-              && localCandidateHeader.hasComputedArguments {
-            // We don't need the local candidate's accessors.
-            _ /*id*/ = buffer.pop(UnsafeRawPointer.self)
-            _ /*getter*/ = buffer.pop(UnsafeRawPointer.self)
-            if localCandidateHeader.isComputedSettable {
-              _ /*setter*/ = buffer.pop(UnsafeRawPointer.self)
-            }
-
-            // Get the instantiated size of the component's own argument
-            // file.
-            let getLayoutRaw = buffer.pop(UnsafeRawPointer.self)
-            let _ /*witnesses*/ = buffer.pop(UnsafeRawPointer.self)
-            let _ /*initializer*/ = buffer.pop(UnsafeRawPointer.self)
-
-            let getLayout = unsafeBitCast(getLayoutRaw,
-              to: RawKeyPathComponent.ComputedArgumentLayoutFn.self)
-
-            let (addedSize, addedAlignmentMask) = getLayout(arguments)
-            // TODO: Handle over-aligned values
-            _sanityCheck(addedAlignmentMask < MemoryLayout<Int>.alignment,
-                         "overaligned computed property element not supported")
-
-            argumentBufferSize += addedSize
-
-            // If the property descriptor also has generic arguments, we need
-            // to store the size so we can invoke the local witnesses on
-            // the arguments. We'll also store those generic arguments at
-            // pointer alignment after the local candidate's arguments.
-            if genericParamCount > 0 {
-              argumentBufferSize =
-                MemoryLayout<Int>._roundingUpToAlignment(argumentBufferSize)
-              argumentBufferSize +=
-                RawKeyPathComponent.Header.externalWithArgumentsExtraSize
-            }
-          } else {
-            // If the local candidate has no arguments, then things are a
-            // little easier. We only need to instantiate the generic arguments
-            // for the external component's accessors.
-            // Discard the local candidate.
-            _ = buffer.popRaw(size: localCandidateSize,
-                              alignment: UInt32.self)
-          }
-
-          // Add the property descriptor's generic arguments to the end, if
-          // any.
-          if genericParamCount > 0 {
-            argumentBufferSize += MemoryLayout<Int>.size * genericParamCount
-          }
-          newComponentSize = MemoryLayout<RawKeyPathComponent.Header>.size
-                           + descriptorHeader.propertyDescriptorBodySize
-                           + argumentBufferSize
-        } else {
-          // If there aren't any captured arguments expected in the external
-          // component, then we only need to adopt its accessors.
-          // Discard the local candidate.
-          _ = buffer.popRaw(size: localCandidateSize,
-                            alignment: UInt32.self)
-          // With no arguments, the instantiated size will be the
-          // same as the pattern size.
-          newComponentSize = MemoryLayout<RawKeyPathComponent.Header>.size
-                           + descriptorHeader.propertyDescriptorBodySize
-        }
-
-      case .external, .optionalChain, .optionalForce, .optionalWrap:
-        _sanityCheckFailure("should not appear as property descriptor")
-      }
-
-      // Round up to pointer alignment if there are following components.
-      if !buffer.data.isEmpty {
-        size += MemoryLayout<Int>._roundingUpToAlignment(newComponentSize)
-      } else {
-        size += newComponentSize
-      }
-
-    case .computed:
-      let settable = header.isComputedSettable
-      let hasArguments = header.hasComputedArguments
-
-      setComputedCapability(for: header)
-
-      _ = buffer.popRaw(size: MemoryLayout<Int>.size * (settable ? 3 : 2),
-                        alignment: Int.self)
-
-      // Get the instantiated size and alignment of the argument payload
-      // by asking the layout function to compute it for our given argument
-      // file.
-      if hasArguments {
-        let getLayoutRaw = buffer.pop(UnsafeRawPointer.self)
-        let _ /*witnesses*/ = buffer.pop(UnsafeRawPointer.self)
-        let _ /*initializer*/ = buffer.pop(UnsafeRawPointer.self)
-
-        let getLayout = unsafeBitCast(getLayoutRaw,
-          to: RawKeyPathComponent.ComputedArgumentLayoutFn.self)
-
-        let (addedSize, addedAlignmentMask) = getLayout(arguments)
-        // TODO: Handle over-aligned values
-        _sanityCheck(addedAlignmentMask < MemoryLayout<Int>.alignment,
-                     "overaligned computed property element not supported")
-
-        // Argument payload replaces the space taken by the initializer
-        // function pointer in the pattern.
-        size += MemoryLayout<Int>._roundingUpToAlignment(addedSize)
-              - MemoryLayout<Int>.size
-      }
-
-    case .optionalChain,
-         .optionalWrap:
-      // Chaining always renders the whole key path read-only.
-      didChain = true
-      break
-
-    case .optionalForce:
-      // No effect.
-      break
-    }
-
-    // Check that we consumed the expected amount of data from the pattern.
-    _sanityCheck(
-      {
-        // Round the amount of data we read up to alignment to include padding,
-        // skewed by the header size.
-        let popped = MemoryLayout<Int>._roundingUpToAlignment(
-           bufferSizeBefore - buffer.data.count
-           - RawKeyPathComponent.Header.pointerAlignmentSkew)
-          + RawKeyPathComponent.Header.pointerAlignmentSkew
-
-        return expectedPop == popped
-      }(),
-      """
-      component size consumed during instance size measurement does not match \
-      component size returned by patternComponentBodySize
-      """)
-
-    // Break if this is the last component.
-    if buffer.data.count == 0 { break }
-
-    // Pop the type accessor reference.
-    _ = buffer.popRaw(size: MemoryLayout<Int>.size,
-                      alignment: Int.self)
-   }
-  }
-
-  _sanityCheck(buffer.data.isEmpty, "didn't read entire pattern")
+  var walker = GetKeyPathClassAndInstanceSizeFromPattern(patternArgs: arguments)
+  _walkKeyPathPattern(pattern, walker: &walker)
 
   // Chaining always renders the whole key path read-only.
-  if didChain {
-    capability = .readOnly
+  if walker.didChain {
+    walker.capability = .readOnly
   }
 
   // Grab the class object for the key path type we'll end up with.
   func openRoot<Root>(_: Root.Type) -> AnyKeyPath.Type {
     func openLeaf<Leaf>(_: Leaf.Type) -> AnyKeyPath.Type {
-      switch capability {
+      switch walker.capability {
       case .readOnly:
         return KeyPath<Root, Leaf>.self
       case .value:
@@ -2613,35 +2887,39 @@ internal func _getKeyPathClassAndInstanceSizeFromPattern(
         return ReferenceWritableKeyPath<Root, Leaf>.self
       }
     }
-    return _openExistential(leaf, do: openLeaf)
+    return _openExistential(walker.leaf!, do: openLeaf)
   }
-  let classTy = _openExistential(root, do: openRoot)
+  let classTy = _openExistential(walker.root!, do: openRoot)
 
-  return (keyPathClass: classTy, rootType: root,
-          size: size,
+  return (keyPathClass: classTy,
+          rootType: walker.root!,
+          size: walker.size,
           // FIXME: Handle overalignment
           alignmentMask: MemoryLayout<Int>._alignmentMask)
 }
 
-internal func _instantiateKeyPathBuffer(
-  _ origPatternBuffer: KeyPathBuffer,
-  _ origDestData: UnsafeMutableRawBufferPointer,
-  _ rootType: Any.Type,
-  _ arguments: UnsafeRawPointer
-) {
-  // NB: patternBuffer and destData alias when the pattern is instantiable
-  // in-line. Therefore, do not read from patternBuffer after the same position
-  // in destData has been written to.
+internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
+  var destData: UnsafeMutableRawBufferPointer
+  let patternArgs: UnsafeRawPointer
+  var base: Any.Type
 
-  var patternBuffer = origPatternBuffer
-  let destHeaderPtr = origDestData.baseAddress.unsafelyUnwrapped
-  var destData = UnsafeMutableRawBufferPointer(
-    start: destHeaderPtr.advanced(by: MemoryLayout<Int>.size),
-    count: origDestData.count - MemoryLayout<Int>.size)
+  init(destData: UnsafeMutableRawBufferPointer,
+       patternArgs: UnsafeRawPointer,
+       root: Any.Type) {
+    self.destData = destData
+    self.patternArgs = patternArgs
+    self.base = root
+  }
 
-  func pushDest<T>(_ value: T) {
+  // Track the triviality of the resulting object data.
+  var isTrivial: Bool = true
+
+  // Track where the reference prefix begins.
+  var endOfReferencePrefixComponent: UnsafeMutableRawPointer? = nil
+  var previousComponentAddr: UnsafeMutableRawPointer? = nil
+
+  mutating func pushDest<T>(_ value: T) {
     _sanityCheck(_isPOD(T.self))
-    var value2 = value
     let size = MemoryLayout<T>.size
     let alignment = MemoryLayout<T>.alignment
     var baseAddress = destData.baseAddress.unsafelyUnwrapped
@@ -2650,400 +2928,371 @@ internal func _instantiateKeyPathBuffer(
       misalign = alignment - misalign
       baseAddress = baseAddress.advanced(by: misalign)
     }
-    _memcpy(dest: baseAddress, src: &value2,
-            size: UInt(size))
+    withUnsafeBytes(of: value) {
+      _memcpy(dest: baseAddress, src: $0.baseAddress.unsafelyUnwrapped,
+              size: UInt(size))
+    }
     destData = UnsafeMutableRawBufferPointer(
       start: baseAddress + size,
       count: destData.count - size - misalign)
   }
 
-  // Track the triviality of the resulting object data.
-  var isTrivial = true
+  mutating func updatePreviousComponentAddr() -> UnsafeMutableRawPointer? {
+    let oldValue = previousComponentAddr
+    previousComponentAddr = destData.baseAddress.unsafelyUnwrapped
+    return oldValue
+  }
 
-  // Track where the reference prefix begins.
-  var endOfReferencePrefixComponent: UnsafeMutableRawPointer? = nil
-  var previousComponentAddr: UnsafeMutableRawPointer? = nil
+  mutating func visitHeader(rootAccessor: MetadataAccessor,
+                            leafAccessor: MetadataAccessor,
+                            kvcCompatibilityString: UnsafeRawPointer) {
+  }
 
-  // Instantiate components that need it.
-  var base: Any.Type = rootType
-  // Some pattern forms are pessimistically larger than what we need in the
-  // instantiated key path. Keep track of this.
-  if !patternBuffer.data.isEmpty {
-   while true {
-    let componentAddr = destData.baseAddress.unsafelyUnwrapped
-    let header = patternBuffer.pop(RawKeyPathComponent.Header.self)
+  mutating func visitStoredComponent(kind: KeyPathStructOrClass,
+                                     mutable: Bool,
+                                     offset: KeyPathPatternStoredOffset) {
+    let previous = updatePreviousComponentAddr()
+    switch kind {
+    case .class:
+      // A mutable class property can end the reference prefix.
+      if mutable {
+        endOfReferencePrefixComponent = previous
+      }
+      fallthrough
 
-    // Ensure that we pop an amount of data consistent with what
-    // RawKeyPathComponent.Header.patternComponentBodySize computes.
-    var bufferSizeBefore = 0
-    var expectedPop = 0
-
-    _sanityCheck({
-      bufferSizeBefore = patternBuffer.data.count
-      expectedPop = header.patternComponentBodySize
-      return true
-    }())
-
-    func tryToResolveOffset(header: RawKeyPathComponent.Header,
-                            getOutOfLineOffset: () -> UInt32) {
-      if header.storedOffsetPayload == RawKeyPathComponent.Header.unresolvedFieldOffsetPayload {
-        // Look up offset in type metadata. The value in the pattern is the
-        // offset within the metadata object.
+    case .struct:
+      // Resolve the offset.
+      switch offset {
+      case .inline(let value):
+        let header = RawKeyPathComponent.Header(stored: kind,
+                                                mutable: mutable,
+                                                inlineOffset: value)
+        pushDest(header)
+      case .outOfLine(let offset):
+        let header = RawKeyPathComponent.Header(storedWithOutOfLineOffset: kind,
+                                                mutable: mutable)
+        pushDest(header)
+        pushDest(offset)
+      case .unresolvedFieldOffset(let offsetOfOffset):
+        // Look up offset in the type metadata. The value in the pattern is
+        // the offset within the metadata object.
         let metadataPtr = unsafeBitCast(base, to: UnsafeRawPointer.self)
-        let offsetOfOffset = getOutOfLineOffset()
-
         let offset: UInt32
-        if (header.kind == .struct) {
-          offset = UInt32(metadataPtr.load(fromByteOffset: Int(offsetOfOffset),
-                                           as: UInt32.self))
-        } else {
+        switch kind {
+        case .class:
           offset = UInt32(metadataPtr.load(fromByteOffset: Int(offsetOfOffset),
                                            as: UInt.self))
+        case .struct:
+          offset = UInt32(metadataPtr.load(fromByteOffset: Int(offsetOfOffset),
+                                           as: UInt32.self))
         }
 
-        // Rewrite the header for a resolved offset.
-        var newHeader = header
-        newHeader.storedOffsetPayload = RawKeyPathComponent.Header.outOfLineOffsetPayload
-        pushDest(newHeader)
+        let header = RawKeyPathComponent.Header(storedWithOutOfLineOffset: kind,
+                                                mutable: mutable)
+        pushDest(header)
         pushDest(offset)
-        return
-      }
-
-      if header.storedOffsetPayload == RawKeyPathComponent.Header.unresolvedIndirectOffsetPayload {
+      case .unresolvedIndirectOffset(let pointerToOffset):
         // Look up offset in the indirectly-referenced variable we have a
         // pointer.
-        let offsetVar = patternBuffer.pop(UnsafeRawPointer.self)
-        let offsetValue = UInt32(offsetVar.load(as: UInt.self))
-        // Rewrite the header for a resolved offset.
-        var newHeader = header
-        newHeader.storedOffsetPayload = RawKeyPathComponent.Header.outOfLineOffsetPayload
-        pushDest(newHeader)
-        pushDest(offsetValue)
-        return
-      }
-
-      // Otherwise, just transfer the pre-resolved component.
-      pushDest(header)
-      if header.storedOffsetPayload == RawKeyPathComponent.Header.outOfLineOffsetPayload {
-        let offset = getOutOfLineOffset() //patternBuffer.pop(UInt32.self)
+        let offset = UInt32(pointerToOffset.pointee)
+        let header = RawKeyPathComponent.Header(storedWithOutOfLineOffset: kind,
+                                                mutable: mutable)
+        pushDest(header)
         pushDest(offset)
       }
     }
+  }
 
-    func tryToResolveComputedAccessors(header: RawKeyPathComponent.Header,
-                                       accessorsBuffer: inout KeyPathBuffer) {
-      // A nonmutating settable property can end the reference prefix and
-      // makes the following key path potentially reference-writable.
-      if header.isComputedSettable && !header.isComputedMutating {
-        endOfReferencePrefixComponent = previousComponentAddr
-      }
-
-      // The ID may need resolution if the property is keyed by a selector.
-      var newHeader = header
-      var id = accessorsBuffer.pop(Int.self)
-      switch header.payload
-                         & RawKeyPathComponent.Header.computedIDResolutionMask {
-      case RawKeyPathComponent.Header.computedIDResolved:
-        // Nothing to do.
-        break
-      case RawKeyPathComponent.Header.computedIDUnresolvedIndirectPointer:
-        // The value in the pattern is a pointer to the actual unique word-sized
-        // value in memory.
-        let idPtr = UnsafeRawPointer(bitPattern: id).unsafelyUnwrapped
-        id = idPtr.load(as: Int.self)
-      default:
-        _sanityCheckFailure("unpossible")
-      }
-      newHeader.payload &= ~RawKeyPathComponent.Header.computedIDResolutionMask
-      pushDest(newHeader)
-      pushDest(id)
-      // Carry over the accessors.
-      let getter = accessorsBuffer.pop(UnsafeRawPointer.self)
-      pushDest(getter)
-      if header.isComputedSettable {
-        let setter = accessorsBuffer.pop(UnsafeRawPointer.self)
-        pushDest(setter)
-      }
+  mutating func visitComputedComponent(mutating: Bool,
+                                   idKind: KeyPathComputedIDKind,
+                                   idResolved: Bool,
+                                   idValueBase: UnsafeRawPointer,
+                                   idValue: Int32,
+                                   getter: UnsafeRawPointer,
+                                   setter: UnsafeRawPointer?,
+                                   arguments: KeyPathPatternComputedArguments?,
+                                   externalArgs: UnsafeBufferPointer<Int32>?) {
+    let previous = updatePreviousComponentAddr()
+    let settable = setter != nil
+    // A nonmutating settable property can end the reference prefix.
+    if settable && !mutating {
+      endOfReferencePrefixComponent = previous
     }
 
-    func readComputedArgumentBuffer(argsBuffer: inout KeyPathBuffer)
-        -> (getLayout: RawKeyPathComponent.ComputedArgumentLayoutFn,
-            witnesses: UnsafePointer<ComputedArgumentWitnesses>,
-            initializer: RawKeyPathComponent.ComputedArgumentInitializerFn) {
-      let getLayoutRaw = argsBuffer.pop(UnsafeRawPointer.self)
-      let getLayout = unsafeBitCast(getLayoutRaw,
-        to: RawKeyPathComponent.ComputedArgumentLayoutFn.self)
+    // Resolve the ID.
+    let resolvedID: UnsafeRawPointer?
 
-      let witnesses = argsBuffer.pop(
-        UnsafePointer<ComputedArgumentWitnesses>.self)
+    switch idKind {
+    case .storedPropertyIndex, .vtableOffset:
+      _sanityCheck(idResolved)
+      // Zero-extend the integer value to get the instantiated id.
+      let value = UInt(UInt32(bitPattern: idValue))
+      resolvedID = UnsafeRawPointer(bitPattern: value)
 
-      if let _ = witnesses.pointee.destroy {
-        isTrivial = false
+    case .pointer:
+      // Resolve the sign-extended relative reference.
+      var absoluteID: UnsafeRawPointer? = idValueBase + Int(idValue)
+
+      // If the pointer ID is "unresolved", then it needs another indirection
+      // to get the final value.
+      if !idResolved {
+        absoluteID = absoluteID.unsafelyUnwrapped
+          .load(as: UnsafeRawPointer?.self)
       }
-
-      let initializerRaw = argsBuffer.pop(UnsafeRawPointer.self)
-      let initializer = unsafeBitCast(initializerRaw,
-        to: RawKeyPathComponent.ComputedArgumentInitializerFn.self)
-
-      return (getLayout, witnesses, initializer)
+      resolvedID = absoluteID
     }
 
-    func tryToResolveComputedArguments(argsBuffer: inout KeyPathBuffer) {
-      guard header.hasComputedArguments else { return }
+    // Bring over the header, getter, and setter.
+    let header = RawKeyPathComponent.Header(computedWithIDKind: idKind,
+          mutating: mutating,
+          settable: settable,
+          hasArguments: arguments != nil || externalArgs != nil,
+          instantiatedFromExternalWithArguments:
+            arguments != nil && externalArgs != nil)
+    pushDest(header)
+    pushDest(resolvedID)
+    pushDest(getter)
+    if let setter = setter {
+      pushDest(setter)
+    }
 
-      let (getLayout, witnesses, initializer)
-        = readComputedArgumentBuffer(argsBuffer: &argsBuffer)
-
-      // Carry over the arguments.
-      let (size, alignmentMask) = getLayout(arguments)
+    if let arguments = arguments {
+      // Instantiate the arguments.
+      let (baseSize, alignmentMask) = arguments.getLayout(patternArgs)
       _sanityCheck(alignmentMask < MemoryLayout<Int>.alignment,
                    "overaligned computed arguments not implemented yet")
 
       // The real buffer stride will be rounded up to alignment.
-      let stride = (size + alignmentMask) & ~alignmentMask
-      pushDest(stride)
-      pushDest(witnesses)
+      var totalSize = (baseSize + alignmentMask) & ~alignmentMask
 
+      // If an external property descriptor also has arguments, they'll be
+      // added to the end with pointer alignment.
+      if let externalArgs = externalArgs {
+        totalSize = MemoryLayout<Int>._roundingUpToAlignment(totalSize)
+        totalSize += MemoryLayout<Int>.size * externalArgs.count
+      }
+
+      pushDest(totalSize)
+      pushDest(arguments.witnesses)
+
+      // A nonnull destructor in the witnesses file indicates the instantiated
+      // payload is nontrivial.
+      if let _ = arguments.witnesses.pointee.destroy {
+        isTrivial = false
+      }
+
+      // If the descriptor has arguments, store the size of its specific
+      // arguments here, so we can drop them when trying to invoke
+      // the component's witnesses.
+      if let externalArgs = externalArgs {
+        pushDest(externalArgs.count * MemoryLayout<Int>.size)
+      }
+
+      // Initialize the local candidate arguments here.
       _sanityCheck(Int(bitPattern: destData.baseAddress) & alignmentMask == 0,
                    "argument destination not aligned")
-      initializer(arguments, destData.baseAddress.unsafelyUnwrapped)
+      arguments.initializer(patternArgs,
+                            destData.baseAddress.unsafelyUnwrapped)
 
       destData = UnsafeMutableRawBufferPointer(
-        start: destData.baseAddress.unsafelyUnwrapped + stride,
-        count: destData.count - stride)
+        start: destData.baseAddress.unsafelyUnwrapped + baseSize,
+        count: destData.count - baseSize)
     }
-
-    switch header.kind {
-    case .struct:
-      // The offset may need to be resolved dynamically.
-      tryToResolveOffset(header: header,
-                         getOutOfLineOffset: { patternBuffer.pop(UInt32.self) })
-    case .class:
-      // Accessing a mutable class property can end the reference prefix, and
-      // makes the following key path potentially reference-writable.
-      if header.isStoredMutable {
-        endOfReferencePrefixComponent = previousComponentAddr
-      }
-      // The offset may need to be resolved dynamically.
-      tryToResolveOffset(header: header,
-                         getOutOfLineOffset: { patternBuffer.pop(UInt32.self) })
-    case .optionalChain,
-         .optionalWrap,
-         .optionalForce:
-      // No instantiation necessary.
-      pushDest(header)
-      break
-    case .computed:
-      tryToResolveComputedAccessors(header: header,
-                                    accessorsBuffer: &patternBuffer)
-      tryToResolveComputedArguments(argsBuffer: &patternBuffer)
-    case .external:
-      // Look at the external property descriptor to see if we should take it
-      // over the component given in the pattern.
-      let genericParamCount = Int(header.payload)
-      let descriptor = patternBuffer.pop(UnsafeRawPointer.self)
-      var descriptorHeader = descriptor.load(as: RawKeyPathComponent.Header.self)
-
-      // Save the generic arguments to the external descriptor.
-      let descriptorGenericArgsBuf = patternBuffer.popRaw(
-        size: MemoryLayout<Int>.size * genericParamCount,
-        alignment: Int.self)
-
-      if descriptorHeader.isTrivialPropertyDescriptor {
-        // If the descriptor is trivial, then instantiate the local candidate.
-        // Continue to keep reading from the buffer as if we started with the
-        // local candidate.
-        continue
+    
+    if let externalArgs = externalArgs {
+      if arguments == nil {
+        // If we're instantiating an external property without any local
+        // arguments, then we only need to instantiate the arguments to the
+        // property descriptor.
+        let stride = MemoryLayout<Int>.size * externalArgs.count
+        pushDest(stride)
+        pushDest(__swift_keyPathGenericWitnessTable_addr())
       }
 
-      // Grab the local candidate header. We may need parts of it to complete
-      // the final component.
-      let localCandidateHeader = patternBuffer.pop(RawKeyPathComponent.Header.self)
-      let localCandidateSize = localCandidateHeader.patternComponentBodySize
-
-      // ...though we still ought to fully consume it before proceeding.
-      _sanityCheck({
-        expectedPop += localCandidateSize
-                    +  MemoryLayout<RawKeyPathComponent.Header>.size
-        return true
-      }())
-
-
-      // Instantiate the component according to the external property
-      // descriptor.
-      switch descriptorHeader.kind {
-      case .class:
-        // Accessing a mutable class property can end the reference prefix,
-        // and makes the following key path potentially reference-writable.
-        if descriptorHeader.isStoredMutable {
-          endOfReferencePrefixComponent = previousComponentAddr
-        }
-        fallthrough
-
-      case .struct:
-        // Drop the local candidate.
-        _ = patternBuffer.popRaw(size: localCandidateSize,
-                                 alignment: Int32.self)
-
-        // Instantiate the offset using the info from the descriptor.
-        tryToResolveOffset(header: descriptorHeader,
-                           getOutOfLineOffset: {
-                             descriptor.load(fromByteOffset: 4,
-                                             as: UInt32.self)
-                           })
-
-      case .computed:
-        var descriptorBuffer = KeyPathBuffer(
-          partialData: UnsafeRawBufferPointer(
-            start: descriptor + MemoryLayout<RawKeyPathComponent.Header>.size,
-            count: descriptorHeader.propertyDescriptorBodySize))
-
-        // If the external declaration is computed, and it takes captured
-        // arguments, then we have to build a bit of a chimera. The canonical
-        // identity and accessors come from the descriptor, but the argument
-        // handling is still as described in the local candidate.
-        if descriptorHeader.hasComputedArguments {
-          // Loop through instantiating all the property descriptor's
-          // generic arguments. We don't write
-          // these immediately, because the computed header and accessors
-          // come first, and if we're instantiating in-place,
-          // they will overwrite the information in the pattern.
-          let genericArgs: [UnsafeRawPointer]
-            = (0 ..< genericParamCount).map {
-              let instantiationFn = descriptorGenericArgsBuf
-                .load(fromByteOffset: MemoryLayout<Int>.size * $0,
-                      as: MetadataAccessor.self)
-              return instantiationFn(arguments)
-            }
-
-          // If the descriptor has generic arguments, record this in the
-          // header. We'll store the size of the external generic arguments
-          // so we can invoke the local candidate's argument witnesses.
-          let localCandidateHasArguments =
-            localCandidateHeader.kind == .computed
-              && localCandidateHeader.hasComputedArguments
-          let descriptorHasArguments = genericParamCount > 0
-          if localCandidateHasArguments && descriptorHasArguments {
-            descriptorHeader.isComputedInstantiatedFromExternalWithArguments =
-              true
-          }
-
-          // Bring in the accessors from the descriptor.
-          tryToResolveComputedAccessors(header: descriptorHeader,
-                                        accessorsBuffer: &descriptorBuffer)
-          _sanityCheck(descriptorBuffer.data.isEmpty)
-
-          if localCandidateHasArguments {
-            // We don't need the local candidate's accessors.
-            _ /*id*/ = patternBuffer.pop(UnsafeRawPointer.self)
-            _ /*getter*/ = patternBuffer.pop(UnsafeRawPointer.self)
-            if localCandidateHeader.isComputedSettable {
-              _ /*setter*/ = patternBuffer.pop(UnsafeRawPointer.self)
-            }
-
-            // Instantiate the arguments from the local candidate.
-            let (getLayout, witnesses, initializer) =
-              readComputedArgumentBuffer(argsBuffer: &patternBuffer)
-
-            // Carry over the arguments.
-            let (baseSize, alignmentMask) = getLayout(arguments)
-            _sanityCheck(alignmentMask < MemoryLayout<Int>.alignment,
-                         "overaligned computed arguments not implemented yet")
-
-            // The real buffer stride will be rounded up to alignment.
-            var totalSize = (baseSize + alignmentMask) & ~alignmentMask
-
-            // If the descriptor also has arguments, they'll be added to the
-            // end with pointer alignment.
-            if descriptorHasArguments {
-              totalSize = MemoryLayout<Int>._roundingUpToAlignment(totalSize)
-              totalSize += MemoryLayout<Int>.size * genericParamCount
-            }
-
-            pushDest(totalSize)
-            pushDest(witnesses)
-
-            // If the descriptor has arguments, store the size of its specific
-            // arguments here, so we can drop them when trying to invoke
-            // the component's witnesses.
-            if descriptorHasArguments {
-              pushDest(genericParamCount * MemoryLayout<Int>.size)
-            }
-
-            // Initialize the local candidate arguments here.
-            _sanityCheck(Int(bitPattern: destData.baseAddress) & alignmentMask == 0,
-                         "argument destination not aligned")
-            initializer(arguments, destData.baseAddress.unsafelyUnwrapped)
-
-            destData = UnsafeMutableRawBufferPointer(
-              start: destData.baseAddress.unsafelyUnwrapped + baseSize,
-              count: destData.count - baseSize)
-
-          } else {
-            // If the local candidate has no arguments, then things are a
-            // little easier. We only need to instantiate the generic arguments
-            // for the external component's accessors.
-            // Discard the local candidate.
-            _ = patternBuffer.popRaw(size: localCandidateSize,
-                                     alignment: Int32.self)
-
-            // Write out the header with the instantiated size and
-            // witnesses of the descriptor.
-            let stride = MemoryLayout<Int>.size * genericParamCount
-            pushDest(stride)
-            pushDest(__swift_keyPathGenericWitnessTable_addr())
-          }
-          // Write the descriptor's generic arguments.
-          for arg in genericArgs {
-            pushDest(arg)
-          }
-        } else {
-          // Discard the local candidate.
-          _ = patternBuffer.popRaw(size: localCandidateSize,
-                                   alignment: Int32.self)
-
-          // The final component is an instantiation of the computed
-          // component from the descriptor.
-          tryToResolveComputedAccessors(header: descriptorHeader,
-                                        accessorsBuffer: &descriptorBuffer)
-          _sanityCheck(descriptorBuffer.data.isEmpty)
-
-          // We know there are no arguments to instantiate.
-        }
-      case .external, .optionalChain, .optionalForce, .optionalWrap:
-        _sanityCheckFailure("should not appear as property descriptor")
+      // Write the descriptor's generic arguments, which should all be relative
+      // references to metadata accessor functions.
+      for i in externalArgs.indices {
+        let base = externalArgs.baseAddress.unsafelyUnwrapped + i
+        let offset = base.pointee
+        let accessorPtr = UnsafeRawPointer(base) + Int(offset)
+        let accessor = unsafeBitCast(accessorPtr, to: MetadataAccessor.self)
+        let result = accessor(patternArgs)
+        pushDest(result)
       }
     }
-
-    // Check that we consumed the expected amount of data from the pattern.
-    _sanityCheck(
-      {
-        let popped = MemoryLayout<Int>._roundingUpToAlignment(
-           bufferSizeBefore - patternBuffer.data.count
-           - RawKeyPathComponent.Header.pointerAlignmentSkew)
-          + RawKeyPathComponent.Header.pointerAlignmentSkew
-        return expectedPop == popped
-      }(),
-      """
-      component size consumed during instantiation does not match \
-      component size returned by patternComponentBodySize
-      """)
-
-    // Break if this is the last component.
-    if patternBuffer.data.count == 0 { break }
-
-    // Resolve the component type.
-    let componentTyAccessor = patternBuffer.pop(MetadataAccessor.self)
-    base = unsafeBitCast(componentTyAccessor(arguments), to: Any.Type.self)
-    pushDest(base)
-    previousComponentAddr = componentAddr
-   }
   }
 
-  // We should have traversed both buffers.
-  _sanityCheck(patternBuffer.data.isEmpty, "did not read the entire pattern")
-  _sanityCheck(destData.count == 0,
-               "did not write to all of the allocated space")
+  mutating func visitOptionalChainComponent() {
+    let _ = updatePreviousComponentAddr()
+    let header = RawKeyPathComponent.Header(optionalChain: ())
+    pushDest(header)
+  }
+  mutating func visitOptionalWrapComponent() {
+    let _ = updatePreviousComponentAddr()
+    let header = RawKeyPathComponent.Header(optionalWrap: ())
+    pushDest(header)
+  }
+  mutating func visitOptionalForceComponent() {
+    let _ = updatePreviousComponentAddr()
+    let header = RawKeyPathComponent.Header(optionalForce: ())
+    pushDest(header)
+  }
+
+  mutating func visitIntermediateComponentType(accessor: MetadataAccessor) {
+    // Call the accessor to get the metadata for the intermediate type.
+    let metadata = unsafeBitCast(accessor(patternArgs), to: Any.Type.self)
+    pushDest(metadata)
+    base = metadata
+  }
+  
+  mutating func finish() {
+    // Should have filled the entire buffer by the time we reach the end of the
+    // pattern.
+    _sanityCheck(destData.isEmpty,
+                 "should have filled entire destination buffer")
+  }
+}
+
+#if INTERNAL_CHECKS_ENABLED
+// In debug builds of the standard library, check that instantiation produces
+// components whose sizes are consistent with the sizing visitor pass.
+internal struct ValidatingInstantiateKeyPathBuffer: KeyPathPatternVisitor {
+  var sizeVisitor: GetKeyPathClassAndInstanceSizeFromPattern
+  var instantiateVisitor: InstantiateKeyPathBuffer
+  let origDest: UnsafeMutableRawPointer
+
+  init(sizeVisitor: GetKeyPathClassAndInstanceSizeFromPattern,
+       instantiateVisitor: InstantiateKeyPathBuffer) {
+    self.sizeVisitor = sizeVisitor
+    self.instantiateVisitor = instantiateVisitor
+    origDest = self.instantiateVisitor.destData.baseAddress.unsafelyUnwrapped
+  }
+
+  mutating func visitHeader(rootAccessor: MetadataAccessor,
+                            leafAccessor: MetadataAccessor,
+                            kvcCompatibilityString: UnsafeRawPointer) {
+    sizeVisitor.visitHeader(rootAccessor: rootAccessor,
+                            leafAccessor: leafAccessor,
+                            kvcCompatibilityString: kvcCompatibilityString)
+    instantiateVisitor.visitHeader(rootAccessor: rootAccessor,
+                                 leafAccessor: leafAccessor,
+                                 kvcCompatibilityString: kvcCompatibilityString)
+  }
+  mutating func visitStoredComponent(kind: KeyPathStructOrClass,
+                                     mutable: Bool,
+                                     offset: KeyPathPatternStoredOffset) {
+    sizeVisitor.visitStoredComponent(kind: kind, mutable: mutable,
+                                     offset: offset)
+    instantiateVisitor.visitStoredComponent(kind: kind, mutable: mutable,
+                                            offset: offset)
+    checkSizeConsistency()
+  }
+  mutating func visitComputedComponent(mutating: Bool,
+                                   idKind: KeyPathComputedIDKind,
+                                   idResolved: Bool,
+                                   idValueBase: UnsafeRawPointer,
+                                   idValue: Int32,
+                                   getter: UnsafeRawPointer,
+                                   setter: UnsafeRawPointer?,
+                                   arguments: KeyPathPatternComputedArguments?,
+                                   externalArgs: UnsafeBufferPointer<Int32>?) {
+    sizeVisitor.visitComputedComponent(mutating: mutating,
+                                       idKind: idKind,
+                                       idResolved: idResolved,
+                                       idValueBase: idValueBase,
+                                       idValue: idValue,
+                                       getter: getter,
+                                       setter: setter,
+                                       arguments: arguments,
+                                       externalArgs: externalArgs)
+    instantiateVisitor.visitComputedComponent(mutating: mutating,
+                                       idKind: idKind,
+                                       idResolved: idResolved,
+                                       idValueBase: idValueBase,
+                                       idValue: idValue,
+                                       getter: getter,
+                                       setter: setter,
+                                       arguments: arguments,
+                                       externalArgs: externalArgs)
+    checkSizeConsistency()
+  }
+  mutating func visitOptionalChainComponent() {
+    sizeVisitor.visitOptionalChainComponent()
+    instantiateVisitor.visitOptionalChainComponent()
+    checkSizeConsistency()
+  }
+  mutating func visitOptionalWrapComponent() {
+    sizeVisitor.visitOptionalWrapComponent()
+    instantiateVisitor.visitOptionalWrapComponent()
+    checkSizeConsistency()
+  }
+  mutating func visitOptionalForceComponent() {
+    sizeVisitor.visitOptionalForceComponent()
+    instantiateVisitor.visitOptionalForceComponent()
+    checkSizeConsistency()
+  }
+  mutating func visitIntermediateComponentType(accessor: MetadataAccessor) {
+    sizeVisitor.visitIntermediateComponentType(accessor: accessor)
+    instantiateVisitor.visitIntermediateComponentType(accessor: accessor)
+    checkSizeConsistency()
+  }
+
+  mutating func finish() {
+    sizeVisitor.finish()
+    instantiateVisitor.finish()
+    checkSizeConsistency()
+  }
+
+  func checkSizeConsistency() {
+    let nextDest = instantiateVisitor.destData.baseAddress.unsafelyUnwrapped
+    let curSize = nextDest - origDest + MemoryLayout<Int>.size
+
+    _sanityCheck(curSize == sizeVisitor.size,
+                 "size and instantiation visitors out of sync")
+  }
+}
+#endif // INTERNAL_CHECKS_ENABLED
+
+internal func _instantiateKeyPathBuffer(
+  _ pattern: UnsafeRawPointer,
+  _ origDestData: UnsafeMutableRawBufferPointer,
+  _ rootType: Any.Type,
+  _ arguments: UnsafeRawPointer
+) {
+  let destHeaderPtr = origDestData.baseAddress.unsafelyUnwrapped
+  var destData = UnsafeMutableRawBufferPointer(
+    start: destHeaderPtr.advanced(by: MemoryLayout<Int>.size),
+    count: origDestData.count - MemoryLayout<Int>.size)
+
+#if INTERNAL_CHECKS_ENABLED
+  // If checks are enabled, use a validating walker that ensures that the
+  // size pre-walk and instantiation walk are in sync.
+  let sizeWalker = GetKeyPathClassAndInstanceSizeFromPattern(
+    patternArgs: arguments)
+  let instantiateWalker = InstantiateKeyPathBuffer(
+    destData: destData,
+    patternArgs: arguments,
+    root: rootType)
+  
+  var walker = ValidatingInstantiateKeyPathBuffer(sizeVisitor: sizeWalker,
+                                          instantiateVisitor: instantiateWalker)
+#else
+  var walker = InstantiateKeyPathBuffer(
+    destData: destData,
+    patternArgs: arguments,
+    root: rootType)
+#endif
+
+  _walkKeyPathPattern(pattern, walker: &walker)
+
+#if INTERNAL_CHECKS_ENABLED
+  let isTrivial = walker.instantiateVisitor.isTrivial
+  let endOfReferencePrefixComponent =
+    walker.instantiateVisitor.endOfReferencePrefixComponent
+#else
+  let isTrivial = walker.isTrivial
+  let endOfReferencePrefixComponent = walker.endOfReferencePrefixComponent
+#endif
 
   // Write out the header.
   let destHeader = KeyPathBuffer.Header(

--- a/test/IRGen/keypath_witness_overrides.swift
+++ b/test/IRGen/keypath_witness_overrides.swift
@@ -5,7 +5,7 @@
 import protocol_overrides
 
 // CHECK: @keypath = private global
-// CHECK-SAME: %swift.method_descriptor* @"$s18protocol_overrides14OriginalGetterPy7ElementQz5IndexQzcigTq"
+// CHECK-SAME: %swift.method_descriptor** @"got.$s18protocol_overrides14OriginalGetterPy7ElementQz5IndexQzcigTq"
 public func getWritableKeyPath<OS: OverridesSetter>(_ c: OS, index: OS.Index) -> AnyKeyPath
 where OS.Index: Hashable {
   let keypath = \OS.[index]

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -38,203 +38,174 @@ sil_vtable C {}
 // CHECK: %TSi = type <{ [[WORD:i.*]] }>
 
 // -- %a: S.x
-// CHECK: [[KP_A:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_A:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- offset of S.x, mutable
 // CHECK-SAME: <i32 0x0180_0000> }>
 
 // -- %b: S.y
-// CHECK: [[KP_B:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_B:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- offset of S.y, immutable
 // CHECK-32-SAME: <i32 0x0100_0004> }>
 // CHECK-64-SAME: <i32 0x0100_0008> }>
 
 // -- %c: S.z
-// CHECK: [[KP_C:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_C:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- offset of S.z, mutable
 // CHECK-32-SAME: <i32 0x0180_0010> }>
 // CHECK-64-SAME: <i32 0x0180_0018> }>
 
 // -- %d: C.x
-// CHECK: [[KP_D:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_D:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- 0x0300_0000 (class) + mutable + offset of C.x
 // CHECK-32-SAME: <i32 0x0380_0008> }>
 // CHECK-64-SAME: <i32 0x0380_0010> }>
 
 // -- %e: C.y
-// CHECK: [[KP_E:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_E:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- 0x0300_0000 (class) + immutable + offset of C.y
 // CHECK-32-SAME: <i32 0x0300_000c> }>
 // CHECK-64-SAME: <i32 0x0300_0018> }>
 
 // -- %f: C.z
-// CHECK: [[KP_F:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_F:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- 0x0300_0000 (class) + mutable offset of C.z
 // CHECK-32-SAME: <i32 0x0380_0018> }>
 // CHECK-64-SAME: <i32 0x0380_0028> }>
 
 // -- %g: S.z.x
-// CHECK: [[KP_G:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_G:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
 //                  -- instantiable in-line, size 12
-// CHECK-32-SAME: <i32 0x8000_000c>,
-//                  -- instantiable in-line, size 20
-// CHECK-64-SAME: <i32 0x8000_0014>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
+// CHECK-SAME: <i32 0x8000_000c>,
 // -- offset of S.z
 // CHECK-32-SAME: <i32 0x0180_0010>,
 // CHECK-64-SAME: <i32 0x0180_0018>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK: %swift.type* (i8*)*
 // -- 0x0300_0000 (class) + offset of C.x
 // CHECK-32-SAME: <i32 0x0380_0008> }>
 // CHECK-64-SAME: <i32 0x0380_0010> }>
 
 // -- %h: C.z.x
-// CHECK: [[KP_H:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_H:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//                  -- instantiable in-line, size 12
-// CHECK-32-SAME: <i32 0x8000_000c>,
-//                  -- instantiable in-line, size 20
-// CHECK-64-SAME: <i32 0x8000_0014>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
+// CHECK-SAME: <i32 0x8000_000c>,
 // -- 0x0300_0000 (class) + offset of C.z
 // CHECK-32-SAME: <i32 0x0380_0018>,
 // CHECK-64-SAME: <i32 0x0380_0028>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK: %swift.type* (i8*)*
 // -- offset of S.x
 // CHECK-SAME: <i32 0x0180_0000> }>
 
 // -- %k: computed
-// CHECK: [[KP_K:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_K:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//              -- instantiable in-line, size 24
-// CHECK-64-SAME: <i32 0x8000_0018>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 //              -- instantiable in-line, size 12
-// CHECK-32-SAME: <i32 0x8000_000c>,
-// -- computed, get-only, identified by function pointer, no args
-// CHECK-SAME: <i32 0x0200_0000>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
-// CHECK-SAME: void ()* @k_id,
-// CHECK-SAME: void (%TSi*, %T8keypaths1SV*)* @k_get }>
+// CHECK-SAME: <i32 0x8000_000c>,
+// -- computed, get-only, identified by (indirected) function pointer, no args
+// CHECK-SAME: <i32 0x0200_0002>,
+// CHECK-SAME: @got.k_id
+// CHECK-SAME: void (%TSi*, %T8keypaths1SV*)* @k_get
 
 // -- %l: computed
-// CHECK: [[KP_L:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_L:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//              -- instantiable in-line, size 32
-// CHECK-64-SAME: <i32 0x8000_0020>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 //              -- instantiable in-line, size 16
-// CHECK-32-SAME: <i32 0x8000_0010>,
-// -- computed, settable, nonmutating, identified by pointer, no args
-// CHECK-SAME: <i32 0x0240_0000>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
-// CHECK-SAME: %swift.method_descriptor* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s8keypaths1CCMn", i32 0, i32 13),
-// CHECK-SAME: void (%TSi*, %T8keypaths1CC**)* @l_get,
-// CHECK-SAME: void (%TSi*, %T8keypaths1CC**)* @l_set }>
+// CHECK-SAME: <i32 0x8000_0010>,
+// -- computed, settable, nonmutating, identified by indirect pointer, no args
+// CHECK-SAME: <i32 0x0240_0002>,
+// CHECK-SAME: @"got.$s8keypaths1CC1wSivgTq"
+// CHECK-SAME: void (%TSi*, %T8keypaths1CC**)* @l_get
+// CHECK-SAME: void (%TSi*, %T8keypaths1CC**)* @l_set
 
 // -- %m: computed
-// CHECK: [[KP_M:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
+// CHECK: [[KP_M:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: [[WORD]]* @keypath_once
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//              -- instantiable in-line, size 32
-// CHECK-64-SAME: <i32 0x8000_0020>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 //              -- instantiable in-line, size 16
-// CHECK-32-SAME: <i32 0x8000_0010>,
+// CHECK-SAME: <i32 0x8000_0010>,
 // -- computed, settable, nonmutating, identified by property offset, no args
 // CHECK-SAME: <i32 0x02e0_0000>,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK-SAME: [[WORD]]
-// CHECK-SAME: void (%swift.function*, %T8keypaths1SV*)* @m_get,
-// CHECK-SAME: void (%swift.function*, %T8keypaths1SV*)* @m_set }>
+// CHECK-SAME: void (%swift.function*, %T8keypaths1SV*)* @m_get
+// CHECK-SAME: void (%swift.function*, %T8keypaths1SV*)* @m_set
 
 
 // -- %i: Gen<A>.x
-// CHECK: [[KP_I:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
-// CHECK-SAME: %swift.type* (i8*)* [[I_GET_GEN_A_A:@[a-z_.0-9]+]],
-// CHECK-SAME: %swift.type* (i8*)* [[I_GET_A:@[a-z_.0-9]+]],
+// CHECK: [[KP_I:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: i32 0
+// CHECK-SAME: %swift.type* (i8*)* [[I_GET_GEN_A_A:@[a-z_.0-9]+]]
+// CHECK-SAME: %swift.type* (i8*)* [[I_GET_A:@[a-z_.0-9]+]]
 //             -- size 8
 // CHECK-SAME: i32 8,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 //             -- struct with runtime-resolved offset, mutable
 // CHECK-SAME: <i32 0x01fffffe>,
 // CHECK-32-SAME: i32 16 }>
 // CHECK-64-SAME: i32 32 }>
 
 // -- %j: Gen<A>.y
-// CHECK: [[KP_J:@keypath.*]] = private global <{ {{.*}} }> <{
-// CHECK-SAME: [[WORD]] 0,
-// CHECK-SAME: %swift.type* (i8*)* [[J_GET_GEN_A_A:@[a-z_.0-9]+]],
-// CHECK-SAME: %swift.type* (i8*)* [[J_GET_A:@[a-z_.0-9]+]],
+// CHECK: [[KP_J:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: i32 0
+// CHECK-SAME: %swift.type* (i8*)* [[J_GET_GEN_A_A:@[a-z_.0-9]+]]
+// CHECK-SAME: %swift.type* (i8*)* [[J_GET_A:@[a-z_.0-9]+]]
 //             -- size 8
 // CHECK-SAME: i32 8,
-// CHECK-64-SAME: [4 x i8] zeroinitializer,
 //             -- struct with runtime-resolved offset
 // CHECK-SAME: <i32 0x01fffffe>,
 // CHECK-32-SAME: i32 20 }>
 // CHECK-64-SAME: i32 36 }>
 
 // -- %t
-// CHECK: [[KP_T:@keypath.*]] = private global <{ {{.*}} }> <{ {{.*}} i32 1, {{.*}} @"$s8keypaths1GV1xxvpMV",
-// CHECK-SAME:   %swift.type* (i8*)* [[T_GET_TYPE_A:@[A-Za-z0-9._]*]],
-//            -- computed get-only property
-// CHECK-SAME:   <i32 0x0208_0000>
+// CHECK: [[KP_T:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 1, {{.*}} @"got.$s8keypaths1GV1xxvpMV"
+// CHECK-SAME:   %swift.type* (i8*)* [[T_GET_TYPE_A:@[A-Za-z0-9._]*]]
+//            -- computed get-only property, identified by indirect pointer
+// CHECK-SAME:   <i32 0x0208_0002>
 
 // -- %u
-// CHECK: [[KP_U:@keypath.*]] = private global <{ {{.*}} }> <{ {{.*}} i32 3, {{.*}} @"$s8keypaths1GVyxqd__cSHRd__luipMV",
-// CHECK-SAME:   %swift.type* (i8*)* [[U_GET_TYPE_A:@[A-Za-z0-9._]*]],
-// CHECK-SAME:   %swift.type* (i8*)* [[U_GET_TYPE_B:@[A-Za-z0-9._]*]],
-// CHECK-SAME:   i8** (i8*)* [[U_GET_WITNESS_HASHABLE:@[A-Za-z0-9._]*]],
-//            -- computed get-only property
-// CHECK-SAME:   <i32 0x0208_0000>
+// CHECK: [[KP_U:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 3, {{.*}} @"got.$s8keypaths1GVyxqd__cSHRd__luipMV"
+// CHECK-SAME:   %swift.type* (i8*)* [[U_GET_TYPE_A:@[A-Za-z0-9._]*]]
+// CHECK-SAME:   %swift.type* (i8*)* [[U_GET_TYPE_B:@[A-Za-z0-9._]*]]
+// CHECK-SAME:   i8** (i8*)* [[U_GET_WITNESS_HASHABLE:@[A-Za-z0-9._]*]]
+//            -- computed get-only property, identified by indirect pointer
+// CHECK-SAME:   <i32 0x0208_0002>
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @stored_property_fixed_offsets()
 sil @stored_property_fixed_offsets : $@convention(thin) () -> () {

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -17,15 +17,15 @@ sil_vtable C {}
 
 sil @x_get : $@convention(thin) (@in_guaranteed C) -> @out NSString
 
-// CHECK: [[KEYPATH_A:@keypath.*]] = private global
+// CHECK: [[KEYPATH_A:@keypath(\..*)?]] = private global
 // --             computed, get-only, indirect identifier
 // CHECK-SAME: <i32 0x0200_0002>,
 // CHECK-SAME: i8** @"\01L_selector(x)"
 
-// CHECK: [[KEYPATH_B:@keypath.*]] = private global
+// CHECK: [[KEYPATH_B:@keypath(\..*)?]] = private global
 // --             class mutable stored property with indirect offset
 // CHECK-SAME: <i32 0x03fffffd>,
-// CHECK-SAME: @"$s13keypaths_objc1CC6storedSivpWvd"
+// CHECK-SAME: @"got.$s13keypaths_objc1CC6storedSivpWvd"
 
 // CHECK-LABEL: define swiftcc void @objc_only_property()
 sil @objc_only_property : $@convention(thin) () -> () {

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -52,27 +52,28 @@ sil_property #ExternalGeneric.rw <T: Comparable> (
   stored_property #ExternalGeneric.rw : $T)
 
 // CHECK: @"$s19property_descriptor15ExternalGenericV10computedROxvpMV" =
-// -- 0x0108_0000 - computed, readonly, has arguments
-// CHECK-SAME:  <{ <i32 0x0208_0000>,
-// CHECK-SAME:     @id_computed, 
-// CHECK-SAME:     [[GET_COMPUTEDRO:@keypath_get[.0-9]*]],
-// CHECK-SAME:     [[GET_ARG_LAYOUT_COMPUTEDRO:@keypath_get_arg_layout[.0-9]*]],
-// CHECK-SAME:     @swift_keyPathGenericWitnessTable,
-// CHECK-SAME:     [[ARG_INIT_COMPUTEDRO:@keypath_arg_init[.0-9]*]] }>
+// -- 0x0108_0000 - computed, readonly, has arguments, identified by indirect
+// CHECK-SAME:  <{ <i32 0x0208_0002>,
+// CHECK-SAME:     @got.id_computed
+// CHECK-SAME:     [[GET_COMPUTEDRO:@keypath_get[.0-9]*]]
+// CHECK-SAME:     [[GET_ARG_LAYOUT_COMPUTEDRO:@keypath_get_arg_layout[.0-9]*]]
+// -- default witness table
+// CHECK-SAME:     i32 0
+// CHECK-SAME:     [[ARG_INIT_COMPUTEDRO:@keypath_arg_init[.0-9]*]]
 sil_property #ExternalGeneric.computedRO <T: Comparable> (
   gettable_property $T,
     id @id_computed : $@convention(thin) () -> (),
     getter @get_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed ExternalGeneric<T>) -> @out T)
 
 // CHECK: @"$s19property_descriptor15ExternalGenericV10computedRWxvpMV" =
-// -- 0x01c8_0000 - computed, settable, mutating, has arguments
-// CHECK-SAME:  <{ <i32 0x02c8_0000>, 
-// CHECK-SAME:     @id_computed,
-// CHECK-SAME:     [[GET_COMPUTEDRW:@keypath_get[.0-9]*]],
-// CHECK-SAME:     [[SET_COMPUTEDRW:@keypath_set[.0-9]*]],
-// CHECK-SAME:     [[GET_ARG_LAYOUT_COMPUTEDRW:@keypath_get_arg_layout[.0-9]*]],
-// CHECK-SAME:     @swift_keyPathGenericWitnessTable,
-// CHECK-SAME:     [[ARG_INIT_COMPUTEDRW:@keypath_arg_init[.0-9]*]] }>
+// -- 0x01c8_0000 - computed, settable, mutating, has arguments, indirect id
+// CHECK-SAME:  <{ <i32 0x02c8_0002>, 
+// CHECK-SAME:     @got.id_computed
+// CHECK-SAME:     [[GET_COMPUTEDRW:@keypath_get[.0-9]*]]
+// CHECK-SAME:     [[SET_COMPUTEDRW:@keypath_set[.0-9]*]]
+// CHECK-SAME:     [[GET_ARG_LAYOUT_COMPUTEDRW:@keypath_get_arg_layout[.0-9]*]]
+// CHECK-SAME:     i32 0
+// CHECK-SAME:     [[ARG_INIT_COMPUTEDRW:@keypath_arg_init[.0-9]*]]
 sil_property #ExternalGeneric.computedRW <T: Comparable> (
   settable_property $T,
     id @id_computed : $@convention(thin) () -> (),
@@ -80,14 +81,14 @@ sil_property #ExternalGeneric.computedRW <T: Comparable> (
     setter @set_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed T, @inout ExternalGeneric<T>) -> ())
 
 // CHECK: @"$s19property_descriptor15ExternalGenericVyxqd__cSHRd__luipMV" =
-// -- 0x01c8_0000 - computed, settable, mutating, has arguments
-// CHECK-SAME:  <{ <i32 0x02c8_0000>, 
-// CHECK-SAME:     @id_computed,
-// CHECK-SAME:     [[GET_SUBSCRIPT:@keypath_get[.0-9]*]],
-// CHECK-SAME:     [[SET_SUBSCRIPT:@keypath_set[.0-9]*]],
-// CHECK-SAME:     [[GET_ARG_LAYOUT_SUBSCRIPT:@keypath_get_arg_layout[.0-9]*]],
-// CHECK-SAME:     @swift_keyPathGenericWitnessTable,
-// CHECK-SAME:     [[ARG_INIT_SUBSCRIPT:@keypath_arg_init[.0-9]*]] }>
+// -- 0x01c8_0000 - computed, settable, mutating, has arguments, indirect id
+// CHECK-SAME:  <{ <i32 0x02c8_0002>, 
+// CHECK-SAME:     @got.id_computed
+// CHECK-SAME:     [[GET_SUBSCRIPT:@keypath_get[.0-9]*]]
+// CHECK-SAME:     [[SET_SUBSCRIPT:@keypath_set[.0-9]*]]
+// CHECK-SAME:     [[GET_ARG_LAYOUT_SUBSCRIPT:@keypath_get_arg_layout[.0-9]*]]
+// CHECK-SAME:     i32 0
+// CHECK-SAME:     [[ARG_INIT_SUBSCRIPT:@keypath_arg_init[.0-9]*]]
 sil_property #ExternalGeneric.subscript <T: Comparable><U: Hashable> (
   settable_property $T,
     id @id_computed : $@convention(thin) () -> (),


### PR DESCRIPTION
Use relative references instead of pointers so that the pattern can be true-const. Instead of trying
to instantiate a constant key path literal in-place, point to a cache variable that we can store
a pointer to the shared instance into when instantiated. Now that the pattern format has diverged
significantly from the instance format, simplify and refactor the instantiation code using a walker
for the pattern format instead of trying to reuse the code for working with instantiated instances.
rdar://problem/42674576