### PR TITLE
always disable deabstraction in dynamic compilation mode

### DIFF
--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -1,6 +1,6 @@
 // TODO: Revert to %target-run-simple-swift once we complete send/recv support for resource/variant tensors.
 // RUN: %target-run-send-recv-handle-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: tensorflow
 

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -1,5 +1,5 @@
 // TODO: Revert to %target-run-simple-swift once we fold dynamic compilation into -Onone.
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 
 import CTensorFlow

--- a/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 
 import TensorFlow

--- a/test/TensorFlowRuntime/gpu_negative_tests.swift
+++ b/test/TensorFlowRuntime/gpu_negative_tests.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // XFAIL: *

--- a/test/TensorFlowRuntime/hangers.swift
+++ b/test/TensorFlowRuntime/hangers.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/models.swift
+++ b/test/TensorFlowRuntime/models.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/random.swift
+++ b/test/TensorFlowRuntime/random.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/raw_ops.swift
+++ b/test/TensorFlowRuntime/raw_ops.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow_swift_bindings

--- a/test/TensorFlowRuntime/retain_release_1.swift
+++ b/test/TensorFlowRuntime/retain_release_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-sese-loops-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sync_runtime.swift
+++ b/test/TensorFlowRuntime/sync_runtime.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
 //
 // TODO(SR-9110): Make this pass in dynamic compilation mode.
-// %target-run-disable-deabstraction-swift
+// %target-run-dynamic-compilation-swift
 //
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/tensor_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_debuglog.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_xla_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_xla_debuglog.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/top_level_1.swift
+++ b/test/TensorFlowRuntime/top_level_1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/top_level_2.swift
+++ b/test/TensorFlowRuntime/top_level_2.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-disable-deabstraction-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1143,12 +1143,6 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
-    config.target_run_swift_disable_deabstraction = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -Xllvm -tf-dynamic-compilation -DTF_DYNAMIC_COMPILATION -Xllvm -tf-disable-deabstraction -o %%t/a.out -module-name main %s && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_simple_swift_sese_loops = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -Xllvm -tf-ensure-single-loop-exit -o %%t/a.out -module-name main %s && '
@@ -1294,7 +1288,6 @@ config.substitutions.append(('%target-run-simple-swift', config.target_run_simpl
 # SWIFT_ENABLE_TENSORFLOW
 config.substitutions.append(('%target-run-send-recv-handle-swift', config.target_run_simple_swift_send_recv_handle))
 config.substitutions.append(('%target-run-dynamic-compilation-swift', config.target_run_swift_dynamic_compilation))
-config.substitutions.append(('%target-run-disable-deabstraction-swift', config.target_run_swift_disable_deabstraction))
 config.substitutions.append(('%target-run-sese-loops-swift', config.target_run_simple_swift_sese_loops))
 config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))
 config.substitutions.append(('%target-run-simple-opt-Osize-swift', config.target_run_simple_opt_Osize_swift))


### PR DESCRIPTION
Now that IRGen can handle everything with deabstraction disabled, we can disable deabstraction in dynamic compilation mode.

This removes the `-tf-disable-deabstraction` compiler flag.

Since TFDeabstraction no longer runs in dynamic compilation mode, I can remove a bunch of special case conditions that only occur in dynamic compilation mode:
* `shouldBeInlined` has a special case to turn off most inlining in dynamic compilation mode. Removed this.
* A special case to allow generic out-parameters when it's in dynamic compilation mode. Removed this.
* A special case to allow nonconst attributes in dynamic compilation mode. Removed this.
* A special case to not promote constants to graph in dynamic compilation mode. Removed this.
* A special case to allow generic TensorGroup inputs in dynamic compilation mode. Removed this.

And one other simplification:
* I removed a check that skips deabstraction when `fn.isAvailableExternally()`. This is correct because the subsequent `!tfc.shouldBePartitioned()` now handles it. (Before this PR, the `!tfc.shouldBePartitioned()` check did not run in dynamic compilation mode, which is why we needed the additional `fn.isAvailableExternally()` check).