### PR TITLE
[AutoDiff] Implement a preview of generalized differential operators

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 454; // Last change: multiple nominal types for operators
+const uint16_t VERSION_MINOR = 455; // Last change: multiple nominal types for operators
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -43,6 +43,8 @@ bool swift::isOwnershipForwardingValueKind(SILNodeKind kind) {
   case SILNodeKind::CondBranchInst:
   case SILNodeKind::DestructureStructInst:
   case SILNodeKind::DestructureTupleInst:
+  // SWIFT_ENABLE_TENSORFLOW
+  case SILNodeKind::GradientInst:
     return true;
   default:
     return false;

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -4461,6 +4461,10 @@ void Differentiation::run() {
       astCtx.Diags.diagnose(f.getLocation().getSourceLoc(),
                             diag::autodiff_incomplete_differentiable_attr);
     }
+    // Not look for `gradient` instructions in transparent functions because
+    // they are to be inlined.
+    if (f.isTransparent())
+      continue;
     for (SILBasicBlock &bb : f) {
       for (SILInstruction &i : bb) {
         // If `i` is a `gradient` instruction, i.e. the SIL-level differential

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7343,30 +7343,6 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         return replacement;
       }
 
-      // SWIFT_ENABLE_TENSORFLOW
-      case DeclTypeCheckingSemantics::GradientOf: {
-        auto *tup = cast<TupleExpr>(apply->getArg());
-        auto arg = tup->getElement(0);
-        auto replacement =
-          GradientExpr::create(tc.Context, apply->getFn()->getLoc(),
-                               apply->getArg()->getStartLoc(), arg, {},
-                               /*resultIndex*/ 0, apply->getArg()->getEndLoc());
-        cs.setType(replacement, simplifyType(openedType));
-        return replacement;
-      }
-
-      case DeclTypeCheckingSemantics::ValueAndGradientOf: {
-        auto *tup = cast<TupleExpr>(apply->getArg());
-        auto arg = tup->getElement(0);
-        auto replacement =
-          ValueAndGradientExpr::create(tc.Context, apply->getFn()->getLoc(),
-                                       apply->getArg()->getStartLoc(), arg, {},
-                                       /*resultIndex*/ 0,
-                                       apply->getArg()->getEndLoc());
-        cs.setType(replacement, simplifyType(openedType));
-        return replacement;
-      }
-      
       case DeclTypeCheckingSemantics::Normal:
         return nullptr;
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1618,10 +1618,6 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
     openedFullType = refType;
     return true;
   }
-  // SWIFT_ENABLE_TENSORFLOW
-  case DeclTypeCheckingSemantics::GradientOf:
-  case DeclTypeCheckingSemantics::ValueAndGradientOf:
-    return false;
   }
 
   llvm_unreachable("Unhandled DeclTypeCheckingSemantics in switch.");

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -919,11 +919,6 @@ TypeChecker::getDeclTypeCheckingSemantics(ValueDecl *decl) {
       return DeclTypeCheckingSemantics::WithoutActuallyEscaping;
     if (semantics->Value.equals("typechecker._openExistential(_:do:)"))
       return DeclTypeCheckingSemantics::OpenExistential;
-    // SWIFT_ENABLE_TENSORFLOW
-    if (semantics->Value.equals("typechecker.gradient(of:)"))
-      return DeclTypeCheckingSemantics::GradientOf;
-    if (semantics->Value.equals("typechecker.valueAndGradient(of:)"))
-      return DeclTypeCheckingSemantics::ValueAndGradientOf;
   }
   return DeclTypeCheckingSemantics::Normal;
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -75,16 +75,6 @@ enum class DeclTypeCheckingSemantics {
   /// The _openExistential(_:do:) declaration, which extracts the value inside
   /// an existential and passes it as a value of its own dynamic type.
   OpenExistential,
-
-  /// SWIFT_ENABLE_TENSORFLOW
-  /// The gradient(of:) declaration, which performs a reverse-mode automatic
-  /// differentiation and returns a function that computes the gradient.
-  GradientOf,
-
-  /// The valueAndGradient(of:) declaration, which performs a reverse-mode
-  /// automatic differentiation and returns a function that computes both the
-  /// original result value and the gradient.
-  ValueAndGradientOf,
 };
 
 /// The result of name lookup.

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -174,6 +174,7 @@ namespace sil_block {
     // SWIFT_ENABLE_TENSORFLOW
     SIL_REVERSE_DIFFERENTIABLE_ATTR,
     SIL_INST_GRAPH_OPERATION,
+    SIL_INST_GRADIENT,
 
     // We also share these layouts from the decls block. Their enumerators must
     // not overlap with ours.
@@ -408,12 +409,22 @@ namespace sil_block {
 
   // SWIFT_ENABLE_TENSORFLOW
   using SILInstGraphOperationLayout = BCRecordLayout<
-      SIL_INST_GRAPH_OPERATION,
-      ValueIDField,          // the (mangled) graph_op name
-      BCVBR<8>,              // number of arguments
-      BCArray<ValueIDField>  // 3 entries per argument (value, type, and type
-                             // category)
-      // followed by 2 entries per result type (type, and type category)
+    SIL_INST_GRAPH_OPERATION,
+    ValueIDField,          // the (mangled) graph_op name
+    BCVBR<8>,              // number of arguments
+    BCArray<ValueIDField>  // 3 entries per argument (value, type, and type
+                           // category)
+    // followed by 2 entries per result type (type, and type category)
+  >;
+  
+  using SILInstGradientLayout = BCRecordLayout<
+    SIL_INST_GRADIENT,
+    BCFixed<3>,         // options
+    TypeIDField,
+    SILTypeCategoryField,
+    ValueIDField,
+    BCFixed<32>,        // result index
+    BCArray<BCFixed<1>> // parameter indices
   >;
 
   // SIL instructions with one type. (alloc_stack)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -897,6 +897,7 @@ void Serializer::writeBlockInfoBlock() {
   // SWIFT_ENABLE_TENSORFLOW
   BLOCK_RECORD(sil_block, SIL_REVERSE_DIFFERENTIABLE_ATTR);
   BLOCK_RECORD(sil_block, SIL_INST_GRAPH_OPERATION);
+  BLOCK_RECORD(sil_block, SIL_INST_GRADIENT);
 
   // These layouts can exist in both decl blocks and sil blocks.
 #define BLOCK_RECORD_WITH_NAMESPACE(K, X) emitRecordID(Out, X, #X, nameBuffer)

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -94,116 +94,18 @@ public extension Differentiable where TangentVector == CotangentVector {
 // Differential Operators
 //===----------------------------------------------------------------------===//
 
-@_transparent @usableFromInline
-func _gradientBodyUnreachable() {
-  // This implementation is never used, since calls to `Swift.gradient(of:)` are
-  // resolved as a special case by the type checker.
-  Builtin.staticReport(_trueAfterDiagnostics(), true._value,
-    ("internal consistency error: 'gradient(of:)' operation failed to resolve"
-      as StaticString).utf8Start._rawValue)
-  Builtin.unreachable()
+@_transparent @_effects(readnone)
+public func gradient<T : Differentiable, R : FloatingPoint>(
+  of f: /*@autodiff*/ @escaping (T) -> R
+) -> (T) -> T {
+  return #gradient(f)
 }
 
-@_transparent @usableFromInline
-func _valueAndGradientBodyUnreachable() {
-  // This implementation is never used, since calls to
-  // `Swift.valueAndGradient(of:)` are resolved as a special case by the type
-  // checker.
-  Builtin.staticReport(_trueAfterDiagnostics(), true._value,
-    ("""
-     internal consistency error: 'valueAndGradient(of:)' operation failed to \
-     resolve
-     """ as StaticString).utf8Start._rawValue)
-  Builtin.unreachable()
-}
-
-@inlinable // FIXME(sil-serialize-all)
-@_transparent @_semantics("typechecker.gradient(of:)")
-public func gradient<T, R>(of function: (T) -> R) -> (T) -> T.CotangentVector
-  where T : Differentiable, R : Differentiable {
-  _gradientBodyUnreachable()
-}
-
-@inlinable // FIXME(sil-serialize-all)
-@_transparent
-@_semantics("typechecker.gradient(of:)")
-public func gradient<T, U, R>(
-  of function: (T, U) -> R
-) -> (T, U) -> (T.CotangentVector, U.CotangentVector)
-  where T : Differentiable, U : Differentiable,
-        R : Differentiable {
-  _gradientBodyUnreachable()
-}
-
-@inlinable // FIXME(sil-serialize-all)
-@_transparent
-@_semantics("typechecker.gradient(of:)")
-public func gradient<T, U, V, R>(
-  of function: (T, U, V) -> R
-) -> (T, U, V) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
-  where T : Differentiable, U : Differentiable,
-        V : Differentiable, R : Differentiable {
-  _gradientBodyUnreachable()
-}
-
-@inlinable // FIXME(sil-serialize-all)
-@_transparent
-@_semantics("typechecker.gradient(of:)")
-public func gradient<T, U, V, W, R>(
-  of function: (T, U, V, W) -> R
-) -> (T, U, V, W) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector,
-                      W.CotangentVector)
-  where T : Differentiable, U : Differentiable,
-        V : Differentiable, W : Differentiable,
-        R : Differentiable {
-  _gradientBodyUnreachable()
-}
-
-@inlinable // FIXME(sil-serialize-all)
-@_transparent
-@_semantics("typechecker.valueAndGradient(of:)")
-public func valueAndGradient<T, R>(
-  of function: (T) -> R
-) -> (T) -> (value: R, gradient: T.CotangentVector)
-  where T : Differentiable, R : Differentiable {
-  _valueAndGradientBodyUnreachable()
-}
-
-@inlinable // FIXME(sil-serialize-all)
-@_transparent
-@_semantics("typechecker.valueAndGradient(of:)")
-public func valueAndGradient<T, U, R>(
-  of function: (T, U) -> R
-) -> (T, U) -> (value: R, gradient: (T.CotangentVector, U.CotangentVector))
-  where T : Differentiable, U : Differentiable,
-        R : Differentiable {
-  _valueAndGradientBodyUnreachable()
-}
-
-@inlinable // FIXME(sil-serialize-all)
-@_transparent
-@_semantics("typechecker.valueAndGradient(of:)")
-public func valueAndGradient<T, U, V, R>(
-  of function: (T, U, V) -> R
-) -> (T, U, V) -> (value: R, gradient: (T.CotangentVector, U.CotangentVector,
-                                        V.CotangentVector))
-  where T : Differentiable, U : Differentiable,
-        V : Differentiable, R : Differentiable {
-  _valueAndGradientBodyUnreachable()
-}
-
-@inlinable // FIXME(sil-serialize-all)
-@_transparent
-@_semantics("typechecker.valueAndGradient(of:)")
-public func valueAndGradient<T, U, V, W, R>(
-  of function: (T, U, V, W) -> R
-) -> (T, U, V, W)
-  -> (value: R, gradient: (T.CotangentVector, U.CotangentVector,
-                           V.CotangentVector, W.CotangentVector))
-  where T : Differentiable, U : Differentiable,
-        V : Differentiable, W : Differentiable,
-        R : Differentiable {
-  _valueAndGradientBodyUnreachable()
+@_transparent @_effects(readnone)
+public func gradient<T : Differentiable, R : FloatingPoint>(
+  at x: T, in f: /*@autodiff*/ @escaping (T) -> R
+) -> T {
+  return #gradient(f)(x)
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1833,6 +1833,25 @@ extension ${Self} : Strideable {
   }
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+//===----------------------------------------------------------------------===//
+// VectorNumeric Conformance
+//===----------------------------------------------------------------------===//
+
+extension ${Self} : VectorNumeric {
+  public typealias Shape = ()
+  public typealias Scalar = ${Self}
+
+  public init(repeating repeatedValue: ${Self}, shape: ()) {
+    self = repeatedValue
+  }
+}
+
+extension ${Self} : Differentiable {
+  public typealias TangentVector = ${Self}
+  public typealias CotangentVector = ${Self}
+}
+
 //===----------------------------------------------------------------------===//
 // AnyHashable
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/gradient_hof_silgen.swift
+++ b/test/AutoDiff/gradient_hof_silgen.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+@_transparent
+public func gradient<T : Differentiable, R : FloatingPoint>(
+  of f: /*@autodiff*/ @escaping (T) -> R
+) -> (T) -> T {
+  return #gradient(f)
+}
+
+// CHECK-LABEL: @{{.*}}gradient{{.*}}
+// CHECK:   [[GRAD:%.*]] = gradient [source 0] [wrt 0] {{%.*}}
+// CHECK:   return [[GRAD]] : $@callee_guaranteed (@in_guaranteed T) -> @out T
+
+@_transparent
+public func gradient2<T : Differentiable, R : FloatingPoint>(
+  at x: T, in f: /*@autodiff*/ @escaping (T) -> R
+) -> T {
+  return #gradient(f)(x)
+}
+
+// CHECK-LABEL: @{{.*}}gradient2{{.*}}
+// CHECK:   [[GRAD:%.*]] = gradient [source 0] [wrt 0] {{%.*}}
+// CHECK:   [[BORROWED_GRAD:%.*]] = begin_borrow [[GRAD]]
+// CHECK:   apply [[BORROWED_GRAD]]

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -74,4 +74,15 @@ SimpleMathTests.test("CaptureGlobal") {
   expectEqual(30, #gradient(foo)(0))
 }
 
+// FIXME: Forced inlining through @_transparent doesn't work on differential
+// operators yet.
+//
+// SimpleMathTests.test("FunctionalDifferentialOperators") {
+//   let x: Float = 3
+//   let dydx = gradient(at: x) { x in
+//     x * x
+//   }
+//   expectEqual(6, dydx)
+// }
+
 runAllTests()


### PR DESCRIPTION
This patch implements a preview of generalized differential operators as higher-order functions using a mandatory inlining hack. This patch includes:
* Serialize/deserialize the `gradient` instruction.
* Allow `gradient` in canonical SIL. Emit a runtime error message from IRGen for now.
* Make floating point types conform to `VectorNumeric` and `Differentiable` so that they can be differentiated.
* Clean up old differential operators that use special type-checking semantics.
* Add transparent `gradient(of:)` and `gradient(at:in:)` operators.