### PR TITLE
[CSDiagnostics] Diagnose attempt to pass `inout` argument to a subscript

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -966,6 +966,10 @@ ERROR(extra_address_of,none,
 ERROR(extra_address_of_unsafepointer,none,
       "'&' is not allowed passing array value as %0 argument",
       (Type))
+ERROR(cannot_pass_inout_arg_to_subscript,none,
+      "cannot pass an inout argument to a subscript; use "
+      "'withUnsafeMutablePointer' to explicitly convert argument "
+      "to a pointer", ())
 
 ERROR(missing_init_on_metatype_initialization,none,
       "initializing from a metatype value must reference 'init' explicitly",

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1055,10 +1055,17 @@ namespace {
 
           if (isa<TupleExpr>(parent) || isa<ParenExpr>(parent)) {
             auto call = parents.find(parent);
-            if (call != parents.end() &&
-                (isa<ApplyExpr>(call->getSecond()) ||
-                 isa<UnresolvedMemberExpr>(call->getSecond())))
-              return finish(true, expr);
+            if (call != parents.end()) {
+              if (isa<ApplyExpr>(call->getSecond()) ||
+                  isa<UnresolvedMemberExpr>(call->getSecond()))
+                return finish(true, expr);
+
+              if (isa<SubscriptExpr>(call->getSecond())) {
+                TC.diagnose(expr->getStartLoc(),
+                            diag::cannot_pass_inout_arg_to_subscript);
+                return finish(false, nullptr);
+              }
+            }
           }
         }
 

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -116,3 +116,19 @@ func r31977679_1(_ properties: [String: String]) -> Any? {
 func r31977679_2(_ properties: [String: String]) -> Any? {
   return properties["foo"] // Ok
 }
+
+// rdar://problem/45819956 - inout-to-pointer in a subscript arg could use a better diagnostic
+func rdar_45819956() {
+  struct S {
+    subscript(takesPtr ptr: UnsafeMutablePointer<Int>) -> Int {
+      get { return 0 }
+    }
+  }
+
+  let s = S()
+  var i = 0
+
+  // TODO: It should be possible to suggest `withUnsafe[Mutable]Pointer` as a fix-it
+  _ = s[takesPtr: &i]
+  // expected-error@-1 {{cannot pass an inout argument to a subscript; use 'withUnsafeMutablePointer' to explicitly convert argument to a pointer}}
+}


### PR DESCRIPTION
Tweak `PreCheckExpression` to diagnose calls to subscript with
`&` arguments, which is not allowed.

Resolves: rdar://problem/45819956
Resolves: [SR-9171](https://bugs.swift.org/browse/SR-9171)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
