### PR TITLE
[String] Add _CocoaString typealias to all build configurations.

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -12,13 +12,14 @@
 
 import SwiftShims
 
+/// Effectively an untyped NSString that doesn't require foundation.
+@usableFromInline
+internal typealias _CocoaString = AnyObject
+
 #if _runtime(_ObjC)
 // Swift's String bridges NSString via this protocol and these
 // variables, allowing the core stdlib to remain decoupled from
 // Foundation.
-
-/// Effectively an untyped NSString that doesn't require foundation.
-public typealias _CocoaString = AnyObject
 
 @usableFromInline // @testable
 @_effects(releasenone)


### PR DESCRIPTION
Conditionally compiling out _CocoaString from 32-bit string will be
way too unweidly. Fixes Android bots.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
