### PR TITLE
make Tensor zero inlinable

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -61,8 +61,12 @@ public extension Tensor where Scalar : Numeric {
 //===----------------------------------------------------------------------===//
 
 extension Tensor : AdditiveArithmetic where Scalar : Numeric {
+  @inlinable
   public static var zero: Tensor {
-    return Tensor(zeros: [])
+    @inline(__always)
+    get {
+      return Tensor(zeros: [])
+    }
   }
 
   /// Adds two tensors and produces their sum.


### PR DESCRIPTION
This is causing a "cannot partition generic function" error when compiling the TensorFlow lib in Piper. It's surprising to me that it's not also causing this error in the cmake build, but I haven't investigated why.