### PR TITLE
build: do not create WinSDK symlinks when unneeded

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -277,19 +277,21 @@ macro(configure_sdk_windows name environment architectures)
     set(WinSDK${arch}UMDir "$ENV{UniversalCRTSdkDir}/Lib/$ENV{UCRTVersion}/um/${WinSDKArchitecture}")
     set(OverlayDirectory "${CMAKE_BINARY_DIR}/winsdk_lib_${arch}_symlinks")
 
-    file(MAKE_DIRECTORY ${OverlayDirectory})
+    if(NOT EXISTS "$ENV{UniversalCRTSdkDir}/Include/$ENV{UCRTVersion}/um/WINDOWS.H")
+      file(MAKE_DIRECTORY ${OverlayDirectory})
 
-    file(GLOB libraries RELATIVE "${WinSDK${arch}UMDir}" "${WinSDK${arch}UMDir}/*")
-    foreach(library ${libraries})
-      get_filename_component(name_we "${library}" NAME_WE)
-      get_filename_component(ext "${library}" EXT)
-      string(TOLOWER "${ext}" lowercase_ext)
-      set(lowercase_ext_symlink_name "${name_we}${lowercase_ext}")
-      if(NOT library STREQUAL lowercase_ext_symlink_name)
-        execute_process(COMMAND
-                        "${CMAKE_COMMAND}" -E create_symlink "${WinSDK${arch}UMDir}/${library}" "${OverlayDirectory}/${lowercase_ext_symlink_name}")
-      endif()
-    endforeach()
+      file(GLOB libraries RELATIVE "${WinSDK${arch}UMDir}" "${WinSDK${arch}UMDir}/*")
+      foreach(library ${libraries})
+        get_filename_component(name_we "${library}" NAME_WE)
+        get_filename_component(ext "${library}" EXT)
+        string(TOLOWER "${ext}" lowercase_ext)
+        set(lowercase_ext_symlink_name "${name_we}${lowercase_ext}")
+        if(NOT library STREQUAL lowercase_ext_symlink_name)
+          execute_process(COMMAND
+                          "${CMAKE_COMMAND}" -E create_symlink "${WinSDK${arch}UMDir}/${library}" "${OverlayDirectory}/${lowercase_ext_symlink_name}")
+        endif()
+      endforeach()
+    endif()
   endforeach()
 
   # Add this to the list of known SDKs.


### PR DESCRIPTION
When building on case insensitive filesystems, there is no need to
create the library symlink forest as the paths will be resolved properly
due to the insensitivity.  This avoids a bit of work and spew on
Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
