### PR TITLE
docs: add missing flag for CMake configure on Windows

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -127,6 +127,7 @@ cmake -G "Ninja"^
  -DLLVM_BUILD_EXTERNAL_COMPILER_RT=TRUE^
  -DLLVM_LIT_ARGS=-sv^
  -DLLVM_TARGETS_TO_BUILD=X86^
+ -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-windows-msvc^
  "%swift_source_dir%/llvm"
 popd
 cmake --build "%swift_source_dir%/build/Ninja-DebugAssert/llvm-windows-amd64"


### PR DESCRIPTION
When building on Windows, we need to set the target triple explicitly to
x86_64-unknown-windows-msvc to ensure that the environment is specified
to define the os condition properly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
