### PR TITLE
Flake8 fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W291
+ignore = W291 W504
 filename = *.py,
            ./utils/80+-check,
            ./utils/backtrace-check,

--- a/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
+++ b/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
@@ -151,9 +151,9 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-    l = LeaksRunnerBenchmarkDriver(
+    driver = LeaksRunnerBenchmarkDriver(
         SWIFT_BIN_DIR, XFAIL_LIST, args.num_samples, args.num_iters)
-    if l.run(args.filter):
+    if driver.run(args.filter):
         sys.exit(0)
     else:
         sys.exit(-1)

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -591,7 +591,7 @@ Totals,2"""
     def test_results_from_merge_verbose(self):
         """Parsing verbose log  merges all PerformanceTestSamples.
         ...this should technically be on TestPerformanceTestResult, but it's
-        easier to write here. ¯\_(ツ)_/¯"""
+        easier to write here. ¯\\_(ツ)_/¯"""
         concatenated_logs = """
     Sample 0,355883
     Sample 1,358817

--- a/utils/backtrace-check
+++ b/utils/backtrace-check
@@ -43,12 +43,12 @@ formatting.""")
 
     found_stack_trace_start = False
     found_stack_trace_entry = False
-    for l in lines:
-        l = l.rstrip("\n")
+    for line in lines:
+        line = line.rstrip("\n")
 
         # First see if we found the start of our stack trace start. If so, set
         # the found stack trace flag and continue.
-        if l == "Current stack trace:":
+        if line == "Current stack trace:":
             assert(not found_stack_trace_start)
             found_stack_trace_start = True
             continue
@@ -59,7 +59,7 @@ formatting.""")
             continue
 
         # Ok, we are in the middle of matching a stack trace entry.
-        m = TARGET_RE.match(l)
+        m = TARGET_RE.match(line)
         # If we fail to match, we have exited the stack trace entry region
         if m is None:
             break

--- a/utils/backtrace-check
+++ b/utils/backtrace-check
@@ -36,8 +36,8 @@ formatting.""")
     args = parser.parse_args()
 
     TARGET_RE = re.compile(
-        "(?P<index>\d+) +(?P<object>\S+) +(?P<address>0x[0-9a-fA-F]{16}) "
-        "(?P<routine>[^+]+) [+] (?P<offset>\d+)")
+        r"(?P<index>\d+) +(?P<object>\S+) +(?P<address>0x[0-9a-fA-F]{16}) "
+        r"(?P<routine>[^+]+) [+] (?P<offset>\d+)")
 
     lines = sys.stdin.readlines()
 

--- a/utils/bug_reducer/tests/test_funcbugreducer.py
+++ b/utils/bug_reducer/tests/test_funcbugreducer.py
@@ -117,7 +117,7 @@ class FuncBugReducerTestCase(unittest.TestCase):
                         "$s9testbasic6foo413yyF" in output)
         re_end = 'testfuncbugreducer_testbasic_'
         re_end += '92196894259b5d6c98d1b77f19240904.sib'
-        output_file_re = re.compile('\*\*\* Final File: .*' + re_end)
+        output_file_re = re.compile(r'\*\*\* Final File: .*' + re_end)
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 1)

--- a/utils/bug_reducer/tests/test_optbugreducer.py
+++ b/utils/bug_reducer/tests/test_optbugreducer.py
@@ -105,7 +105,7 @@ class OptBugReducerTestCase(unittest.TestCase):
         self.assertTrue('*** Found miscompiling passes!' in output)
         self.assertTrue('*** Final Passes: --bug-reducer-tester' in output)
         re_end = 'testoptbugreducer_testbasic_initial'
-        output_file_re = re.compile('\*\*\* Final File: .*' + re_end)
+        output_file_re = re.compile(r'\*\*\* Final File: .*' + re_end)
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 1)
@@ -134,7 +134,7 @@ class OptBugReducerTestCase(unittest.TestCase):
         self.assertTrue('*** Found miscompiling passes!' in output)
         self.assertTrue('*** Final Passes: --bug-reducer-tester' in output)
         re_end = 'testoptbugreducer_testsuffixinneedofprefix_initial'
-        output_file_re = re.compile('\*\*\* Final File: .*' + re_end)
+        output_file_re = re.compile(r'\*\*\* Final File: .*' + re_end)
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 1)
@@ -167,7 +167,7 @@ class OptBugReducerTestCase(unittest.TestCase):
         self.assertTrue('*** Final Passes: --bug-reducer-tester' in output)
         re_end = 'testoptbugreducer_testreducefunction_initial_'
         re_end += '30775a3d942671a403702a9846afa7a4.sib'
-        output_file_re = re.compile('\*\*\* Final File: .*' + re_end)
+        output_file_re = re.compile(r'\*\*\* Final File: .*' + re_end)
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 1)

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -21,7 +21,7 @@ categories = [
     ["CPP", re.compile('^(__Z|_+swift)')],
 
     # Objective-C
-    ["ObjC", re.compile('^[+-]\[')],
+    ["ObjC", re.compile(r'^[+-]\[')],
 
     # Swift
     ["Partial Apply", re.compile('^__(TPA|T0.*T[aA]$)')],
@@ -80,7 +80,7 @@ def read_sizes(sizes, file_name, function_details, group_by_prefix):
     architectures = subprocess.check_output(
         ["otool", "-V", "-f", file_name]).split("\n")
     arch = None
-    arch_pattern = re.compile('architecture ([\S]+)')
+    arch_pattern = re.compile(r'architecture ([\S]+)')
     for architecture in architectures:
         arch_match = arch_pattern.match(architecture)
         if arch_match:
@@ -115,10 +115,10 @@ def read_sizes(sizes, file_name, function_details, group_by_prefix):
     start_addr = None
     end_addr = None
 
-    section_pattern = re.compile(' +sectname ([\S]+)')
-    size_pattern = re.compile(' +size ([\da-fx]+)')
-    asmline_pattern = re.compile('^([0-9a-fA-F]+)\s')
-    label_pattern = re.compile('^((\-*\[[^\]]*\])|[^\/\s]+):$')
+    section_pattern = re.compile(r' +sectname ([\S]+)')
+    size_pattern = re.compile(r' +size ([\da-fx]+)')
+    asmline_pattern = re.compile(r'^([0-9a-fA-F]+)\s')
+    label_pattern = re.compile(r'^((\-*\[[^\]]*\])|[^\/\s]+):$')
 
     for line in content:
         asmline_match = asmline_pattern.match(line)

--- a/utils/create-filecheck-test.py
+++ b/utils/create-filecheck-test.py
@@ -26,17 +26,17 @@ args = parser.parse_args()
 
 seen_variables = set([])
 ssa_re = re.compile('[%](\d+)')
-for l in args.input.readlines():
-    l = l[:l.find('//')].rstrip() + "\n"
+for line in args.input.readlines():
+    line = line[:line.find('//')].rstrip() + "\n"
     have_match = False
-    for match in ssa_re.finditer(l):
+    for match in ssa_re.finditer(line):
         have_match = True
         var = match.groups()[0]
         if var not in seen_variables:
-            l = l.replace('%' + var, '[[VAR_%s:%%[0-9]+]]' % var)
+            line = line.replace('%' + var, '[[VAR_%s:%%[0-9]+]]' % var)
             seen_variables.add(var)
         else:
-            l = l.replace('%' + var, '[[VAR_%s]]' % var)
+            line = line.replace('%' + var, '[[VAR_%s]]' % var)
     if have_match:
-        l = '// CHECK: ' + l
-    args.o.write(l)
+        line = '// CHECK: ' + line
+    args.o.write(line)

--- a/utils/create-filecheck-test.py
+++ b/utils/create-filecheck-test.py
@@ -25,7 +25,7 @@ parser.add_argument('-o', type=argparse.FileType('w'),
 args = parser.parse_args()
 
 seen_variables = set([])
-ssa_re = re.compile('[%](\d+)')
+ssa_re = re.compile(r'[%](\d+)')
 for line in args.input.readlines():
     line = line[:line.find('//')].rstrip() + "\n"
     have_match = False

--- a/utils/generate_confusables.py
+++ b/utils/generate_confusables.py
@@ -57,7 +57,7 @@ def main(args=sys.argv):
 
     pairs = []
     with open(confusablesFilePath, 'r') as f:
-        pattern = re.compile("(.+)\W+;\W+(.+)\W+;")
+        pattern = re.compile(r"(.+)\W+;\W+(.+)\W+;")
         for line in f:
             match = pattern.match(line)
             if match is not None:

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -99,7 +99,7 @@ tokenize_re = re.compile(
   )
 ''', re.VERBOSE | re.MULTILINE)
 
-gyb_block_close = re.compile('\}%[ \t]*\n?')
+gyb_block_close = re.compile(r'\}%[ \t]*\n?')
 
 
 def token_pos_to_index(token_pos, start, line_starts):

--- a/utils/jobstats/jobstats.py
+++ b/utils/jobstats/jobstats.py
@@ -266,7 +266,7 @@ def find_profiles_in(profiledir, select_stat=[]):
                 if profiletype not in profiles:
                     profiles[profiletype] = dict()
                 profiles[profiletype][counter] = fullpath
-            except:
+            except Exception:
                 pass
     return profiles
 

--- a/utils/jobstats/jobstats.py
+++ b/utils/jobstats/jobstats.py
@@ -199,7 +199,7 @@ AUXPATSTR = (r"(?P<module>[^-]+)-(?P<input>[^-]+)-(?P<triple>[^-]+)" +
 AUXPAT = re.compile(AUXPATSTR)
 
 TIMERPATSTR = (r"time\.swift-(?P<jobkind>\w+)\." + AUXPATSTR +
-               "\.(?P<timerkind>\w+)$")
+               r"\.(?P<timerkind>\w+)$")
 TIMERPAT = re.compile(TIMERPATSTR)
 
 FILEPATSTR = (r"^stats-(?P<start>\d+)-swift-(?P<kind>\w+)-" +

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -24,8 +24,8 @@ def run_build_script_with_data_file(build_script, data_file, verbose=False):
     build_script_args = [
         build_script,
         DEFAULT_PRESENTS,
-        'extra_swift_args=^Swift$;-Xfrontend\;' +
-        '-external-pass-pipeline-filename\;-Xfrontend\;%s' % data_file]
+        r'extra_swift_args=^Swift$;-Xfrontend\;' +
+        r'-external-pass-pipeline-filename\;-Xfrontend\;%s' % data_file]
     sys.stdout.write("Running build script with: %s..." %
                      ' '.join(build_script_args))
     sys.stdout.flush()

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -33,7 +33,7 @@ from jobstats import (list_stats_dir_profiles,
                       load_stats_dir, merge_all_jobstats)
 
 
-MODULE_PAT = re.compile('^(\w+)\.')
+MODULE_PAT = re.compile(r'^(\w+)\.')
 
 
 def module_name_of_stat(name):
@@ -439,7 +439,7 @@ def evaluate(args):
     vargs = vars_of_args(args)
     merged = merge_all_jobstats(load_stats_dir(d, **vargs), **vargs)
     env = {}
-    ident = re.compile('(\w+)$')
+    ident = re.compile(r'(\w+)$')
     for (k, v) in merged.stats.items():
         if k.startswith("time.") or '.time.' in k:
             continue
@@ -472,7 +472,7 @@ def evaluate_delta(args):
     new_stats = merge_all_jobstats(load_stats_dir(new, **vargs), **vargs)
 
     env = {}
-    ident = re.compile('(\w+)$')
+    ident = re.compile(r'(\w+)$')
     for r in compare_stats(args, old_stats.stats, new_stats.stats):
         if r.name.startswith("time.") or '.time.' in r.name:
             continue

--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -33,7 +33,7 @@ class SwiftLexer(RegexLexer):
 
     _isa = r'([a-zA-Z_][a-zA-Z0-9_]*)(\s*)(:)(\s*)([A-Z0-9_][a-zA-Z0-9_]*)'
     _isa_comma = r'([a-zA-Z_][a-zA-Z0-9_]*)(\s*)(:)(\s*)' + \
-                 '([A-Z0-9_][a-zA-Z0-9_]*)(,\s?)'
+                 r'([A-Z0-9_][a-zA-Z0-9_]*)(,\s?)'
     _name = u'([@a-zA-Z_\U00000100-\U00100000]' + \
             u'[a-zA-Z0-9_\U00000100-\U00100000]*)'
 
@@ -206,7 +206,7 @@ class SwiftLexer(RegexLexer):
                 Name.Attribute,
                 Punctuation,
                 Whitespace)),
-            (':\s*', Punctuation),
+            (r':\s*', Punctuation),
             include('tuple'),
             include('var-isa-comma'),
             include('var-isa-pop'),
@@ -299,7 +299,7 @@ class SwiftLexer(RegexLexer):
         ],
 
         'in-interpolated': [
-            ('\)', String.Interpol, '#pop'),
+            (r'\)', String.Interpol, '#pop'),
             include('root2'),
         ],
 

--- a/utils/resolve-crashes.py
+++ b/utils/resolve-crashes.py
@@ -18,9 +18,9 @@ def execute_cmd(cmd):
 
 # The regular expression we use to match compiler-crasher lines.
 regex = re.compile(
-    '.*Swift(.*) :: '
-    '(compiler_crashers|compiler_crashers_2|IDE/crashers|SIL/crashers)'
-    '/(.*\.swift|.*\.sil).*')
+    r'.*Swift(.*) :: '
+    r'(compiler_crashers|compiler_crashers_2|IDE/crashers|SIL/crashers)'
+    r'/(.*\.swift|.*\.sil).*')
 
 # Take the output of lit as standard input.
 for line in sys.stdin:

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -174,7 +174,7 @@ func main() {
     N = CommandLine.arguments[1].toInt()!
   }
 """
-        main_body = """
+        main_body = r"""
   name = "%s"
   if CommandLine.arguments.count <= 2 || CommandLine.arguments[2] == name {
     let start = __mach_absolute_time__()

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -225,10 +225,10 @@ def run_parallel(fn, pool_args, n_processes=0):
     if n_processes == 0:
         n_processes = cpu_count() * 2
 
-    l = Lock()
+    lk = Lock()
     print("Running ``%s`` with up to %d processes." %
           (fn.__name__, n_processes))
-    pool = Pool(processes=n_processes, initializer=init, initargs=(l,))
+    pool = Pool(processes=n_processes, initializer=init, initargs=(lk,))
     results = pool.map_async(func=fn, iterable=pool_args).get(999999)
     pool.close()
     pool.join()

--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -136,7 +136,7 @@ def process_stack(binary, dyn_libs, stack):
         try:
             framePC = int(stack_tokens[2], 16)
             symbol_offset = int(stack_tokens[-1], 10)
-        except:
+        except Exception:
             full_stack.append({"line": line, "framePC": 0, "dynlib_fname": ""})
             continue
 
@@ -161,7 +161,7 @@ def process_stack(binary, dyn_libs, stack):
         try:
             sym_line = symbolicate_one(frame_addr, frame_idx, dynlib_fname)
             print(sym_line)
-        except:
+        except Exception:
             print(frame["line"].rstrip())
         frame_idx = frame_idx + 1
 


### PR DESCRIPTION
This PR fixes 3 classes of flake8 lints in newer flake8 editions (ambiguous variable name, unknown escape, and bare except). These are all plausibly error sources and I am happy to have them fixed.

I suggest W504 is better to just ignore and have proposed doing so here -- it's a "which side of a binary operator should a newline go on" issue -- and it seems like a cause of needless churn rather than an important potential bug. Googling around, nobody seems to think it's an especially robust choice and even [Flake8's page related to the previous state of affairs, when the bit was set the other way](https://lintlyci.github.io/Flake8Rules/rules/W503.html) has truly perplexing language on it.