### PR TITLE
[Driver] Remove unused OutputFileMap param

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -270,14 +270,12 @@ public:
   /// \param[out] TopLevelActions The main Actions to build Jobs for.
   /// \param TC the default host tool chain.
   /// \param OI The OutputInfo for which Actions should be generated.
-  /// \param OFM The OutputFileMap for the compilation; used to find any
-  /// cross-build information.
   /// \param OutOfDateMap If present, information used to decide which files
   /// need to be rebuilt.
   /// \param C The Compilation to which Actions should be added.
   void buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
                     const ToolChain &TC, const OutputInfo &OI,
-                    const OutputFileMap *OFM, const InputInfoMap *OutOfDateMap,
+                    const InputInfoMap *OutOfDateMap,
                     Compilation &C) const;
 
   /// Construct the OutputFileMap for the driver from the given arguments.
@@ -331,7 +329,6 @@ private:
                          CommandOutput *Output) const;
 
   void chooseSwiftModuleOutputPath(Compilation &C,
-                                   const OutputFileMap *OFM,
                                    const TypeToPathMap *OutputMap,
                                    StringRef workingDirectory,
                                    CommandOutput *Output) const;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -947,7 +947,7 @@ Driver::buildCompilation(const ToolChain &TC,
 
   // Construct the graph of Actions.
   SmallVector<const Action *, 8> TopLevelActions;
-  buildActions(TopLevelActions, TC, OI, OFM ? OFM.getPointer() : nullptr,
+  buildActions(TopLevelActions, TC, OI,
                rebuildEverything ? nullptr : &outOfDateMap, *C);
 
   if (Diags.hadAnyError())
@@ -1662,7 +1662,6 @@ Driver::computeCompilerMode(const DerivedArgList &Args,
 
 void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
                           const ToolChain &TC, const OutputInfo &OI,
-                          const OutputFileMap *OFM,
                           const InputInfoMap *OutOfDateMap,
                           Compilation &C) const {
   const DerivedArgList &Args = C.getArgs();
@@ -2473,8 +2472,7 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
                     Output.get());
 
   if (OI.ShouldGenerateModule && isa<CompileJobAction>(JA))
-    chooseSwiftModuleOutputPath(C, OFM, OutputMap, workingDirectory,
-                                Output.get());
+    chooseSwiftModuleOutputPath(C, OutputMap, workingDirectory, Output.get());
 
   if (OI.ShouldGenerateModule &&
       (isa<CompileJobAction>(JA) || isa<MergeModuleJobAction>(JA)))
@@ -2660,7 +2658,6 @@ void Driver::computeMainOutput(
 }
 
 void Driver::chooseSwiftModuleOutputPath(Compilation &C,
-                                         const OutputFileMap *OFM,
                                          const TypeToPathMap *OutputMap,
                                          StringRef workingDirectory,
                                          CommandOutput *Output) const {


### PR DESCRIPTION
While looking at the use of `OutputFileMap`, I noticed in a couple functions it was an unused parameter. This change removes these unused `OFM` parameters.
