### PR TITLE
[Mangling] Mangle types as generic only when they have generic arguments.

### DIFF
--- a/test/DebugInfo/typealias.swift
+++ b/test/DebugInfo/typealias.swift
@@ -12,6 +12,14 @@ class DWARF {
   fileprivate static func usePrivateType() -> PrivateType { return () }
 }
 
+struct Generic<T> {
+  enum Inner {
+    case value
+  }
+}
+
+typealias Specific = Generic<Int>
+
 func main () {
   // CHECK-DAG: !DILocalVariable(name: "a",{{.*}} type: ![[DIEOFFSET]]
   let a : DWARF.DIEOffset = 123
@@ -23,6 +31,11 @@ func main () {
   // CHECK-DAG: !DILocalVariable(name: "c",{{.*}} type: ![[PRIVATETYPE]]
   let c = DWARF.usePrivateType()
   markUsed(c);
+
+  // CHECK-DAG: !DILocalVariable(name: "d", {{.*}} type: [[NONGENERIC_TYPE:![0-9]+]])
+  // CHECK: [[NONGENERIC_TYPE]] = !DICompositeType(tag: DW_TAG_structure_type{{.*}} identifier: "$s9typealias7GenericV5InnerOD"
+  let d: Specific.Inner = .value
+  markUsed(d)
 }
 
 main();

--- a/validation-test/compiler_crashers_2_fixed/0181-sr8930.swift
+++ b/validation-test/compiler_crashers_2_fixed/0181-sr8930.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-frontend -emit-ir -g -o - %s 
+
+// REQUIRES: objc_interop
+
+import Foundation
+public final class Foo: NSObject, Collection {
+  public var storage = [String: Any]()
+  
+  public typealias DictionaryType = [String: Any]
+  public typealias IndexDistance = Int
+  public typealias Indices = DictionaryType.Indices
+  public typealias Iterator = DictionaryType.Iterator
+  public typealias SubSequence = DictionaryType.SubSequence
+  public typealias Index = DictionaryType.Index
+  
+  public var startIndex: Index { return storage.startIndex }
+  public var endIndex: DictionaryType.Index { return storage.endIndex }
+  public subscript(position: Index) -> Iterator.Element {
+    return storage[position]
+  }
+  
+  public subscript(bounds: Range<Index>) -> SubSequence {
+    return storage[bounds]
+  }
+  
+  public var indices: Indices { return storage.indices }
+  
+  public subscript(key: String) -> Any? {
+    get { return storage[key] }
+    set { storage[key] = newValue }
+  }
+  
+  public func index(after i: Index) -> Index { return storage.index(after: i) }
+  
+  public func makeIterator() -> DictionaryIterator<String, Any> {
+    return storage.makeIterator()
+  }
+  
+  public override func value(forKey key: String) -> Any? {
+    return storage[key]
+  }
+
+  public override func value(forUndefinedKey key: String) -> Any? {
+    return storage[key]
+  }
+}


### PR DESCRIPTION
The `isSpecialized()` check didn’t account for the possibility that a
typealias in a parent of a nominal type could be non-generic when the
parent declaration was generic, leading to incorrect mangling that stated
that they were generic but had no generic arguments.

Fixes SR-8930 / rdar://problem/45216653 and rdar://problem/45813164.
