### PR TITLE
[ASTVerifier] Fix pre-check to look at subscript arguments

### DIFF
--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -132,3 +132,15 @@ func rdar_45819956() {
   _ = s[takesPtr: &i]
   // expected-error@-1 {{cannot pass an inout argument to a subscript; use 'withUnsafeMutablePointer' to explicitly convert argument to a pointer}}
 }
+
+// rdar://problem/45825806 - [SR-7190] Array-to-pointer in subscript arg crashes compiler
+func rdar_45825806() {
+  struct S {
+    subscript(takesPtr ptr: UnsafePointer<Int>) -> Int {
+      get { return 0 }
+    }
+  }
+
+  let s = S()
+  _ = s[takesPtr: [1, 2, 3]] // Ok
+}


### PR DESCRIPTION
`array-to-pointer` and other conversions are not restricted to apply
expressions, (dynamic) subscript arguments have them too, which
verifier has to support.

Resolves: rdar://problem/45825806

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
