### PR TITLE
[test] un-XFAIL passing parse_stdlib test.

### DIFF
--- a/validation-test/SIL/parse_stdlib.sil
+++ b/validation-test/SIL/parse_stdlib.sil
@@ -3,6 +3,3 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=true %t.sil > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
-
-// <rdar://problem/36754225> Swift CI: parse_stdlib.sil tests failing with vtable verification
-// XFAIL: (objc_interop && asserts)


### PR DESCRIPTION
The problematic class no longer exists, so the test passes.
