### PR TITLE
Reflection: conditionally build the target library

### DIFF
--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -19,11 +19,13 @@ if (LLVM_ENABLE_ASSERTIONS)
     "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
 endif(LLVM_ENABLE_ASSERTIONS)
 
-add_swift_target_library(swiftReflection STATIC TARGET_LIBRARY
-  ${swiftReflection_SOURCES}
-  C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}
-  LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
-  INSTALL_IN_COMPONENT dev)
+if(SWIFT_BUILD_STDLIB)
+  add_swift_target_library(swiftReflection STATIC TARGET_LIBRARY
+    ${swiftReflection_SOURCES}
+    C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}
+    LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
+    INSTALL_IN_COMPONENT dev)
+endif()
 
 # Build a specific version for the host with the host toolchain.  This is going
 # to be used by tools (e.g. lldb)


### PR DESCRIPTION
There is a build of the reflection library for the tools which we want to build
if we are building the tools.  The target library should only be built if we are
building the standard library.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
