### PR TITLE
Revert "Revert "Revert "[Build System: CMake] make add_swift_library …

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1319,12 +1319,66 @@ endfunction()
 #
 # Usage:
 #   add_swift_host_library(name
-#     [FORCE_BUILD_OPTIMIZED]
-#     [...]
+#     [SHARED]
+#     [STATIC]
+#     [DEPENDS dep1 ...]
+#     [LINK_LIBRARIES dep1 ...]
+#     [INTERFACE_LINK_LIBRARIES dep1 ...]
+#     [SWIFT_MODULE_DEPENDS dep1 ...]
+#     [LLVM_COMPONENT_DEPENDS comp1 ...]
+#     [FILE_DEPENDS target1 ...]
+#     [C_COMPILE_FLAGS flag1...]
+#     [LINK_FLAGS flag1...]
+#     [INSTALL]
+#     INSTALL_IN_COMPONENT comp
+#     source1 [source2 source3 ...])
+#
+# name
+#   Name of the library (e.g., swiftParse).
+#
+# SHARED
+#   Build a shared library.
+#
+# STATIC
+#   Build a static library.
+#
+# DEPENDS
+#   Targets that this library depends on.
+#
+# LINK_LIBRARIES
+#   Libraries this library depends on.
+#
+# LLVM_COMPONENT_DEPENDS
+#   LLVM components this library depends on.
+#
+# FILE_DEPENDS
+#   Additional files this library depends on.
+#
+# C_COMPILE_FLAGS
+#   Extra compiler flags (C, C++, ObjC).
+#
+# LINK_FLAGS
+#   Extra linker flags.
+#
+# INSTALL_IN_COMPONENT comp
+#   The Swift installation component that this library belongs to.
+#
+# source1 ...
+#   Sources to add into this library.
 function(add_swift_host_library name)
-  set(options FORCE_BUILD_OPTIMIZED)
+  set(options
+        FORCE_BUILD_OPTIMIZED
+        SHARED
+        STATIC)
   set(single_parameter_options)
-  set(multiple_parameter_options GYB_SOURCES)
+  set(multiple_parameter_options
+        C_COMPILE_FLAGS
+        DEPENDS
+        FILE_DEPENDS
+        INTERFACE_LINK_LIBRARIES
+        LINK_FLAGS
+        LINK_LIBRARIES
+        LLVM_COMPONENT_DEPENDS)
 
   cmake_parse_arguments(ASHL
                         "${options}"
@@ -1333,13 +1387,29 @@ function(add_swift_host_library name)
                         ${ARGN})
   set(ASHL_SOURCES ${ASHL_UNPARSED_ARGUMENTS})
 
-  handle_gyb_sources(gyb_generated_targets ASHL_GYB_SOURCES
-    ${SWIFT_HOST_VARIANT_ARCH})
-  llvm_add_library(${name} ${ASHL_GYB_SOURCES} ${ASHL_UNPARSED_ARGUMENTS}
-    DEPENDS ${gyb_generated_targets})
-  if(ASHL_FORCE_BUILD_OPTIMIZED)
-    target_compile_options(${name} PRIVATE "-O2")
+  translate_flags(ASHL "${options}")
+
+  if(NOT ASHL_SHARED AND NOT ASHL_STATIC)
+    message(FATAL_ERROR "Either SHARED or STATIC must be specified")
   endif()
+
+  _add_swift_library_single(
+    ${name}
+    ${name}
+    ${ASHL_SHARED_keyword}
+    ${ASHL_STATIC_keyword}
+    ${ASHL_SOURCES}
+    SDK ${SWIFT_HOST_VARIANT_SDK}
+    ARCHITECTURE ${SWIFT_HOST_VARIANT_ARCH}
+    DEPENDS ${ASHL_DEPENDS}
+    LINK_LIBRARIES ${ASHL_LINK_LIBRARIES}
+    LLVM_COMPONENT_DEPENDS ${ASHL_LLVM_COMPONENT_DEPENDS}
+    FILE_DEPENDS ${ASHL_FILE_DEPENDS}
+    C_COMPILE_FLAGS ${ASHL_C_COMPILE_FLAGS}
+    LINK_FLAGS ${ASHL_LINK_FLAGS}
+    INTERFACE_LINK_LIBRARIES ${ASHL_INTERFACE_LINK_LIBRARIES}
+    INSTALL_IN_COMPONENT "dev"
+    )
 
   swift_install_in_component(dev
     TARGETS ${name}

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -63,22 +63,40 @@ add_swift_host_library(swiftAST STATIC
   TypeWalker.cpp
   USRGeneration.cpp
 
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftMarkup
     swiftBasic
     swiftSyntax
 
-  LINK_COMPONENTS
+  INTERFACE_LINK_LIBRARIES
+    # Clang dependencies.
+    # FIXME: Clang should really export these in some reasonable manner.
+    clangCodeGen
+    clangIndex
+    clangFormat
+    clangToolingCore
+    clangFrontendTool
+    clangFrontend
+    clangDriver
+    clangSerialization
+    clangParse
+    clangSema
+    clangAnalysis
+    clangEdit
+    clangRewriteFrontend
+    clangRewrite
+    clangAST
+    clangLex
+    clangAPINotes
+    clangBasic
+
+  LLVM_COMPONENT_DEPENDS
     bitreader bitwriter coroutines coverage irreader debuginfoDWARF
     profiledata instrumentation object objcarcopts mc mcparser
     bitreader bitwriter lto ipo option core support ${LLVM_TARGETS_TO_BUILD}
 
   ${EXTRA_AST_FLAGS}
   )
-target_link_libraries(swiftAST
-                      INTERFACE
-                        clangTooling
-                        clangFrontendTool)
 
 # intrinsics_gen is the LLVM tablegen target that generates the include files
 # where intrinsics and attributes are declared. swiftAST depends on these

--- a/lib/ASTSectionImporter/CMakeLists.txt
+++ b/lib/ASTSectionImporter/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_swift_host_library(swiftASTSectionImporter STATIC
   ASTSectionImporter.cpp
-  LINK_LIBS swiftBasic
-  LINK_COMPONENTS core)
+  LINK_LIBRARIES swiftBasic
+  LLVM_COMPONENT_DEPENDS core)
 

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -1,11 +1,14 @@
 
 # On non-Darwin require UUID.
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(UUID_INCLUDE "")
   set(UUID_LIBRARIES "")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(UUID_INCLUDE "")
   set(UUID_LIBRARIES "rpcrt4.lib")
 else()
   find_package(UUID REQUIRED)
+  set(UUID_INCLUDE "-I${UUID_INCLUDE_DIRS}")
 endif()
 
 # Figure out if we can track VC revisions.
@@ -99,16 +102,13 @@ add_swift_host_library(swiftBasic STATIC
   # Platform-agnostic fallback TaskQueue implementation
   Default/TaskQueue.inc
 
-  GYB_SOURCES
-    UnicodeExtendedGraphemeClusters.cpp.gyb
-  LINK_LIBS
+  UnicodeExtendedGraphemeClusters.cpp.gyb
+
+  C_COMPILE_FLAGS ${UUID_INCLUDE}
+  LINK_LIBRARIES
     swiftDemangling
     ${UUID_LIBRARIES}
-  LINK_COMPONENTS
-    support)
-target_include_directories(swiftBasic
-                           PRIVATE
-                             ${UUID_INCLUDE_DIRS})
+  LLVM_COMPONENT_DEPENDS support)
 
 message(STATUS "Swift version: ${SWIFT_VERSION}")
 message(STATUS "Swift vendor: ${SWIFT_VENDOR}")

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -16,7 +16,7 @@ add_swift_host_library(swiftClangImporter STATIC
   ImportName.cpp
   ImportType.cpp
   SwiftLookupTable.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftAST
     swiftParse
 )

--- a/lib/Demangling/CMakeLists.txt
+++ b/lib/Demangling/CMakeLists.txt
@@ -9,8 +9,7 @@ add_swift_host_library(swiftDemangling
                     OldRemangler.cpp
                     Punycode.cpp
                     Remangler.cpp
-                    TypeDecoder.cpp)
-target_compile_definitions(swiftDemangling
-                           PRIVATE
-                             LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
+                    TypeDecoder.cpp
+                  C_COMPILE_FLAGS
+                    -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -19,8 +19,7 @@ set(swiftDriver_targetDefines)
 add_swift_host_library(swiftDriver STATIC
   ${swiftDriver_sources}
   DEPENDS SwiftOptions
-  LINK_LIBS
-    swiftAST swiftBasic swiftOption)
+  LINK_LIBRARIES swiftAST swiftBasic swiftOption)
 
 # Generate the static-stdlib-args.lnk file used by -static-stdlib option
 # for 'GenericUnix' (eg linux)

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -12,7 +12,7 @@ add_swift_host_library(swiftFrontend STATIC
   SerializedDiagnosticConsumer.cpp
   DEPENDS
     SwiftOptions
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftSIL
     swiftMigrator
     swiftOption

--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -5,7 +5,7 @@ add_swift_host_library(swiftFrontendTool STATIC
   TBD.cpp
   DEPENDS
     swift-syntax-generated-headers SwiftOptions
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftIndex
     swiftIDE
     swiftTBDGen swiftIRGen swiftSIL swiftSILGen swiftSILOptimizer

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -13,7 +13,7 @@ add_swift_host_library(swiftIDE STATIC
   IDETypeChecking.cpp
   APIDigesterData.cpp
   SourceEntityWalker.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftFrontend
     swiftClangImporter
     swiftParse

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -50,7 +50,7 @@ add_swift_host_library(swiftIRGen STATIC
   SwiftTargetInfo.cpp
   TypeLayoutDumper.cpp
   TypeLayoutVerifier.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftAST
     swiftLLVMPasses
     swiftSIL

--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_swift_host_library(swiftImmediate STATIC
   Immediate.cpp
   REPL.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftIDE
     swiftFrontend
     swiftSILGen
     swiftSILOptimizer
     swiftIRGen
-  LINK_COMPONENTS
+  LLVM_COMPONENT_DEPENDS
     linker mcjit)
 

--- a/lib/Index/CMakeLists.txt
+++ b/lib/Index/CMakeLists.txt
@@ -3,5 +3,5 @@ add_swift_host_library(swiftIndex STATIC
   IndexDataConsumer.cpp
   IndexRecord.cpp
   IndexSymbol.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftAST)

--- a/lib/LLVMPasses/CMakeLists.txt
+++ b/lib/LLVMPasses/CMakeLists.txt
@@ -6,7 +6,7 @@ add_swift_host_library(swiftLLVMPasses STATIC
   LLVMInlineTree.cpp
   LLVMMergeFunctions.cpp
 
-  LINK_COMPONENTS
-    analysis
+  LLVM_COMPONENT_DEPENDS
+  analysis
   )
 

--- a/lib/Markup/CMakeLists.txt
+++ b/lib/Markup/CMakeLists.txt
@@ -2,7 +2,8 @@ add_swift_host_library(swiftMarkup STATIC
   AST.cpp
   LineList.cpp
   Markup.cpp
-  LINK_LIBS
+  
+  LINK_LIBRARIES
     libcmark_static)
 target_compile_definitions(swiftMarkup
                            PRIVATE

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -49,8 +49,7 @@ add_swift_host_library(swiftMigrator STATIC
   Migrator.cpp
   MigrationState.cpp
   RewriteBufferEditsReceiver.cpp
-  LINK_LIBS
-    swiftSyntax swiftIDE)
+  LINK_LIBRARIES swiftSyntax swiftIDE)
 
 add_dependencies(swiftMigrator
   "symlink_migrator_data")

--- a/lib/Option/CMakeLists.txt
+++ b/lib/Option/CMakeLists.txt
@@ -2,6 +2,6 @@ add_swift_host_library(swiftOption STATIC
   Options.cpp
   SanitizerOptions.cpp
   DEPENDS SwiftOptions
-  LINK_LIBS
-    swiftBasic)
+  LINK_LIBRARIES swiftBasic
+  FILE_DEPENDS SwiftOptions)
 

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -13,7 +13,7 @@ add_swift_host_library(swiftParse STATIC
   Scope.cpp
   SyntaxParsingCache.cpp
   SyntaxParsingContext.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftAST
     swiftSyntax
 )

--- a/lib/ParseSIL/CMakeLists.txt
+++ b/lib/ParseSIL/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_host_library(swiftParseSIL STATIC
   ParseSIL.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftParse
     swiftSema
     swiftSIL

--- a/lib/PrintAsObjC/CMakeLists.txt
+++ b/lib/PrintAsObjC/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_host_library(swiftPrintAsObjC STATIC
   PrintAsObjC.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftIDE
     swiftFrontend
     swiftClangImporter

--- a/lib/RemoteAST/CMakeLists.txt
+++ b/lib/RemoteAST/CMakeLists.txt
@@ -15,5 +15,5 @@ add_swift_host_library(swiftRemoteAST STATIC
   RemoteAST.cpp
   InProcessMemoryReader.cpp
   ${REMOTE_LIB_HEADERS}
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftSema swiftIRGen)

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -44,7 +44,7 @@ add_swift_host_library(swiftSIL STATIC
   SILWitnessTable.cpp
   TypeLowering.cpp
   ValueOwnership.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftSerialization
     swiftSema
 )

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -30,6 +30,6 @@ add_swift_host_library(swiftSILGen STATIC
   SILGenStmt.cpp
   SILGenThunk.cpp
   SILGenType.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftSIL
 )

--- a/lib/SILOptimizer/CMakeLists.txt
+++ b/lib/SILOptimizer/CMakeLists.txt
@@ -35,5 +35,4 @@ add_subdirectory(Utils)
 
 add_swift_host_library(swiftSILOptimizer STATIC
   ${SILOPTIMIZER_SOURCES}
-  LINK_LIBS
-    swiftSIL)
+  LINK_LIBRARIES swiftSIL)

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -58,7 +58,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckSwitchStmt.cpp
   TypeCheckType.cpp
   TypeChecker.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftParse
     swiftAST
     swiftSerialization

--- a/lib/Serialization/CMakeLists.txt
+++ b/lib/Serialization/CMakeLists.txt
@@ -7,6 +7,6 @@ add_swift_host_library(swiftSerialization STATIC
   SerializedSILLoader.cpp
   SerializeDoc.cpp
   SerializeSIL.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftClangImporter)
 

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -2,11 +2,10 @@ add_swift_host_library(swiftDemangle
                   SHARED
                     SwiftDemangle.cpp
                     MangleHack.cpp
-                  LINK_LIBS
-                    swiftDemangling)
-target_compile_definitions(swiftDemangle
-                           PRIVATE
-                             LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
+                  LINK_LIBRARIES
+                    swiftDemangling
+                  C_COMPILE_FLAGS
+                    -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 
 swift_install_in_component(compiler
     TARGETS swiftDemangle

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -5,15 +5,14 @@ else()
 endif()
 
 add_swift_host_library(swiftSyntax STATIC
+  SyntaxNodes.cpp.gyb
+  SyntaxBuilders.cpp.gyb
+  SyntaxKind.cpp.gyb
+  SyntaxFactory.cpp.gyb
+  SyntaxVisitor.cpp.gyb
+  Trivia.cpp.gyb
   RawSyntax.cpp
   Syntax.cpp
   SyntaxData.cpp
-  UnknownSyntax.cpp
-  GYB_SOURCES
-    SyntaxNodes.cpp.gyb
-    SyntaxBuilders.cpp.gyb
-    SyntaxKind.cpp.gyb
-    SyntaxFactory.cpp.gyb
-    SyntaxVisitor.cpp.gyb
-    Trivia.cpp.gyb
-    SyntaxSerialization.cpp.gyb)
+  SyntaxSerialization.cpp.gyb
+  UnknownSyntax.cpp)

--- a/lib/TBDGen/CMakeLists.txt
+++ b/lib/TBDGen/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(tapi)
 add_swift_host_library(swiftTBDGen STATIC
   ${TAPI_SOURCES}
   TBDGen.cpp
-  LINK_LIBS
+  LINK_LIBRARIES
     swiftAST
     swiftSIL
 )


### PR DESCRIPTION
…a wrapper to add_llvm_library"""

This reverts commit 121f5b64beecc3630aea635c304e24e539c2f9b2.

Sorry to revert this again. This commit makes some pretty big changes. After
messing with the merge-conflict created by this internally, I did not feel
comfortable landing this now. I talked with Saleem and he agreed with me that
this was the right thing to do.
