### PR TITLE
[test] SILOptimizer/string_literals.swift: Mark as unsupported on 32-bit

### DIFF
--- a/test/SILOptimizer/string_literals.swift
+++ b/test/SILOptimizer/string_literals.swift
@@ -2,6 +2,9 @@
 // RUN: %target-swift-frontend -parse-as-library -Osize -emit-ir  %s | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
+// The 7-bit discriminator complicates codegen on 32-bit platforms.
+// UNSUPPORTED: PTRSIZE=32
+
 // This is an end-to-end test to ensure that the optimizer generates
 // optimal code for string literals
 


### PR DESCRIPTION
We can’t currently constant-fold away the initialization of `StringObject`’s 7-bit discriminator field, so string literal initialization is a bit more complicated on 32-bit platforms.

rdar://problem/45845142