### PR TITLE
Create a new kind of SESE region to deal with shared blocks

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -301,10 +301,9 @@ SESERegionBuilder::processAcyclicRegionExcludingEnd(SILBasicBlock *startBB,
                  "Function region should end with an unconditional branch");
           nextBB = branch->getDestBB();
         }
-        iter =
-            functionRegions
-                .try_emplace(currentBB, std::make_pair(subSESERegion, nextBB))
-                .first;
+        auto emplace_result = functionRegions.try_emplace(
+            currentBB, std::make_pair(subSESERegion, nextBB));
+        iter = emplace_result.first;
       }
       results.push_back(llvm::make_unique<FunctionSESERegion>(iter->second.first));
       currentBB = iter->second.second;

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -161,7 +161,8 @@ namespace {
     /// of each loop, and points to the region produced for it.
     llvm::DenseMap<SILBasicBlock*, WhileLoopSESERegion*> loopPreheaders;
 
-    /// Function blocks.
+    /// Map that keeps track of the underlying SESERegionTree for the
+    /// FunctionSESERegion that starts at the given block.
     llvm::DenseMap<SILBasicBlock *,
                    std::pair<std::shared_ptr<SESERegionTree>, SILBasicBlock *>>
         functionRegions;
@@ -291,7 +292,6 @@ SESERegionBuilder::processAcyclicRegionExcludingEnd(SILBasicBlock *startBB,
         // separate function in the lowered graph.
         std::shared_ptr<SESERegionTree> subSESERegion(
             processAcyclicRegion(currentBB, subRegionEndBB).release());
-        // results.push_back(llvm::make_unique<FunctionSESERegion>(subSESERegion));
         SILBasicBlock *nextBB = nullptr;
         if (subRegionEndBB == endBB) {
           nextBB = endBB;

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.h
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.h
@@ -96,8 +96,7 @@ namespace tf {
     }
   };
 
-  /// This region represents a sequence region that is shared between different
-  /// nodes.
+  /// Represents an SESERegion that is shared between different SESERegions.
   class FunctionSESERegion : public SESERegionTree {
     std::shared_ptr<SESERegionTree> functionRegionTree;
 

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.h
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.h
@@ -34,7 +34,7 @@ namespace tf {
       Sequence,
       WhileLoop,
       Conditional,
-      Function
+      Shared
     };
   protected:
     KindTy kind;
@@ -97,20 +97,22 @@ namespace tf {
   };
 
   /// Represents an SESERegion that is shared between different SESERegions.
-  class FunctionSESERegion : public SESERegionTree {
-    std::shared_ptr<SESERegionTree> functionRegionTree;
+  class SharedSESERegion : public SESERegionTree {
+    std::shared_ptr<SESERegionTree> sharedRegionTree;
 
   public:
-    FunctionSESERegion(
-        const std::shared_ptr<SESERegionTree> &functionRegionTree)
-        : SESERegionTree(Function), functionRegionTree(functionRegionTree) {}
+    SharedSESERegion(
+        const std::shared_ptr<SESERegionTree> &sharedRegionTree)
+        : SESERegionTree(Shared), sharedRegionTree(sharedRegionTree) {}
 
-    SESERegionTree* getFunctionRegion() const { return functionRegionTree.get(); }
+    SESERegionTree *getSharedRegionTree() const {
+      return sharedRegionTree.get();
+    }
 
     void print(llvm::raw_ostream &OS, unsigned indent = 0) const;
 
     static bool classof(const SESERegionTree *n) {
-      return n->getKind() == Function;
+      return n->getKind() == Shared;
     }
   };
 

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.h
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.h
@@ -33,7 +33,8 @@ namespace tf {
       SingleBlock,
       Sequence,
       WhileLoop,
-      Conditional
+      Conditional,
+      Function
     };
   protected:
     KindTy kind;
@@ -92,6 +93,25 @@ namespace tf {
 
     static bool classof(const SESERegionTree *n) {
       return n->getKind() == Sequence;
+    }
+  };
+
+  /// This region represents a sequence region that is shared between different
+  /// nodes.
+  class FunctionSESERegion : public SESERegionTree {
+    std::shared_ptr<SESERegionTree> functionRegionTree;
+
+  public:
+    FunctionSESERegion(
+        const std::shared_ptr<SESERegionTree> &functionRegionTree)
+        : SESERegionTree(Function), functionRegionTree(functionRegionTree) {}
+
+    SESERegionTree* getFunctionRegion() const { return functionRegionTree.get(); }
+
+    void print(llvm::raw_ostream &OS, unsigned indent = 0) const;
+
+    static bool classof(const SESERegionTree *n) {
+      return n->getKind() == Function;
     }
   };
 

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -587,7 +587,7 @@ public: // Lowering functionality.
   GLStatus lowerBasicBlock(SILBasicBlock *bb, bool skipTerminator = false);
   GLStatus lowerRegion(SESERegionTree *region);
   GLStatus lowerSequenceRegion(SequenceSESERegion *r);
-  GLStatus lowerFunctionRegion(FunctionSESERegion *r);
+  GLStatus lowerSharedRegion(SharedSESERegion *r);
   GLStatus lowerWhileLoopRegion(WhileLoopSESERegion *r);
   GLStatus lowerConditionalRegion(ConditionalSESERegion *r);
 
@@ -2003,7 +2003,7 @@ GLStatus TFGraphFunctionLowering::lowerSequenceRegion(SequenceSESERegion *r) {
     // Do not clear the outputs if the next region is a function as the outputs
     // are required to process that function region.
     auto &graphFn = getCurrentGraphFunction();
-    if (child->getKind() == SESERegionTree::Function) {
+    if (child->getKind() == SESERegionTree::Shared) {
       for (int i = 0, e = graphFn.outputs.size(); i != e; ++i) {
         addValueMapping({graphFn.outputs[i].first, 0},
                         graphFn.outputs[i].second);
@@ -2017,8 +2017,8 @@ GLStatus TFGraphFunctionLowering::lowerSequenceRegion(SequenceSESERegion *r) {
   return GLStatus::Success;
 }
 
-GLStatus TFGraphFunctionLowering::lowerFunctionRegion(FunctionSESERegion *r) {
-  return lowerRegion(r->getFunctionRegion());
+GLStatus TFGraphFunctionLowering::lowerSharedRegion(SharedSESERegion *r) {
+  return lowerRegion(r->getSharedRegionTree());
 }
 
 /// Given a conditional branch, produce the TF_Output for its branch condition.
@@ -2521,8 +2521,8 @@ GLStatus TFGraphFunctionLowering::lowerRegion(SESERegionTree *region) {
     return lowerBasicBlock(cast<SingleBlockSESERegion>(region)->getBB());
   case SESERegionTree::Sequence:
     return lowerSequenceRegion(cast<SequenceSESERegion>(region));
-  case SESERegionTree::Function:
-    return lowerFunctionRegion(cast<FunctionSESERegion>(region));
+  case SESERegionTree::Shared:
+    return lowerSharedRegion(cast<SharedSESERegion>(region));
   case SESERegionTree::WhileLoop:
     return lowerWhileLoopRegion(cast<WhileLoopSESERegion>(region));
   case SESERegionTree::Conditional:

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2013,17 +2013,13 @@ GLStatus TFGraphFunctionLowering::lowerSequenceRegion(SequenceSESERegion *r) {
 }
 
 GLStatus TFGraphFunctionLowering::lowerFunctionRegion(FunctionSESERegion *r) {
-  GLStatus S = GLStatus::Success;
   auto &graphFn = getCurrentGraphFunction();
   for (int i = 0, e = graphFn.outputs.size(); i != e; ++i) {
     addValueMapping({graphFn.outputs[i].first, 0},
                     graphFn.outputs[i].second);
   }
   graphFn.outputs.clear();
-  S = lowerRegion(r->getFunctionRegion());
-  if (S != GLStatus::Success)
-    return S;
-  return GLStatus::Success;
+  return lowerRegion(r->getFunctionRegion());
 }
 
 /// Given a conditional branch, produce the TF_Output for its branch condition.

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2002,9 +2002,14 @@ GLStatus TFGraphFunctionLowering::lowerSequenceRegion(SequenceSESERegion *r) {
     // in the sequence. Hence, clear outputs for the current function if any.
     // Do not clear the outputs if the next region is a function as the outputs
     // are required to process that function region.
-    if (child->getKind() != SESERegionTree::Function) {
-      getCurrentGraphFunction().outputs.clear();
+    auto &graphFn = getCurrentGraphFunction();
+    if (child->getKind() == SESERegionTree::Function) {
+      for (int i = 0, e = graphFn.outputs.size(); i != e; ++i) {
+        addValueMapping({graphFn.outputs[i].first, 0},
+                        graphFn.outputs[i].second);
+      }
     }
+    graphFn.outputs.clear();
     GLStatus S = lowerRegion(child.get());
     if (S != GLStatus::Success)
       return S;
@@ -2013,12 +2018,6 @@ GLStatus TFGraphFunctionLowering::lowerSequenceRegion(SequenceSESERegion *r) {
 }
 
 GLStatus TFGraphFunctionLowering::lowerFunctionRegion(FunctionSESERegion *r) {
-  auto &graphFn = getCurrentGraphFunction();
-  for (int i = 0, e = graphFn.outputs.size(); i != e; ++i) {
-    addValueMapping({graphFn.outputs[i].first, 0},
-                    graphFn.outputs[i].second);
-  }
-  graphFn.outputs.clear();
   return lowerRegion(r->getFunctionRegion());
 }
 

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -232,8 +232,6 @@ struct TFGraphFunctionLowering
   const std::string &funcNodeBaseName;
   llvm::DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>>
       &graphFunctions;
-  // Map from FunctionSESERegion to corresponding graph function bodies.
-  llvm::DenseMap<FunctionSESERegion *, GraphFunctionBody> functionRegionBodies;
   TF_Graph *resultGraph;
   TF_Status *status;
 
@@ -2002,8 +2000,8 @@ GLStatus TFGraphFunctionLowering::lowerSequenceRegion(SequenceSESERegion *r) {
   for (auto &child : r->getNodes()) {
     // The outputs for a sequence corresponds to the outputs of the last region
     // in the sequence. Hence, clear outputs for the current function if any.
-    // Do not clear the outputs if the next region is a function as we the
-    // outputs would become the inputs for that function region.
+    // Do not clear the outputs if the next region is a function as the outputs
+    // are required to process that function region.
     if (child->getKind() != SESERegionTree::Function) {
       getCurrentGraphFunction().outputs.clear();
     }

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2507,6 +2507,8 @@ GLStatus TFGraphFunctionLowering::lowerRegion(SESERegionTree *region) {
     return lowerBasicBlock(cast<SingleBlockSESERegion>(region)->getBB());
   case SESERegionTree::Sequence:
     return lowerSequenceRegion(cast<SequenceSESERegion>(region));
+  case SESERegionTree::Function:
+    return lowerRegion(cast<FunctionSESERegion>(region)->getFunctionRegion());
   case SESERegionTree::WhileLoop:
     return lowerWhileLoopRegion(cast<WhileLoopSESERegion>(region));
   case SESERegionTree::Conditional:

--- a/test/TensorFlow/shared_sese_lowering.sil
+++ b/test/TensorFlow/shared_sese_lowering.sil
@@ -1,0 +1,88 @@
+// This example tests the canonicalization and lowering of a graph with SharedSESERegion.
+// RUN: %target-sil-opt -tf-lower-graph -tf-dump-intermediates -tf-dump-graph -assume-parsing-unqualified-ownership-sil %s -o /dev/null | %FileCheck %s
+import Builtin
+import Swift
+import TensorFlow
+
+sil @$funcWithSharedSESE :  $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>, TensorHandle<Bool>) -> TensorHandle<Float> {
+bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, %2 : $TensorHandle<Bool>):
+  %3 = graph_op "tf_tensor_to_i1"(%2 : $TensorHandle<Bool>) {__device: "ALL_DEVICES"} : $Builtin.Int1
+	cond_br %3, bb1, bb2
+
+bb1:
+  %4 = graph_op "tf_tensor_to_i1"(%2 : $TensorHandle<Bool>)  {__device: "ALL_DEVICES"} : $Builtin.Int1
+	cond_br %4, bb3, bb4
+
+bb2:
+  %5 = graph_op "tf_tensor_to_i1"(%2 : $TensorHandle<Bool>)  {__device: "ALL_DEVICES"} : $Builtin.Int1
+	cond_br %5, bb5, bb6
+
+bb3:
+  br bb8(%0 : $TensorHandle<Float>)
+
+bb4:
+  br bb7(%0: $TensorHandle<Float>)
+
+bb5:
+  br bb7(%1: $TensorHandle<Float>)
+
+bb6:
+  br bb8(%1 : $TensorHandle<Float>)
+
+bb7(%8: $TensorHandle<Float>):
+  %6 = graph_op "Add"(%0 : $TensorHandle<Float>, %8 : $TensorHandle<Float>) {__device: "ALL_DEVICES"} : $TensorHandle<Float> 
+  br bb8(%6 : $TensorHandle<Float>)
+
+bb8(%7: $TensorHandle<Float>):
+  return %7 : $TensorHandle<Float>
+}			 
+
+// CHECK-LABEL:--- XLA CFG Canonicalize: {{.*}}funcWithSharedSESE{{.*}}
+// CHECK:[sequence
+// CHECK:  {condition Header: bb0
+// CHECK:    {condition Header: bb1
+// CHECK:      block bb3
+// CHECK:      [sequence
+// CHECK:        block bb4
+// CHECK:        {shared
+// CHECK:          block bb7
+// CHECK:        }]}
+// CHECK:    {condition Header: bb2
+// CHECK:      [sequence
+// CHECK:        block bb5
+// CHECK:        {shared
+// CHECK:          block bb7
+// CHECK:        }]
+// CHECK:      block bb6}}
+// CHECK:  block bb8]
+// CHECK:--- XLA CFG Canonicalize end
+
+// Check that the shared block `bb7` consisting of "Add" is lowered twice.
+// CHECK-LABEL:--- TFPartition GraphDef Proto: {{.*}}funcWithSharedSESE{{.*}}
+// CHECK:library {
+// CHECK:  function {
+// CHECK:    signature {
+// CHECK:    node_def {
+// CHECK:      name: "op/{{.*}}"
+// CHECK:      op: "Add"
+// CHECK:      device: "/job:localhost/replica:0/task:0/device:CPU:0"
+// CHECK:      attr {
+// CHECK:        key: "T"
+// CHECK:        value {
+// CHECK:          type: DT_FLOAT
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:    node_def {
+// CHECK:      name: "op/{{.*}}"
+// CHECK:      op: "Add"
+// CHECK:      device: "/job:localhost/replica:0/task:0/device:CPU:0"
+// CHECK:      attr {
+// CHECK:        key: "T"
+// CHECK:        value {
+// CHECK:          type: DT_FLOAT
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -63,14 +63,14 @@ SESERegionTests.testAllBackends("testFunctionRegion") {
 // CHECK:      block {{bb[0-9]+}}
 // CHECK:      [sequence
 // CHECK:        block {{bb[0-9]+}}
-// CHECK:        {function
+// CHECK:        {shared
 // CHECK:          block [[FBLK:bb[0-9]+]]
 // CHECK:        }]}
 // CHECK:    {condition Header: {{bb[0-9]+}}
 // CHECK:      block {{bb[0-9]+}}
 // CHECK:      [sequence
 // CHECK:        block {{bb[0-9]+}}
-// CHECK:        {function
+// CHECK:        {shared
 // CHECK:          block [[FBLK]]
 // CHECK:        }]}}
 // CHECK:  block {{bb[0-9]+}}]
@@ -129,7 +129,7 @@ SESERegionTests.testAllBackends("testFunctionRegionWithLoop") {
 // CHECK:      block {{bb[0-9]+}}
 // CHECK:      [sequence
 // CHECK:        block {{bb[0-9]+}}
-// CHECK:        {function
+// CHECK:        {shared
 // CHECK:          [sequence
 // CHECK:            <while Preheader: [[PHDR:bb[0-9]+]], Header: [[HDR:bb[0-9]+]], exit: [[EXIT:bb[0-9]+]]
 // CHECK:              [sequence
@@ -143,7 +143,7 @@ SESERegionTests.testAllBackends("testFunctionRegionWithLoop") {
 // CHECK:      block {{bb[0-9]+}}
 // CHECK:      [sequence
 // CHECK:        block {{bb[0-9]+}}
-// CHECK:        {function
+// CHECK:        {shared
 // CHECK:          [sequence
 // CHECK:            <while Preheader: [[PHDR]], Header: [[HDR]], exit: [[EXIT]]
 // CHECK:              [sequence

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -1,0 +1,159 @@
+// This test has various test cases to check that SESE regions are computed correctly.
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -emit-sil -O %s -verify | %FileCheck %s
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+var SESERegionTests = TestSuite("SESERegion")
+
+enum TestError : Error {
+  case NegativeOutOfBound
+  case PositiveOutOfBound
+}
+
+public func testFunctionRegion(_ count : Int32) -> Tensor<Int32> {
+  var result = Tensor<Int32>(0)
+  do {
+    if count > 0 {
+      if count < 100 {
+				// expected-warning @+2 {{value implicitly copied to the host}}
+				// expected-warning @+1 {{value implicitly copied to the host}}
+        result += 1
+      } else {
+        result += 2
+        throw TestError.PositiveOutOfBound
+      }
+    } else {
+      if count > -100 {
+				// expected-warning @+2 {{value implicitly copied to the host}}
+				// expected-warning @+1 {{value implicitly copied to the host}}
+        result += 3
+      } else {
+        result += 4
+        throw TestError.NegativeOutOfBound
+      }
+    } // expected-note {{value used here}}
+		// expected-note @+1 {{value used here}}
+	} catch { // expected-note {{value used here}}
+		// expected-warning @+2 {{value implicitly copied to the host}}
+		// expected-warning @+1 {{value implicitly copied to the host}}
+    result += 5
+  }
+  return result
+}
+
+// expected-note @+3 {{value used here}}
+// expected-note @+2 {{value used here}}
+// expected-note @+1 {{value used here}}
+SESERegionTests.testAllBackends("testFunctionRegion") { 
+  expectEqualWithScalarTensor(1, testFunctionRegion(99))
+  expectEqualWithScalarTensor(7, testFunctionRegion(101))
+  expectEqualWithScalarTensor(3, testFunctionRegion(-99))
+  expectEqualWithScalarTensor(9, testFunctionRegion(-101))
+}
+
+// CHECK-LABEL:--- XLA CFG Canonicalize: {{.*}}testFunctionRegion{{.*}}
+// CHECK:[sequence
+// CHECK:  {condition Header: {{bb[0-9]+}}
+// CHECK:    {condition Header: {{bb[0-9]+}}
+// CHECK:      block {{bb[0-9]+}}
+// CHECK:      [sequence
+// CHECK:        block {{bb[0-9]+}}
+// CHECK:        {function
+// CHECK:          block [[FBLK:bb[0-9]+]]
+// CHECK:        }]}
+// CHECK:    {condition Header: {{bb[0-9]+}}
+// CHECK:      block {{bb[0-9]+}}
+// CHECK:      [sequence
+// CHECK:        block {{bb[0-9]+}}
+// CHECK:        {function
+// CHECK:          block [[FBLK]]
+// CHECK:        }]}}
+// CHECK:  block {{bb[0-9]+}}]
+// CHECK:--- XLA CFG Canonicalize end
+
+public func testFunctionRegionWithLoop(_ count : Int32) -> Tensor<Int32> {
+  var result = Tensor<Int32>(0)
+  do {
+    if count > 0 {
+      if count < 100 {
+				// expected-warning @+2 {{value implicitly copied to the host}}
+				// expected-warning @+1 {{value implicitly copied to the host}}
+        result += 1
+      } else {
+        result += 2
+        throw TestError.PositiveOutOfBound
+      }
+    } else {
+      if count > -100 {
+				// expected-warning @+2 {{value implicitly copied to the host}}
+				// expected-warning @+1 {{value implicitly copied to the host}}
+        result += 3
+      } else {
+        result += 4
+        throw TestError.NegativeOutOfBound
+      }
+    } // expected-note {{value used here}}
+		// expected-note @+1 {{value used here}}
+	} catch { // expected-note {{value used here}}
+    var i: Int32 = 0
+    while i < 2 {
+			// expected-warning @+2 {{value implicitly copied to the host}}
+			// expected-warning @+1 {{value implicitly copied to the host}}
+      result += 5
+      i += 1
+    }
+  }
+  return result
+}
+
+// expected-note @+3 {{value used here}}
+// expected-note @+2 {{value used here}}
+// expected-note @+1 {{value used here}}
+SESERegionTests.testAllBackends("testFunctionRegionWithLoop") { 
+  expectEqualWithScalarTensor(1, testFunctionRegionWithLoop(99))
+  expectEqualWithScalarTensor(12, testFunctionRegionWithLoop(101))
+  expectEqualWithScalarTensor(3, testFunctionRegionWithLoop(-99))
+  expectEqualWithScalarTensor(14, testFunctionRegionWithLoop(-101))
+}
+
+
+// CHECK-LABEL:--- XLA CFG Canonicalize: {{.*}}testFunctionRegionWithLoop{{.*}}
+// CHECK:[sequence
+// CHECK:  {condition Header: {{bb[0-9]+}}
+// CHECK:    {condition Header: {{bb[0-9]+}}
+// CHECK:      block {{bb[0-9]+}}
+// CHECK:      [sequence
+// CHECK:        block {{bb[0-9]+}}
+// CHECK:        {function
+// CHECK:          [sequence
+// CHECK:            <while Preheader: [[PHDR:bb[0-9]+]], Header: [[HDR:bb[0-9]+]], exit: [[EXIT:bb[0-9]+]]
+// CHECK:              [sequence
+// CHECK:                {condition Header: [[COND:bb[0-9]+]]
+// CHECK:                  block [[TRUEBLK:bb[0-9]+]]
+// CHECK:                  block [[FALSEBLK:bb[0-9]+]]}
+// CHECK:                block [[MERGEBLK:bb[0-9]+]]]>
+// CHECK:            block [[LATCH:bb[0-9]+]]
+// CHECK:        }]}
+// CHECK:    {condition Header: {{bb[0-9]+}}
+// CHECK:      block {{bb[0-9]+}}
+// CHECK:      [sequence
+// CHECK:        block {{bb[0-9]+}}
+// CHECK:        {function
+// CHECK:          [sequence
+// CHECK:            <while Preheader: [[PHDR]], Header: [[HDR]], exit: [[EXIT]]
+// CHECK:              [sequence
+// CHECK:                {condition Header: [[COND]]
+// CHECK:                  block [[TRUEBLK]]
+// CHECK:                  block [[FALSEBLK]]}
+// CHECK:                block [[MERGEBLK]]]>
+// CHECK:            block [[LATCH]]]
+// CHECK:        }]}}
+// CHECK:  block {{bb[0-9]+}}]
+// CHECK:--- XLA CFG Canonicalize end
+
+runAllTests()

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -20,8 +20,8 @@ public func testFunctionRegion(_ count : Int32) -> Tensor<Int32> {
   do {
     if count > 0 {
       if count < 100 {
-				// expected-warning @+2 {{value implicitly copied to the host}}
-				// expected-warning @+1 {{value implicitly copied to the host}}
+        // expected-warning @+2 {{value implicitly copied to the host}}
+        // expected-warning @+1 {{value implicitly copied to the host}}
         result += 1
       } else {
         result += 2
@@ -29,18 +29,18 @@ public func testFunctionRegion(_ count : Int32) -> Tensor<Int32> {
       }
     } else {
       if count > -100 {
-				// expected-warning @+2 {{value implicitly copied to the host}}
-				// expected-warning @+1 {{value implicitly copied to the host}}
+        // expected-warning @+2 {{value implicitly copied to the host}}
+        // expected-warning @+1 {{value implicitly copied to the host}}
         result += 3
       } else {
         result += 4
         throw TestError.NegativeOutOfBound
       }
     } // expected-note {{value used here}}
-		// expected-note @+1 {{value used here}}
-	} catch { // expected-note {{value used here}}
-		// expected-warning @+2 {{value implicitly copied to the host}}
-		// expected-warning @+1 {{value implicitly copied to the host}}
+    // expected-note @+1 {{value used here}}
+  } catch { // expected-note {{value used here}}
+    // expected-warning @+2 {{value implicitly copied to the host}}
+    // expected-warning @+1 {{value implicitly copied to the host}}
     result += 5
   }
   return result
@@ -81,8 +81,8 @@ public func testFunctionRegionWithLoop(_ count : Int32) -> Tensor<Int32> {
   do {
     if count > 0 {
       if count < 100 {
-				// expected-warning @+2 {{value implicitly copied to the host}}
-				// expected-warning @+1 {{value implicitly copied to the host}}
+        // expected-warning @+2 {{value implicitly copied to the host}}
+        // expected-warning @+1 {{value implicitly copied to the host}}
         result += 1
       } else {
         result += 2
@@ -90,20 +90,20 @@ public func testFunctionRegionWithLoop(_ count : Int32) -> Tensor<Int32> {
       }
     } else {
       if count > -100 {
-				// expected-warning @+2 {{value implicitly copied to the host}}
-				// expected-warning @+1 {{value implicitly copied to the host}}
+        // expected-warning @+2 {{value implicitly copied to the host}}
+        // expected-warning @+1 {{value implicitly copied to the host}}
         result += 3
       } else {
         result += 4
         throw TestError.NegativeOutOfBound
       }
     } // expected-note {{value used here}}
-		// expected-note @+1 {{value used here}}
-	} catch { // expected-note {{value used here}}
+    // expected-note @+1 {{value used here}}
+  } catch { // expected-note {{value used here}}
     var i: Int32 = 0
     while i < 2 {
-			// expected-warning @+2 {{value implicitly copied to the host}}
-			// expected-warning @+1 {{value implicitly copied to the host}}
+      // expected-warning @+2 {{value implicitly copied to the host}}
+      // expected-warning @+1 {{value implicitly copied to the host}}
       result += 5
       i += 1
     }

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -15,7 +15,7 @@ enum TestError : Error {
   case PositiveOutOfBound
 }
 
-public func testFunctionRegion(_ count : Int32) -> Tensor<Int32> {
+public func testSharedRegion(_ count : Int32) -> Tensor<Int32> {
   var result = Tensor<Int32>(0)
   do {
     if count > 0 {
@@ -49,14 +49,14 @@ public func testFunctionRegion(_ count : Int32) -> Tensor<Int32> {
 // expected-note @+3 {{value used here}}
 // expected-note @+2 {{value used here}}
 // expected-note @+1 {{value used here}}
-SESERegionTests.testAllBackends("testFunctionRegion") { 
-  expectEqualWithScalarTensor(1, testFunctionRegion(99))
-  expectEqualWithScalarTensor(7, testFunctionRegion(101))
-  expectEqualWithScalarTensor(3, testFunctionRegion(-99))
-  expectEqualWithScalarTensor(9, testFunctionRegion(-101))
+SESERegionTests.testAllBackends("testSharedRegion") { 
+  expectEqualWithScalarTensor(1, testSharedRegion(99))
+  expectEqualWithScalarTensor(7, testSharedRegion(101))
+  expectEqualWithScalarTensor(3, testSharedRegion(-99))
+  expectEqualWithScalarTensor(9, testSharedRegion(-101))
 }
 
-// CHECK-LABEL:--- XLA CFG Canonicalize: {{.*}}testFunctionRegion{{.*}}
+// CHECK-LABEL:--- XLA CFG Canonicalize: {{.*}}testSharedRegion{{.*}}
 // CHECK:[sequence
 // CHECK:  {condition Header: {{bb[0-9]+}}
 // CHECK:    {condition Header: {{bb[0-9]+}}
@@ -76,7 +76,7 @@ SESERegionTests.testAllBackends("testFunctionRegion") {
 // CHECK:  block {{bb[0-9]+}}]
 // CHECK:--- XLA CFG Canonicalize end
 
-public func testFunctionRegionWithLoop(_ count : Int32) -> Tensor<Int32> {
+public func testSharedRegionWithLoop(_ count : Int32) -> Tensor<Int32> {
   var result = Tensor<Int32>(0)
   do {
     if count > 0 {
@@ -114,15 +114,15 @@ public func testFunctionRegionWithLoop(_ count : Int32) -> Tensor<Int32> {
 // expected-note @+3 {{value used here}}
 // expected-note @+2 {{value used here}}
 // expected-note @+1 {{value used here}}
-SESERegionTests.testAllBackends("testFunctionRegionWithLoop") { 
-  expectEqualWithScalarTensor(1, testFunctionRegionWithLoop(99))
-  expectEqualWithScalarTensor(12, testFunctionRegionWithLoop(101))
-  expectEqualWithScalarTensor(3, testFunctionRegionWithLoop(-99))
-  expectEqualWithScalarTensor(14, testFunctionRegionWithLoop(-101))
+SESERegionTests.testAllBackends("testSharedRegionWithLoop") { 
+  expectEqualWithScalarTensor(1, testSharedRegionWithLoop(99))
+  expectEqualWithScalarTensor(12, testSharedRegionWithLoop(101))
+  expectEqualWithScalarTensor(3, testSharedRegionWithLoop(-99))
+  expectEqualWithScalarTensor(14, testSharedRegionWithLoop(-101))
 }
 
 
-// CHECK-LABEL:--- XLA CFG Canonicalize: {{.*}}testFunctionRegionWithLoop{{.*}}
+// CHECK-LABEL:--- XLA CFG Canonicalize: {{.*}}testSharedRegionWithLoop{{.*}}
 // CHECK:[sequence
 // CHECK:  {condition Header: {{bb[0-9]+}}
 // CHECK:    {condition Header: {{bb[0-9]+}}


### PR DESCRIPTION
In certain cases, the current SESERegion builder constructs SESE regions such some blocks the SESE region are not dominated by the start block of the region. The following CFG is a good example (all edges go down):
```
     +--[0]--+
     |       |
    [1]     [2]
   /   \   /   \
  |      |     |
[3]     [4]   [5]
  \      |     /
   +--->[6]<--+
```
The generate SESE regions tree is as follows:

```
[sequence
  {condition Header: bb0
    {condition Header: bb1
      block bb3
      block bb4}
    {condition Header: bb2
      block bb4
      block bb5}
  block bb6]
```

Note that `bb4` is shared between the two regions, thereby, violating the single entry single exit property. Also, in this case, `bb4` is not dominated by `bb1` or `bb2` the start blocks of the corresponding regions. This causes issues when lowering the SESERegionTree to a graph. 

This PR takes care of such cases by effectively "outlining"  block `bb4` into a new SharedSESE region and takes care of it appropriately during graph lowering.

Resolves [SR-8590](https://bugs.swift.org/browse/SR-8590).

