### PR TITLE
[5.0]  [Runtime] Use the old remangler to compute the @objc protocol name.

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -732,7 +732,7 @@ emitWitnessTableGeneratorForKeyPath(IRGenModule &IGM,
 static unsigned getClassFieldIndex(ClassDecl *classDecl, VarDecl *property) {
   SmallVector<ClassDecl *, 3> superclasses;
   for (auto *superDecl = classDecl; superDecl != nullptr;
-       superDecl = classDecl->getSuperclassDecl()) {
+       superDecl = superDecl->getSuperclassDecl()) {
     superclasses.push_back(superDecl);
   }
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -997,8 +997,7 @@ public:
 #if SWIFT_OBJC_INTEROP
     // Look for a Swift-defined @objc protocol with the Swift 3 mangling that
     // is used for Objective-C entities.
-    std::string objcMangledName =
-      "_TtP" + mangledName.substr(0, mangledName.size()-1) + "_";
+    std::string objcMangledName = "_Tt" + mangleNodeOld(node) + "_";
     if (auto protocol = objc_getProtocol(objcMangledName.c_str()))
       return ProtocolDescriptorRef::forObjC(protocol);
 #endif

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -33,7 +33,14 @@ struct G<T> {
   subscript<U: Hashable>(x: U) -> T { get set }
 }
 
+class C1: C { }
+class C2: C1 {
+  var reabstracted: () -> ()
+}
+
 sil_vtable C {}
+sil_vtable C1 {}
+sil_vtable C2 {}
 
 // CHECK: %TSi = type <{ [[WORD:i.*]] }>
 
@@ -195,6 +202,10 @@ sil_vtable C {}
 // CHECK-SAME: void (%swift.function*, %T8keypaths1SV*)* @m_get,
 // CHECK-SAME: void (%swift.function*, %T8keypaths1SV*)* @m_set }>
 
+// -- %m2: reabstracted
+// Note: the contents here aren't interesting. The test triggered infinite
+// looping in the compiler at one point.
+// CHECK: [[KP_M:@keypath.*]] = private global <{ {{.*}} }> <{
 
 // -- %i: Gen<A>.x
 // CHECK: [[KP_I:@keypath.*]] = private global <{ {{.*}} }> <{
@@ -261,6 +272,7 @@ entry:
   %k = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @k_id : $@convention(thin) () -> (), getter @k_get : $@convention(thin) (@in_guaranteed S) -> @out Int)
   %l = keypath $KeyPath<C, Int>, (root $C; settable_property $Int, id #C.w!getter.1, getter @l_get : $@convention(thin) (@in_guaranteed C) -> @out Int, setter @l_set : $@convention(thin) (@in_guaranteed Int, @in_guaranteed C) -> ())
   %m = keypath $KeyPath<S, () -> ()>, (root $S; settable_property $() -> (), id ##S.reabstracted, getter @m_get : $@convention(thin) (@in_guaranteed S) -> @out @callee_guaranteed () -> @out (), setter @m_set : $@convention(thin) (@in_guaranteed @callee_guaranteed () -> @out (), @inout S) -> ())
+  %m2 = keypath $KeyPath<C2, () -> ()>, (root $C2; settable_property $() -> (), id ##C2.reabstracted, getter @m2_get : $@convention(thin) (@in_guaranteed C2) -> @out @callee_guaranteed () -> @out (), setter @m2_set : $@convention(thin) (@in_guaranteed @callee_guaranteed () -> @out (), @inout C2) -> ())
 
   return undef : $()
 }
@@ -273,6 +285,9 @@ sil @l_set : $@convention(thin) (@in_guaranteed Int, @in_guaranteed C) -> ()
 
 sil @m_get : $@convention(thin) (@in_guaranteed S) -> @out @callee_guaranteed () -> @out ()
 sil @m_set : $@convention(thin) (@in_guaranteed @callee_guaranteed () -> @out (), @inout S) -> ()
+
+sil @m2_get : $@convention(thin) (@in_guaranteed C2) -> @out @callee_guaranteed () -> @out ()
+sil @m2_set : $@convention(thin) (@in_guaranteed @callee_guaranteed () -> @out (), @inout C2) -> ()
 
 struct Gen<T, U> {
   var x: T

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -15,6 +15,7 @@ let DemangleToMetadataTests = TestSuite("DemangleToMetadataObjC")
 @objc protocol P1 { }
 protocol P2 { }
 @objc protocol P3: P1 { }
+@objc protocol mainP4 { }
 
 DemangleToMetadataTests.test("@objc classes") {
   expectEqual(type(of: C()), _typeByMangledName("4main1CC")!)
@@ -25,10 +26,13 @@ DemangleToMetadataTests.test("@objc enums") {
 }
 
 func f1_composition_objc_protocol(_: P1) { }
+func f1_composition_objc_protocol_P4(_: mainP4) { }
 
 DemangleToMetadataTests.test("@objc protocols") {
   expectEqual(type(of: f1_composition_objc_protocol),
               _typeByMangledName("yy4main2P1_pc")!)
+  expectEqual(type(of: f1_composition_objc_protocol_P4),
+              _typeByMangledName("yy4main0A2P4_pc")!)
 }
 
 DemangleToMetadataTests.test("Objective-C classes") {


### PR DESCRIPTION
The “old” mangling that is used for runtime names of @objc protocols
uses a simpler substitution scheme, so you can’t simply take a mangled
name from the new mangling and fix up the ends.

Fixes rdar://problem/45685649.