### PR TITLE
Bridged Strings should have some different/additional overrides for performance (<rdar://problem/26236614>)

### DIFF
--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -104,12 +104,28 @@ _swift_shims_CFStringRef _Nonnull _swift_stdlib_CFStringCreateWithBytes(
 SWIFT_RUNTIME_STDLIB_API
 const char *_Nullable _swift_stdlib_CFStringGetCStringPtr(
     _swift_shims_CFStringRef _Nonnull theString,
-
     _swift_shims_CFStringEncoding encoding);
 
 SWIFT_RUNTIME_STDLIB_API
 _swift_shims_CFStringRef _Nonnull _swift_stdlib_objcDebugDescription(
     id _Nonnull nsObject);
+  
+SWIFT_RUNTIME_STDLIB_API
+_swift_shims_CFComparisonResult _swift_stdlib_CFStringCompare(
+    _swift_shims_CFStringRef _Nonnull string,
+    _swift_shims_CFStringRef _Nonnull string2);
+  
+SWIFT_RUNTIME_STDLIB_API
+__swift_uint8_t _swift_stdlib_isNSString(id _Nonnull obj);
+
+SWIFT_RUNTIME_STDLIB_API
+_swift_shims_CFHashCode _swift_stdlib_CFStringHashNSString(id _Nonnull obj);
+
+SWIFT_RUNTIME_STDLIB_API
+_swift_shims_CFHashCode
+_swift_stdlib_CFStringHashCString(const _swift_shims_UInt8 * _Nonnull bytes,
+                                  _swift_shims_CFIndex length);
+  
 #endif // __OBJC2__
 
 #ifdef __cplusplus

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -69,6 +69,30 @@ internal func _cocoaStringSubscript(
   return _swift_stdlib_CFStringGetCharacterAtIndex(cfSelf, position)
 }
 
+@_effects(readonly)
+internal func _cocoaStringCompare(
+  _ string: _CocoaString, _ other: _CocoaString
+) -> Int {
+  let cfSelf: _swift_shims_CFStringRef = string
+  let cfOther: _swift_shims_CFStringRef = other
+  return _swift_stdlib_CFStringCompare(cfSelf, cfOther)
+}
+
+@_effects(readonly)
+internal func _cocoaHashString(
+  _ string: _CocoaString
+  ) -> UInt {
+  return _swift_stdlib_CFStringHashNSString(string)
+}
+
+@_effects(readonly)
+internal func _cocoaHashASCIIBytes(
+  _ bytes: UnsafePointer<UInt8>,
+  length: Int
+  ) -> UInt {
+  return _swift_stdlib_CFStringHashCString(bytes, length)
+}
+
 //
 // Conversion from NSString to Swift's native representation
 //
@@ -225,36 +249,6 @@ public class __SwiftNativeNSString {
   deinit {}
 }
 
-/// A shadow for the "core operations" of NSString.
-///
-/// Covers a set of operations everyone needs to implement in order to
-/// be a useful `NSString` subclass.
-@objc
-public protocol _NSStringCore : _NSCopying /* _NSFastEnumeration */ {
-
-  // The following methods should be overridden when implementing an
-  // NSString subclass.
-
-  @objc(length)
-  var length: Int { get }
-
-  @objc(characterAtIndex:)
-  func character(at index: Int) -> UInt16
-
- // We also override the following methods for efficiency.
-
-  @objc(getCharacters:range:)
-  func getCharacters(
-   _ buffer: UnsafeMutablePointer<UInt16>,
-   range aRange: _SwiftNSRange)
-
-  @objc(_fastCharacterContents)
-  func _fastCharacterContents() -> UnsafePointer<UInt16>?
-
-  @objc(_fastCStringContents)
-  func _fastCStringContents() -> UnsafePointer<CChar>?
-}
-
 // Called by the SwiftObject implementation to get the description of a value
 // as an NSString.
 @_silgen_name("swift_stdlib_getDescription")
@@ -264,14 +258,10 @@ public func _getDescription<T>(_ x: T) -> AnyObject {
 
 #else // !_runtime(_ObjC)
 
-@_fixed_layout // FIXME(sil-serialize-all)
-public class __SwiftNativeNSString {
-  @usableFromInline // FIXME(sil-serialize-all)
+internal class __SwiftNativeNSString {
   internal init() {}
   deinit {}
 }
-
-public protocol _NSStringCore: class {}
 
 #endif
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -55,7 +55,7 @@ extension _StringGuts {
     self.init(_StringObject(immortal: bufPtr, isASCII: isASCII))
   }
 
-  @inlinable @inline(__always)
+  @inline(__always)
   internal init(_ storage: _StringStorage) {
     self.init(_StringObject(storage))
   }

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -81,7 +81,7 @@ internal struct _StringObject {
   @usableFromInline @_frozen
   internal enum Variant {
     case immortal(UInt)
-    case native(_AbstractStringStorage)
+    case native(AnyObject)
     case bridged(_CocoaString)
 
     @inlinable @inline(__always)
@@ -1029,7 +1029,6 @@ extension _StringObject {
     }
   }
 
-  @inlinable
   internal var nativeStorage: _StringStorage {
     @inline(__always) get {
 #if arch(i386) || arch(arm)
@@ -1187,7 +1186,7 @@ extension _StringObject {
 #endif
   }
 
-  @inlinable @inline(__always)
+  @inline(__always)
   internal init(_ storage: _StringStorage) {
 #if arch(i386) || arch(arm)
     self.init(

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -82,6 +82,24 @@ swift::_swift_stdlib_CFStringCreateWithSubstring(
   return cast(CFStringCreateWithSubstring(cast(alloc), cast(str), cast(range)));
 }
 
+_swift_shims_CFComparisonResult
+swift::_swift_stdlib_CFStringCompare(
+                              _swift_shims_CFStringRef string,
+                              _swift_shims_CFStringRef string2) {
+  return cast(CFStringCompareWithOptionsAndLocale(cast(string),
+                                                  cast(string2),
+                                                  { 0, CFStringGetLength(cast(string)) },
+                                                  0,
+                                                  NULL));
+}
+
+__swift_uint8_t
+swift::_swift_stdlib_isNSString(id obj) {
+  //TODO: we can likely get a small perf win by using _NSIsNSString on
+  //sufficiently new OSs
+  return CFGetTypeID((CFTypeRef)obj) == CFStringGetTypeID() ? 1 : 0;
+}
+
 _swift_shims_UniChar
 swift::_swift_stdlib_CFStringGetCharacterAtIndex(_swift_shims_CFStringRef theString,
                                                  _swift_shims_CFIndex idx) {
@@ -114,5 +132,22 @@ _swift_shims_CFStringRef
 swift::_swift_stdlib_objcDebugDescription(id _Nonnull nsObject) {
   return [nsObject debugDescription];
 }
+
+extern "C" CFHashCode CFStringHashCString(const uint8_t *bytes, CFIndex len);
+extern "C" CFHashCode CFStringHashNSString(id str);
+
+
+_swift_shims_CFHashCode
+swift::_swift_stdlib_CFStringHashNSString(id _Nonnull obj) {
+  return CFStringHashNSString(obj);
+}
+
+_swift_shims_CFHashCode
+swift::_swift_stdlib_CFStringHashCString(const _swift_shims_UInt8 * _Nonnull bytes,
+                                  _swift_shims_CFIndex length) {
+  return CFStringHashCString(bytes, length);
+}
+
+
 #endif
 

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -45,8 +45,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-extern "C" CFHashCode CFStringHashCString(const uint8_t *bytes, CFIndex len);
-
 using namespace swift;
 
 // NOTE: older runtimes called these _SwiftNativeNSXXXBase. The two must
@@ -130,14 +128,6 @@ swift_stdlib_compareNSStringDeterministicUnicodeCollationPtr(void *Lhs,
   // 'kCFCompareNonliteral' actually means "normalize to NFD".
   int Result = CFStringCompare((__bridge CFStringRef)lhs,
                                (__bridge CFStringRef)rhs, kCFCompareNonliteral);
-  return Result;
-}
-
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-size_t
-swift_stdlib_CFStringHashCString(const uint8_t *bytes, CFIndex len) {
-  CFHashCode Result = CFStringHashCString(bytes, len);
-
   return Result;
 }
 

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -61,3 +61,17 @@ Var Hasher._core has declared type change from _BufferingHasher<Hasher._Core> to
 Var Hasher._Core._buffer is added to a non-resilient type
 Var Hasher._Core._state in a non-resilient type changes position from 0 to 1
 
+Class _AbstractStringStorage has been removed
+Constructor _StringGuts.init(_:) has been removed
+Constructor _StringObject.init(_:) has been removed
+Constructor _StringStorage.init() has been removed
+Var _StringObject.nativeStorage has been removed
+Var _StringStorage._countAndFlags has been removed
+Var _StringStorage._realCapacityAndFlags has been removed
+Var _StringStorage.count has been removed
+Var _StringStorage.mutableStart has been removed
+Var _StringStorage.start has been removed
+Class _StringStorage is now without @_fixed_layout
+Class _SharedStringStorage has removed conformance to _NSStringCore
+Class _StringStorage has removed conformance to _NSStringCore
+Protocol _NSStringCore has been removed


### PR DESCRIPTION
This provides specialized overrides of more NSString methods, as well as moving dynamic dispatch boundaries around and sprinkling @_effects in to reduce refcounting overhead.

rdar://problem/26236614