### PR TITLE
Require @usableFromInline on associated type witnesses

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1691,6 +1691,14 @@ ERROR(type_witness_not_accessible_type,none,
       "%0 %1 must be as accessible as its enclosing type because it "
       "matches a requirement in protocol %3",
       (DescriptiveDeclKind, DeclName, AccessLevel, DeclName))
+ERROR(witness_not_usable_from_inline,none,
+      "%0 %1 must be declared '@usableFromInline' because "
+      "because it matches a requirement in protocol %2",
+      (DescriptiveDeclKind, DeclName, DeclName))
+WARNING(witness_not_usable_from_inline_warn,none,
+        "%0 %1 should be declared '@usableFromInline' because "
+        "because it matches a requirement in protocol %2",
+        (DescriptiveDeclKind, DeclName, DeclName))
 ERROR(type_witness_objc_generic_parameter,none,
       "type %0 involving Objective-C type parameter%select{| %1}2 cannot be "
       "used for associated type %3 of protocol %4",

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -504,6 +504,7 @@ extension _ArrayBuffer {
     return count
   }
 
+  @usableFromInline
   internal typealias Indices = Range<Int>
 
   //===--- private --------------------------------------------------------===//

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -28,7 +28,9 @@ import SwiftShims
 @usableFromInline
 @_fixed_layout
 internal struct _CocoaArrayWrapper : RandomAccessCollection {
+  @usableFromInline
   typealias Indices = Range<Int>
+
   @inlinable
   internal var startIndex: Int {
     return 0

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -551,6 +551,7 @@ extension _ContiguousArrayBuffer : RandomAccessCollection {
     return count
   }
 
+  @usableFromInline
   internal typealias Indices = Range<Int>
 }
 

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -344,6 +344,7 @@ internal struct _SliceBuffer<Element>
     }
   }
 
+  @usableFromInline
   internal typealias Indices = Range<Int>
 
   //===--- misc -----------------------------------------------------------===//

--- a/test/Compatibility/attr_usableFromInline_protocol.swift
+++ b/test/Compatibility/attr_usableFromInline_protocol.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4.2
+
+public protocol PublicProtoWithReqs {
+  associatedtype Assoc
+  func foo()
+}
+
+@usableFromInline struct UFIAdopter<T> : PublicProtoWithReqs {}
+// expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+extension UFIAdopter {
+  typealias Assoc = Int
+  // expected-note@-1 {{'Assoc' declared here}}
+  func foo() {}
+}
+
+@usableFromInline struct UFIAdopterAllInOne<T> : PublicProtoWithReqs {
+  typealias Assoc = Int
+  // expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+  func foo() {}
+}
+
+internal struct InternalAdopter<T> : PublicProtoWithReqs {}
+extension InternalAdopter {
+  typealias Assoc = Int // okay
+  func foo() {} // okay
+}
+
+
+@usableFromInline protocol UFIProtoWithReqs {
+  associatedtype Assoc
+  func foo()
+}
+
+public struct PublicAdopter<T> : UFIProtoWithReqs {}
+// expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
+extension PublicAdopter {
+  typealias Assoc = Int
+  // expected-note@-1 {{'Assoc' declared here}}
+  func foo() {}
+}
+extension InternalAdopter: UFIProtoWithReqs {} // okay

--- a/test/attr/attr_usableFromInline_protocol.swift
+++ b/test/attr/attr_usableFromInline_protocol.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-swift-frontend -typecheck -disable-access-control %s
+
+public protocol PublicProtoWithReqs {
+  associatedtype Assoc
+  func foo()
+}
+
+@usableFromInline struct UFIAdopter<T> : PublicProtoWithReqs {}
+// expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+extension UFIAdopter {
+  typealias Assoc = Int
+  // expected-note@-1 {{'Assoc' declared here}}
+  func foo() {}
+}
+
+@usableFromInline struct UFIAdopterAllInOne<T> : PublicProtoWithReqs {
+  typealias Assoc = Int
+  // expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+  func foo() {}
+}
+
+internal struct InternalAdopter<T> : PublicProtoWithReqs {}
+extension InternalAdopter {
+  typealias Assoc = Int // okay
+  func foo() {} // okay
+}
+
+
+@usableFromInline protocol UFIProtoWithReqs {
+  associatedtype Assoc
+  func foo()
+}
+
+public struct PublicAdopter<T> : UFIProtoWithReqs {}
+// expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
+extension PublicAdopter {
+  typealias Assoc = Int
+  // expected-note@-1 {{'Assoc' declared here}}
+  func foo() {}
+}
+extension InternalAdopter: UFIProtoWithReqs {} // okay


### PR DESCRIPTION
...when the protocol and the conforming type are not both public but are both public-or-usableFromInline. It's possible to write inlinable functions that depend on these types:

```
public protocol HasAssoc {
  associatedtype Assoc
}
public func getAssoc<T: HasAssoc>(_: T) -> T.Assoc

@usableFromInline struct Impl: HasAssoc {
  @usableFromInline typealias Assoc = Int
}

@inlinable func test() {
  let x: Int = getAssoc(Impl())
}
```

rdar://problem/43824052