### PR TITLE
[android] Fix function signature to match usage in libdispatch.

### DIFF
--- a/stdlib/public/SwiftShims/DispatchOverlayShims.h
+++ b/stdlib/public/SwiftShims/DispatchOverlayShims.h
@@ -239,7 +239,7 @@ static inline void _swift_dispatch_source_set_registration_handler(
 }
 
 #if defined(__ANDROID__)
-extern void _dispatch_install_thread_detach_callback(dispatch_function_t cb);
+extern void _dispatch_install_thread_detach_callback(void (*cb)(void));
 #endif
 
 static inline void _swift_dispatch_retain(dispatch_object_t object) {


### PR DESCRIPTION
The function signature in libdispatch doesn't use a dispatch_function_t
so compiling for Android should have fail, since the Swift code uses the
function without any parameters.

See
https://github.com/apple/swift-corelibs-libdispatch/blob/master/private/queue_private.h#L345
in which the function is defined with the signatured used in this
change.
