### PR TITLE
[SILGen] Always serialize witness tables in non-resilient modules

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -549,6 +549,10 @@ public:
   /// modules, but in a manner that ensures that all copies are equivalent.
   bool isSynthesizedNonUnique() const;
 
+  /// Whether clients from outside the module can rely on the value witnesses
+  /// being consistent across versions of the framework.
+  bool isResilient() const;
+
   /// Retrieve the type witness and type decl (if one exists)
   /// for the given associated type.
   std::pair<Type, TypeDecl *>

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -285,7 +285,8 @@ public:
                       IsSerialized_t isSerialized);
 
   // Whether a conformance should be serialized.
-  static bool conformanceIsSerialized(ProtocolConformance *conformance);
+  static bool
+  conformanceIsSerialized(const NormalProtocolConformance *conformance);
 
   /// Call \c fn on each (split apart) conditional requirement of \c conformance
   /// that should appear in a witness table, i.e., conformance requirements that

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -387,6 +387,23 @@ bool NormalProtocolConformance::isSynthesizedNonUnique() const {
   return isa<ClangModuleUnit>(getDeclContext()->getModuleScopeContext());
 }
 
+bool NormalProtocolConformance::isResilient() const {
+  // If the type is non-resilient or the module we're in is non-resilient, the
+  // conformance is non-resilient.
+  // FIXME: Looking at the type is not the right long-term solution. We need an
+  // explicit mechanism for declaring conformances as 'fragile', or even
+  // individual witnesses.
+  if (!getType()->getAnyNominal()->isResilient())
+    return false;
+
+  switch (getDeclContext()->getParentModule()->getResilienceStrategy()) {
+  case ResilienceStrategy::Resilient:
+    return true;
+  case ResilienceStrategy::Default:
+    return false;
+  }
+}
+
 Optional<ArrayRef<Requirement>>
 ProtocolConformance::getConditionalRequirementsIfAvailable() const {
   CONFORMANCE_SUBCLASS_DISPATCH(getConditionalRequirementsIfAvailable, ());

--- a/test/SILGen/witness_tables_serialized.swift
+++ b/test/SILGen/witness_tables_serialized.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// This file is also used by witness_tables_serialized_import.swift.
+
+// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-NONRESILIENT %s
+// RUN: %target-swift-emit-silgen -enable-sil-ownership -enable-resilience %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
 
 public protocol PublicProtocol {}
 
@@ -8,11 +11,20 @@ internal protocol InternalProtocol {}
 @_fixed_layout
 public struct PublicStruct : PublicProtocol, InternalProtocol {}
 
+public struct PublicResilientStruct : PublicProtocol, InternalProtocol {}
+
 @usableFromInline
 internal struct InternalStruct : PublicProtocol, InternalProtocol {}
 
-// CHECK-LABEL: sil_witness_table [serialized] PublicStruct: PublicProtocol
-// CHECK-LABEL: sil_witness_table [serialized] PublicStruct: InternalProtocol
+// CHECK: sil_witness_table [serialized] PublicStruct: PublicProtocol
+// CHECK: sil_witness_table [serialized] PublicStruct: InternalProtocol
 
-// CHECK-LABEL: sil_witness_table [serialized] InternalStruct: PublicProtocol
-// CHECK-LABEL: sil_witness_table [serialized] InternalStruct: InternalProtocol
+// CHECK-NONRESILIENT: sil_witness_table [serialized] PublicResilientStruct: PublicProtocol
+// CHECK-NONRESILIENT: sil_witness_table [serialized] PublicResilientStruct: InternalProtocol
+// CHECK-RESILIENT: sil_witness_table PublicResilientStruct: PublicProtocol
+// CHECK-RESILIENT: sil_witness_table PublicResilientStruct: InternalProtocol
+
+// CHECK-NONRESILIENT: sil_witness_table [serialized] InternalStruct: PublicProtocol
+// CHECK-NONRESILIENT: sil_witness_table [serialized] InternalStruct: InternalProtocol
+// CHECK-RESILIENT: sil_witness_table InternalStruct: PublicProtocol
+// CHECK-RESILIENT: sil_witness_table InternalStruct: InternalProtocol

--- a/test/SILGen/witness_tables_serialized_import.swift
+++ b/test/SILGen/witness_tables_serialized_import.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-module %S/witness_tables_serialized.swift -o %t -enable-resilience
+// RUN: %target-swift-emit-silgen -enable-sil-ownership -I %t %s | %FileCheck %s
+
+import witness_tables_serialized
+
+public protocol AnotherPublicProtocol {}
+
+@usableFromInline
+internal protocol AnotherInternalProtocol {}
+
+extension PublicResilientStruct : AnotherPublicProtocol, AnotherInternalProtocol {}
+
+// CHECK: sil_witness_table [serialized] PublicResilientStruct: AnotherPublicProtocol
+// CHECK: sil_witness_table [serialized] PublicResilientStruct: AnotherInternalProtocol


### PR DESCRIPTION
...even if the conforming nominal type is resilient. It's the owner of the conformance whose resilience matters.

I also factored this part out into a separate check at the AST level so we can tweak it, and also so I can use it to (slightly) speed up compiling a resilient swiftinterface.