### PR TITLE
Add option to dump AST to files

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -41,6 +41,7 @@ TYPE("sil",                 SIL,                       "sil",             "")
 TYPE("sib",                 SIB,                       "sib",             "")
 
 // Output types
+TYPE("ast-dump",            ASTDump,                   "ast",             "")
 TYPE("image",               Image,                     "out",             "")
 TYPE("object",              Object,                    "o",               "")
 TYPE("dSYM",                dSYM,                      "dSYM",            "")

--- a/include/swift/Basic/PrimarySpecificPaths.h
+++ b/include/swift/Basic/PrimarySpecificPaths.h
@@ -27,8 +27,9 @@ namespace swift {
 class PrimarySpecificPaths {
 public:
   /// The name of the main output file,
-  /// that is, the .o file for this input. If there is no such file, contains an
-  /// empty string. If the output is to be written to stdout, contains "-".
+  /// that is, the .o file for this input (or a file specified by -o).
+  /// If there is no such file, contains an empty string. If the output
+  /// is to be written to stdout, contains "-".
   std::string OutputFilename;
 
   SupplementaryOutputPaths SupplementaryOutputs;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -85,8 +85,7 @@ namespace {
     PrintWithColorRAII(raw_ostream &os, TerminalColor color)
     : OS(os), ShowColors(false)
     {
-      if (&os == &llvm::errs() || &os == &llvm::outs())
-        ShowColors = llvm::errs().has_colors() && llvm::outs().has_colors();
+      ShowColors = os.has_colors();
 
       if (ShowColors)
         OS.changeColor(color.Color, color.Bold);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -416,13 +416,9 @@ namespace {
   public:
     raw_ostream &OS;
     unsigned Indent;
-    bool ShowColors;
 
     explicit PrintPattern(raw_ostream &os, unsigned indent = 0)
-      : OS(os), Indent(indent), ShowColors(false) {
-      if (&os == &llvm::errs() || &os == &llvm::outs())
-        ShowColors = llvm::errs().has_colors() && llvm::outs().has_colors();
-    }
+      : OS(os), Indent(indent) { }
 
     void printRec(Decl *D) { D->dump(OS, Indent + 2); }
     void printRec(Expr *E) { E->dump(OS, Indent + 2); }
@@ -544,13 +540,9 @@ namespace {
   public:
     raw_ostream &OS;
     unsigned Indent;
-    bool ShowColors;
 
     explicit PrintDecl(raw_ostream &os, unsigned indent = 0)
-      : OS(os), Indent(indent), ShowColors(false) {
-      if (&os == &llvm::errs() || &os == &llvm::outs())
-        ShowColors = llvm::errs().has_colors() && llvm::outs().has_colors();
-    }
+      : OS(os), Indent(indent) { }
     
     void printRec(Decl *D) { PrintDecl(OS, Indent + 2).visit(D); }
     void printRec(Expr *E) { E->dump(OS, Indent+2); }
@@ -2712,13 +2704,9 @@ class PrintTypeRepr : public TypeReprVisitor<PrintTypeRepr> {
 public:
   raw_ostream &OS;
   unsigned Indent;
-  bool ShowColors;
 
   PrintTypeRepr(raw_ostream &os, unsigned indent)
-    : OS(os), Indent(indent), ShowColors(false) {
-    if (&os == &llvm::errs() || &os == &llvm::outs())
-      ShowColors = llvm::errs().has_colors() && llvm::outs().has_colors();
-  }
+    : OS(os), Indent(indent) { }
 
   void printRec(Decl *D) { D->dump(OS, Indent + 2); }
   void printRec(Expr *E) { E->dump(OS, Indent + 2); }

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -70,6 +70,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_SIL:
   case file_types::TY_Dependencies:
   case file_types::TY_Assembly:
+  case file_types::TY_ASTDump:
   case file_types::TY_RawSIL:
   case file_types::TY_LLVM_IR:
   case file_types::TY_ObjCHeader:
@@ -117,6 +118,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_TBD:
   case file_types::TY_SIL:
   case file_types::TY_Dependencies:
+  case file_types::TY_ASTDump:
   case file_types::TY_RawSIL:
   case file_types::TY_ObjCHeader:
   case file_types::TY_AutolinkFile:
@@ -147,6 +149,7 @@ bool file_types::isAfterLLVM(ID Id) {
 bool file_types::isPartOfSwiftCompilation(ID Id) {
   switch (Id) {
   case file_types::TY_Swift:
+  case file_types::TY_ASTDump:
   case file_types::TY_SIL:
   case file_types::TY_RawSIL:
   case file_types::TY_SIB:

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -149,7 +149,6 @@ bool file_types::isAfterLLVM(ID Id) {
 bool file_types::isPartOfSwiftCompilation(ID Id) {
   switch (Id) {
   case file_types::TY_Swift:
-  case file_types::TY_ASTDump:
   case file_types::TY_SIL:
   case file_types::TY_RawSIL:
   case file_types::TY_SIB:
@@ -174,6 +173,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_ClangModuleFile:
   case file_types::TY_SwiftDeps:
   case file_types::TY_Nothing:
+  case file_types::TY_ASTDump:
   case file_types::TY_Remapping:
   case file_types::TY_IndexData:
   case file_types::TY_ModuleTrace:

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1411,11 +1411,15 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.CompilerOutputType = file_types::TY_Remapping;
       OI.LinkAction = LinkKind::None;
       break;
+
+    case options::OPT_dump_ast:
+      OI.CompilerOutputType = file_types::TY_ASTDump;
+      break;
+
     case options::OPT_parse:
     case options::OPT_resolve_imports:
     case options::OPT_typecheck:
     case options::OPT_dump_parse:
-    case options::OPT_dump_ast:
     case options::OPT_emit_syntax:
     case options::OPT_print_ast:
     case options::OPT_dump_type_refinement_contexts:
@@ -1764,6 +1768,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
           break;
         }
         LLVM_FALLTHROUGH;
+      case file_types::TY_ASTDump:
       case file_types::TY_Image:
       case file_types::TY_dSYM:
       case file_types::TY_Dependencies:

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1389,6 +1389,10 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.CompilerOutputType = file_types::TY_LLVM_BC;
       break;
 
+    case options::OPT_dump_ast:
+      OI.CompilerOutputType = file_types::TY_ASTDump;
+      break;
+
     case options::OPT_emit_pch:
       OI.CompilerMode = OutputInfo::Mode::SingleCompile;
       OI.CompilerOutputType = file_types::TY_PCH;
@@ -1410,10 +1414,6 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
     case options::OPT_update_code:
       OI.CompilerOutputType = file_types::TY_Remapping;
       OI.LinkAction = LinkKind::None;
-      break;
-
-    case options::OPT_dump_ast:
-      OI.CompilerOutputType = file_types::TY_ASTDump;
       break;
 
     case options::OPT_parse:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -398,7 +398,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_PCH:
     return "-emit-pch";
   case file_types::TY_ASTDump:
-      return "-dump-ast";
+    return "-dump-ast";
   case file_types::TY_RawSIL:
     return "-emit-silgen";
   case file_types::TY_SIL:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -397,6 +397,8 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
     return "-c";
   case file_types::TY_PCH:
     return "-emit-pch";
+  case file_types::TY_ASTDump:
+      return "-dump-ast";
   case file_types::TY_RawSIL:
     return "-emit-silgen";
   case file_types::TY_SIL:
@@ -652,6 +654,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_ImportedModules:
     case file_types::TY_TBD:
     case file_types::TY_SwiftModuleFile:
+    case file_types::TY_ASTDump:
     case file_types::TY_RawSIL:
     case file_types::TY_RawSIB:
     case file_types::TY_SIL:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -688,6 +688,9 @@ static SourceFile *getPrimaryOrMainSourceFile(CompilerInvocation &Invocation,
 /// Dumps the AST of all available primary source files. If corresponding output
 /// files were specified, use them; otherwise, dump the AST to stdout.
 static void dumpAST(CompilerInstance &Instance) {
+  // FIXME: WMO doesn't use the notion of primary files, so this doesn't do the
+  // right thing. Perhaps it'd be best to ignore WMO when dumping the AST, just
+  // like WMO ignores `-incremental`.
   for (SourceFile *sourceFile: Instance.getPrimarySourceFiles()) {
     const StringRef OutputFilename =
       Instance.getPrimarySpecificPathsForSourceFile(*sourceFile).OutputFilename;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -687,15 +687,24 @@ static SourceFile *getPrimaryOrMainSourceFile(CompilerInvocation &Invocation,
 
 /// Dumps the AST of all available primary source files. If corresponding output
 /// files were specified, use them; otherwise, dump the AST to stdout.
-static void dumpAST(CompilerInstance &Instance) {
+static void dumpAST(CompilerInvocation &Invocation,
+                    CompilerInstance &Instance) {
   // FIXME: WMO doesn't use the notion of primary files, so this doesn't do the
   // right thing. Perhaps it'd be best to ignore WMO when dumping the AST, just
   // like WMO ignores `-incremental`.
-  for (SourceFile *sourceFile: Instance.getPrimarySourceFiles()) {
-    const StringRef OutputFilename =
-      Instance.getPrimarySpecificPathsForSourceFile(*sourceFile).OutputFilename;
-    auto OS = getFileOutputStream(OutputFilename, Instance.getASTContext());
-    sourceFile->dump(*OS);
+
+  auto primaryFiles = Instance.getPrimarySourceFiles();
+  if (!primaryFiles.empty()) {
+    for (SourceFile *sourceFile: primaryFiles) {
+      auto PSPs = Instance.getPrimarySpecificPathsForSourceFile(*sourceFile);
+      auto OutputFilename = PSPs.OutputFilename;
+      auto OS = getFileOutputStream(OutputFilename, Instance.getASTContext());
+      sourceFile->dump(*OS);
+    }
+  } else {
+    // Some invocations don't have primary files. In that case, we default to
+    // looking for the main file and dumping it to `stdout`.
+    getPrimaryOrMainSourceFile(Invocation, Instance)->dump(llvm::outs());
   }
 }
 
@@ -742,7 +751,7 @@ static Optional<bool> dumpASTIfNeeded(CompilerInvocation &Invocation,
 
   case FrontendOptions::ActionType::DumpParse:
   case FrontendOptions::ActionType::DumpAST:
-    dumpAST(Instance);
+    dumpAST(Invocation, Instance);
     break;
 
   case FrontendOptions::ActionType::EmitImportedModules:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -686,18 +686,13 @@ static SourceFile *getPrimaryOrMainSourceFile(CompilerInvocation &Invocation,
 }
 
 /// Dumps the AST of all available primary source files. If corresponding output
-/// files were specified, use them; otherwise, dump the AST to stderr.
+/// files were specified, use them; otherwise, dump the AST to stdout.
 static void dumpAST(CompilerInstance &Instance) {
-  for(SourceFile *sourceFile: Instance.getPrimarySourceFiles()) {
+  for (SourceFile *sourceFile: Instance.getPrimarySourceFiles()) {
     const StringRef OutputFilename =
       Instance.getPrimarySpecificPathsForSourceFile(*sourceFile).OutputFilename;
-    // PSP.OutputFilename is "-" whenever the output should be written to the console.
-    if (OutputFilename == "-") {
-      sourceFile->dump();
-    } else {
-      auto OS = getFileOutputStream(OutputFilename, Instance.getMainModule()->getASTContext());
-      sourceFile->dump(*OS);
-    }
+    auto OS = getFileOutputStream(OutputFilename, Instance.getASTContext());
+    sourceFile->dump(*OS);
   }
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -685,6 +685,19 @@ static SourceFile *getPrimaryOrMainSourceFile(CompilerInvocation &Invocation,
   return SF;
 }
 
+static void dumpAST(CompilerInvocation &Invocation, CompilerInstance &Instance) {
+  SourceFile *sourceFile = getPrimaryOrMainSourceFile(Invocation, Instance);
+  const StringRef OutputFilename =
+  Instance.getPrimarySpecificPathsForSourceFile(*sourceFile).OutputFilename;
+  // PSP.OutputFilename is "-" whenever the output should be written to stdout.
+  if (OutputFilename == "-") {
+    sourceFile->dump();
+  } else {
+    auto OS = getFileOutputStream(OutputFilename, Instance.getMainModule()->getASTContext());
+    sourceFile->dump(*OS);
+  }
+}
+
 /// We may have been told to dump the AST (either after parsing or
 /// type-checking, which is already differentiated in
 /// CompilerInstance::performSema()), so dump or print the main source file and
@@ -728,7 +741,7 @@ static Optional<bool> dumpASTIfNeeded(CompilerInvocation &Invocation,
 
   case FrontendOptions::ActionType::DumpParse:
   case FrontendOptions::ActionType::DumpAST:
-    getPrimaryOrMainSourceFile(Invocation, Instance)->dump();
+    dumpAST(Invocation, Instance);
     break;
 
   case FrontendOptions::ActionType::EmitImportedModules:

--- a/test/Driver/actions.swift
+++ b/test/Driver/actions.swift
@@ -11,6 +11,10 @@
 // BASICC: 0: input, "{{.*}}actions.swift", swift
 // BASICC: 1: compile, {0}, object
 
+// RUN: %swiftc_driver -driver-print-actions -dump-ast %s 2>&1 | %FileCheck %s -check-prefix=BASICAST
+// BASICAST: 0: input, "{{.*}}actions.swift", swift
+// BASICAST: 1: compile, {0}, ast-dump
+
 // RUN: %swiftc_driver -driver-print-actions -emit-sil %s 2>&1 | %FileCheck %s -check-prefix=BASICSIL
 // BASICSIL: 0: input, "{{.*}}actions.swift", swift
 // BASICSIL: 1: compile, {0}, sil

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -7,6 +7,10 @@
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix COMPLEX %s < %t.complex.txt
 
+// RUN: %swiftc_driver -driver-print-jobs -dump-ast -target x86_64-apple-macosx10.9 %s 2>&1 > %t.ast.txt
+// RUN: %FileCheck %s < %t.ast.txt
+// RUN: %FileCheck -check-prefix AST %s < %t.ast.txt
+
 // RUN: %swiftc_driver -driver-print-jobs -emit-silgen -target x86_64-apple-macosx10.9 %s 2>&1 > %t.silgen.txt
 // RUN: %FileCheck %s < %t.silgen.txt
 // RUN: %FileCheck -check-prefix SILGEN %s < %t.silgen.txt
@@ -73,6 +77,10 @@
 // COMPLEX-DAG: -emit-reference-dependencies-path {{(.*/)?driver-compile[^ /]+}}.swiftdeps
 // COMPLEX: -o {{.+}}.o
 
+
+// AST: bin/swift
+// AST: -dump-ast
+// AST: -o -
 
 // SILGEN: bin/swift
 // SILGEN: -emit-silgen

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -9,7 +9,11 @@
 
 // RUN: %swiftc_driver -driver-print-jobs -dump-ast -target x86_64-apple-macosx10.9 %s 2>&1 > %t.ast.txt
 // RUN: %FileCheck %s < %t.ast.txt
-// RUN: %FileCheck -check-prefix AST %s < %t.ast.txt
+// RUN: %FileCheck -check-prefix AST-STDOUT %s < %t.ast.txt
+
+// RUN: %swiftc_driver -driver-print-jobs -dump-ast -target x86_64-apple-macosx10.9 %s -o output.ast > %t.ast.txt
+// RUN: %FileCheck %s < %t.ast.txt
+// RUN: %FileCheck -check-prefix AST-O %s < %t.ast.txt
 
 // RUN: %swiftc_driver -driver-print-jobs -emit-silgen -target x86_64-apple-macosx10.9 %s 2>&1 > %t.silgen.txt
 // RUN: %FileCheck %s < %t.silgen.txt
@@ -78,9 +82,13 @@
 // COMPLEX: -o {{.+}}.o
 
 
-// AST: bin/swift
-// AST: -dump-ast
-// AST: -o -
+// AST-STDOUT: bin/swift
+// AST-STDOUT: -dump-ast
+// AST-STDOUT: -o -
+
+// AST-O: bin/swift
+// AST-O: -dump-ast
+// AST-O: -o output.ast
 
 // SILGEN: bin/swift
 // SILGEN: -emit-silgen

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -118,14 +118,14 @@
 // DUPLICATE-NAME: note: filenames are used to distinguish private declarations with the same name
 
 // FILELIST: bin/swift
-// FILELIST: -filelist [[SOURCES:(["][^"]+|[^ ]+)sources([^"]+["]|[^ ]+)]]
-// FILELIST: -primary-filelist  [[PRIMARY_FILELIST:(["][^"]+|[^ ]+)primaryInputs([^"]+["]|[^ ]+)]]
-// FILELIST: -supplementary-output-file-map [[SUPPLEMENTARY_OUTPUT_FILEMAP:(["][^"]+|[^ ]+)supplementaryOutputs([^"]+["]|[^ ]+)]]
+// FILELIST: -filelist [[SOURCES:(["][^"]+sources[^"]+["]|[^ ]+sources[^ ]+)]]
+// FILELIST: -primary-filelist  {{(["][^"]+primaryInputs[^"]+["]|[^ ]+primaryInputs[^ ]+)}}
+// FILELIST: -supplementary-output-file-map {{(["][^"]+supplementaryOutputs[^"]+["]|[^ ]+supplementaryOutputs[^ ]+)}}
 // FILELIST: -output-filelist {{[^-]}}
 // FILELIST-NEXT: bin/swift
 // FILELIST: -filelist [[SOURCES]]
-// FILELIST: -primary-filelist  {{(["][^"]+|[^ ]+)primaryInputs([^"]+["]|[^ ]+)}}
-// FILELIST: -supplementary-output-file-map {{(["][^"]+|[^ ]+)supplementaryOutputs([^"]+["]|[^ ]+)}}
+// FILELIST: -primary-filelist  {{(["][^"]+primaryInputs[^"]+["]|[^ ]+primaryInputs[^ ]+)}}
+// FILELIST: -supplementary-output-file-map {{(["][^"]+supplementaryOutputs[^"]+["]|[^ ]+supplementaryOutputs[^ ]+)}}
 // FILELIST: -output-filelist {{[^-]}}
 
 // UPDATE-CODE: DISTINCTIVE-PATH/usr/bin/swift

--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -6,16 +6,16 @@
 // CHECK-NOT: Handled
 // CHECK: Handled a.swift
 // CHECK-NEXT: Supplementary "./a.swift":
-// CHECK-NEXT: Supplementary swiftdoc: "./a.swiftdoc"
 // CHECK-NEXT: Supplementary swiftmodule: "./a.swiftmodule"
+// CHECK-NEXT: Supplementary swiftdoc: "./a.swiftdoc"
 // CHECK-NEXT: Handled b.swift
 // CHECK-NEXT: Supplementary "./b.swift":
-// CHECK-NEXT: Supplementary swiftdoc: "./b.swiftdoc"
 // CHECK-NEXT: Supplementary swiftmodule: "./b.swiftmodule"
+// CHECK-NEXT: Supplementary swiftdoc: "./b.swiftdoc"
 // CHECK-NEXT: Handled c.swift
 // CHECK-NEXT: Supplementary "./c.swift":
-// CHECK-NEXT: Supplementary swiftdoc: "./c.swiftdoc"
 // CHECK-NEXT: Supplementary swiftmodule: "./c.swiftmodule"
+// CHECK-NEXT: Supplementary swiftdoc: "./c.swiftdoc"
 // CHECK-NEXT: Handled modules
 // CHECK-NOT: Handled
 

--- a/test/Frontend/ast-dump.swift
+++ b/test/Frontend/ast-dump.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: echo 'public func a() { }' >%t/a.swift
+// RUN: echo 'public func b() { }' >%t/b.swift
+// RUN: echo 'public func main() {a(); b()}' >%t/main.swift
+
+// Test printing to stdout
+// RUN: %target-swift-frontend -dump-ast -primary-file %t/a.swift %t/b.swift %t/main.swift -module-name main -o - 2>&1 | %FileCheck -check-prefix A-AST %s
+// RUN: %target-swift-frontend -dump-ast %t/a.swift -primary-file %t/b.swift %t/main.swift -module-name main -o - 2>&1 | %FileCheck -check-prefix B-AST %s
+// RUN: %target-swift-frontend -dump-ast %t/a.swift %t/b.swift -primary-file %t/main.swift -module-name main -o - 2>&1 | %FileCheck -check-prefix MAIN-AST %s
+
+// Test printing to files
+// RUN: %target-swift-frontend -dump-ast -primary-file %t/a.swift %t/b.swift %t/main.swift -module-name main -o %t/a.ast
+// RUN: %FileCheck -check-prefix A-AST %s < %t/a.ast
+// RUN: %target-swift-frontend -dump-ast %t/a.swift -primary-file %t/b.swift %t/main.swift -module-name main -o %t/b.ast
+// RUN: %FileCheck -check-prefix B-AST %s < %t/b.ast
+// RUN: %target-swift-frontend -dump-ast %t/a.swift %t/b.swift -primary-file %t/main.swift -module-name main -o %t/main.ast
+// RUN: %FileCheck -check-prefix MAIN-AST %s < %t/main.ast
+
+// Test batch mode
+// RUN: %target-swift-frontend -dump-ast -primary-file %t/a.swift -primary-file %t/b.swift -primary-file %t/main.swift -module-name main -o %t/a_batch.ast -o %t/b_batch.ast -o %t/main_batch.ast
+// RUN: %FileCheck -check-prefix A-AST %s < %t/a_batch.ast
+// RUN: %FileCheck -check-prefix B-AST %s < %t/b_batch.ast
+// RUN: %FileCheck -check-prefix MAIN-AST %s < %t/main_batch.ast
+
+
+// Check a.swift's AST
+// A-AST: (source_file "{{.*}}a.swift"
+// A-AST-NEXT: (func_decl
+// A-AST-SAME: "a()"
+
+// Check b.swift's AST
+// B-AST: (source_file "{{[^)]*}}b.swift"
+// B-AST-NEXT: (func_decl
+// B-AST-SAME: "b()"
+
+// Check main.swift's AST
+// MAIN-AST: (source_file "{{.*}}main.swift"
+// MAIN-AST-NEXT: (func_decl {{[^)]*}} "main()" interface type='() -> ()' access=public
+// MAIN-AST: (call_expr
+// MAIN-AST-NEXT: decl=main.(file).a()@{{.*}}a.swift
+// MAIN-AST-NEXT: (tuple_expr type='()'
+// MAIN-AST: (call_expr
+// MAIN-AST-NEXT: decl=main.(file).b()@{{.*}}b.swift
+// MAIN-AST-NEXT: (tuple_expr type='()'

--- a/test/Frontend/ast-dump.swift
+++ b/test/Frontend/ast-dump.swift
@@ -24,21 +24,30 @@
 
 
 // Check a.swift's AST
-// A-AST: (source_file "{{.*}}a.swift"
+// A-AST: (source_file
+// A-AST-SAME: a.swift
+
 // A-AST-NEXT: (func_decl
-// A-AST-SAME: "a()"
+// A-AST-SAME: a()
+
 
 // Check b.swift's AST
-// B-AST: (source_file "{{[^)]*}}b.swift"
+// B-AST: (source_file
+// B-AST-SAME: b.swift
+
 // B-AST-NEXT: (func_decl
-// B-AST-SAME: "b()"
+// B-AST-SAME: b()
+
 
 // Check main.swift's AST
-// MAIN-AST: (source_file "{{.*}}main.swift"
-// MAIN-AST-NEXT: (func_decl {{[^)]*}} "main()" interface type='() -> ()' access=public
+// MAIN-AST: (source_file
+// MAIN-AST-SAME: main.swift
+
+// MAIN-AST: (func_decl
+// MAIN-AST-SAME: main()
+
 // MAIN-AST: (call_expr
-// MAIN-AST-NEXT: decl=main.(file).a()@{{.*}}a.swift
-// MAIN-AST-NEXT: (tuple_expr type='()'
+// MAIN-AST-NEXT: a()
+
 // MAIN-AST: (call_expr
-// MAIN-AST-NEXT: decl=main.(file).b()@{{.*}}b.swift
-// MAIN-AST-NEXT: (tuple_expr type='()'
+// MAIN-AST-NEXT: b()

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -1,5 +1,5 @@
 // RUN: not %target-swift-frontend -dump-parse %s 2>&1 | %FileCheck %s
-// RUN: not %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s -check-prefix=CHECK-AST
+// RUN: not %target-swift-frontend -dump-ast %s | %FileCheck %s -check-prefix=CHECK-AST
 
 // CHECK-LABEL: (func_decl{{.*}}"foo(_:)"
 // CHECK-AST-LABEL: (func_decl{{.*}}"foo(_:)"

--- a/test/NameBinding/import-resolution-overload.swift
+++ b/test/NameBinding/import-resolution-overload.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_vars.swift
 // RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -verify
 
-// RUN: not %target-swift-frontend -dump-ast %s -I %t -sdk "" > %t.astdump 2>&1
+// RUN: not %target-swift-frontend -dump-ast %s -I %t -sdk "" > %t.astdump
 // RUN: %FileCheck %s < %t.astdump
 
 import overload_intFunctions

--- a/test/Parse/if_expr.swift
+++ b/test/Parse/if_expr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
 // CHECK: (func_decl{{.*}}"r13756261(_:_:)"
 func r13756261(_ x: Bool, _ y: Int) -> Int {

--- a/test/Parse/multiline_normalize_newline.swift
+++ b/test/Parse/multiline_normalize_newline.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -dump-parse %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -dump-parse %s | %FileCheck %s
 
 // CR
 _ = """"""

--- a/test/Parse/multiline_string.swift
+++ b/test/Parse/multiline_string.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
 import Swift
 

--- a/test/Parse/raw_string.swift
+++ b/test/Parse/raw_string.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck --strict-whitespace %s
 
 import Swift
 

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 4.2 -verify -dump-ast -enable-resilience %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-ON %s
-// RUN: %target-swift-frontend -typecheck -swift-version 4.2 -verify -dump-ast -enable-resilience -enable-testing %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-ON %s
-// RUN: not %target-swift-frontend -typecheck -swift-version 4.2 -dump-ast %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-OFF %s
-// RUN: not %target-swift-frontend -typecheck -swift-version 4.2 -dump-ast %s -enable-testing 2>&1 | %FileCheck --check-prefix=RESILIENCE-OFF %s
+// RUN: %target-swift-frontend -typecheck -swift-version 4.2 -verify -dump-ast -enable-resilience %s | %FileCheck --check-prefix=RESILIENCE-ON %s
+// RUN: %target-swift-frontend -typecheck -swift-version 4.2 -verify -dump-ast -enable-resilience -enable-testing %s | %FileCheck --check-prefix=RESILIENCE-ON %s
+// RUN: not %target-swift-frontend -typecheck -swift-version 4.2 -dump-ast %s | %FileCheck --check-prefix=RESILIENCE-OFF %s
+// RUN: not %target-swift-frontend -typecheck -swift-version 4.2 -dump-ast %s -enable-testing | %FileCheck --check-prefix=RESILIENCE-OFF %s
 
 //
 // Public types with @_fixed_layout are always fixed layout

--- a/test/attr/attr_native_dynamic.swift
+++ b/test/attr/attr_native_dynamic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 5 -typecheck -dump-ast %s 2>&1 | %FileCheck  %s
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -dump-ast %s | %FileCheck  %s
 
 struct Strukt {
   // CHECK: (struct_decl {{.*}} "Strukt"

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference
 // RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference | %FileCheck %s
-// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference 2> %t.dump
-// RUN: %FileCheck -check-prefix CHECK-DUMP %s < %t.dump
+// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference > %t.ast
+// RUN: %FileCheck -check-prefix CHECK-DUMP %s < %t.ast
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/decl/protocol/associated_type_overrides.swift
+++ b/test/decl/protocol/associated_type_overrides.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -dump-ast %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -dump-ast %s | %FileCheck %s
 
 protocol P1 {
   associatedtype A

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -disable-nskeyedarchiver-diagnostics 2>&1 | %FileCheck -check-prefix CHECK-NO-DIAGS %s
 
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast 2> %t.ast
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast > %t.ast
 // RUN: %FileCheck %s < %t.ast
 
 // REQUIRES: objc_interop

--- a/test/decl/protocol/conforms/nscoding_availability_osx.swift
+++ b/test/decl/protocol/conforms/nscoding_availability_osx.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target x86_64-apple-macosx10.50 -verify
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target x86_64-apple-macosx10.50 -dump-ast 2> %t.ast
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target x86_64-apple-macosx10.50 -dump-ast > %t.ast
 // RUN: %FileCheck %s < %t.ast
 
 // REQUIRES: objc_interop

--- a/test/decl/protocol/override.swift
+++ b/test/decl/protocol/override.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -dump-ast > %t.ast 2>&1
+// RUN: %target-typecheck-verify-swift -dump-ast > %t.ast
 // RUN: %FileCheck %s < %t.ast
 
 // Test overriding of protocol members.

--- a/test/expr/capture/dynamic_self.swift
+++ b/test/expr/capture/dynamic_self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
 // CHECK: func_decl{{.*}}"clone()" interface type='(Android) -> () -> Self'
 

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
 func doSomething<T>(_ t: T) {}
 

--- a/test/expr/capture/nested.swift
+++ b/test/expr/capture/nested.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
 // CHECK: func_decl{{.*}}"foo2(_:)"
 func foo2(_ x: Int) -> (Int) -> (Int) -> Int {

--- a/test/expr/capture/top-level-guard.swift
+++ b/test/expr/capture/top-level-guard.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir %s > /dev/null
 
-// RUN: %target-swift-frontend -dump-ast -DVAR %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -dump-ast -DVAR %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir -DVAR %s > /dev/null
 
 // CHECK: (top_level_code_decl

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -6,7 +6,7 @@
 // FIXME: END -enable-source-import hackaround
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -typecheck %s -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -dump-ast -verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -dump-ast -verify | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -dump-ast 2> %t.ast
+// RUN: %target-typecheck-verify-swift -dump-ast > %t.ast
 // RUN: %FileCheck %s < %t.ast
 
 // Verify that upcasts of array literals upcast the individual elements in place


### PR DESCRIPTION
This adds two things:
- Calling `swiftc -dump-ast foo.swift [...] -o foo.ast` will dump the AST to the file `foo.ast`, instead of dumping it to `stderr` as usual.
- Calling `swiftc -dump-ast -output-file-map=outputFileMap.json *.swift [...]`, given an `outputFileMap.json` file that contains entries in the form `"ast-dump": "foo.ast"`, will dump the ASTs of the input files to their respective output files in the file map.

This should serve as a valid workaround to a bug mentioned in [the forums](https://forums.swift.org/t/error-when-dumping-the-ast-for-hundreds-of-files/17578) where the AST dump functionality crashes when called with too many input files. A few implementation details were also discussed in the same forum post.

As an aside, this also fixes a comment in `include/swift/Basic/PrimarySpecificPaths.h` that was incorrect.
