### PR TITLE
[AST] AssociatedTypeDecls cannot override itself

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3210,6 +3210,7 @@ AssociatedTypeDecl *AssociatedTypeDecl::getAssociatedTypeAnchor() const {
   // Find the best anchor among the anchors of the overridden decls.
   AssociatedTypeDecl *bestAnchor = nullptr;
   for (auto assocType : overridden) {
+    assert(this != assocType && "AssociatedTypeDecl cannot override itself");
     auto anchor = assocType->getAssociatedTypeAnchor();
     if (!bestAnchor || compare(anchor, bestAnchor) < 0)
       bestAnchor = anchor;


### PR DESCRIPTION
This makes a validation test crash reliably via `assert()` instead of relying on stack/memory exhaustion.