### PR TITLE
build: add a dependency target for non-stdlib builds

### DIFF
--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -25,6 +25,8 @@ if(SWIFT_BUILD_STDLIB)
     C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}
     LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
     INSTALL_IN_COMPONENT dev)
+else()
+  add_custom_target(swiftReflection-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})
 endif()
 
 # Build a specific version for the host with the host toolchain.  This is going


### PR DESCRIPTION
When building without the standard library, we need to create the dependency
target manually to track the dependencies internally.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
