### PR TITLE
[String] Expunge Unicode parser, en/de/transcoder from ABI

### DIFF
--- a/stdlib/public/core/ASCII.swift
+++ b/stdlib/public/core/ASCII.swift
@@ -18,35 +18,26 @@ extension Unicode.ASCII : Unicode.Encoding {
   public typealias CodeUnit = UInt8
   public typealias EncodedScalar = CollectionOfOne<CodeUnit>
 
-  @inlinable // FIXME(sil-serialize-all)
   public static var encodedReplacementCharacter : EncodedScalar {
     return EncodedScalar(0x1a) // U+001A SUBSTITUTE; best we can do for ASCII
   }
 
-  @inline(__always)
-  @inlinable
   public static func _isScalar(_ x: CodeUnit) -> Bool {
     return true
   }
 
-  @inline(__always)
   @inlinable
   public static func decode(_ source: EncodedScalar) -> Unicode.Scalar {
     return Unicode.Scalar(_unchecked: UInt32(
         source.first._unsafelyUnwrappedUnchecked))
   }
   
-  @inline(__always)
   @inlinable
-  public static func encode(
-    _ source: Unicode.Scalar
-  ) -> EncodedScalar? {
+  public static func encode(_ source: Unicode.Scalar) -> EncodedScalar? {
     guard source.value < (1&<<7) else { return nil }
     return EncodedScalar(UInt8(truncatingIfNeeded: source.value))
   }
 
-  @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
   public static func transcode<FromEncoding : Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
@@ -64,9 +55,7 @@ extension Unicode.ASCII : Unicode.Encoding {
     return encode(FromEncoding.decode(content))
   }
 
-  @_fixed_layout // FIXME(sil-serialize-all)
   public struct Parser {
-    @inlinable // FIXME(sil-serialize-all)
     public init() { }
   }
   
@@ -78,7 +67,6 @@ extension Unicode.ASCII.Parser : Unicode.Parser {
   public typealias Encoding = Unicode.ASCII
 
   /// Parses a single Unicode scalar value from `input`.
-  @inlinable // FIXME(sil-serialize-all)
   public mutating func parseScalar<I : IteratorProtocol>(
     from input: inout I
   ) -> Unicode.ParseResult<Encoding.EncodedScalar>

--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -19,19 +19,18 @@ public struct _UIntBuffer<
   Storage: UnsignedInteger & FixedWidthInteger, 
   Element: UnsignedInteger & FixedWidthInteger
 > {
-  public var _storage: Storage
-  public var _bitCount: UInt8
+  @usableFromInline
+  internal var _storage: Storage
+  @usableFromInline
+  internal var _bitCount: UInt8
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
-  public init(_storage: Storage, _bitCount: UInt8) {
+  @inlinable
+  internal init(_storage: Storage, _bitCount: UInt8) {
     self._storage = _storage
     self._bitCount = _bitCount
   }
   
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
-  public init(containing e: Element) {
+  internal init(containing e: Element) {
     _storage = Storage(truncatingIfNeeded: e)
     _bitCount = UInt8(truncatingIfNeeded: Element.bitWidth)
   }
@@ -42,12 +41,8 @@ extension _UIntBuffer : Sequence {
   
   @_fixed_layout
   public struct Iterator : IteratorProtocol, Sequence {
-    @inlinable // FIXME(sil-serialize-all)
-    @inline(__always)
-    public init(_ x: _UIntBuffer) { _impl = x }
+    internal init(_ x: _UIntBuffer) { _impl = x }
     
-    @inlinable // FIXME(sil-serialize-all)
-    @inline(__always)
     public mutating func next() -> Element? {
       if _impl._bitCount == 0 { return nil }
       defer {
@@ -56,71 +51,48 @@ extension _UIntBuffer : Sequence {
       }
       return Element(truncatingIfNeeded: _impl._storage)
     }
-    public
+    internal
     var _impl: _UIntBuffer
   }
   
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public func makeIterator() -> Iterator {
     return Iterator(self)
   }
 }
 
 extension _UIntBuffer : Collection {  
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout
   public struct Index : Comparable {
-    @usableFromInline
     internal var bitOffset: UInt8
     
-    @inlinable // FIXME(sil-serialize-all)
     internal init(bitOffset: UInt8) { self.bitOffset = bitOffset }
     
-    @inlinable // FIXME(sil-serialize-all)
     public static func == (lhs: Index, rhs: Index) -> Bool {
       return lhs.bitOffset == rhs.bitOffset
     }
-    @inlinable // FIXME(sil-serialize-all)
     public static func < (lhs: Index, rhs: Index) -> Bool {
       return lhs.bitOffset < rhs.bitOffset
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  public var startIndex : Index {
-    @inline(__always)
-    get { return Index(bitOffset: 0) }
-  }
+  public var startIndex : Index { return Index(bitOffset: 0) }
   
-  @inlinable // FIXME(sil-serialize-all)
-  public var endIndex : Index {
-    @inline(__always)
-    get { return Index(bitOffset: _bitCount) }
-  }
+  public var endIndex : Index { return Index(bitOffset: _bitCount) }
   
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public func index(after i: Index) -> Index {
     return Index(bitOffset: i.bitOffset &+ _elementWidth)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal var _elementWidth : UInt8 {
     return UInt8(truncatingIfNeeded: Element.bitWidth)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
   public subscript(i: Index) -> Element {
-    @inline(__always)
-    get {
-      return Element(truncatingIfNeeded: _storage &>> i.bitOffset)
-    }
+    return Element(truncatingIfNeeded: _storage &>> i.bitOffset)
   }
 }
 
 extension _UIntBuffer : BidirectionalCollection {
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public func index(before i: Index) -> Index {
     return Index(bitOffset: i.bitOffset &- _elementWidth)
   }
@@ -129,61 +101,44 @@ extension _UIntBuffer : BidirectionalCollection {
 extension _UIntBuffer : RandomAccessCollection {
   public typealias Indices = DefaultIndices<_UIntBuffer>
   
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     let x = Int(i.bitOffset) &+ n &* Element.bitWidth
     return Index(bitOffset: UInt8(truncatingIfNeeded: x))
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public func distance(from i: Index, to j: Index) -> Int {
     return (Int(j.bitOffset) &- Int(i.bitOffset)) / Element.bitWidth
   }
 }
 
 extension FixedWidthInteger {
-  @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
   internal func _fullShiftLeft<N: FixedWidthInteger>(_ n: N) -> Self {
     return (self &<< ((n &+ 1) &>> 1)) &<< (n &>> 1)
   }
-  @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
   internal func _fullShiftRight<N: FixedWidthInteger>(_ n: N) -> Self {
     return (self &>> ((n &+ 1) &>> 1)) &>> (n &>> 1)
   }
-  @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
   internal static func _lowBits<N: FixedWidthInteger>(_ n: N) -> Self {
     return ~((~0 as Self)._fullShiftLeft(n))
   }
 }
 
 extension Range {
-  @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
   internal func _contains_(_ other: Range) -> Bool {
     return other.clamped(to: self) == other
   }
 }
 
 extension _UIntBuffer : RangeReplaceableCollection {
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public init() {
     _storage = 0
     _bitCount = 0
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public var capacity: Int {
     return Storage.bitWidth / Element.bitWidth
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public mutating func append(_ newElement: Element) {
     _debugPrecondition(count + 1 <= capacity)
     _storage &= ~(Storage(Element.max) &<< _bitCount)
@@ -191,8 +146,6 @@ extension _UIntBuffer : RangeReplaceableCollection {
     _bitCount = _bitCount &+ _elementWidth
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   @discardableResult
   public mutating func removeFirst() -> Element {
     _debugPrecondition(!isEmpty)
@@ -202,8 +155,6 @@ extension _UIntBuffer : RangeReplaceableCollection {
     return result
   }
   
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public mutating func replaceSubrange<C: Collection>(
     _ target: Range<Index>, with replacement: C
   ) where C.Element == Element {

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_frozen // FIXME(sil-serialize-all)
   public enum UTF16 {
   case _swift3Buffer(Unicode.UTF16.ForwardParser)
   }
@@ -20,28 +19,20 @@ extension Unicode.UTF16 : Unicode.Encoding {
   public typealias CodeUnit = UInt16
   public typealias EncodedScalar = _UIntBuffer<UInt32, UInt16>
 
-  @inlinable // FIXME(sil-serialize-all)
-  internal static var _replacementCodeUnit: CodeUnit {
-    @inline(__always) get { return 0xfffd }
-  }
+  internal static var _replacementCodeUnit: CodeUnit { return 0xfffd }
   
-  @inlinable // FIXME(sil-serialize-all)
   public static var encodedReplacementCharacter : EncodedScalar {
     return EncodedScalar(_storage: 0xFFFD, _bitCount: 16)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func _isASCII(_ x: CodeUnit) -> Bool  {
     return x <= 0x7f
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func _isScalar(_ x: CodeUnit) -> Bool  {
     return x & 0xf800 != 0xd800
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   internal static func _decodeSurrogates(
     _ lead: CodeUnit,
     _ trail: CodeUnit
@@ -53,7 +44,7 @@ extension Unicode.UTF16 : Unicode.Encoding {
         (UInt32(lead & 0x03ff) &<< 10 | UInt32(trail & 0x03ff)))
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public static func decode(_ source: EncodedScalar) -> Unicode.Scalar {
     let bits = source._storage
     if _fastPath(source._bitCount == 16) {
@@ -66,7 +57,7 @@ extension Unicode.UTF16 : Unicode.Encoding {
     return Unicode.Scalar(_unchecked: value)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public static func encode(
     _ source: Unicode.Scalar
   ) -> EncodedScalar? {
@@ -81,8 +72,6 @@ extension Unicode.UTF16 : Unicode.Encoding {
     return EncodedScalar(_storage: r, _bitCount: 32)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public static func transcode<FromEncoding : Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
@@ -125,18 +114,14 @@ extension Unicode.UTF16 : Unicode.Encoding {
     return encode(FromEncoding.decode(content))
   }
   
-  @_fixed_layout // FIXME(sil-serialize-all)
   public struct ForwardParser {
     public typealias _Buffer = _UIntBuffer<UInt32, UInt16>
-    @inlinable // FIXME(sil-serialize-all)
     public init() { _buffer = _Buffer() }
     public var _buffer: _Buffer
   }
   
-  @_fixed_layout // FIXME(sil-serialize-all)
   public struct ReverseParser {
     public typealias _Buffer = _UIntBuffer<UInt32, UInt16>
-    @inlinable // FIXME(sil-serialize-all)
     public init() { _buffer = _Buffer() }
     public var _buffer: _Buffer
   }
@@ -145,7 +130,6 @@ extension Unicode.UTF16 : Unicode.Encoding {
 extension UTF16.ReverseParser : Unicode.Parser, _UTFParser {
   public typealias Encoding = Unicode.UTF16
 
-  @inlinable // FIXME(sil-serialize-all)
   public func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8) {
     _sanityCheck(  // this case handled elsewhere
       !Encoding._isScalar(UInt16(truncatingIfNeeded: _buffer._storage)))
@@ -155,7 +139,6 @@ extension UTF16.ReverseParser : Unicode.Parser, _UTFParser {
     return (false, 1*16)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
     return Encoding.EncodedScalar(
       _storage:
@@ -168,7 +151,6 @@ extension UTF16.ReverseParser : Unicode.Parser, _UTFParser {
 extension Unicode.UTF16.ForwardParser : Unicode.Parser, _UTFParser {
   public typealias Encoding = Unicode.UTF16
   
-  @inlinable // FIXME(sil-serialize-all)
   public func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8) {
     _sanityCheck(  // this case handled elsewhere
       !Encoding._isScalar(UInt16(truncatingIfNeeded: _buffer._storage)))
@@ -178,7 +160,6 @@ extension Unicode.UTF16.ForwardParser : Unicode.Parser, _UTFParser {
     return (false, 1*16)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
     var r = _buffer
     r._bitCount = bitCount

--- a/stdlib/public/core/UTF32.swift
+++ b/stdlib/public/core/UTF32.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_frozen // FIXME(sil-serialize-all)
+  @_frozen
   public enum UTF32 {
   case _swift3Codec
   }
@@ -20,39 +20,29 @@ extension Unicode.UTF32 : Unicode.Encoding {
   public typealias CodeUnit = UInt32
   public typealias EncodedScalar = CollectionOfOne<UInt32>
 
-  @inlinable // FIXME(sil-serialize-all)
-  internal static var _replacementCodeUnit: CodeUnit {
-    @inline(__always) get { return 0xFFFD }
-  }
+  internal static var _replacementCodeUnit: CodeUnit { return 0xFFFD }
   
-  @inlinable // FIXME(sil-serialize-all)
   public static var encodedReplacementCharacter : EncodedScalar {
     return EncodedScalar(_replacementCodeUnit)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public static func _isScalar(_ x: CodeUnit) -> Bool  {
     return true
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
+  @inlinable
   public static func decode(_ source: EncodedScalar) -> Unicode.Scalar {
     return Unicode.Scalar(_unchecked: source.first!)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
+  @inlinable
   public static func encode(
     _ source: Unicode.Scalar
   ) -> EncodedScalar? {
     return EncodedScalar(source.value)
   }
   
-  @_fixed_layout // FIXME(sil-serialize-all)
   public struct Parser {
-    @inlinable // FIXME(sil-serialize-all)
     public init() { }
   }
   
@@ -64,7 +54,6 @@ extension UTF32.Parser : Unicode.Parser {
   public typealias Encoding = Unicode.UTF32
 
   /// Parses a single Unicode scalar value from `input`.
-  @inlinable // FIXME(sil-serialize-all)
   public mutating func parseScalar<I : IteratorProtocol>(
     from input: inout I
   ) -> Unicode.ParseResult<Encoding.EncodedScalar>

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -18,20 +18,16 @@ extension Unicode {
 
 extension Unicode.UTF8 : _UnicodeEncoding {
   public typealias CodeUnit = UInt8
-  public typealias EncodedScalar = _ValidUTF8Buffer<UInt32>
+  public typealias EncodedScalar = _ValidUTF8Buffer
 
-  @inlinable // FIXME(sil-serialize-all)
   public static var encodedReplacementCharacter : EncodedScalar {
     return EncodedScalar.encodedReplacementCharacter
   }
 
-  @inline(__always)
-  @inlinable
   public static func _isScalar(_ x: CodeUnit) -> Bool {
     return x & 0x80 == 0
   }
 
-  @inline(__always)
   @inlinable
   public static func decode(_ source: EncodedScalar) -> Unicode.Scalar {
     switch source.count {
@@ -59,7 +55,6 @@ extension Unicode.UTF8 : _UnicodeEncoding {
     }
   }
   
-  @inline(__always)
   @inlinable
   public static func encode(
     _ source: Unicode.Scalar
@@ -88,8 +83,6 @@ extension Unicode.UTF8 : _UnicodeEncoding {
       _biasedBits: (o | c ) &+ 0b0__1000_0001__1000_0001__1000_0001__1111_0001)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public static func transcode<FromEncoding : _UnicodeEncoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
@@ -120,20 +113,14 @@ extension Unicode.UTF8 : _UnicodeEncoding {
     return encode(FromEncoding.decode(content))
   }
 
-  @_fixed_layout
   public struct ForwardParser {
     public typealias _Buffer = _UIntBuffer<UInt32, UInt8>
-    @inline(__always)
-    @inlinable
     public init() { _buffer = _Buffer() }
     public var _buffer: _Buffer
   }
   
-  @_fixed_layout
   public struct ReverseParser {
     public typealias _Buffer = _UIntBuffer<UInt32, UInt8>
-    @inline(__always)
-    @inlinable
     public init() { _buffer = _Buffer() }
     public var _buffer: _Buffer
   }
@@ -141,8 +128,6 @@ extension Unicode.UTF8 : _UnicodeEncoding {
 
 extension UTF8.ReverseParser : Unicode.Parser, _UTFParser {
   public typealias Encoding = Unicode.UTF8
-  @inline(__always)
-  @inlinable
   public func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8) {
     _sanityCheck(_buffer._storage & 0x80 != 0) // this case handled elsewhere
     if _buffer._storage                & 0b0__1110_0000__1100_0000
@@ -176,8 +161,6 @@ extension UTF8.ReverseParser : Unicode.Parser, _UTFParser {
 
   /// Returns the length of the invalid sequence that ends with the LSB of
   /// buffer.
-  @inline(never)
-  @usableFromInline
   internal func _invalidLength() -> UInt8 {
     if _buffer._storage                 & 0b0__1111_0000__1100_0000
                                        == 0b0__1110_0000__1000_0000 {
@@ -206,8 +189,6 @@ extension UTF8.ReverseParser : Unicode.Parser, _UTFParser {
     return 1
   }
   
-  @inline(__always)
-  @inlinable
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
     let x = UInt32(truncatingIfNeeded: _buffer._storage.byteSwapped)
     let shift = 32 &- bitCount
@@ -218,8 +199,6 @@ extension UTF8.ReverseParser : Unicode.Parser, _UTFParser {
 extension Unicode.UTF8.ForwardParser : Unicode.Parser, _UTFParser {
   public typealias Encoding = Unicode.UTF8
 
-  @inline(__always)
-  @inlinable
   public func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8) {
     _sanityCheck(_buffer._storage & 0x80 != 0) // this case handled elsewhere
     
@@ -254,7 +233,6 @@ extension Unicode.UTF8.ForwardParser : Unicode.Parser, _UTFParser {
   /// Returns the length of the invalid sequence that starts with the LSB of
   /// buffer.
   @inline(never)
-  @usableFromInline
   internal func _invalidLength() -> UInt8 {
     if _buffer._storage               & 0b0__1100_0000__1111_0000
                                      == 0b0__1000_0000__1110_0000 {
@@ -277,7 +255,6 @@ extension Unicode.UTF8.ForwardParser : Unicode.Parser, _UTFParser {
     return 1
   }
   
-  @inlinable // FIXME(sil-serialize-all)
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
     let x = UInt32(_buffer._storage) &+ 0x01010101
     return _ValidUTF8Buffer(_biasedBits: x & ._lowBits(bitCount))

--- a/stdlib/public/core/UTFEncoding.swift
+++ b/stdlib/public/core/UTFEncoding.swift
@@ -28,8 +28,6 @@ public protocol _UTFParser {
 extension _UTFParser
 where Encoding.EncodedScalar : RangeReplaceableCollection {
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public mutating func parseScalar<I : IteratorProtocol>(
     from input: inout I
   ) -> Unicode.ParseResult<Encoding.EncodedScalar>

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -141,7 +141,6 @@ public protocol UnicodeCodec : Unicode.Encoding {
 /// units.
 extension Unicode.UTF8 : UnicodeCodec {
   /// Creates an instance of the UTF-8 codec.
-  @inlinable // FIXME(sil-serialize-all)
   public init() { self = ._swift3Buffer(ForwardParser()) }
 
   /// Starts or continues decoding a UTF-8 sequence.
@@ -185,8 +184,6 @@ extension Unicode.UTF8 : UnicodeCodec {
   /// - Returns: A `UnicodeDecodingResult` instance, representing the next
   ///   Unicode scalar, an indication of an error, or an indication that the
   ///   UTF sequence has been fully decoded.
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public mutating func decode<I : IteratorProtocol>(
     _ input: inout I
   ) -> UnicodeDecodingResult where I.Element == CodeUnit {
@@ -218,7 +215,6 @@ extension Unicode.UTF8 : UnicodeCodec {
   /// - Requires: There is at least one used byte in `buffer`, and the unused
   ///   space in `buffer` is filled with some value not matching the UTF-8
   ///   continuation byte form (`0b10xxxxxx`).
-  @inlinable // FIXME(sil-serialize-all)
   public // @testable
   static func _decodeOne(_ buffer: UInt32) -> (result: UInt32?, length: UInt8) {
     // Note the buffer is read least significant byte first: [ #3 #2 #1 #0 ].
@@ -258,8 +254,6 @@ extension Unicode.UTF8 : UnicodeCodec {
   ///   - input: The Unicode scalar value to encode.
   ///   - processCodeUnit: A closure that processes one code unit argument at a
   ///     time.
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
   public static func encode(
     _ input: Unicode.Scalar,
     into processCodeUnit: (CodeUnit) -> Void
@@ -294,19 +288,16 @@ extension Unicode.UTF8 : UnicodeCodec {
   ///
   /// - Parameter byte: A UTF-8 code unit.
   /// - Returns: `true` if `byte` is a continuation byte; otherwise, `false`.
-  @inlinable // FIXME(sil-serialize-all)
   public static func isContinuation(_ byte: CodeUnit) -> Bool {
     return byte & 0b11_00__0000 == 0b10_00__0000
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func _nullCodeUnitOffset(
     in input: UnsafePointer<CodeUnit>
   ) -> Int {
     return Int(_swift_stdlib_strlen_unsigned(input))
   }
   // Support parsing C strings as-if they are UTF8 strings.
-  @inlinable // FIXME(sil-serialize-all)
   public static func _nullCodeUnitOffset(
     in input: UnsafePointer<CChar>
   ) -> Int {
@@ -318,7 +309,6 @@ extension Unicode.UTF8 : UnicodeCodec {
 /// units.
 extension Unicode.UTF16 : UnicodeCodec {
   /// Creates an instance of the UTF-16 codec.
-  @inlinable // FIXME(sil-serialize-all)
   public init() { self = ._swift3Buffer(ForwardParser()) }
 
   /// Starts or continues decoding a UTF-16 sequence.
@@ -362,7 +352,6 @@ extension Unicode.UTF16 : UnicodeCodec {
   /// - Returns: A `UnicodeDecodingResult` instance, representing the next
   ///   Unicode scalar, an indication of an error, or an indication that the
   ///   UTF sequence has been fully decoded.
-  @inlinable // FIXME(sil-serialize-all)
   public mutating func decode<I : IteratorProtocol>(
     _ input: inout I
   ) -> UnicodeDecodingResult where I.Element == CodeUnit {
@@ -380,7 +369,6 @@ extension Unicode.UTF16 : UnicodeCodec {
   /// Try to decode one Unicode scalar, and return the actual number of code
   /// units it spanned in the input.  This function may consume more code
   /// units than required for this scalar.
-  @inlinable // FIXME(sil-serialize-all)
   internal mutating func _decodeOne<I : IteratorProtocol>(
     _ input: inout I
   ) -> (UnicodeDecodingResult, Int) where I.Element == CodeUnit {
@@ -413,7 +401,6 @@ extension Unicode.UTF16 : UnicodeCodec {
   ///   - input: The Unicode scalar value to encode.
   ///   - processCodeUnit: A closure that processes one code unit argument at a
   ///     time.
-  @inlinable // FIXME(sil-serialize-all)
   public static func encode(
     _ input: Unicode.Scalar,
     into processCodeUnit: (CodeUnit) -> Void
@@ -430,7 +417,6 @@ extension Unicode.UTF16 : UnicodeCodec {
 /// units.
 extension Unicode.UTF32 : UnicodeCodec {
   /// Creates an instance of the UTF-32 codec.
-  @inlinable // FIXME(sil-serialize-all)
   public init() { self = ._swift3Codec }
 
   /// Starts or continues decoding a UTF-32 sequence.
@@ -474,14 +460,12 @@ extension Unicode.UTF32 : UnicodeCodec {
   /// - Returns: A `UnicodeDecodingResult` instance, representing the next
   ///   Unicode scalar, an indication of an error, or an indication that the
   ///   UTF sequence has been fully decoded.
-  @inlinable // FIXME(sil-serialize-all)
   public mutating func decode<I : IteratorProtocol>(
     _ input: inout I
   ) -> UnicodeDecodingResult where I.Element == CodeUnit {
     return UTF32._decode(&input)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal static func _decode<I : IteratorProtocol>(
     _ input: inout I
   ) -> UnicodeDecodingResult where I.Element == CodeUnit {
@@ -510,7 +494,6 @@ extension Unicode.UTF32 : UnicodeCodec {
   ///   - input: The Unicode scalar value to encode.
   ///   - processCodeUnit: A closure that processes one code unit argument at a
   ///     time.
-  @inlinable // FIXME(sil-serialize-all)
   public static func encode(
     _ input: Unicode.Scalar,
     into processCodeUnit: (CodeUnit) -> Void
@@ -554,8 +537,6 @@ extension Unicode.UTF32 : UnicodeCodec {
 ///     unit at a time.
 /// - Returns: `true` if the translation detected encoding errors in `input`;
 ///   otherwise, `false`.
-@inlinable // FIXME(sil-serialize-all)
-@inline(__always)
 public func transcode<
   Input : IteratorProtocol,
   InputEncoding : Unicode.Encoding,
@@ -604,12 +585,10 @@ protocol _StringElement {
 }
 
 extension UTF16.CodeUnit : _StringElement {
-  @inlinable // FIXME(sil-serialize-all)
   public // @testable
   static func _toUTF16CodeUnit(_ x: UTF16.CodeUnit) -> UTF16.CodeUnit {
     return x
   }
-  @inlinable // FIXME(sil-serialize-all)
   public // @testable
   static func _fromUTF16CodeUnit(
     _ utf16: UTF16.CodeUnit
@@ -619,13 +598,11 @@ extension UTF16.CodeUnit : _StringElement {
 }
 
 extension UTF8.CodeUnit : _StringElement {
-  @inlinable // FIXME(sil-serialize-all)
   public // @testable
   static func _toUTF16CodeUnit(_ x: UTF8.CodeUnit) -> UTF16.CodeUnit {
     _sanityCheck(x <= 0x7f, "should only be doing this with ASCII")
     return UTF16.CodeUnit(truncatingIfNeeded: x)
   }
-  @inlinable // FIXME(sil-serialize-all)
   public // @testable
   static func _fromUTF16CodeUnit(
     _ utf16: UTF16.CodeUnit
@@ -659,7 +636,7 @@ extension UTF16 {
   ///
   /// - Parameter x: A Unicode scalar value.
   /// - Returns: The width of `x` when encoded in UTF-16, either `1` or `2`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public static func width(_ x: Unicode.Scalar) -> Int {
     return x.value <= 0xFFFF ? 1 : 2
   }
@@ -681,7 +658,7 @@ extension UTF16 {
   ///   surrogate pair when encoded in UTF-16. To check whether `x` is
   ///   represented by a surrogate pair, use `UTF16.width(x) == 2`.
   /// - Returns: The leading surrogate code unit of `x` when encoded in UTF-16.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public static func leadSurrogate(_ x: Unicode.Scalar) -> UTF16.CodeUnit {
     _precondition(width(x) == 2)
     return 0xD800 + UTF16.CodeUnit(truncatingIfNeeded:
@@ -705,7 +682,7 @@ extension UTF16 {
   ///   surrogate pair when encoded in UTF-16. To check whether `x` is
   ///   represented by a surrogate pair, use `UTF16.width(x) == 2`.
   /// - Returns: The trailing surrogate code unit of `x` when encoded in UTF-16.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public static func trailSurrogate(_ x: Unicode.Scalar) -> UTF16.CodeUnit {
     _precondition(width(x) == 2)
     return 0xDC00 + UTF16.CodeUnit(truncatingIfNeeded:
@@ -733,7 +710,7 @@ extension UTF16 {
   /// - Parameter x: A UTF-16 code unit.
   /// - Returns: `true` if `x` is a high-surrogate code unit; otherwise,
   ///   `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public static func isLeadSurrogate(_ x: CodeUnit) -> Bool {
     return (x & 0xFC00) == 0xD800
   }
@@ -760,12 +737,11 @@ extension UTF16 {
   /// - Parameter x: A UTF-16 code unit.
   /// - Returns: `true` if `x` is a low-surrogate code unit; otherwise,
   ///   `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public static func isTrailSurrogate(_ x: CodeUnit) -> Bool {
     return (x & 0xFC00) == 0xDC00
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public // @testable
   static func _copy<T : _StringElement, U : _StringElement>(
     source: UnsafeMutablePointer<T>,
@@ -820,7 +796,6 @@ extension UTF16 {
   ///   contained only ASCII characters. If `repairingIllFormedSequences` is
   ///   `false` and an ill-formed sequence is detected, this method returns
   ///   `nil`.
-  @inlinable // FIXME(sil-serialize-all)
   public static func transcodedLength<
     Input : IteratorProtocol,
     Encoding : Unicode.Encoding
@@ -876,7 +851,7 @@ extension UTF16 {
 extension Unicode.Scalar {
   /// Create an instance with numeric value `value`, bypassing the regular
   /// precondition checks for code point validity.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   internal init(_unchecked value: UInt32) {
     _sanityCheck(value < 0xD800 || value > 0xDFFF,
       "high- and low-surrogate code points are not valid Unicode scalar values")
@@ -887,7 +862,6 @@ extension Unicode.Scalar {
 }
 
 extension UnicodeCodec {
-  @inlinable // FIXME(sil-serialize-all)
   public static func _nullCodeUnitOffset(
     in input: UnsafePointer<CodeUnit>
   ) -> Int {
@@ -914,6 +888,6 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
 }
 
 /// A namespace for Unicode utilities.
-@_frozen // FIXME(sil-serialize-all)
+@_frozen
 public enum Unicode {}
 

--- a/stdlib/public/core/UnicodeEncoding.swift
+++ b/stdlib/public/core/UnicodeEncoding.swift
@@ -62,10 +62,8 @@ public protocol _UnicodeEncoding {
 
 extension _UnicodeEncoding {
   // See note on declaration of requirement, above
-  @inlinable // FIXME(sil-serialize-all)
   public static func _isScalar(_ x: CodeUnit) -> Bool { return false }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func transcode<FromEncoding : Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
@@ -75,7 +73,6 @@ extension _UnicodeEncoding {
   /// Converts from encoding-independent to encoded representation, returning
   /// `encodedReplacementCharacter` if the scalar can't be represented in this
   /// encoding.
-  @inlinable // FIXME(sil-serialize-all)
   internal static func _encode(_ content: Unicode.Scalar) -> EncodedScalar {
     return encode(content) ?? encodedReplacementCharacter
   }
@@ -83,7 +80,6 @@ extension _UnicodeEncoding {
   /// Converts a scalar from another encoding's representation, returning
   /// `encodedReplacementCharacter` if the scalar can't be represented in this
   /// encoding.
-  @inlinable // FIXME(sil-serialize-all)
   internal static func _transcode<FromEncoding : Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar {
@@ -91,7 +87,6 @@ extension _UnicodeEncoding {
       ?? encodedReplacementCharacter
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal static func _transcode<
   Source: Sequence, SourceEncoding: Unicode.Encoding>(
     _ source: Source,

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -451,7 +451,6 @@ func _ascii16(_ c: Unicode.Scalar) -> UTF16.CodeUnit {
 }
 
 extension Unicode.Scalar {
-  @inlinable // FIXME(sil-serialize-all)
   internal static var _replacementCharacter: Unicode.Scalar {
     return Unicode.Scalar(_value: UTF32._replacementCodeUnit)
   }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -75,3 +75,94 @@ Class _StringStorage is now without @_fixed_layout
 Class _SharedStringStorage has removed conformance to _NSStringCore
 Class _StringStorage has removed conformance to _NSStringCore
 Protocol _NSStringCore has been removed
+
+
+Constructor _ValidUTF8Buffer.Iterator.init(_:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Constructor _ValidUTF8Buffer.init() has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.Index.<(_:_:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.Index.==(_:_:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.Iterator.next() has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.append(_:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.append(contentsOf:) has generic signature change from <τ_0_0, τ_1_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger, τ_1_0 : FixedWidthInteger, τ_1_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.distance(from:to:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.index(_:offsetBy:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.index(after:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.index(before:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.makeIterator() has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.removeFirst() has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Func _ValidUTF8Buffer.replaceSubrange(_:with:) has generic signature change from <τ_0_0, τ_1_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger, τ_1_0 : Collection, τ_1_0.Element == UInt8> to <τ_0_0 where τ_0_0 : Collection, τ_0_0.Element == UInt8>
+Struct _ValidUTF8Buffer has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Struct _ValidUTF8Buffer.Index has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Struct _ValidUTF8Buffer.Iterator has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Subscript _ValidUTF8Buffer.subscript(_:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Constructor _UIntBuffer.Index.init(bitOffset:) has been removed
+Constructor _ValidUTF8Buffer.Index.init(_biasedBits:) has been removed
+Func FixedWidthInteger._fullShiftLeft(_:) has been removed
+Func FixedWidthInteger._fullShiftRight(_:) has been removed
+Func FixedWidthInteger._lowBits(_:) has been removed
+Func Range._contains_(_:) has been removed
+Func Unicode.UTF16._decodeOne(_:) has been removed
+Func Unicode.UTF16._decodeSurrogates(_:_:) has been removed
+Func Unicode.UTF32._decode(_:) has been removed
+Func Unicode.UTF8.ForwardParser._invalidLength() has been removed
+Func Unicode.UTF8.ReverseParser._invalidLength() has been removed
+Func _UnicodeEncoding._encode(_:) has been removed
+Func _UnicodeEncoding._transcode(_:from:) has been removed
+Func _UnicodeEncoding._transcode(_:from:into:) has been removed
+Func _ValidUTF8Buffer._isValid(_:) has been removed
+
+Var Unicode.Scalar._replacementCharacter has been removed
+Var Unicode.UTF16._replacementCodeUnit has been removed
+Var Unicode.UTF32._replacementCodeUnit has been removed
+Var _UIntBuffer._elementWidth has been removed
+Constructor _ValidUTF8Buffer.Iterator.init(_:) has parameter 0 type change from _ValidUTF8Buffer<τ_0_0> to _ValidUTF8Buffer
+Constructor _ValidUTF8Buffer.init() has return type change from _ValidUTF8Buffer<τ_0_0> to _ValidUTF8Buffer
+Enum Unicode.UTF8 has type witness type for _UnicodeEncoding.EncodedScalar changing from _ValidUTF8Buffer<UInt32> to _ValidUTF8Buffer
+Func Unicode.UTF8.ForwardParser._bufferedScalar(bitCount:) has return type change from _ValidUTF8Buffer<UInt32> to _ValidUTF8Buffer
+Func Unicode.UTF8.ReverseParser._bufferedScalar(bitCount:) has return type change from _ValidUTF8Buffer<UInt32> to _ValidUTF8Buffer
+Func Unicode.UTF8.decode(_:) has parameter 0 type change from _ValidUTF8Buffer<UInt32> to _ValidUTF8Buffer
+Func Unicode.UTF8.encode(_:) has return type change from Optional<_ValidUTF8Buffer<UInt32>> to Optional<_ValidUTF8Buffer>
+Func Unicode.UTF8.transcode(_:from:) has return type change from Optional<_ValidUTF8Buffer<UInt32>> to Optional<_ValidUTF8Buffer>
+Func _ValidUTF8Buffer.append(contentsOf:) has parameter 0 type change from _ValidUTF8Buffer<τ_1_0> to _ValidUTF8Buffer
+Struct _ValidUTF8Buffer has type witness type for BidirectionalCollection.Indices changing from DefaultIndices<_ValidUTF8Buffer<τ_0_0>> to DefaultIndices<_ValidUTF8Buffer>
+Struct _ValidUTF8Buffer has type witness type for BidirectionalCollection.SubSequence changing from Slice<_ValidUTF8Buffer<τ_0_0>> to Slice<_ValidUTF8Buffer>
+Struct _ValidUTF8Buffer has type witness type for Collection.Indices changing from DefaultIndices<_ValidUTF8Buffer<τ_0_0>> to DefaultIndices<_ValidUTF8Buffer>
+Struct _ValidUTF8Buffer has type witness type for Collection.SubSequence changing from Slice<_ValidUTF8Buffer<τ_0_0>> to Slice<_ValidUTF8Buffer>
+Struct _ValidUTF8Buffer has type witness type for RandomAccessCollection.Indices changing from DefaultIndices<_ValidUTF8Buffer<τ_0_0>> to DefaultIndices<_ValidUTF8Buffer>
+Struct _ValidUTF8Buffer has type witness type for RandomAccessCollection.SubSequence changing from Slice<_ValidUTF8Buffer<τ_0_0>> to Slice<_ValidUTF8Buffer>
+Struct _ValidUTF8Buffer has type witness type for RangeReplaceableCollection.SubSequence changing from Slice<_ValidUTF8Buffer<τ_0_0>> to Slice<_ValidUTF8Buffer>
+Struct _ValidUTF8Buffer has type witness type for Sequence.SubSequence changing from Slice<_ValidUTF8Buffer<τ_0_0>> to Slice<_ValidUTF8Buffer>
+Var Unicode.UTF8.encodedReplacementCharacter has declared type change from _ValidUTF8Buffer<UInt32> to _ValidUTF8Buffer
+Var _ValidUTF8Buffer.Index._biasedBits has declared type change from τ_0_0 to UInt32
+Var _ValidUTF8Buffer.Iterator._biasedBits has declared type change from τ_0_0 to UInt32
+Var _ValidUTF8Buffer._biasedBits has declared type change from τ_0_0 to UInt32
+Var _ValidUTF8Buffer.encodedReplacementCharacter has declared type change from _ValidUTF8Buffer<τ_0_0> to _ValidUTF8Buffer
+Enum Unicode.ASCII is now without @_frozen
+Enum Unicode.UTF16 is now without @_frozen
+Enum Unicode.UTF32 is now without @_frozen
+Enum Unicode.UTF8 is now without @_frozen
+Struct Unicode.ASCII.Parser is now without @_fixed_layout
+Struct Unicode.UTF16.ForwardParser is now without @_fixed_layout
+Struct Unicode.UTF16.ReverseParser is now without @_fixed_layout
+Struct Unicode.UTF32.Parser is now without @_fixed_layout
+Struct Unicode.UTF8.ForwardParser is now without @_fixed_layout
+Struct Unicode.UTF8.ReverseParser is now without @_fixed_layout
+EnumElement Unicode.UTF16._swift3Buffer is no longer a stored property
+EnumElement Unicode.UTF32._swift3Codec is no longer a stored property
+EnumElement Unicode.UTF8._swift3Buffer is no longer a stored property
+Var Unicode.UTF16.ForwardParser._buffer is no longer a stored property
+Var Unicode.UTF16.ReverseParser._buffer is no longer a stored property
+Var Unicode.UTF8.ForwardParser._buffer is no longer a stored property
+Var Unicode.UTF8.ReverseParser._buffer is no longer a stored property
+
+Constructor _UIntBuffer.Iterator.init(_:) has been removed
+Constructor _UIntBuffer.init(containing:) has been removed
+Constructor _ValidUTF8Buffer.init(_biasedBits:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Constructor _ValidUTF8Buffer.init(_biasedBits:) has parameter 0 type change from τ_0_0 to UInt32
+Constructor _ValidUTF8Buffer.init(_biasedBits:) has return type change from _ValidUTF8Buffer<τ_0_0> to _ValidUTF8Buffer
+Constructor _ValidUTF8Buffer.init(_containing:) has generic signature change from <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger> to
+Constructor _ValidUTF8Buffer.init(_containing:) has return type change from _ValidUTF8Buffer<τ_0_0> to _ValidUTF8Buffer
+Var _UIntBuffer.Iterator._impl has removed its setter
+Var _UIntBuffer._bitCount has removed its setter
+Var _UIntBuffer._storage has removed its setter
+

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -40,4 +40,5 @@ Constructor String.init(stringInterpolation:) has parameter 0 type change from [
 /* Decl Attribute changes */
 
 /* Protocol Requirement Changes */
+TypeAlias Unicode.UTF8.EncodedScalar has underlying type change from _ValidUTF8Buffer<UInt32> to _ValidUTF8Buffer
 Protocol StringProtocol has added inherited protocol ExpressibleByStringInterpolation


### PR DESCRIPTION
The built-in parsers suffer from a few problems:

1. They're obnoxious to use
2. They're really slow
3. They generate a ton of code
4. They slow down compilation time and optimization time
5. Their innards are hard-coded into our ABI
6. They're not used **anywhere** in all of Github*


\* Sole exception is SwiftNIO, who used it to do ASCII checking, but discovered it was a really bad idea for reasons \#2-4.

This PR attempts to very aggressively expunge them from our ABI. We might have to add back in some inlinable annotations, but the more freedom we can reserve for the future, the better.

It also does this to the encoders/decoders, with the goal of greatly reducing our ABI surface area.