### PR TITLE
SILOptimizer: avoid accessing the class properties if not necessary in redundant load elimination

### DIFF
--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -599,20 +599,7 @@ ProjectionPath::expandTypeIntoLeafProjectionPaths(SILType B, SILModule *Mod,
 
     LLVM_DEBUG(llvm::dbgs() << "Visiting type: " << Ty << "\n");
 
-    // Get the first level projection of the current type.
-    Projections.clear();
-    Projection::getFirstLevelProjections(Ty, *Mod, Projections);
-
-    // Reached the end of the projection tree, this field can not be expanded
-    // anymore.
-    if (Projections.empty()) {
-      LLVM_DEBUG(llvm::dbgs() << "    No projections. "
-                 "Finished projection list\n");
-      Paths.push_back(PP);
-      continue;
-    }
-
-    // If this is a class type, we also have reached the end of the type
+    // If this is a class type, we have reached the end of the type
     // tree for this type.
     //
     // We do not push its next level projection into the worklist,
@@ -631,6 +618,19 @@ ProjectionPath::expandTypeIntoLeafProjectionPaths(SILType B, SILModule *Mod,
     //
     if (Ty.getClassOrBoundGenericClass()) {
       LLVM_DEBUG(llvm::dbgs() << "    Found class. Finished projection list\n");
+      Paths.push_back(PP);
+      continue;
+    }
+
+    // Get the first level projection of the current type.
+    Projections.clear();
+    Projection::getFirstLevelProjections(Ty, *Mod, Projections);
+
+    // Reached the end of the projection tree, this field can not be expanded
+    // anymore.
+    if (Projections.empty()) {
+      LLVM_DEBUG(llvm::dbgs() << "    No projections. "
+                 "Finished projection list\n");
       Paths.push_back(PP);
       continue;
     }


### PR DESCRIPTION
The fix here is to just swap two bail-out conditions.
It's a NFC regarding the performed optimization, but it avoids importing class properties, which is not needed.

This is a speculative fix for rdar://problem/45806457
