### PR TITLE
 SIL: Private methods of open resilient classes don't need to be public 

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -912,6 +912,8 @@ SubclassScope SILDeclRef::getSubclassScope() const {
   case AccessLevel::Public:
     return SubclassScope::Internal;
   case AccessLevel::Open:
+    if (classType->isResilient())
+      return SubclassScope::Internal;
     return SubclassScope::External;
   }
 

--- a/test/IRGen/method_linkage.swift
+++ b/test/IRGen/method_linkage.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-resilience | %FileCheck %s --check-prefix=RESILIENT
 
 // Test if all methods which go into a vtable have at least the visibility of its class.
 // Reason: Derived classes from "outside" still have to put the less visible base members
@@ -17,22 +18,26 @@
 
 class Base {
   // CHECK: define hidden swiftcc void @"$s14method_linkage4Base{{.*}}3foo0
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage4Base{{.*}}3foo0
   @inline(never)
   fileprivate func foo() {
   }
 
   // CHECK: define internal swiftcc void @"$s14method_linkage4Base{{.*}}3bar0
+  // RESILIENT: define internal swiftcc void @"$s14method_linkage4Base{{.*}}3bar0
   @inline(never)
   fileprivate final func bar() {
   }
 
   // CHECK: define hidden swiftcc void @"$s14method_linkage4Base{{.*}}5other0
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage4Base{{.*}}5other0
   @inline(never)
   fileprivate func other() {
   }
 }
 class Derived : Base {
   // CHECK: define internal swiftcc void @"$s14method_linkage7Derived{{.*}}3foo0
+  // RESILIENT: define internal swiftcc void @"$s14method_linkage7Derived{{.*}}3foo0
   @inline(never)
   fileprivate final override func foo() {
   }
@@ -40,6 +45,7 @@ class Derived : Base {
 
 extension Base {
   // CHECK: define internal swiftcc void @"$s14method_linkage4Base{{.*}}7extfunc0
+  // RESILIENT: define internal swiftcc void @"$s14method_linkage4Base{{.*}}7extfunc0
   @inline(never)
   fileprivate func extfunc() {
   }
@@ -49,11 +55,13 @@ public class PublicClass {
   internal init() {}
 
   // CHECK: define hidden swiftcc void @"$s14method_linkage11PublicClass{{.*}}4pfoo0
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage11PublicClass{{.*}}4pfoo0
   @inline(never)
   fileprivate func pfoo() {
   }
 
   // CHECK: define hidden swiftcc void @"$s14method_linkage11PublicClassC4pbaryyF
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage11PublicClassC4pbaryyF
   @inline(never)
   internal func pbar() {
   }
@@ -63,11 +71,13 @@ open class OpenClass {
   internal init() {}
 
   // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage9OpenClassC4pfoo0
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage9OpenClassC4pfoo0
   @inline(never)
   fileprivate func pfoo() {
   }
 
   // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage9OpenClassC4pbaryyF
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage9OpenClassC4pbaryyF
   @inline(never)
   internal func pbar() {
   }

--- a/test/IRGen/vtable_symbol_linkage.swift
+++ b/test/IRGen/vtable_symbol_linkage.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
+
 // RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/BaseModule.%target-dylib-extension
 // RUN: %target-build-swift -I %t %s %t/BaseModule.%target-dylib-extension -o %t/a.out
+
+// RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/BaseModule.%target-dylib-extension -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience
+// RUN: %target-build-swift -I %t %s %t/BaseModule.%target-dylib-extension -o %t/a.out -Xfrontend -enable-class-resilience
 
 // Check if the program can be linked without undefined symbol errors.
 


### PR DESCRIPTION
Part of rdar://problem/40432647.