### PR TITLE
[stdlib] Fix the abi checker test for both assert and no-assert builds

### DIFF
--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -118,7 +118,6 @@ func _stdlib_atomicLoadARCRef(
 // These pieces are used in ThreadLocalStorage.swift in debug builds.
 // For tests, see similar functions from SwiftPrivate/AtomicInt.swift.gyb
 //===----------------------------------------------------------------------===//
-#if INTERNAL_CHECKS_ENABLED
 internal func _swift_stdlib_atomicLoadInt(
   object target: UnsafeMutablePointer<Int>) -> Int {
 #if arch(i386) || arch(arm)
@@ -133,7 +132,6 @@ internal func _swift_stdlib_atomicLoadInt(
 % for bits in [ 32, 64 ]:
 
 // Warning: no overflow checking.
-@inlinable // FIXME(sil-serialize-all)
 internal func _swift_stdlib_atomicFetchAddInt${bits}(
   object target: UnsafeMutablePointer<Int${bits}>,
   operand: Int${bits}) -> Int${bits} {
@@ -162,7 +160,6 @@ internal func _swift_stdlib_atomicFetchAddInt(
 #endif
   return Int(value)
 }
-#endif // INTERNAL_CHECKS_ENABLED
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -21,6 +21,8 @@ Func _stdlib_atomicCompareExchangeStrongInt64(object:expected:desired:) has been
 Func _stdlib_atomicCompareExchangeStrongUInt32(object:expected:desired:) has been removed
 Func _stdlib_atomicCompareExchangeStrongUInt64(object:expected:desired:) has been removed
 Func _swift_stdlib_atomicFetchAddInt(object:operand:) has been removed
+Func _swift_stdlib_atomicFetchAddInt32(object:operand:) has been removed
+Func _swift_stdlib_atomicFetchAddInt64(object:operand:) has been removed
 Func _swift_stdlib_atomicFetchAddUInt32(object:operand:) has been removed
 Func _swift_stdlib_atomicFetchAddUInt64(object:operand:) has been removed
 Func _swift_stdlib_atomicFetchAndInt(object:operand:) has been removed


### PR DESCRIPTION
A few internal functions were defined within the #if
INTERNAL_CHECKS_ENABLED block, which made the results different between
stdlib configurations with assertions enabled and without. Since these
fucntions are internal and are not @inlinable, it is OK to have them
unconditionally.

<rdar://problem/45880586>