### PR TITLE
[Frontend] Add experimental flag to skip non-inlinable function bodies

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -409,6 +409,15 @@ public:
         const_cast<DeclContext *>(this)->getInnermostDeclarationDeclContext();
   }
 
+  /// Returns the innermost context that is an AbstractFunctionDecl whose
+  /// body has been skipped.
+  LLVM_READONLY
+  DeclContext *getInnermostSkippedFunctionContext();
+  const DeclContext *getInnermostSkippedFunctionContext() const {
+    return
+        const_cast<DeclContext *>(this)->getInnermostSkippedFunctionContext();
+  }
+
   /// Returns the semantic parent of this context.  A context has a
   /// parent if and only if it is not a module context.
   DeclContext *getParent() const {

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -128,6 +128,9 @@ ERROR(error_mode_cannot_emit_module_source_info,none,
       "this mode does not support emitting module source info files", ())
 ERROR(error_mode_cannot_emit_interface,none,
       "this mode does not support emitting module interface files", ())
+ERROR(cannot_emit_ir_skipping_function_bodies,none,
+      "-experimental-skip-non-inlinable-function-bodies does not support "
+      "emitting IR", ())
 
 WARNING(emit_reference_dependencies_without_primary_file,none,
   "ignoring -emit-reference-dependencies (requires -primary-file)", ())

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -70,6 +70,9 @@ public:
   /// Whether to stop the optimization pipeline after serializing SIL.
   bool StopOptimizationAfterSerialization = false;
 
+  /// Whether to skip emitting non-inlinable function bodies.
+  bool SkipNonInlinableFunctionBodies = false;
+
   /// Optimization mode being used.
   OptimizationMode OptMode = OptimizationMode::NotSet;
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -180,6 +180,8 @@ public:
   /// \sa swift::SharedTimer
   bool DebugTimeCompilation = false;
 
+  bool SkipNonInlinableFunctionBodies = false;
+
   /// The path to which we should output statistics files.
   std::string StatsOutputDir;
 
@@ -339,6 +341,7 @@ private:
 
 public:
   static bool doesActionGenerateSIL(ActionType);
+  static bool doesActionGenerateIR(ActionType);
   static bool doesActionProduceOutput(ActionType);
   static bool doesActionProduceTextualOutput(ActionType);
   static bool needsProperModuleName(ActionType);

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -254,6 +254,10 @@ def stats_output_dir: Separate<["-"], "stats-output-dir">,
 def trace_stats_events: Flag<["-"], "trace-stats-events">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Trace changes to stats in -stats-output-dir">;
+def experimental_skip_non_inlinable_function_bodies:
+  Flag<["-"], "experimental-skip-non-inlinable-function-bodies">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Skip type-checking and SIL generation for non-inlinable function bodies">;
 def profile_stats_events: Flag<["-"], "profile-stats-events">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Profile changes to stats in -stats-output-dir">;

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -311,6 +311,9 @@ PASS(SimplifyUnreachableContainingBlocks, "simplify-unreachable-containing-block
      "Utility pass. Removes all non-term insts from blocks with unreachable terms")
 PASS(SerializeSILPass, "serialize-sil",
      "Utility pass. Serializes the current SILModule")
+PASS(NonInlinableFunctionSkippingChecker, "check-non-inlinable-function-skipping",
+     "Utility pass to ensure -experimental-skip-non-inlinable-function-bodies "
+     "skips everything it should")
 PASS(YieldOnceCheck, "yield-once-check",
     "Check correct usage of yields in yield-once coroutines")
 PASS(OSLogOptimization, "os-log-optimization", "Optimize os log calls")

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -187,6 +187,11 @@ namespace swift {
     /// If set, dumps wall time taken to type check each expression to
     /// llvm::errs().
     DebugTimeExpressions = 1 << 3,
+
+    /// If set, the typechecker will skip typechecking non-inlinable function
+    /// bodies. Set this if you're trying to quickly emit a module or module
+    /// interface without a full compilation.
+    SkipNonInlinableFunctionBodies = 1 << 4,
   };
 
   /// Once parsing and name-binding are complete, this walks the AST to resolve

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -231,6 +231,17 @@ Decl *DeclContext::getInnermostDeclarationDeclContext() {
   return nullptr;
 }
 
+DeclContext *DeclContext::getInnermostSkippedFunctionContext() {
+  auto dc = this;
+  do {
+    if (auto afd = dyn_cast<AbstractFunctionDecl>(dc))
+      if (afd->isBodySkipped())
+        return afd;
+  } while ((dc = dc->getParent()));
+
+  return nullptr;
+}
+
 DeclContext *DeclContext::getParentForLookup() const {
   if (isa<ProtocolDecl>(this) || isa<ExtensionDecl>(this)) {
     // If we are inside a protocol or an extension, skip directly

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -161,6 +161,12 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (checkUnusedSupplementaryOutputPaths())
     return true;
 
+  if (FrontendOptions::doesActionGenerateIR(Opts.RequestedAction)
+      && Opts.SkipNonInlinableFunctionBodies) {
+    Diags.diagnose(SourceLoc(), diag::cannot_emit_ir_skipping_function_bodies);
+    return true;
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_module_link_name))
     Opts.ModuleLinkName = A->getValue();
 
@@ -219,6 +225,8 @@ void ArgsToFrontendOptionsConverter::computeDebugTimeOptions() {
   Opts.DebugTimeExpressionTypeChecking |=
       Args.hasArg(OPT_debug_time_expression_type_checking);
   Opts.DebugTimeCompilation |= Args.hasArg(OPT_debug_time_compilation);
+  Opts.SkipNonInlinableFunctionBodies |=
+      Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies);
   if (const Arg *A = Args.getLastArg(OPT_stats_output_dir)) {
     Opts.StatsOutputDir = A->getValue();
     if (Args.getLastArg(OPT_trace_stats_events)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -763,6 +763,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_sil_merge_partial_modules))
     Opts.MergePartialModules = true;
 
+  if (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies))
+    Opts.SkipNonInlinableFunctionBodies = true;
+
   // Parse the optimization level.
   // Default to Onone settings if no option is passed.
   Opts.OptMode = OptimizationMode::NoOptimization;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -886,6 +886,9 @@ OptionSet<TypeCheckingFlags> CompilerInstance::computeTypeCheckingOptions() {
   if (options.DebugTimeExpressionTypeChecking) {
     TypeCheckOptions |= TypeCheckingFlags::DebugTimeExpressions;
   }
+  if (options.SkipNonInlinableFunctionBodies) {
+    TypeCheckOptions |= TypeCheckingFlags::SkipNonInlinableFunctionBodies;
+  }
   return TypeCheckOptions;
 }
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -520,6 +520,41 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   llvm_unreachable("unhandled action");
 }
 
+bool FrontendOptions::doesActionGenerateIR(ActionType action) {
+  switch (action) {
+  case ActionType::NoneAction:
+  case ActionType::Parse:
+  case ActionType::DumpParse:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::DumpAST:
+  case ActionType::EmitSyntax:
+  case ActionType::PrintAST:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::DumpTypeInfo:
+  case ActionType::CompileModuleFromInterface:
+  case ActionType::Typecheck:
+  case ActionType::ResolveImports:
+  case ActionType::MergeModules:
+  case ActionType::EmitModuleOnly:
+  case ActionType::EmitPCH:
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIL:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::EmitImportedModules:
+    return false;
+  case ActionType::Immediate:
+  case ActionType::REPL:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitObject:
+    return true;
+  }
+  llvm_unreachable("unhandled action");
+}
+
 
 const PrimarySpecificPaths &
 FrontendOptions::getPrimarySpecificPathsForAtMostOnePrimary() const {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1669,9 +1669,13 @@ void SILGenModule::emitSourceFile(SourceFile *sf) {
     visit(D);
   }
 
-  for (Decl *D : sf->LocalTypeDecls) {
-    FrontendStatsTracer StatsTracer(getASTContext().Stats, "SILgen-tydecl", D);
-    visit(D);
+  for (TypeDecl *TD : sf->LocalTypeDecls) {
+    FrontendStatsTracer StatsTracer(getASTContext().Stats, "SILgen-tydecl", TD);
+    // FIXME: Delayed parsing would prevent these types from being added to the
+    //        module in the first place.
+    if (TD->getDeclContext()->getInnermostSkippedFunctionContext())
+      continue;
+    visit(TD);
   }
 }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -102,6 +102,14 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   // there.
   const auto &Options = P.getOptions();
   P.addClosureLifetimeFixup();
+
+#ifndef NDEBUG
+  // Add a verification pass to check our work when skipping non-inlinable
+  // function bodies.
+  if (Options.SkipNonInlinableFunctionBodies)
+    P.addNonInlinableFunctionSkippingChecker();
+#endif
+
   if (Options.shouldOptimize()) {
     P.addSemanticARCOpts();
     P.addDestroyHoisting();

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -7,6 +7,7 @@ silopt_register_sources(
   BugReducerTester.cpp
   CFGPrinter.cpp
   CallerAnalysisPrinter.cpp
+  NonInlinableFunctionSkippingChecker.cpp
   ComputeDominanceInfo.cpp
   ComputeLoopInfo.cpp
   ConstantEvaluatorTester.cpp

--- a/lib/SILOptimizer/UtilityPasses/NonInlinableFunctionSkippingChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/NonInlinableFunctionSkippingChecker.cpp
@@ -1,0 +1,107 @@
+//===------------- NonInlinableFunctionSkippingChecker.cpp ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+
+/// Determines whether we should have skipped SILGenning a function that
+/// appears in a SILModule. This only applies when
+/// \c -experimental-skip-non-inlinable-function-bodies is enabled.
+static bool shouldHaveSkippedFunction(const SILFunction &F) {
+  assert(F.getModule().getOptions().SkipNonInlinableFunctionBodies &&
+         "this check only makes sense if we're skipping function bodies");
+
+  // First, we only care about functions that haven't been marked serialized.
+  // If they've been marked serialized, they will end up in the final module
+  // and we needed to SILGen them.
+  if (F.isSerialized())
+    return false;
+
+  // Next, we're looking for functions that shouldn't have a body, but do. If
+  // the function doesn't have a body (i.e. it's an external declaration), we
+  // skipped it successfully.
+  if (F.isExternalDeclaration())
+    return false;
+
+  // Thunks and specializations are automatically synthesized, so it's fine that
+  // they end up in the module.
+  if (F.isThunk() || F.isSpecialization())
+    return false;
+
+  // FIXME: We can probably skip property initializers, too.
+  auto func = F.getLocation().getAsASTNode<AbstractFunctionDecl>();
+  if (!func)
+    return false;
+
+  // If a body is synthesized/implicit, it shouldn't be skipped.
+  if (func->isImplicit())
+    return false;
+
+  // Local function bodies in inlinable code are okay to show up in the module.
+  if (func->getDeclContext()->isLocalContext())
+    return false;
+
+  // FIXME: Identify __ivar_destroyer, __allocating_init, and
+  //        __deallocating_deinit, which have no special marking, are always
+  //        emitted, and do have a source location with the original decl
+  //        attached.
+  if (isa<DestructorDecl>(func) || isa<ConstructorDecl>(func))
+    return false;
+
+  // If none of those conditions trip, then this is something that _should_
+  // be serialized in the module even when we're skipping non-inlinable
+  // function bodies.
+  return true;
+}
+
+namespace {
+
+/// This is a verification utility pass that's meant to be used with
+/// \c -experimental-skip-non-inlinable-function-bodies. It checks all the
+/// functions in a module and ensures that, if the function was written in
+/// source and not serialized, then it wasn't even SILGen'd.
+class NonInlinableFunctionSkippingChecker : public SILModuleTransform {
+  void run() override {
+    // Skip this if we're not skipping function bodies
+    if (!getModule()->getOptions().SkipNonInlinableFunctionBodies)
+      return;
+
+    // Skip this verification for SwiftOnoneSupport
+    if (getModule()->isOptimizedOnoneSupportModule())
+      return;
+
+    for (auto &F : *getModule()) {
+      if (!shouldHaveSkippedFunction(F))
+        continue;
+
+      llvm::dbgs() << "Function serialized that should have been skipped!\n";
+      F.getLocation().dump(F.getModule().getSourceManager());
+      llvm::dbgs() << "\n";
+      F.dump();
+      abort();
+    }
+  }
+
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createNonInlinableFunctionSkippingChecker() {
+  return new NonInlinableFunctionSkippingChecker();
+}

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1765,6 +1765,82 @@ static void validatePrecedenceGroup(PrecedenceGroupDecl *PGD) {
   }
 }
 
+static Optional<unsigned>
+getParamIndex(const ParameterList *paramList, const ParamDecl *decl) {
+  ArrayRef<ParamDecl *> params = paramList->getArray();
+  for (unsigned i = 0; i < params.size(); ++i) {
+    if (params[i] == decl) return i;
+  }
+  return None;
+}
+
+static void
+checkInheritedDefaultValueRestrictions(TypeChecker &TC, ParamDecl *PD) {
+  if (PD->getDefaultArgumentKind() != DefaultArgumentKind::Inherited)
+    return;
+
+  auto *DC = PD->getInnermostDeclContext();
+  const SourceFile *SF = DC->getParentSourceFile();
+  assert((SF && SF->Kind == SourceFileKind::Interface || PD->isImplicit()) &&
+         "explicit inherited default argument outside of a module interface?");
+
+  // The containing decl should be a designated initializer.
+  auto ctor = dyn_cast<ConstructorDecl>(DC);
+  if (!ctor || ctor->isConvenienceInit()) {
+    TC.diagnose(
+        PD, diag::inherited_default_value_not_in_designated_constructor);
+    return;
+  }
+
+  // The decl it overrides should also be a designated initializer.
+  auto overridden = ctor->getOverriddenDecl();
+  if (!overridden || overridden->isConvenienceInit()) {
+    TC.diagnose(
+        PD, diag::inherited_default_value_used_in_non_overriding_constructor);
+    if (overridden)
+      TC.diagnose(overridden, diag::overridden_here);
+    return;
+  }
+
+  // The corresponding parameter should have a default value.
+  Optional<unsigned> idx = getParamIndex(ctor->getParameters(), PD);
+  assert(idx && "containing decl does not contain param?");
+  ParamDecl *equivalentParam = overridden->getParameters()->get(*idx);
+  if (equivalentParam->getDefaultArgumentKind() == DefaultArgumentKind::None) {
+    TC.diagnose(PD, diag::corresponding_param_not_defaulted);
+    TC.diagnose(equivalentParam, diag::inherited_default_param_here);
+  }
+}
+
+/// Check the default arguments that occur within this pattern.
+static void checkDefaultArguments(TypeChecker &tc, ParameterList *params,
+                                  ValueDecl *VD) {
+  for (auto *param : *params) {
+    checkInheritedDefaultValueRestrictions(tc, param);
+    if (!param->getDefaultValue() ||
+        !param->hasInterfaceType() ||
+        param->getInterfaceType()->hasError())
+      continue;
+
+    Expr *e = param->getDefaultValue();
+    auto *initContext = param->getDefaultArgumentInitContext();
+
+    auto resultTy =
+        tc.typeCheckParameterDefault(e, initContext, param->getType(),
+                                    /*isAutoClosure=*/param->isAutoClosure());
+
+    if (resultTy) {
+      param->setDefaultValue(e);
+    }
+
+    tc.checkInitializerErrorHandling(initContext, e);
+
+    // Walk the checked initializer and contextualize any closures
+    // we saw there.
+    (void)tc.contextualizeInitializer(initContext, e);
+  }
+}
+
 PrecedenceGroupDecl *TypeChecker::lookupPrecedenceGroup(DeclContext *dc,
                                                         Identifier name,
                                                         SourceLoc nameLoc) {
@@ -2384,7 +2460,7 @@ public:
     (void) SD->getImplInfo();
 
     TC.checkParameterAttributes(SD->getIndices());
-    TC.checkDefaultArguments(SD->getIndices(), SD);
+    checkDefaultArguments(TC, SD->getIndices(), SD);
 
     if (SD->getDeclContext()->getSelfClassDecl()) {
       checkDynamicSelfType(SD, SD->getValueInterfaceType());
@@ -2982,6 +3058,8 @@ public:
 
     if (FD->getDeclContext()->getSelfClassDecl())
       checkDynamicSelfType(FD, FD->getResultInterfaceType());
+
+    checkDefaultArguments(TC, FD->getParameters(), FD);
   }
 
   void visitModuleDecl(ModuleDecl *) { }
@@ -2997,7 +3075,7 @@ public:
 
     if (auto *PL = EED->getParameterList()) {
       TC.checkParameterAttributes(PL);
-      TC.checkDefaultArguments(PL, EED);
+      checkDefaultArguments(TC, PL, EED);
     }
 
     // Yell if our parent doesn't have a raw type but we have a raw value.
@@ -3252,6 +3330,8 @@ public:
     } else {
       TC.definedFunctions.push_back(CD);
     }
+
+    checkDefaultArguments(TC, CD->getParameters(), CD);
   }
 
   void visitDestructorDecl(DestructorDecl *DD) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1835,82 +1835,6 @@ Stmt *StmtChecker::visitBraceStmt(BraceStmt *BS) {
   return BS;
 }
 
-static Optional<unsigned>
-getParamIndex(const ParameterList *paramList, const ParamDecl *decl) {
-  ArrayRef<ParamDecl *> params = paramList->getArray();
-  for (unsigned i = 0; i < params.size(); ++i) {
-    if (params[i] == decl) return i;
-  }
-  return None;
-}
-
-static void
-checkInheritedDefaultValueRestrictions(TypeChecker &TC, ParamDecl *PD) {
-  if (PD->getDefaultArgumentKind() != DefaultArgumentKind::Inherited)
-    return;
-
-  auto *DC = PD->getInnermostDeclContext();
-  const SourceFile *SF = DC->getParentSourceFile();
-  assert((SF && SF->Kind == SourceFileKind::Interface || PD->isImplicit()) &&
-         "explicit inherited default argument outside of a module interface?");
-
-  // The containing decl should be a designated initializer.
-  auto ctor = dyn_cast<ConstructorDecl>(DC);
-  if (!ctor || ctor->isConvenienceInit()) {
-    TC.diagnose(
-        PD, diag::inherited_default_value_not_in_designated_constructor);
-    return;
-  }
-
-  // The decl it overrides should also be a designated initializer.
-  auto overridden = ctor->getOverriddenDecl();
-  if (!overridden || overridden->isConvenienceInit()) {
-    TC.diagnose(
-        PD, diag::inherited_default_value_used_in_non_overriding_constructor);
-    if (overridden)
-      TC.diagnose(overridden, diag::overridden_here);
-    return;
-  }
-
-  // The corresponding parameter should have a default value.
-  Optional<unsigned> idx = getParamIndex(ctor->getParameters(), PD);
-  assert(idx && "containing decl does not contain param?");
-  ParamDecl *equivalentParam = overridden->getParameters()->get(*idx);
-  if (equivalentParam->getDefaultArgumentKind() == DefaultArgumentKind::None) {
-    TC.diagnose(PD, diag::corresponding_param_not_defaulted);
-    TC.diagnose(equivalentParam, diag::inherited_default_param_here);
-  }
-}
-
-/// Check the default arguments that occur within this pattern.
-void TypeChecker::checkDefaultArguments(ParameterList *params,
-                                        ValueDecl *VD) {
-  for (auto *param : *params) {
-    checkInheritedDefaultValueRestrictions(*this, param);
-    if (!param->getDefaultValue() ||
-        !param->hasInterfaceType() ||
-        param->getInterfaceType()->hasError())
-      continue;
-
-    Expr *e = param->getDefaultValue();
-    auto *initContext = param->getDefaultArgumentInitContext();
-
-    auto resultTy =
-        typeCheckParameterDefault(e, initContext, param->getType(),
-                                  /*isAutoClosure=*/param->isAutoClosure());
-
-    if (resultTy) {
-      param->setDefaultValue(e);
-    }
-
-    checkInitializerErrorHandling(initContext, e);
-
-    // Walk the checked initializer and contextualize any closures
-    // we saw there.
-    (void)contextualizeInitializer(initContext, e);
-  }
-}
-
 void TypeChecker::checkRawValueExpr(EnumDecl *ED, EnumElementDecl *EED) {
   Type rawTy = ED->getRawType();
   Expr *rawValue = EED->getRawValueExpr();
@@ -2159,7 +2083,6 @@ TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
 
   // FIXME(InterfaceTypeRequest): Remove this.
   (void)AFD->getInterfaceType();
-  tc.checkDefaultArguments(AFD->getParameters(), AFD);
 
   BraceStmt *body = AFD->getBody();
   if (!body || AFD->isBodyTypeChecked())

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -393,6 +393,13 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
     if (Options.contains(TypeCheckingFlags::ForImmediateMode))
       TC.setInImmediateMode(true);
 
+    if (Options.contains(TypeCheckingFlags::SkipNonInlinableFunctionBodies))
+      // Disable this optimization if we're compiling SwiftOnoneSupport, because
+      // we _definitely_ need to look inside every declaration to figure out
+      // what gets prespecialized.
+      if (!SF.getParentModule()->isOnoneSupportModule())
+        TC.setSkipNonInlinableBodies(true);
+
     // Lookup the swift module.  This ensures that we record all known
     // protocols in the AST.
     (void) TC.getStdlibModule(&SF);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1006,11 +1006,9 @@ public:
   Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
                                    ReferenceOwnershipAttr *attr);
 
-  /// Check the default arguments that occur within this value decl.
-  void checkDefaultArguments(ParameterList *params, ValueDecl *VD);
   /// Check the raw value expression in this enum element.
   void checkRawValueExpr(EnumDecl *parent, EnumElementDecl *Elt);
-
+  
   virtual void resolveDeclSignature(ValueDecl *VD) override {
     validateDecl(VD);
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -616,6 +616,10 @@ private:
   /// when executing scripts.
   bool InImmediateMode = false;
 
+  /// Indicate that the type checker should skip type-checking non-inlinable
+  /// function bodies.
+  bool SkipNonInlinableFunctionBodies = false;
+
   /// Closure expressions whose bodies have already been prechecked as
   /// part of trying to apply a function builder.
   llvm::DenseMap<ClosureExpr *, FunctionBuilderClosurePreCheck>
@@ -705,6 +709,14 @@ public:
   /// considering a switch statement "too complex".
   void setSwitchCheckingInvocationThreshold(unsigned invocationCount) {
     SwitchCheckingInvocationThreshold = invocationCount;
+  }
+
+  void setSkipNonInlinableBodies(bool skip) {
+    SkipNonInlinableFunctionBodies = skip;
+  }
+
+  bool canSkipNonInlinableBodies() const {
+    return SkipNonInlinableFunctionBodies;
   }
 
   bool getInImmediateMode() {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4602,8 +4602,15 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
     nextFile->getOpaqueReturnTypeDecls(opaqueReturnTypeDecls);
 
     for (auto TD : localTypeDecls) {
+
+      // FIXME: We should delay parsing function bodies so these type decls
+      //        don't even get added to the file.
+      if (TD->getDeclContext()->getInnermostSkippedFunctionContext())
+        continue;
+
       hasLocalTypes = true;
       Mangle::ASTMangler Mangler;
+
       std::string MangledName =
           evaluateOrDefault(M->getASTContext().evaluator,
                             MangleLocalTypeDeclRequest { TD },

--- a/test/Frontend/skip-non-inlinable-function-bodies.swift
+++ b/test/Frontend/skip-non-inlinable-function-bodies.swift
@@ -1,0 +1,248 @@
+// RUN: %empty-directory(%t)
+
+// 1. Make sure you can't -emit-ir or -c when you're skipping non-inlinable function bodies
+
+// RUN: not %target-swift-frontend -emit-ir %s -experimental-skip-non-inlinable-function-bodies %s 2>&1 | %FileCheck %s --check-prefix ERROR
+// RUN: not %target-swift-frontend -c %s -experimental-skip-non-inlinable-function-bodies %s 2>&1 | %FileCheck %s --check-prefix ERROR
+// ERROR: -experimental-skip-non-inlinable-function-bodies does not support emitting IR
+
+// 2. Emit the SIL for a module and check it against the expected strings in function bodies.
+//    If we're doing the right skipping, then the strings that are CHECK-NOT'd won't have been typechecked or SILGen'd.
+
+// RUN: %target-swift-frontend -emit-sil -O -experimental-skip-non-inlinable-function-bodies %s 2>&1 | %FileCheck %s --check-prefixes CHECK,CHECK-SIL-ONLY
+
+// 3. Emit the module interface while skipping non-inlinable function bodies. Check it against the same set of strings.
+
+// RUN: %target-swift-frontend -typecheck %s -enable-library-evolution -emit-module-interface-path %t/Module.skipping.swiftinterface -experimental-skip-non-inlinable-function-bodies
+// RUN: %FileCheck %s --check-prefixes CHECK,CHECK-INTERFACE-ONLY < %t/Module.skipping.swiftinterface
+
+// 4. Emit the module interface normally. Also check it against the same set of strings.
+
+// RUN: %target-swift-frontend -typecheck %s -enable-library-evolution -emit-module-interface-path %t/Module.swiftinterface
+// RUN: %FileCheck %s --check-prefixes CHECK,CHECK-INTERFACE-ONLY < %t/Module.swiftinterface
+
+// 5. The module interfaces should be exactly the same.
+
+// RUN: diff -u %t/Module.skipping.swiftinterface %t/Module.swiftinterface
+
+@usableFromInline
+@inline(never)
+func _blackHole(_ s: String) {}
+
+public struct Struct {
+  @inlinable public func inlinableFunc() {
+    _blackHole("@inlinable method body") // CHECK: @inlinable method body
+  }
+
+  @inline(__always)
+  public func inlineAlwaysFunc() {
+    _blackHole("@inline(__always) method body") // CHECK-NOT: @inline(__always) method body
+  }
+
+  @_transparent
+  public func transparentFunc() {
+    _blackHole("@_transparent method body") // CHECK: @_transparent method body
+  }
+
+  func internalFunc() {
+    _blackHole("internal method body") // CHECK-NOT: internal method body
+  }
+
+  public func publicFunc() {
+    _blackHole("public method body") // CHECK-NOT: public method body
+  }
+
+  private func privateFunc() {
+    _blackHole("private method body") // CHECK-NOT: private method body
+  }
+
+  @inlinable public init() {
+    _blackHole("@inlinable init body") // CHECK: @inlinable init body
+  }
+
+  @inline(__always) public init(a: Int) {
+    _blackHole("@inline(__always) init body") // CHECK-NOT: @inline(__always) init body
+  }
+
+  @_transparent public init(b: Int) {
+    _blackHole("@_transparent init body") // CHECK: @_transparent init body
+  }
+
+  init(c: Int) {
+    _blackHole("internal init body") // CHECK-NOT: internal init body
+  }
+
+  public init(d: Int) {
+    _blackHole("public init body") // CHECK-NOT: public init body
+  }
+
+  private init(e: Int) {
+    _blackHole("private init body") // CHECK-NOT: private init body
+  }
+
+  @inlinable public subscript() -> Int {
+    _blackHole("@inlinable subscript getter") // CHECK: @inlinable subscript getter
+    return 0
+  }
+
+  @inline(__always) public subscript(a: Int, b: Int) -> Int {
+    _blackHole("@inline(__always) subscript getter") // CHECK-NOT: @inline(__always) subscript getter
+    return 0
+  }
+
+  public subscript(a: Int, b: Int, c: Int) -> Int {
+    @_transparent get {
+      _blackHole("@_transparent subscript getter") // CHECK: @_transparent subscript getter
+      return 0
+    }
+  }
+
+  subscript(a: Int, b: Int, c: Int, d: Int) -> Int {
+    _blackHole("internal subscript getter") // CHECK-NOT: internal subscript getter
+    return 0
+  }
+
+  public subscript(a: Int, b: Int, c: Int, d: Int, e: Int) -> Int {
+    _blackHole("public subscript getter") // CHECK-NOT: public subscript getter
+    return 0
+  }
+
+  private subscript(e: Int) -> Int {
+    _blackHole("private subscript getter") // CHECK-NOT: private subscript getter
+    return 0
+  }
+
+  @inlinable public var inlinableVar: Int {
+    _blackHole("@inlinable getter body") // CHECK: @inlinable getter body
+    return 0
+  }
+
+  @inline(__always) public var inlineAlwaysVar: Int {
+    _blackHole("@inline(__always) getter body") // CHECK-NOT: @inline(__always) getter body
+    return 0
+  }
+
+  @_transparent public var transparentVar: Int {
+    _blackHole("@_transparent getter body") // CHECK: @_transparent getter body
+    return 0
+  }
+
+  public var publicVar: Int {
+    _blackHole("public getter body") // CHECK-NOT: public getter body
+    return 0
+  }
+
+  public var inlinableSetter: Int {
+    get { 0 }
+    @inlinable set {
+      _blackHole("@inlinable setter body") // CHECK: @inlinable setter body
+    }
+  }
+
+  public var inlineAlwaysSetter: Int {
+    get { 0 }
+    @inline(__always) set {
+      _blackHole("@inline(__always) setter body") // CHECK-NOT: @inline(__always) setter body
+    }
+  }
+
+  public var regularSetter: Int {
+    get { 0 }
+    set {
+      _blackHole("@inline(__always) setter body") // CHECK-NOT: regular setter body
+    }
+  }
+}
+
+@_fixed_layout
+public class InlinableDesubscript {
+  @inlinable deinit {
+    _blackHole("@inlinable deinit body") // CHECK: @inlinable deinit body
+  }
+}
+
+@_fixed_layout
+public class InlineAlwaysDeinit {
+  @inline(__always) deinit {
+    _blackHole("@inline(__always) deinit body") // CHECK-NOT: @inline(__always) deinit body
+  }
+}
+
+public class NormalDeinit {
+  deinit {
+    _blackHole("regular deinit body") // CHECK-NOT: regular deinit body
+  }
+}
+
+@inlinable public func inlinableFunc() {
+  _blackHole("@inlinable func body") // CHECK: @inlinable func body
+}
+
+@inline(__always) public func inlineAlwaysFunc() {
+  _blackHole("@inline(__always) func body") // CHECK-NOT: @inline(__always) func body
+}
+
+@_transparent public func transparentFunc() {
+  _blackHole("@_transparent func body") // CHECK: @_transparent func body
+}
+
+func internalFunc() {
+  _blackHole("internal func body") // CHECK-NOT: internal func body
+}
+
+public func publicFunc() {
+  _blackHole("public func body") // CHECK-NOT: public func body
+}
+
+private func privateFunc() {
+  _blackHole("private func body") // CHECK-NOT: private func body
+}
+
+@inlinable
+public func inlinableLocalTypeFunc() {
+  typealias InlinableLocalType = Int
+  _blackHole("@inlinable func body with local type") // CHECK: @inlinable func body with local type
+  func takesInlinableLocalType(_ x: InlinableLocalType) {
+    _blackHole("nested func body inside @inlinable func body taking local type") // CHECK: nested func body inside @inlinable func body taking local type
+  }
+  takesInlinableLocalType(0)
+}
+
+@inline(__always) public func inlineAlwaysLocalTypeFunc() {
+  typealias InlineAlwaysLocalType = Int
+  _blackHole("@inline(__always) func body with local type") // CHECK-NOT: @inline(__always) func body with local type
+  func takesInlineAlwaysLocalType(_ x: InlineAlwaysLocalType) {
+    _blackHole("nested func body inside @inline(__always) func body taking local type") // CHECK-NOT: nested func body inside @inline(__always) func body taking local type
+  }
+  takesInlineAlwaysLocalType(0)
+}
+
+@_transparent public func _transparentLocalTypeFunc() {
+  typealias TransparentLocalType = Int
+  _blackHole("@_transparent func body with local type") // CHECK: @_transparent func body with local type
+  func takesTransparentLocalType(_ x: TransparentLocalType) {
+    _blackHole("nested func body inside @_transparent func body taking local type") // CHECK: nested func body inside @_transparent func body taking local type
+  }
+  takesTransparentLocalType(0)
+}
+
+public func publicLocalTypeFunc() {
+  typealias LocalType = Int
+  _blackHole("public func body with local type") // CHECK-NOT: public func body with local type
+  func takesLocalType(_ x: LocalType) {
+    _blackHole("nested func body inside public func body taking local type") // CHECK-NOT: nested func body inside public func body taking local type
+  }
+  takesLocalType(0)
+}
+@inlinable
+public func inlinableNestedLocalTypeFunc() {
+  func nestedFunc() {
+    _blackHole("nested func body inside @inlinable func body") // CHECK: nested func body inside @inlinable func body
+    typealias InlinableNestedLocalType = Int
+    func takesLocalType(_ x: InlinableNestedLocalType) {
+      _blackHole("nested func body inside @inlinable func body taking local type") // CHECK: nested func body inside @inlinable func body taking local type
+    }
+    takesLocalType(0)
+  }
+  nestedFunc()
+}


### PR DESCRIPTION
This patch adds an experimental flag to skip non-inlinable function
bodies and turns it on for the standard library and overlay
`.swiftmodules`.

This flag is disabled if the requested action generates IR.

---

This option causes some small improvements in the time it takes to type check and generate an optimized and unoptimized standard library `.swiftmodule`

| Mode                                 | Optimization | Time     | Time (Skipping) | Ratio |
|:-------------------------------------|:-------------|:---------|:----------------|:------|
| `-emit-parseable-module-interface`   | N/A          | 16.254s  | 14.947s         | 1.09x |
| `-emit-module`                       | `-Onone`     | 21.685s  | 19.462s         | 1.11x |
| `-emit-module`                       | `-O`         | 50.526s  | 35.234s         | 1.43x |

However, since the standard library is full of inlinable code, it doesn't benefit much from skipping non-inlinable code.

To find a more representative Swift project with little inlinable code, I ran these benchmarks against the current master of SwiftLint, which shows much stronger wins:

| Mode                                 | Optimization | Time     | Time (Skipping) | Ratio     |
|:-------------------------------------|:-------------|:---------|:----------------|:----------|
| `-emit-parseable-module-interface`   | N/A          | 13.179s  | 1.732s          | **7.70x** |
| `-emit-module`                       | `-Onone`     | 16.21s   | 2.719s          | **5.88x** |
| `-emit-module`                       | `-O`         | 63.408s  | 12.186s         | **5.26x** |