### PR TITLE
[WIP] [Runtime] Use retroactive protocol conformances when demangling to metadata

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2293,11 +2293,17 @@ public:
     return TypeRef.getTypeContextDescriptor(getTypeKind());
   }
 
+  /// Whether this is a retroactive conformance.
+  bool isRetroactive() const {
+    return Flags.isRetroactive();
+  }
+
   /// Retrieve the context of a retroactive conformance.
-  const TargetContextDescriptor<Runtime> *getRetroactiveContext() const {
+  ConstTargetPointer<Runtime, TargetContextDescriptor<Runtime>>
+  getRetroactiveContext() const {
     if (!Flags.isRetroactive()) return nullptr;
 
-    return this->template getTrailingObjects<RelativeContextPointer<Runtime>>();
+    return *this->template getTrailingObjects<RelativeContextPointer<Runtime>>();
   }
 
   /// Whether this conformance is non-unique because it has been synthesized

--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -50,6 +50,8 @@ public:
   using BuiltType = swift::Type;
   using BuiltNominalTypeDecl = swift::NominalTypeDecl *;
   using BuiltProtocolDecl = swift::ProtocolDecl *;
+  using BuiltProtocolConformanceRef = swift::NormalProtocolConformance *;
+  using BuiltProtocolConformance = void *; // a swift::ProtocolConformanceRef
   explicit ASTBuilder(ASTContext &ctx) : Ctx(ctx) {}
 
   ASTContext &getASTContext() { return Ctx; }
@@ -69,10 +71,13 @@ public:
 
   Type createNominalType(NominalTypeDecl *decl, Type parent);
 
-  Type createBoundGenericType(NominalTypeDecl *decl, ArrayRef<Type> args);
-
-  Type createBoundGenericType(NominalTypeDecl *decl, ArrayRef<Type> args,
-                              Type parent);
+  Type createBoundGenericType(
+           NominalTypeDecl *decl, ArrayRef<Type> args,
+           ArrayRef<std::pair<unsigned, BuiltProtocolConformance>> retroactive);
+  Type createBoundGenericType(
+           NominalTypeDecl *decl, ArrayRef<Type> args,
+           ArrayRef<std::pair<unsigned, BuiltProtocolConformance>> retroactive,
+           Type parent);
 
   Type createTupleType(ArrayRef<Type> eltTypes, StringRef labels,
                        bool isVariadic);
@@ -108,6 +113,15 @@ public:
   Type getUnnamedForeignClassType();
 
   Type getOpaqueType();
+
+  BuiltProtocolConformanceRef
+  createProtocolConformanceRef(Type conformingType, ProtocolDecl *protocol,
+                               StringRef module);
+
+  BuiltProtocolConformance
+  createProtocolConformance(Type conformingType,
+                            NormalProtocolConformance *normal,
+                            ArrayRef<BuiltProtocolConformance> conditionalReqs);
 
 private:
   bool validateNominalParent(NominalTypeDecl *decl, Type parent);

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -162,6 +162,10 @@ public:
   using BuiltNominalTypeDecl = Optional<std::string>;
   using BuiltProtocolDecl = Optional<std::pair<std::string, bool /*isObjC*/>>;
 
+  // FIXME: These are stubs
+  using BuiltProtocolConformanceRef = char;
+  using BuiltProtocolConformance = char;
+
   TypeRefBuilder();
 
   TypeRefBuilder(const TypeRefBuilder &other) = delete;
@@ -240,15 +244,21 @@ public:
   }
 
   const BoundGenericTypeRef *
-  createBoundGenericType(const Optional<std::string> &mangledName,
-                         const std::vector<const TypeRef *> &args) {
+  createBoundGenericType(
+      const Optional<std::string> &mangledName,
+      const std::vector<const TypeRef *> &args,
+      ArrayRef<std::pair<unsigned, BuiltProtocolConformance>> retroactive) {
+    // FIXME: Retroactive conformances.
     return BoundGenericTypeRef::create(*this, *mangledName, args, nullptr);
   }
 
   const BoundGenericTypeRef *
-  createBoundGenericType(const Optional<std::string> &mangledName,
-                         const std::vector<const TypeRef *> &args,
-                         const TypeRef *parent) {
+  createBoundGenericType(
+           const Optional<std::string> &mangledName,
+           const std::vector<const TypeRef *> &args,
+           ArrayRef<std::pair<unsigned, BuiltProtocolConformance>> retroactive,
+           const TypeRef *parent) {
+    // FIXME: Retroactive conformances.
     return BoundGenericTypeRef::create(*this, *mangledName, args, parent);
   }
 
@@ -347,6 +357,22 @@ public:
 
   const OpaqueTypeRef *getOpaqueType() {
     return OpaqueTypeRef::get();
+  }
+
+  BuiltProtocolConformanceRef createProtocolConformanceRef(
+                                                     BuiltType conformingType,
+                                                     BuiltProtocolDecl protocol,
+                                                     StringRef module) {
+    // FIXME: Implement protocol conformance descriptor lookup.
+    return false;
+  }
+
+  BuiltProtocolConformance createProtocolConformance(
+      BuiltType conformingType,
+      BuiltProtocolConformanceRef conformance,
+      ArrayRef<BuiltProtocolConformance> conditionalReqs) {
+    // FIXME: Implement witness table computation.
+    return false;
   }
 
   ///

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1694,7 +1694,7 @@ private:
       auto builtGenerics = getGenericSubst(metadata, descriptor);
       if (builtGenerics.empty())
         return BuiltType();
-      nominal = Builder.createBoundGenericType(typeDecl, builtGenerics);
+      nominal = Builder.createBoundGenericType(typeDecl, builtGenerics, { });
     } else {
       nominal = Builder.createNominalType(typeDecl);
     }

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -86,8 +86,10 @@ Type ASTBuilder::createNominalType(NominalTypeDecl *decl, Type parent) {
   return NominalType::get(decl, parent, Ctx);
 }
 
-Type ASTBuilder::createBoundGenericType(NominalTypeDecl *decl,
-                                        ArrayRef<Type> args) {
+Type ASTBuilder::createBoundGenericType(
+       NominalTypeDecl *decl,
+       ArrayRef<Type> args,
+       ArrayRef<std::pair<unsigned, BuiltProtocolConformance>> retroactive) {
   // If the declaration isn't generic, fail.
   if (!decl->isGenericContext())
     return Type();
@@ -123,9 +125,11 @@ Type ASTBuilder::createBoundGenericType(NominalTypeDecl *decl,
   return substType;
 }
 
-Type ASTBuilder::createBoundGenericType(NominalTypeDecl *decl,
-                                        ArrayRef<Type> args,
-                                        Type parent) {
+Type ASTBuilder::createBoundGenericType(
+    NominalTypeDecl *decl,
+    ArrayRef<Type> args,
+    ArrayRef<std::pair<unsigned, BuiltProtocolConformance>> retroactive,
+    Type parent) {
   // If the declaration isn't generic, fail.
   if (!decl->getGenericParams())
     return Type();
@@ -684,4 +688,21 @@ ASTBuilder::findForeignNominalTypeDecl(StringRef name,
   }
 
   return consumer.Result;
+}
+
+auto ASTBuilder::createProtocolConformanceRef(Type conformingType,
+                                              ProtocolDecl *protocol,
+                                              StringRef module)
+    -> BuiltProtocolConformanceRef {
+  // FIXME: Implement lookup.
+  return nullptr;
+}
+
+auto ASTBuilder::createProtocolConformance(
+                      Type conformingType,
+                      NormalProtocolConformance *normal,
+                      ArrayRef<BuiltProtocolConformance> conditionalReqs)
+    -> BuiltProtocolConformance {
+  // FIXME: Implement specialization.
+  return nullptr;
 }

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -70,7 +70,7 @@ struct HashableConformanceEntry {
 // FIXME(performance): consider merging this cache into the regular
 // protocol conformance cache.
 static ConcurrentMap<HashableConformanceEntry, /*Destructor*/ false>
-HashableConformances;
+  HashableConformances;
 
 template<bool KnownToConformToHashable>
 LLVM_ATTRIBUTE_ALWAYS_INLINE
@@ -80,8 +80,10 @@ static const Metadata *findHashableBaseTypeImpl(const Metadata *type) {
           HashableConformances.find(HashableConformanceKey{type})) {
     return entry->baseTypeThatConformsToHashable;
   }
-  if (!KnownToConformToHashable &&
-      !swift_conformsToProtocol(type, &HashableProtocolDescriptor)) {
+
+  auto conformance =
+    _conformsToSwiftProtocol(type, &HashableProtocolDescriptor, StringRef());
+  if (!KnownToConformToHashable && !conformance) {
     // Don't cache the negative response because we don't invalidate
     // this cache when a new conformance is loaded dynamically.
     return nullptr;
@@ -89,7 +91,7 @@ static const Metadata *findHashableBaseTypeImpl(const Metadata *type) {
   // By this point, `type` is known to conform to `Hashable`.
 
   const Metadata *baseTypeThatConformsToHashable =
-    findConformingSuperclass(type, &HashableProtocolDescriptor);
+    findConformingSuperclass(type, conformance);
   HashableConformances.getOrInsert(HashableConformanceKey{type},
                                    baseTypeThatConformsToHashable);
   return baseTypeThatConformsToHashable;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4117,7 +4117,7 @@ swift::swift_getAssociatedTypeWitness(MetadataRequest request,
     // For a class, chase the superclass chain up until we hit the
     // type that specified the conformance.
     auto originalConformingType = findConformingSuperclass(conformingType,
-                                                           protocol);
+                                                           conformance);
     SubstGenericParametersFromMetadata substitutions(originalConformingType);
     assocTypeMetadata = _getTypeByMangledName(mangledName, substitutions);
   }

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -452,8 +452,9 @@ public:
                            ProtocolDescriptorRef protocol,
                            const WitnessTable **conformance);
 
-  /// Determine whether the given type conforms to the given Swift protocol.
-  const WitnessTable *
+  /// Determine whether the given type conforms to the given Swift protocol,
+  /// returning the appropriate protocol conformance descriptor when it does.
+  const ProtocolConformanceDescriptor *
   _conformsToSwiftProtocol(const Metadata * const type,
                            const ProtocolDescriptor *protocol,
                            const char *module);

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -452,6 +452,12 @@ public:
                            ProtocolDescriptorRef protocol,
                            const WitnessTable **conformance);
 
+  /// Determine whether the given type conforms to the given Swift protocol.
+  const WitnessTable *
+  _conformsToSwiftProtocol(const Metadata * const type,
+                           const ProtocolDescriptor *protocol,
+                           const char *module);
+
   /// Given a type that we know conforms to the given protocol, find the
   /// superclass that introduced the conformance.
   const Metadata *findConformingSuperclass(const Metadata *type,

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -464,10 +464,11 @@ public:
                            const ProtocolDescriptor *protocol,
                            StringRef module);
 
-  /// Given a type that we know conforms to the given protocol, find the
-  /// superclass that introduced the conformance.
-  const Metadata *findConformingSuperclass(const Metadata *type,
-                                           const ProtocolDescriptor *protocol);
+  /// Given a type that we know can be used with the given conformance, find
+  /// the superclass that introduced the conformance.
+  const Metadata *findConformingSuperclass(
+                             const Metadata *type,
+                             const ProtocolConformanceDescriptor *conformance);
 
 } // end namespace swift
 

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -341,12 +341,17 @@ public:
   /// generic requirements (e.g., those that need to be
   /// passed to an instantiation function) will be added to this vector.
   ///
+  /// \param getWitnessTable Function object that returns the Ith witness table,
+  /// if it's already known. This can return NULL to indicate that the witness
+  /// table should be looked up dynamically.
+  ///
   /// \returns true if an error occurred, false otherwise.
   bool _checkGenericRequirements(
-                    llvm::ArrayRef<GenericRequirementDescriptor> requirements,
-                    std::vector<const void *> &extraArguments,
-                    SubstFlatGenericParameterFn substFlatGenericParam,
-                    SubstGenericParameterFn substGenericParam);
+          llvm::ArrayRef<GenericRequirementDescriptor> requirements,
+          std::vector<const void *> &extraArguments,
+          SubstFlatGenericParameterFn substFlatGenericParam,
+          SubstGenericParameterFn substGenericParam,
+          std::function<const WitnessTable *(unsigned index)> getWitnessTable);
 
   /// A helper function which avoids performing a store if the destination
   /// address already contains the source value.  This is useful when

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -457,7 +457,7 @@ public:
   const ProtocolConformanceDescriptor *
   _conformsToSwiftProtocol(const Metadata * const type,
                            const ProtocolDescriptor *protocol,
-                           const char *module);
+                           StringRef module);
 
   /// Given a type that we know conforms to the given protocol, find the
   /// superclass that introduced the conformance.

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -583,6 +583,11 @@ namespace {
   };
 }
 
+static bool shouldWarnAboutConflictingConformances() {
+  return SWIFT_LAZY_CONSTANT(
+           (bool)getenv("SWIFT_ENABLE_CONFLICTING_CONFORMANCES_CHECK"));
+}
+
 const ProtocolConformanceDescriptor *
 swift::_conformsToSwiftProtocol(const Metadata * const type,
                                 const ProtocolDescriptor *protocol,
@@ -733,7 +738,7 @@ swift::_conformsToSwiftProtocol(const Metadata * const type,
       // If we have only retroactive conformances, complain about the
       // conflict.
       // FIXME: Only do this once per type descriptor/protocol combination.
-      if (!foundNonRetroactive) {
+      if (!foundNonRetroactive && shouldWarnAboutConflictingConformances()) {
         // Form the list of modules in which we found retroactive conformances.
         std::string moduleNamesStr;
         const char *firstModuleName = nullptr;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -513,42 +513,74 @@ recur:
     return ConformanceCacheResult::cacheMiss();
 }
 
-/// Checks if a given candidate is a type itself, one of its
-/// superclasses or a related generic type.
-///
-/// This check is supposed to use the same logic that is used
-/// by searchInConformanceCache.
-///
-/// \param candidate Pointer to a Metadata or a NominalTypeDescriptor.
-///
-static
-bool isRelatedType(const Metadata *type, const void *candidate,
-                   bool candidateIsMetadata) {
+namespace {
+  /// Describes a protocol conformance "candidate" that can be checked
+  /// against the
+  class ConformanceCandidate {
+    const void *candidate;
+    bool candidateIsMetadata;
 
-  while (true) {
-    // Check whether the types match.
-    if (candidateIsMetadata && type == candidate)
-      return true;
+  public:
+    ConformanceCandidate() : candidate(0), candidateIsMetadata(false) { }
 
-    // Check whether the nominal type descriptors match.
-    if (!candidateIsMetadata) {
-      const auto *description = type->getTypeContextDescriptor();
-      auto candidateDescription =
-        static_cast<const TypeContextDescriptor *>(candidate);
-      if (description && equalContexts(description, candidateDescription))
+    ConformanceCandidate(const ProtocolConformanceDescriptor &conformance)
+      : ConformanceCandidate()
+    {
+      if (auto metadata = conformance.getCanonicalTypeMetadata()) {
+        candidate = metadata;
+        candidateIsMetadata = true;
+        return;
+      }
+
+      if (auto description = conformance.getTypeContextDescriptor()) {
+        candidate = description;
+        candidateIsMetadata = false;
+        return;
+      }
+    }
+
+    /// Retrieve the conforming type as metadata, or NULL if the candidate's
+    /// conforming type is described in another way (e.g., a nominal type
+    /// descriptor).
+    const Metadata *getConformingTypeAsMetadata() const {
+      return candidateIsMetadata ? static_cast<const Metadata *>(candidate)
+                                 : nullptr;
+    }
+
+    /// Whether the conforming type exactly matches the conformance candidate.
+    bool matches(const Metadata *conformingType) const {
+      // Check whether the types match.
+      if (candidateIsMetadata && conformingType == candidate)
         return true;
+
+      // Check whether the nominal type descriptors match.
+      if (!candidateIsMetadata) {
+        const auto *description = conformingType->getTypeContextDescriptor();
+        auto candidateDescription =
+          static_cast<const TypeContextDescriptor *>(candidate);
+        if (description && equalContexts(description, candidateDescription))
+          return true;
+      }
+
+      return false;
     }
 
-    // If there is a superclass, look there.
-    if (auto superclass = _swift_class_getSuperclass(type)) {
-      type = superclass;
-      continue;
+    /// Retrieve the type that matches the conformance candidate, which may
+    /// be a superclass of the given type. Returns null if this type does not
+    /// match this conformance.
+    const Metadata *getMatchingType(const Metadata *conformingType) const {
+      while (conformingType) {
+        // Check for a match.
+        if (matches(conformingType))
+          return conformingType;
+
+        // Look for a superclass.
+        conformingType = _swift_class_getSuperclass(conformingType);
+      }
+
+      return nullptr;
     }
-
-    break;
-  }
-
-  return false;
+  };
 }
 
 const ProtocolConformanceDescriptor *
@@ -661,34 +693,18 @@ swift::_conformsToSwiftProtocol(const Metadata * const type,
     for (const auto &record : section) {
       auto &descriptor = *record.get();
 
-      // If the record applies to a specific type, cache it.
-      if (auto metadata = descriptor.getCanonicalTypeMetadata()) {
-        auto P = descriptor.getProtocol();
+      // We only care about conformances to the same protocol.
+      if (descriptor.getProtocol() != protocol)
+        continue;
 
-        // Look for an exact match.
-        if (protocol != P)
-          continue;
+      // If there's a matching type, record the positive result.
+      ConformanceCandidate candidate(descriptor);
+      if (candidate.getMatchingType(type)) {
+        const Metadata *matchingType = candidate.getConformingTypeAsMetadata();
+        if (!matchingType)
+          matchingType = type;
 
-        if (!isRelatedType(type, metadata, /*candidateIsMetadata=*/true))
-          continue;
-
-        // Record the conformance descriptor.
-        recordResult(descriptor, metadata);
-      } else if (descriptor.getTypeKind()
-                   == TypeReferenceKind::DirectNominalTypeDescriptor ||
-                 descriptor.getTypeKind()
-                  == TypeReferenceKind::IndirectNominalTypeDescriptor) {
-        auto R = descriptor.getTypeContextDescriptor();
-        auto P = descriptor.getProtocol();
-
-        // Look for an exact match.
-        if (protocol != P)
-          continue;
-
-        if (!isRelatedType(type, R, /*candidateIsMetadata=*/false))
-          continue;
-
-        recordResult(descriptor, type);
+        recordResult(descriptor, matchingType);
       }
     }
   }
@@ -928,18 +944,13 @@ bool swift::_checkGenericRequirements(
 }
 
 const Metadata *swift::findConformingSuperclass(
-                                          const Metadata *type,
-                                          const ProtocolDescriptor *protocol) {
-  const Metadata *conformingType = type;
-  while (true) {
-    const Metadata *superclass = _swift_class_getSuperclass(conformingType);
-    if (!superclass)
-      break;
-    if (!swift_conformsToProtocol(superclass, protocol))
-      break;
-    conformingType = superclass;
-  }
+                            const Metadata *type,
+                            const ProtocolConformanceDescriptor *conformance) {
+  // Figure out which type we're looking for.
+  ConformanceCandidate candidate(*conformance);
 
+  const Metadata *conformingType = candidate.getMatchingType(type);
+  assert(conformingType);
   return conformingType;
 }
 

--- a/test/Runtime/Inputs/RetroactiveA.swift
+++ b/test/Runtime/Inputs/RetroactiveA.swift
@@ -1,0 +1,9 @@
+import RetroactiveCommon
+
+extension CommonStruct : CommonP1 {
+  public typealias AssocType = Int
+}
+
+public func getCommonRequiresP1_Struct() -> Any.Type {
+  return CommonRequiresP1<CommonStruct>.self
+}

--- a/test/Runtime/Inputs/RetroactiveB.swift
+++ b/test/Runtime/Inputs/RetroactiveB.swift
@@ -1,0 +1,9 @@
+import RetroactiveCommon
+
+extension CommonStruct : CommonP1 {
+  public typealias AssocType = String
+}
+
+public func getCommonRequiresP1_Struct() -> Any.Type {
+  return CommonRequiresP1<CommonStruct>.self
+}

--- a/test/Runtime/Inputs/RetroactiveCommon.swift
+++ b/test/Runtime/Inputs/RetroactiveCommon.swift
@@ -1,0 +1,9 @@
+public struct CommonStruct { }
+
+public protocol CommonP1 {
+  associatedtype AssocType
+}
+
+public struct CommonRequiresP1<T: CommonP1> {
+  public init() { }
+}

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -1,11 +1,17 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -parse-stdlib %s -module-name main -o %t/a.out
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation %S/Inputs/RetroactiveCommon.swift -emit-module-path %t/RetroactiveCommon.swiftmodule -emit-object -o %t/RetroactiveCommon.o
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveA.swift -emit-module-path %t/RetroactiveA.swiftmodule -emit-object -o %t/RetroactiveA.o
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveB.swift -emit-module-path %t/RetroactiveB.swiftmodule -emit-object -o %t/RetroactiveB.o
+// RUN: %target-build-swift -parse-stdlib -I %t %s %t/RetroactiveCommon.o %t/RetroactiveA.o %t/RetroactiveB.o -module-name main -o %t/a.out 
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 
 import Swift
 import StdlibUnittest
+import RetroactiveCommon
+import RetroactiveA
+import RetroactiveB
 
 let DemangleToMetadataTests = TestSuite("DemangleToMetadata")
 
@@ -432,6 +438,13 @@ DemangleToMetadataTests.test("Nested types in same-type-constrained extensions")
   // V !: P3 in InnerTEqualsU
   // T != ConformsToP1 in InnerTEqualsConformsToP1
   // V !: P3 in InnerTEqualsConformsToP1
+}
+
+DemangleToMetadataTests.test("Retroactive conformances") {
+  expectEqual(RetroactiveA.getCommonRequiresP1_Struct(),
+    _typeByMangledName("17RetroactiveCommon16CommonRequiresP1Vy17RetroactiveCommon12CommonStructV17RetroactiveCommon12CommonStructV17RetroactiveCommon8CommonP112RetroactiveAyHCg_G")!)
+  expectEqual(RetroactiveB.getCommonRequiresP1_Struct(),
+    _typeByMangledName("17RetroactiveCommon16CommonRequiresP1Vy17RetroactiveCommon12CommonStructV17RetroactiveCommon12CommonStructV17RetroactiveCommon8CommonP112RetroactiveByHCg_G")!)
 }
 
 runAllTests()

--- a/test/Runtime/multiple_conformances.swift
+++ b/test/Runtime/multiple_conformances.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation %S/Inputs/RetroactiveCommon.swift -emit-module-path %t/RetroactiveCommon.swiftmodule -emit-object -o %t/RetroactiveCommon.o
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveA.swift -emit-module-path %t/RetroactiveA.swiftmodule -emit-object -o %t/RetroactiveA.o
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveB.swift -emit-module-path %t/RetroactiveB.swiftmodule -emit-object -o %t/RetroactiveB.o
+// RUN: %target-build-swift -I %t %s %t/RetroactiveCommon.o %t/RetroactiveA.o %t/RetroactiveB.o -module-name main -o %t/a.out 
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out > %t.log 2>&1
+// RUN: %FileCheck %s < %t.log
+
+// REQUIRES: executable_test
+
+import RetroactiveCommon
+import RetroactiveA
+import RetroactiveB
+
+// CHECK: Swift runtime warning: multiple conformances for 'RetroactiveCommon.CommonStruct: CommonP1' found in modules 'RetroactiveA' and 'RetroactiveB'. Arbitrarily selecting conformance from module 'RetroactiveA'
+let demangled1 = _typeByMangledName("17RetroactiveCommon16CommonRequiresP1Vy17RetroactiveCommon12CommonStructVG")!

--- a/test/Runtime/multiple_conformances.swift
+++ b/test/Runtime/multiple_conformances.swift
@@ -4,7 +4,7 @@
 // RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveB.swift -emit-module-path %t/RetroactiveB.swiftmodule -emit-object -o %t/RetroactiveB.o
 // RUN: %target-build-swift -I %t %s %t/RetroactiveCommon.o %t/RetroactiveA.o %t/RetroactiveB.o -module-name main -o %t/a.out 
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out > %t.log 2>&1
+// RUN: env SWIFT_ENABLE_CONFLICTING_CONFORMANCES_CHECK=1 %target-run %t/a.out > %t.log 2>&1
 // RUN: %FileCheck %s < %t.log
 
 // REQUIRES: executable_test

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -63,18 +63,18 @@ TEST(TypeRefTest, UniqueBoundGenericTypeRef) {
   auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
   auto GTP01 = Builder.createGenericTypeParameterType(0, 1);
 
-  auto BG1 = Builder.createBoundGenericType(ABC, {}, nullptr);
-  auto BG2 = Builder.createBoundGenericType(ABC, {}, nullptr);
-  auto BG3 = Builder.createBoundGenericType(ABCD, {}, nullptr);
+  auto BG1 = Builder.createBoundGenericType(ABC, {}, {}, nullptr);
+  auto BG2 = Builder.createBoundGenericType(ABC, {}, {}, nullptr);
+  auto BG3 = Builder.createBoundGenericType(ABCD, {}, {}, nullptr);
 
   EXPECT_EQ(BG1, BG2);
   EXPECT_NE(BG2, BG3);
 
   std::vector<const TypeRef *> GenericParams { GTP00, GTP01 };
 
-  auto BG4 = Builder.createBoundGenericType(ABC, GenericParams, nullptr);
-  auto BG5 = Builder.createBoundGenericType(ABC, GenericParams, nullptr);
-  auto BG6 = Builder.createBoundGenericType(ABCD, GenericParams, nullptr);
+  auto BG4 = Builder.createBoundGenericType(ABC, GenericParams, {}, nullptr);
+  auto BG5 = Builder.createBoundGenericType(ABC, GenericParams, {}, nullptr);
+  auto BG6 = Builder.createBoundGenericType(ABCD, GenericParams, {}, nullptr);
 
   EXPECT_EQ(BG4, BG5);
   EXPECT_NE(BG5, BG6);
@@ -388,6 +388,7 @@ TEST(TypeRefTest, UniqueAfterSubstitution) {
 
   auto ConcreteBG = Builder.createBoundGenericType(MangledName,
                                                    ConcreteArgs,
+                                                   {},
                                                    /*parent*/ nullptr);
 
   auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
@@ -395,7 +396,7 @@ TEST(TypeRefTest, UniqueAfterSubstitution) {
   std::vector<const TypeRef *> GenericParams { GTP00, GTP01 };
 
   auto Unbound = Builder.createBoundGenericType(MangledName, GenericParams,
-                                                /*parent*/ nullptr);
+                                                { }, /*parent*/ nullptr);
 
   GenericArgumentMap Subs;
   Subs[{0,0}] = NominalInt;
@@ -415,7 +416,7 @@ TEST(TypeRefTest, NestedTypes) {
   std::string ParentName("parent");
   std::vector<const TypeRef *> ParentArgs { GTP00 };
   auto Parent = Builder.createBoundGenericType(ParentName, ParentArgs,
-                                               /*parent*/ nullptr);
+                                               { }, /*parent*/ nullptr);
 
   std::string ChildName("child");
   auto Child = Builder.createNominalType(ChildName, Parent);
@@ -428,7 +429,7 @@ TEST(TypeRefTest, NestedTypes) {
   std::vector<const TypeRef *> SubstParentArgs { SubstArg };
   auto SubstParent = Builder.createBoundGenericType(ParentName,
                                                     SubstParentArgs,
-                                                    /*parent*/ nullptr);
+                                                    { }, /*parent*/ nullptr);
   auto SubstChild = Builder.createNominalType(ChildName, SubstParent);
 
   GenericArgumentMap Subs;
@@ -447,7 +448,7 @@ TEST(TypeRefTest, DeriveSubstitutions) {
   std::string NominalName("nominal");
   std::vector<const TypeRef *> NominalArgs { GTP00 };
   auto Nominal = Builder.createBoundGenericType(NominalName, NominalArgs,
-                                               /*parent*/ nullptr);
+                                                { }, /*parent*/ nullptr);
 
   auto Result = Builder.createTupleType({GTP00, GTP01}, "", false);
   auto Func =


### PR DESCRIPTION
Extend TypeDecoder with the ability to demangle (concrete) protocol
conformances, and pass along demangled retroactive conformances to
it’s builder’s createBoundGenericType().

Extend the mangled name -> metadata code in the runtime to use retroactive
conformances when satisfying generic requirements. If a retroactive
conformance is provided, the corresponding witness table will be used
instead of the one found by swift_conformsToProtocol(). This allows us to
properly demangle type names involving retroactive conformances.