### PR TITLE
[SR-9205][SourceKit] Recognize operators declared as `static func`

### DIFF
--- a/test/SourceKit/Indexing/index_operators.swift
+++ b/test/SourceKit/Indexing/index_operators.swift
@@ -1,0 +1,23 @@
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
+// RUN: diff -u %s.response %t.response
+
+class ClassA {
+    init(){}
+}
+
+func +(lhs: ClassA, rhs: ClassA) -> ClassA {
+    return lhs
+}
+
+struct StructB {
+    func method() {
+        let a = ClassA()
+        let b = a + a
+        let c = StructB()
+        let d = c - c
+    }
+
+    public static func -(lhs: StructB, rhs: StructB) -> StructB {
+        return lhs
+    }
+}

--- a/test/SourceKit/Indexing/index_operators.swift.response
+++ b/test/SourceKit/Indexing/index_operators.swift.response
@@ -1,0 +1,161 @@
+{
+  key.hash: <hash>,
+  key.dependencies: [
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "Swift",
+      key.filepath: Swift.swiftmodule,
+      key.hash: <hash>,
+      key.is_system: 1
+    }
+  ],
+  key.entities: [
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.name: "ClassA",
+      key.usr: "s:15index_operators6ClassAC",
+      key.line: 4,
+      key.column: 7,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init()",
+          key.usr: "s:15index_operators6ClassACACycfc",
+          key.line: 5,
+          key.column: 5
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.operator.infix,
+      key.name: "+(_:_:)",
+      key.usr: "s:15index_operators1poiyAA6ClassACAD_ADtF",
+      key.line: 8,
+      key.column: 6,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.class,
+          key.name: "ClassA",
+          key.usr: "s:15index_operators6ClassAC",
+          key.line: 8,
+          key.column: 13
+        },
+        {
+          key.kind: source.lang.swift.ref.class,
+          key.name: "ClassA",
+          key.usr: "s:15index_operators6ClassAC",
+          key.line: 8,
+          key.column: 26
+        },
+        {
+          key.kind: source.lang.swift.ref.class,
+          key.name: "ClassA",
+          key.usr: "s:15index_operators6ClassAC",
+          key.line: 8,
+          key.column: 37
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "StructB",
+      key.usr: "s:15index_operators7StructBV",
+      key.line: 12,
+      key.column: 8,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "method()",
+          key.usr: "s:15index_operators7StructBV6methodyyF",
+          key.line: 13,
+          key.column: 10,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.class,
+              key.name: "ClassA",
+              key.usr: "s:15index_operators6ClassAC",
+              key.line: 14,
+              key.column: 17
+            },
+            {
+              key.kind: source.lang.swift.ref.function.constructor,
+              key.name: "init()",
+              key.usr: "s:15index_operators6ClassACACycfc",
+              key.line: 14,
+              key.column: 17
+            },
+            {
+              key.kind: source.lang.swift.ref.function.operator.infix,
+              key.name: "+(_:_:)",
+              key.usr: "s:15index_operators1poiyAA6ClassACAD_ADtF",
+              key.line: 15,
+              key.column: 19
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "StructB",
+              key.usr: "s:15index_operators7StructBV",
+              key.line: 16,
+              key.column: 17
+            },
+            {
+              key.kind: source.lang.swift.ref.function.constructor,
+              key.name: "init()",
+              key.usr: "s:15index_operators7StructBVACycfc",
+              key.line: 16,
+              key.column: 17
+            },
+            {
+              key.kind: source.lang.swift.ref.function.operator.infix,
+              key.name: "-(_:_:)",
+              key.usr: "s:15index_operators7StructBV1soiyA2C_ACtFZ",
+              key.line: 17,
+              key.column: 19
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.operator.infix,
+          key.name: "-(_:_:)",
+          key.usr: "s:15index_operators7StructBV1soiyA2C_ACtFZ",
+          key.line: 20,
+          key.column: 24,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "StructB",
+              key.usr: "s:15index_operators7StructBV",
+              key.line: 20,
+              key.column: 31
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "StructB",
+              key.usr: "s:15index_operators7StructBV",
+              key.line: 20,
+              key.column: 45
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "StructB",
+              key.usr: "s:15index_operators7StructBV",
+              key.line: 20,
+              key.column: 57
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.public
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: "s:15index_operators7StructBVACycfc",
+          key.line: 12,
+          key.column: 8
+        }
+      ]
+    }
+  ]
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -545,21 +545,24 @@ UIdent SwiftLangSupport::getUIDForSymbol(SymbolInfo sym, bool isRef) {
     return UID_FOR(TypeAlias);
 
   case SymbolKind::Function:
+  case SymbolKind::StaticMethod:
     if (sym.SubKind == SymbolSubKind::SwiftPrefixOperator)
       return UID_FOR(FunctionPrefixOperator);
     if (sym.SubKind == SymbolSubKind::SwiftPostfixOperator)
       return UID_FOR(FunctionPostfixOperator);
     if (sym.SubKind == SymbolSubKind::SwiftInfixOperator)
       return UID_FOR(FunctionInfixOperator);
-    return UID_FOR(FunctionFree);
+    if (sym.Kind == SymbolKind::StaticMethod) {
+      return UID_FOR(MethodStatic);
+    } else {
+      return UID_FOR(FunctionFree);
+    }
   case SymbolKind::Variable:
     return UID_FOR(VarGlobal);
   case SymbolKind::InstanceMethod:
     return UID_FOR(MethodInstance);
   case SymbolKind::ClassMethod:
     return UID_FOR(MethodClass);
-  case SymbolKind::StaticMethod:
-    return UID_FOR(MethodStatic);
   case SymbolKind::InstanceProperty:
     if (sym.SubKind == SymbolSubKind::SwiftSubscript)
       return UID_FOR(Subscript);


### PR DESCRIPTION
SourceKit was correctly attributing operator UIDs for global operators, but operators declared inside types as `public static func` were being given the regular static method's UID. This PR makes SourceKit attribute operator UIDs for them as well.

Resolves [SR-9205](https://bugs.swift.org/browse/SR-9205).