### PR TITLE
Add -lm to Glibc.modulemap on Linux

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -120,6 +120,9 @@ module SwiftGlibc [system] {
       export *
     }
     module math {
+% if CMAKE_SDK == "LINUX":
+      link "m"
+% end
       header "${GLIBC_INCLUDE_PATH}/math.h"
       export *
     }


### PR DESCRIPTION
Unlike Darwin, on Linux when using functions from math.h the m library
needs to be added to the compilation. This should be explicit in the
module map, rather than being implicit in the driver.

Resolves [SR-9198](https://bugs.swift.org/browse/SR-9198).
