### PR TITLE
Revert "Verify that a GenericTypeParamDecl's depth and index are correct"

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2738,37 +2738,6 @@ public:
       verifyCheckedBase(nominal);
     }
 
-    void verifyCheckedAlways(GenericTypeParamDecl *GTPD) {
-      PrettyStackTraceDecl debugStack("verifying GenericTypeParamDecl", GTPD);
-
-      const DeclContext *DC = GTPD->getDeclContext();
-      if (!GTPD->getDeclContext()->isInnermostContextGeneric()) {
-        Out << "DeclContext of GenericTypeParamDecl does not have "
-               "generic params";
-        abort();
-      }
-
-      GenericParamList *paramList =
-          static_cast<const GenericContext *>(DC)->getGenericParams();
-      if (!paramList) {
-        Out << "DeclContext of GenericTypeParamDecl does not have "
-               "generic params";
-        abort();
-      }
-
-      if (paramList->size() <= GTPD->getIndex() ||
-          paramList->getParams()[GTPD->getIndex()] != GTPD) {
-        Out << "GenericTypeParamDecl has incorrect index";
-        abort();
-      }
-      if (paramList->getDepth() != GTPD->getDepth()) {
-        Out << "GenericTypeParamDecl has incorrect depth";
-        abort();
-      }
-
-      verifyCheckedBase(GTPD);
-    }
-
     void verifyChecked(ExtensionDecl *ext) {
       // Make sure that the protocol conformances are complete.
       for (auto conformance : ext->getLocalConformances()) {


### PR DESCRIPTION
This reverts #20100. It's causing problems on the Source Compatibility bot.

rdar://problem/45912707