### PR TITLE
[ParseableInterface] Don't bother computing default witness tables

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -823,11 +823,13 @@ public:
       genVTable.emitVTable();
     }
 
-    // Build a default witness table if this is a protocol.
+    // Build a default witness table if this is a protocol that needs one.
     if (auto protocol = dyn_cast<ProtocolDecl>(theType)) {
-      if (!protocol->isObjC() &&
-          protocol->isResilient())
-        SGM.emitDefaultWitnessTable(protocol);
+      if (!protocol->isObjC() && protocol->isResilient()) {
+        auto *SF = protocol->getParentSourceFile();
+        if (!SF || SF->Kind != SourceFileKind::Interface)
+          SGM.emitDefaultWitnessTable(protocol);
+      }
       return;
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3155,6 +3155,7 @@ public:
     if (!PD->hasValidSignature())
       return;
 
+    auto *SF = PD->getParentSourceFile();
     {
       // Check for circular inheritance within the protocol.
       SmallVector<ProtocolDecl *, 8> path;
@@ -3162,7 +3163,7 @@ public:
       checkCircularity(TC, PD, diag::circular_protocol_def,
                        DescriptiveDeclKind::Protocol, path);
 
-      if (auto *SF = PD->getParentSourceFile()) {
+      if (SF) {
         if (auto *tracker = SF->getReferencedNameTracker()) {
           bool isNonPrivate =
               (PD->getFormalAccess() > AccessLevel::FilePrivate);
@@ -3184,7 +3185,8 @@ public:
 
     TC.checkDeclCircularity(PD);
     if (PD->isResilient())
-      TC.inferDefaultWitnesses(PD);
+      if (!SF || SF->Kind != SourceFileKind::Interface)
+        TC.inferDefaultWitnesses(PD);
 
     if (TC.Context.LangOpts.DebugGenericSignatures) {
       auto requirementsSig =

--- a/test/ParseableInterface/Conformances.swiftinterface
+++ b/test/ParseableInterface/Conformances.swiftinterface
@@ -2,7 +2,9 @@
 // swift-module-flags: 
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-resilience -o %t/Conformances.swiftmodule %s
+// RUN: %target-swift-frontend -emit-module-path %t/Conformances.swiftmodule -enable-resilience -emit-sil -o %t/Conformances.sil %s
+// RUN: %FileCheck -check-prefix CHECK-MODULE %s < %t/Conformances.sil
+// RUN: %FileCheck -check-prefix NEGATIVE-MODULE %s < %t/Conformances.sil
 // RUN: %target-swift-frontend -emit-sil -I %t %S/Inputs/ConformancesUser.swift -O | %FileCheck %s
 
 public protocol MyProto {
@@ -11,6 +13,15 @@ public protocol MyProto {
   var prop: Int { get set }
   subscript(index: Int) -> Int { get set }
 }
+extension MyProto {
+  public func method() {}
+}
+
+// Make sure there's no default witness table. (But also make sure we printed at
+// least some regular witness tables, or we'll have to change the test.)
+// CHECK-MODULE: sil_witness_table{{.+}}: MyProto module Conformances
+// NEGATIVE-MODULE-NOT: sil_default_witness_table{{.+}}MyProto
+
 
 @_fixed_layout // allow conformance devirtualization
 public struct FullStructImpl: MyProto {
@@ -31,7 +42,8 @@ public struct OpaqueStructImpl: MyProto {}
 
 // CHECK-LABEL: sil @$s16ConformancesUser10testOpaqueSiyF
 // CHECK: function_ref @$s12Conformances7MyProtoPxycfC
-// CHECK: function_ref @$s12Conformances7MyProtoP6methodyyF
+// Note the default implementation is filled in here.
+// CHECK: function_ref @$s12Conformances7MyProtoPAAE6methodyyF
 // CHECK: function_ref @$s12Conformances7MyProtoP4propSivs
 // CHECK: function_ref @$s12Conformances7MyProtoPyS2icig
 // CHECK: end sil function '$s16ConformancesUser10testOpaqueSiyF'


### PR DESCRIPTION
These are only used within the original module today, so we can skip filling them in.