### PR TITLE
Disable runtime exclusivity checks with -Ounchecked.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -771,6 +771,11 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     Opts.VerifyExclusivity
       = A->getOption().matches(OPT_enable_verify_exclusivity);
   }
+  // If runtime asserts are disabled in general, also disable runtime
+  // exclusivity checks unless explicitly requested.
+  if (Opts.RemoveRuntimeAsserts)
+    Opts.EnforceExclusivityDynamic = false;
+
   if (const Arg *A = Args.getLastArg(options::OPT_enforce_exclusivity_EQ)) {
     parseExclusivityEnforcementOptions(A, Opts, Diags);
   }

--- a/test/SILOptimizer/access_enforcement_noescape.swift
+++ b/test/SILOptimizer/access_enforcement_noescape.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -module-name access_enforcement_noescape -enable-sil-ownership -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -parse-as-library %s | %FileCheck %s
-// REQUIRES: asserts
 
 // This tests SILGen and AccessEnforcementSelection as a single set of tests.
 // (Some static/dynamic enforcement selection is done in SILGen, and some is

--- a/test/SILOptimizer/access_enforcement_options.swift
+++ b/test/SILOptimizer/access_enforcement_options.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -enable-sil-ownership -Onone -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=NONE
+// RUN: %target-swift-frontend -enable-sil-ownership -Osize -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=OPT
+// RUN: %target-swift-frontend -enable-sil-ownership -O -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=OPT
+// RUN: %target-swift-frontend -enable-sil-ownership -Ounchecked -emit-sil -parse-as-library %s | %FileCheck %s --check-prefix=CHECK --check-prefix=UNCHECKED
+
+@inline(never)
+func takesInoutAndEscaping(_: inout Int, _ f: @escaping () -> ()) {
+  f()
+}
+
+@inline(never)
+func escapeClosure(_ f: @escaping () -> ()) -> () -> () {
+  return f
+}
+
+public func accessIntTwice() {
+  var x = 0
+  takesInoutAndEscaping(&x, escapeClosure({ x = 3 }))
+}
+
+// accessIntTwice()
+// CHECK-LABEL: sil @$s26access_enforcement_options0A8IntTwiceyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box ${ var Int }, var, name "x"
+// CHECK: [[PROJ:%.*]] = project_box [[BOX]] : ${ var Int }, 0
+// NONE: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[PROJ]] : $*Int
+// OPT: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[PROJ]] : $*Int
+// UNCHECKED-NOT: = begin_access
+// CHECK-LABEL: } // end sil function '$s26access_enforcement_options0A8IntTwiceyyF'
+
+// closure #1 in accessIntTwice()
+// CHECK-LABEL: sil private @$s26access_enforcement_options0A8IntTwiceyyFyycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
+// CHECK: bb0(%0 : ${ var Int }):
+// CHECK: [[PROJ:%.*]] = project_box %0 : ${ var Int }, 0
+// NONE: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[PROJ]] : $*Int
+// OPT: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[PROJ]] : $*Int
+// UNCHECKED-NOT: = begin_access
+// CHECK-LABEL: } // end sil function '$s26access_enforcement_options0A8IntTwiceyyFyycfU_'

--- a/test/SILOptimizer/access_marker_elim.sil
+++ b/test/SILOptimizer/access_marker_elim.sil
@@ -1,5 +1,5 @@
 // RUN: %target-sil-opt -enforce-exclusivity=unchecked -emit-sorted-sil -access-marker-elim %s | %FileCheck %s --check-prefix=UNCHECKED
-// FIXME: %target-sil-opt -enforce-exclusivity=checked -emit-sorted-sil -access-marker-elim %s | %FileCheck %s --check-prefix=CHECKED
+// RUN: %target-sil-opt -enforce-exclusivity=checked -emit-sorted-sil -access-marker-elim %s | %FileCheck %s --check-prefix=CHECKED
 
 sil_stage raw
 
@@ -78,7 +78,7 @@ bb0:
 // UNCHECKED-LABEL: } // end sil function 'f020_boxArg'
 //
 // CHECKED-LABEL: sil hidden @f020_boxArg : $@convention(thin) (@owned { var Builtin.Int64 }) -> () {
-// CHECKED: bb0(%0 : ${ var Builtin.Int64 }):
+// CHECKED: bb0(%0 : @owned ${ var Builtin.Int64 }):
 // CHECKED:  [[ADR:%.*]] = project_box %0 : ${ var Builtin.Int64 }, 0
 // CHECKED:  [[VAL:%.*]] = integer_literal $Builtin.Int64, 42
 // CHECKED:  [[ACCESS:%.*]] = begin_access [modify] [unknown] [[ADR]]


### PR DESCRIPTION
If runtime asserts are disabled in general, also disable runtime
exclusivity checks unless explicitly requested.

-Ounchecked is an unsupported benchmarking mode, but, if used, it
should disable all runtime assertions. Exclusivity checks are no more
essential than integer overflow or bounds checks.
