### PR TITLE
[ABI] Eliminate the special structure for generic parameter references.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -113,7 +113,7 @@ Globals
   global ::= context 'MXE'               // extension descriptor
   global ::= context 'MXX'               // anonymous context descriptor
   global ::= context identifier 'MXY'    // anonymous context descriptor
-  global ::= type assoc-type-list 'MXA'  // generic parameter ref
+  global ::= type assoc-type-list 'MXA'  // generic parameter ref (HISTORICAL)
   global ::= protocol 'Mp'               // protocol descriptor
 
   global ::= nominal-type 'Mo'           // class metadata immediate member base offset

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4103,31 +4103,6 @@ void IRGenModule::emitProtocolDecl(ProtocolDecl *protocol) {
 // Generic requirements.
 //===----------------------------------------------------------------------===//
 
-/// Add a generic parameter reference to the given constant struct builder.
-static void addGenericParamRef(IRGenModule &IGM, ConstantStructBuilder &B,
-                               GenericSignature *sig, CanType type) {
-  // type should be either a generic parameter or dependent member type
-  // thereof.
-
-  if (auto genericParam = dyn_cast<GenericTypeParamType>(type)) {
-    // We can encode the ordinal of a direct type parameter reference
-    // inline.
-    auto ordinal = sig->getGenericParamOrdinal(genericParam);
-    B.addInt32(ordinal << 1);
-    return;
-  }
-
-  if (auto dmt = dyn_cast<DependentMemberType>(type)) {
-    // We have to encode the associated type path out-of-line.
-    auto assocTypeRecord = IGM.getAddrOfAssociatedTypeGenericParamRef(sig, dmt);
-
-    B.addTaggedRelativeOffset(IGM.Int32Ty, assocTypeRecord, 1);
-    return;
-  }
-
-  llvm_unreachable("not a generic parameter");
-}
-
 /// Add a generic requirement to the given constant struct builder.
 static void addGenericRequirement(IRGenModule &IGM, ConstantStructBuilder &B,
                                   GenericRequirementsMetadata &metadata,
@@ -4141,7 +4116,9 @@ static void addGenericRequirement(IRGenModule &IGM, ConstantStructBuilder &B,
     ++metadata.NumGenericExtraArguments;
 
   B.addInt(IGM.Int32Ty, flags.getIntValue());
-  addGenericParamRef(IGM, B, sig, paramType->getCanonicalType());
+  auto typeName =
+    IGM.getTypeRef(paramType->getCanonicalType(), MangledTypeRefRole::Metadata);
+  B.addRelativeAddress(typeName);
   addReference();
 }
 

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -282,17 +282,6 @@ public:
     return finalize();
   }
 
-  std::string mangleAssociatedTypeGenericParamRef(unsigned baseOrdinal,
-                                                  CanType member) {
-    beginMangling();
-    bool isFirstAssociatedTypeIdentifier = true;
-    appendType(GenericTypeParamType::get(0, baseOrdinal,
-                                         member->getASTContext()));
-    appendAssociatedTypePath(member, isFirstAssociatedTypeIdentifier);
-    appendOperator("MXA");
-    return finalize();
-  }
-
   void appendAssociatedTypePath(CanType associatedType, bool &isFirst) {
     if (auto memberType = dyn_cast<DependentMemberType>(associatedType)) {
       appendAssociatedTypePath(memberType.getBase(), isFirst);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -880,8 +880,6 @@ public:
                                            ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfKeyPathPattern(KeyPathPattern *pattern,
                                           SILLocation diagLoc);
-  llvm::Constant *getAddrOfAssociatedTypeGenericParamRef(GenericSignature *sig,
-                                                    CanDependentMemberType dmt);
   ConstantReference getConstantReferenceForProtocolDescriptor(ProtocolDecl *proto);
 
   ConstantIntegerLiteral getConstantIntegerLiteral(APInt value);

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -227,6 +227,29 @@ static const TypeContextDescriptor *
 _findNominalTypeDescriptor(Demangle::NodePointer node,
                            Demangle::Demangler &Dem);
 
+/// Find the context descriptor for the type extended by the given extension.
+static const TypeContextDescriptor *
+_findExtendedTypeContextDescriptor(const ExtensionContextDescriptor *extension,
+                                   Demangle::NodePointer *demangledNode
+                                     = nullptr) {
+  Demangle::NodePointer localNode;
+  Demangle::NodePointer &node = demangledNode ? *demangledNode : localNode;
+
+  auto mangledName = extension->getMangledExtendedContext();
+  auto demangler = getDemanglerForRuntimeTypeResolution();
+  node = demangler.demangleType(mangledName);
+  if (!node)
+    return nullptr;
+  if (node->getKind() == Node::Kind::Type) {
+    if (node->getNumChildren() < 1)
+      return nullptr;
+    node = node->getChild(0);
+  }
+  node = stripGenericArgsFromContextNode(node, demangler);
+
+  return _findNominalTypeDescriptor(node, demangler);
+}
+
 /// Recognize imported tag types, which have a special mangling rule.
 ///
 /// This should be kept in sync with the AST mangler and with
@@ -392,24 +415,15 @@ swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
       
       // Check that the context being extended matches as well.
       auto extendedContextNode = node->getChild(1);
-      auto extendedContextMangledName = extension->getMangledExtendedContext();
       auto demangler = getDemanglerForRuntimeTypeResolution();
-      auto extendedContextDemangled =
-         demangler.demangleType(extendedContextMangledName);
-      if (!extendedContextDemangled)
-        return false;
-      if (extendedContextDemangled->getKind() == Node::Kind::Type) {
-        if (extendedContextDemangled->getNumChildren() < 1)
-          return false;
-        extendedContextDemangled = extendedContextDemangled->getChild(0);
-      }
-      extendedContextDemangled =
-        stripGenericArgsFromContextNode(extendedContextDemangled, demangler);
-      
+
       auto extendedDescriptorFromNode =
         _findNominalTypeDescriptor(extendedContextNode, demangler);
+
+      Demangle::NodePointer extendedContextDemangled;
       auto extendedDescriptorFromDemangled =
-        _findNominalTypeDescriptor(extendedContextDemangled, demangler);
+        _findExtendedTypeContextDescriptor(extension,
+                                           &extendedContextDemangled);
 
       // Determine whether the contexts match.
       bool contextsMatch =
@@ -418,6 +432,7 @@ swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
                       extendedDescriptorFromDemangled);
       
 #if SWIFT_OBJC_INTEROP
+      // If we have manglings of the same Objective-C type, the contexts match.
       if (!contextsMatch &&
           (!extendedDescriptorFromNode || !extendedDescriptorFromDemangled) &&
           sameObjCTypeManglings(extendedContextNode,
@@ -804,6 +819,13 @@ Optional<unsigned> swift::_depthIndexToFlatIndex(
 bool swift::_gatherGenericParameterCounts(
                                  const ContextDescriptor *descriptor,
                                  std::vector<unsigned> &genericParamCounts) {
+  // If we have an extension descriptor, extract the extended type and use
+  // that.
+  if (auto extension = dyn_cast<ExtensionContextDescriptor>(descriptor)) {
+    if (auto extendedType = _findExtendedTypeContextDescriptor(extension))
+      descriptor = extendedType;
+  }
+
   // Once we hit a non-generic descriptor, we're done.
   if (!descriptor->isGeneric()) return false;
 
@@ -1396,6 +1418,25 @@ const Metadata *SubstGenericParametersFromWrittenArgs::operator()(
   return nullptr;
 }
 
+/// Demangle the given type name to a generic parameter reference, which
+/// will be returned as (depth, index).
+static Optional<std::pair<unsigned, unsigned>>
+demangleToGenericParamRef(StringRef typeName) {
+  Demangler demangler;
+  NodePointer node = demangler.demangleType(typeName);
+  if (!node)
+    return None;
+
+  // Find the flat index that the right-hand side refers to.
+  if (node->getKind() == Demangle::Node::Kind::Type)
+    node = node->getChild(0);
+  if (node->getKind() != Demangle::Node::Kind::DependentGenericParamType)
+    return None;
+
+  return std::pair<unsigned, unsigned>(node->getChild(0)->getIndex(),
+                                       node->getChild(1)->getIndex());
+}
+
 void swift::gatherWrittenGenericArgs(
                              const Metadata *metadata,
                              const TypeContextDescriptor *description,
@@ -1462,21 +1503,23 @@ void swift::gatherWrittenGenericArgs(
     if (req.Flags.getKind() != GenericRequirementKind::SameType)
       continue;
 
-    // Where the left-hand side is a generic parameter.
-    if (req.Param.begin() != req.Param.end())
+    auto lhsParam = demangleToGenericParamRef(req.getParam());
+    if (!lhsParam)
       continue;
 
     // If we don't yet have an argument for this parameter, it's a
     // same-type-to-concrete constraint.
-    unsigned lhsFlatIndex = req.Param.getRootParamIndex();
-    if (lhsFlatIndex >= allGenericArgs.size())
+    auto lhsFlatIndex =
+      _depthIndexToFlatIndex(lhsParam->first, lhsParam->second,
+                             genericParamCounts);
+    if (!lhsFlatIndex || *lhsFlatIndex >= allGenericArgs.size())
       continue;
 
-    if (!allGenericArgs[lhsFlatIndex]) {
+    if (!allGenericArgs[*lhsFlatIndex]) {
       // Substitute into the right-hand side.
       SubstGenericParametersFromWrittenArgs substitutions(allGenericArgs,
                                                           genericParamCounts);
-      allGenericArgs[lhsFlatIndex] =
+      allGenericArgs[*lhsFlatIndex] =
           _getTypeByMangledName(req.getMangledTypeName(), substitutions);
       continue;
     }
@@ -1484,28 +1527,20 @@ void swift::gatherWrittenGenericArgs(
     // If we do have an argument for this parameter, it might be that
     // the right-hand side is itself a generic parameter, which means
     // we have a same-type constraint A == B where A is already filled in.
-    Demangler demangler;
-    NodePointer node = demangler.demangleType(req.getMangledTypeName());
-    if (!node)
-      continue;
-
-    // Find the flat index that the right-hand side refers to.
-    if (node->getKind() == Demangle::Node::Kind::Type)
-      node = node->getChild(0);
-    if (node->getKind() != Demangle::Node::Kind::DependentGenericParamType)
+    auto rhsParam = demangleToGenericParamRef(req.getMangledTypeName());
+    if (!rhsParam)
       continue;
 
     auto rhsFlatIndex =
-      _depthIndexToFlatIndex(node->getChild(0)->getIndex(),
-                             node->getChild(1)->getIndex(),
+      _depthIndexToFlatIndex(rhsParam->first, rhsParam->second,
                              genericParamCounts);
     if (!rhsFlatIndex || *rhsFlatIndex >= allGenericArgs.size())
       continue;
 
-    if (allGenericArgs[*rhsFlatIndex] || !allGenericArgs[lhsFlatIndex])
+    if (allGenericArgs[*rhsFlatIndex] || !allGenericArgs[*lhsFlatIndex])
       continue;
 
-    allGenericArgs[*rhsFlatIndex] = allGenericArgs[lhsFlatIndex];
+    allGenericArgs[*rhsFlatIndex] = allGenericArgs[*lhsFlatIndex];
   }
 }
 

--- a/test/IRGen/generic_types.swift
+++ b/test/IRGen/generic_types.swift
@@ -147,14 +147,15 @@ struct X2: P2 {
   typealias A = X1
 }
 
-// Check for correct root generic parameters in the generic requirements of X3.
-// CHECK-LABEL: @"$sq_1A13generic_types2P2P_MXA" = linkonce_odr hidden constant
+// Check for correct generic parameters in the nominal type descriptor
+// CHECK-LABEL: @"$s13generic_types2X3VMn" =
 
 // Root: generic parameter 1
-// CHECK-SAME: i32 1
+// CHECK-SAME: @"symbolic q_"
 
-// Protocol P2
-// CHECK-SAME: $s13generic_types2P2Mp
+// U.A (via P2)
+// CHECK-SAME: @"symbolic 1A_____Qy_ 13generic_types2P2P
+
 struct X3<T, U> where U: P2, U.A: P1 { }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s13generic_types1ACMi"(%swift.type_descriptor*, i8**, i8*) {{.*}} {

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -54,7 +54,9 @@ protocol ABO : A, B, O { func abo() }
 // CHECK-SAME:   i32 1,
 // CHECK-SAME:   i32 0,
 // AnyObject layout constraint
-// CHECK-SAME:   i32 31, i32 0, i32 0
+// CHECK-SAME:   i32 31,
+// CHECK-SAME:   @"symbolic x"
+// CHECK-SAME:   i32 0
 // CHECK-SAME: }
 
 // -- @objc protocol OPT uses ObjC symbol mangling and layout
@@ -76,11 +78,13 @@ protocol ABO : A, B, O { func abo() }
 // CHECK-SAME:   i32 2, i32 3, i32 0
 
 // Inheritance from A
-// CHECK-SAME:   i32 128, i32 0
+// CHECK-SAME:   i32 128,
+// CHECK-SAME:   @"symbolic x"
 // CHECK-SAME: @"$s17protocol_metadata1AMp"
 
 // Inheritance from B
-// CHECK-SAME:   i32 128, i32 0
+// CHECK-SAME:   i32 128,
+// CHECK-SAME:   @"symbolic x"
 // CHECK-SAME:   @"$s17protocol_metadata1BMp"
 // CHECK: }
 

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -25,7 +25,7 @@ import resilient_protocol
 
 // Requirement signature
 // CHECK-SAME:   i32 128,
-// CHECK-SAME:   @"$sx1T19protocol_resilience17ResilientProtocolP_MXA"
+// CHECK-SAME:   @"symbolic 1T_____Qz 19protocol_resilience17ResilientProtocolP"
 // CHECK-SAME:   @"$s19protocol_resilience17ResilientProtocolMp"
 
 // Protocol requirements

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -68,12 +68,6 @@ extension Y: OtherResilientProtocol { }
 public struct ConformsWithAssocRequirements : ProtocolWithAssocTypeDefaults {
 }
 
-// CHECK-USAGE: @"$sx1T18resilient_protocol24ProtocolWithRequirementsP_MXA" =
-// CHECK-USAGE-SAME: i32 0
-// CHECK-USAGE-SAME: @"{{got.|__imp_}}$s18resilient_protocol24ProtocolWithRequirementsMp"
-// CHECK-USAGE-SAME: @"$sx1T18resilient_protocol24ProtocolWithRequirementsP_MXA"
-// CHECK-USAGE-SAME: %swift.protocol_requirement** @"{{got.|__imp_}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl"
-
 // CHECK-USAGE: @"$s31protocol_resilience_descriptors21ConditionallyConformsVyxG010resilient_A024ProtocolWithRequirementsAaeFRzAA1YV1TRtzlMc"
 extension ConditionallyConforms: ProtocolWithRequirements
 where Element: ProtocolWithRequirements, Element.T == Y {


### PR DESCRIPTION
TargetGenericParamRef is a specialized structure used to describe the
subject of a generic requirement, e.g., the “T.Assoc” in “T.Assoc: P”.
Replace it with a mangled name, for several reasons:

1) Mangled type names are also fairly concise, can often be shared, and
are a well-tested path
2) Mangled type names can express any type, which might be useful in the
future
3) This structure doesn’t accommodate specifically stating where the
conformances come from (to extract associated type witnesses). Neither
can mangled names, but we’d like to do that work in only one place.

This change exposed an existing bug where we improperly calculated the
generic parameter counts for extensions of nested generic types. Fix that
bug here (which broke an execution test).
