### PR TITLE
Use super trampolines to let us override several more NSString methods (-UTF8String, -cStringUsingEncoding:, and -getCString:maxLength:encoding:) for performance

### DIFF
--- a/benchmark/single-source/ObjectiveCBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCBridgingStubs.swift
@@ -37,6 +37,7 @@ public let ObjectiveCBridgingStubs = [
   BenchmarkInfo(name: "ObjectiveCBridgeStringRangeOfString", runFunction: run_ObjectiveCBridgeStringRangeOfString, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
   BenchmarkInfo(name: "ObjectiveCBridgeStringHash", runFunction: run_ObjectiveCBridgeStringHash, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
   BenchmarkInfo(name: "ObjectiveCBridgeStringUTF8String", runFunction: run_ObjectiveCBridgeStringUTF8String, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
+  BenchmarkInfo(name: "ObjectiveCBridgeStringCStringUsingEncoding", runFunction: run_ObjectiveCBridgeStringCStringUsingEncoding, tags: [.validation, .String, .bridging], setUpFunction: setup_StringBridgeBenchmark),
 ]
 
 var b:BridgeTester! = nil
@@ -382,6 +383,17 @@ public func run_ObjectiveCBridgeStringUTF8String(N: Int) {
   for _ in 0 ..< N {
     autoreleasepool {
       b.testUTF8String()
+    }
+  }
+  #endif
+}
+
+@inline(never)
+public func run_ObjectiveCBridgeStringCStringUsingEncoding(N: Int) {
+  #if _runtime(_ObjC)
+  for _ in 0 ..< N {
+    autoreleasepool {
+      b.testCStringUsingEncoding()
     }
   }
   #endif

--- a/benchmark/utils/ObjectiveCTests/ObjectiveCTests.h
+++ b/benchmark/utils/ObjectiveCTests/ObjectiveCTests.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testIsEqualToString2;
 - (void)testIsEqualToStringAllSwift;
 - (void)testUTF8String;
+- (void)testCStringUsingEncoding;
 - (void)testGetUTF8Contents;
 - (void)testGetASCIIContents;
 - (void)testRangeOfString;

--- a/benchmark/utils/ObjectiveCTests/ObjectiveCTests.m
+++ b/benchmark/utils/ObjectiveCTests/ObjectiveCTests.m
@@ -249,6 +249,30 @@
   }
 }
 
+- (void)testCStringUsingEncoding {
+  for (NSString *str1 in bridgedStrings) {
+    @autoreleasepool {
+      for (int i = 0; i < 100; i++) {
+        (void)[str1 cStringUsingEncoding: NSASCIIStringEncoding];
+      }
+    }
+  }
+  for (NSString *str1 in bridgedStrings) {
+    @autoreleasepool {
+      for (int i = 0; i < 100; i++) {
+        (void)[str1 cStringUsingEncoding: NSUTF8StringEncoding];
+      }
+    }
+  }
+  for (NSString *str1 in bridgedStrings) {
+    @autoreleasepool {
+      for (int i = 0; i < 100; i++) {
+        (void)[str1 cStringUsingEncoding: NSUnicodeStringEncoding];
+      }
+    }
+  }
+}
+
 - (void)testGetUTF8Contents {
   for (NSString *str1 in bridgedStrings) {
     for (int i = 0; i < 200; i++) {

--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -125,6 +125,18 @@ SWIFT_RUNTIME_STDLIB_API
 _swift_shims_CFHashCode
 _swift_stdlib_CFStringHashCString(const _swift_shims_UInt8 * _Nonnull bytes,
                                   _swift_shims_CFIndex length);
+
+SWIFT_RUNTIME_STDLIB_API
+const __swift_uint8_t * _Nullable
+_swift_stdlib_NSStringCStringUsingEncodingTrampoline(id _Nonnull obj,
+                                                     unsigned long encoding);
+
+SWIFT_RUNTIME_STDLIB_API
+__swift_uint8_t
+_swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
+                                         _swift_shims_UInt8 *buffer,
+                                         _swift_shims_CFIndex maxLength,
+                                         unsigned long encoding);
   
 #endif // __OBJC2__
 

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -93,6 +93,33 @@ internal func _cocoaHashASCIIBytes(
   return _swift_stdlib_CFStringHashCString(bytes, length)
 }
 
+// These "trampolines" are effectively objc_msgSend_super.
+// They bypass our implementations to use NSString's
+
+@_effects(readonly)
+internal func _cocoaCStringUsingEncodingTrampoline(
+  _ string: _CocoaString,
+  _ encoding: UInt)
+  -> UnsafePointer<UInt8>? {
+    return _swift_stdlib_NSStringCStringUsingEncodingTrampoline(
+      string,
+      encoding)
+}
+
+
+@_effects(releasenone)
+internal func _cocoaGetCStringTrampoline(
+                             _ string: _CocoaString,
+                             _ buffer: UnsafeMutablePointer<UInt8>,
+                             _ maxLength: Int,
+                             _ encoding: UInt)
+  -> Int8 {
+    return Int8(_swift_stdlib_NSStringGetCStringTrampoline(string,
+                                                    buffer,
+                                                    maxLength,
+                                                    encoding))
+}
+
 //
 // Conversion from NSString to Swift's native representation
 //

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -21,6 +21,7 @@
 #if SWIFT_OBJC_INTEROP
 #import <CoreFoundation/CoreFoundation.h>
 #include "../SwiftShims/CoreFoundationShims.h"
+#import <objc/runtime.h>
 
 using namespace swift;
 
@@ -146,6 +147,32 @@ _swift_shims_CFHashCode
 swift::_swift_stdlib_CFStringHashCString(const _swift_shims_UInt8 * _Nonnull bytes,
                                   _swift_shims_CFIndex length) {
   return CFStringHashCString(bytes, length);
+}
+
+const __swift_uint8_t *
+swift::_swift_stdlib_NSStringCStringUsingEncodingTrampoline(id _Nonnull obj,
+                                                  unsigned long encoding) {
+  typedef __swift_uint8_t * _Nullable (*cStrImplPtr)(id, SEL, unsigned long);
+  cStrImplPtr imp = (cStrImplPtr)class_getMethodImplementation([obj superclass],
+                                                               @selector(cStringUsingEncoding:));
+  return imp(obj, @selector(cStringUsingEncoding:), encoding);
+}
+
+__swift_uint8_t
+swift::_swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
+                                         _swift_shims_UInt8 *buffer,
+                                         _swift_shims_CFIndex maxLength,
+                                         unsigned long encoding) {
+  typedef __swift_uint8_t (*getCStringImplPtr)(id,
+                                             SEL,
+                                             _swift_shims_UInt8 *,
+                                             _swift_shims_CFIndex,
+                                             unsigned long);
+  SEL sel = @selector(getCString:maxLength:encoding:);
+  getCStringImplPtr imp = (getCStringImplPtr)class_getMethodImplementation([obj superclass], sel);
+  
+  return imp(obj, sel, buffer, maxLength, encoding);
+
 }
 
 

--- a/test/stdlib/NSStringAPI.swift
+++ b/test/stdlib/NSStringAPI.swift
@@ -687,6 +687,18 @@ NSStringAPIs.test("getBytes(_:maxLength:usedLength:encoding:options:range:remain
 NSStringAPIs.test("getCString(_:maxLength:encoding:)") {
   let s = "abc あかさた"
   do {
+    // A significantly too small buffer
+    let bufferLength = 1
+    var buffer = Array(
+      repeating: CChar(bitPattern: 0xff), count: bufferLength)
+    let result = s.getCString(&buffer, maxLength: 100,
+                              encoding: .utf8)
+    expectFalse(result)
+    let result2 = s.getCString(&buffer, maxLength: 1,
+                              encoding: .utf8)
+    expectFalse(result2)
+  }
+  do {
     // The largest buffer that cannot accommodate the string plus null terminator.
     let bufferLength = 16
     var buffer = Array(
@@ -694,6 +706,9 @@ NSStringAPIs.test("getCString(_:maxLength:encoding:)") {
     let result = s.getCString(&buffer, maxLength: 100,
       encoding: .utf8)
     expectFalse(result)
+    let result2 = s.getCString(&buffer, maxLength: 16,
+                              encoding: .utf8)
+    expectFalse(result2)
   }
   do {
     // The smallest buffer where the result can fit.
@@ -707,6 +722,10 @@ NSStringAPIs.test("getCString(_:maxLength:encoding:)") {
     let result = s.getCString(&buffer, maxLength: 100,
       encoding: .utf8)
     expectTrue(result)
+    expectEqualSequence(expectedStr, buffer)
+    let result2 = s.getCString(&buffer, maxLength: 17,
+                              encoding: .utf8)
+    expectTrue(result2)
     expectEqualSequence(expectedStr, buffer)
   }
   do {


### PR DESCRIPTION
Put some more overrides in place that fall back to NSString for cases they don't handle, using a silly indirection mechanism

rdar://problem/45894634