### PR TITLE
Add specific diagnostic for case-let-as[?!] to sema

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4430,6 +4430,9 @@ WARNING(redundant_particular_literal_case,none,
 NOTE(redundant_particular_literal_case_here,none,
      "first occurrence of identical literal pattern is here", ())
 
+ERROR(case_as_punct,none,
+      "'as' in 'case' statement dose not use '%select{?|!}0'", (bool))
+
 WARNING(non_exhaustive_switch_warn,none, "switch must be exhaustive", ())
 WARNING(non_exhaustive_switch_unknown_only,none,
         "switch covers known cases, but %0 may have additional unknown values"

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1169,7 +1169,7 @@ public:
         assert(isa<CaseStmt>(initialCaseVarDecl->getParentPatternStmt()));
 
         if (vd->hasType() && initialCaseVarDecl->hasType() &&
-            !initialCaseVarDecl->isInvalid() &&
+            !initialCaseVarDecl->isInvalid() && !vd->isInvalid() &&
             !vd->getType()->isEqual(initialCaseVarDecl->getType())) {
           TC.diagnose(vd->getLoc(), diag::type_mismatch_multiple_pattern_list,
                       vd->getType(), initialCaseVarDecl->getType());

--- a/test/Sema/case_let_with_condcast.swift
+++ b/test/Sema/case_let_with_condcast.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift 
+
+// from bug SR-2022
+
+let a: Any
+let b: Any
+
+switch a {
+
+case let arr as [Int]:
+    print(arr)
+
+    // expected-error@+1 {{'as' in 'case' statement dose not use '?'}}
+case let n as? Float: 
+    print(n)
+
+    // expected-error@+1 {{'as' in 'case' statement dose not use '!'}}
+case let s as! String: 
+    print(s)
+
+    // expected-error@+2 {{'as' in 'case' statement dose not use '?'}}	
+case let n as Int where n == 0,
+     let n as? Int where n == 1:
+    print(n)
+
+    // We should still be allowed to use as? in the guard expression etc.	
+case let n as Int where n == (b as? Int):
+    print("It's the same as `b`, \(b as? Int)")
+
+default: print("Some other value...")
+} 


### PR DESCRIPTION
Bug SR-2022 suggests improving the error message for using `as?` in a case/let where a
plain `as`  (no question mark) should have been used. 

In swift  this erroneous code:
```
  switch myVariable {
    case let n as? Float:  // <-- should be `as` not `as?`
```
currently produces these diagnostics:   
```
	SR-2022.swift:13:13: warning: cast from '_' to unrelated type 'Float' always fails
        case let n as? Float:
                 ~ ^   ~~~~~
	SR-2022.swift:13:13: warning: cast from '_' to unrelated type 'Float' always fails
        case let n as? Float:
                 ~ ^   ~~~~~
	SR-2022.swift:13:13: error: expression pattern of type 'Float?' cannot match values of type 'Any'
        case let n as? Float:
                 ~~^~~~~~~~~
```
With this PR, a specific check is inserted into sema for this case producing:
`'as' in 'case' statement dose not use '?'`
with a fixit to remove the '?'
![image](https://user-images.githubusercontent.com/7078804/48245038-9c3f2a00-e3ae-11e8-90fd-70680c979a0d.png)

`as!` will be handled the same way as `as?`


Resolves #44631.