### PR TITLE
AST: Use resilient access pattern for stored properties of resilient types visible via -enable-testing

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1765,17 +1765,17 @@ bool AbstractStorageDecl::isFormallyResilient() const {
   if (getAttrs().hasAttribute<FixedLayoutAttr>())
     return false;
 
-  // Private and (unversioned) internal variables always have a
-  // fixed layout.
-  if (!getFormalAccessScope(/*useDC=*/nullptr,
-                            /*treatUsableFromInlineAsPublic=*/true).isPublic())
-    return false;
-
   // If we're an instance property of a nominal type, query the type.
   auto *dc = getDeclContext();
   if (!isStatic())
     if (auto *nominalDecl = dc->getSelfNominalTypeDecl())
       return nominalDecl->isResilient();
+
+  // Non-public global and static variables always have a
+  // fixed layout.
+  if (!getFormalAccessScope(/*useDC=*/nullptr,
+                            /*treatUsableFromInlineAsPublic=*/true).isPublic())
+    return false;
 
   return true;
 }

--- a/test/Inputs/resilient_struct.swift
+++ b/test/Inputs/resilient_struct.swift
@@ -91,3 +91,7 @@ public struct ResilientWeakRef {
 public struct ResilientRef {
   public var r: Referent
 }
+
+public struct ResilientWithInternalField {
+  var x: Int
+}

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -module-name struct_resilience -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -enable-sil-ownership -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-emit-silgen -module-name struct_resilience -I %t -enable-sil-ownership -enable-resilience %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -enable-sil-ownership %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-emit-silgen -I %t -enable-sil-ownership -enable-resilience %s | %FileCheck %s
 
 import resilient_struct
 

--- a/test/SILGen/struct_resilience_testable.swift
+++ b/test/SILGen/struct_resilience_testable.swift
@@ -1,0 +1,19 @@
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-testing -emit-module-path=%t/resilient_struct.swiftmodule -enable-sil-ownership %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-emit-silgen -I %t -enable-sil-ownership %s | %FileCheck %s
+
+@testable import resilient_struct
+
+// CHECK-LABEL: sil @$s26struct_resilience_testable37takesResilientStructWithInternalFieldySi010resilient_A00eghI0VF : $@convention(thin) (@in_guaranteed ResilientWithInternalField) -> Int
+// CHECK: [[COPY:%.*]] = alloc_stack $ResilientWithInternalField
+// CHECK: copy_addr %0 to [initialization] [[COPY]] : $*ResilientWithInternalField
+// CHECK: [[FN:%.*]] = function_ref @$s16resilient_struct26ResilientWithInternalFieldV1xSivg : $@convention(method) (@in_guaranteed ResilientWithInternalField) -> Int
+// CHECK: [[RESULT:%.*]] = apply [[FN]]([[COPY]])
+// CHECK: destroy_addr [[COPY]]
+// CHECK: dealloc_stack [[COPY]]
+// CHECK: return [[RESULT]]
+
+public func takesResilientStructWithInternalField(_ s: ResilientWithInternalField) -> Int {
+  return s.x
+}


### PR DESCRIPTION
Fixes <rdar://problem/45919829>.