### PR TITLE
[stdib] Remove RandomNumberGenerator._fill(bytes:)

### DIFF
--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -61,27 +61,6 @@ public protocol RandomNumberGenerator {
   ///
   /// - Returns: An unsigned 64-bit random value.
   mutating func next() -> UInt64
-
-  // FIXME: De-underscore after swift-evolution amendment
-  mutating func _fill(bytes buffer: UnsafeMutableRawBufferPointer)
-}
-
-extension RandomNumberGenerator {
-  @inlinable
-  public mutating func _fill(bytes buffer: UnsafeMutableRawBufferPointer) {
-    // FIXME: Optimize
-    var chunk: UInt64 = 0
-    var chunkBytes = 0
-    for i in 0..<buffer.count {
-      if chunkBytes == 0 {
-        chunk = next()
-        chunkBytes = UInt64.bitWidth / 8
-      }
-      buffer[i] = UInt8(truncatingIfNeeded: chunk)
-      chunk >>= UInt8.bitWidth
-      chunkBytes -= 1
-    }
-  }
 }
 
 extension RandomNumberGenerator {
@@ -166,12 +145,5 @@ public struct SystemRandomNumberGenerator : RandomNumberGenerator {
     var random: UInt64 = 0
     swift_stdlib_random(&random, MemoryLayout<UInt64>.size)
     return random
-  }
-
-  @inlinable
-  public mutating func _fill(bytes buffer: UnsafeMutableRawBufferPointer) {
-    if !buffer.isEmpty {
-      swift_stdlib_random(buffer.baseAddress!, buffer.count)
-    }
   }
 }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -78,3 +78,6 @@ Protocol _NSStringCore has been removed
 
 Constructor ManagedBuffer.init(_doNotCallMe:) has been removed
 Func _makeAnyHashableUpcastingToHashableBaseType(_:storingResultInto:) has been removed
+
+Func RandomNumberGenerator._fill(bytes:) has been removed
+Func SystemRandomNumberGenerator._fill(bytes:) has been removed

--- a/validation-test/stdlib/Random.swift
+++ b/validation-test/stdlib/Random.swift
@@ -3,10 +3,18 @@
 
 import StdlibUnittest
 import StdlibCollectionUnittest
+import SwiftShims // for swift_stdlib_random
 
 let RandomTests = TestSuite("Random")
 
 // _fill(bytes:)
+
+extension RandomNumberGenerator {
+  func _fill(bytes buffer: UnsafeMutableRawBufferPointer) {
+    guard let start = buffer.baseAddress else { return }
+    swift_stdlib_random(start, buffer.count)
+  }
+}
 
 RandomTests.test("_fill(bytes:)") {
   for count in [100, 1000] {


### PR DESCRIPTION
This hidden customization point isn’t used in the stdlib anymore.
