### PR TITLE
Register TensorFlowGraph functions in TFPartition for eager mode globally.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2700,8 +2700,6 @@ void CallEmission::setArgs(Explosion &original, bool isOutlined,
   case SILFunctionTypeRepresentation::Block:
     adjusted.add(getCallee().getBlockObject());
     LLVM_FALLTHROUGH;
-  // SWIFT_ENABLE_TENSORFLOW
-  case SILFunctionTypeRepresentation::TensorFlow:
   case SILFunctionTypeRepresentation::CFunctionPointer:
     externalizeArguments(IGF, getCallee(), original, adjusted,
                          Temporaries, isOutlined);
@@ -2719,6 +2717,8 @@ void CallEmission::setArgs(Explosion &original, bool isOutlined,
 
   case SILFunctionTypeRepresentation::Closure:
   case SILFunctionTypeRepresentation::Method:
+  // SWIFT_ENABLE_TENSORFLOW
+  case SILFunctionTypeRepresentation::TensorFlow:
   case SILFunctionTypeRepresentation::Thin:
   case SILFunctionTypeRepresentation::Thick: {
     // Check for value arguments that need to be passed indirectly.

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -481,6 +481,14 @@ fileprivate extension _ExecutionContext {
   }
 }
 
+public extension _ExecutionContext {
+  /// Load functions from a graph encoded as a byte-pointer and length into the
+  /// tensorflow eagerContext.
+  func loadFunctionsFromGraph(byteAddress: UnsafeRawPointer, byteCount: Int) {
+    _ = loadProgramInBytes(byteAddress, count: byteCount)
+  }
+}
+
 @usableFromInline
 internal func dumpTensorContent<Scalar : _TensorFlowDataTypeCompatible>(
   _ inputTensor: CTensorHandle, _: Scalar.Type
@@ -1121,6 +1129,21 @@ public func _TFCFinishTensorComputation(
 @_silgen_name("_swift_tfc_TerminateTensorComputation")
 public func _TFCTerminateTensorComputation(_ computation: _TensorComputation) {
   computation.terminate()
+}
+
+/// Registers all functions in a graph into the eager context if in eager mode.
+///
+/// - Parameters:
+///   - programByteAddress: The address of the raw program.
+///   - programByteCount: The number of bytes in the program.
+@inlinable
+@_silgen_name("_swift_tfc_RegisterTensorFunctions")
+public func _TFCRegisterTensorFunctions(
+  _ programByteAddress: UnsafeRawPointer,
+  _ programByteCount: Int
+) {
+  _ExecutionContext.global.loadFunctionsFromGraph(byteAddress: programByteAddress,
+                                                  byteCount: programByteCount)
 }
 
 /// Creates a scalar CTensorHandle value for the given data type.

--- a/test/TensorFlowRuntime/accelerator_only.swift
+++ b/test/TensorFlowRuntime/accelerator_only.swift
@@ -1,0 +1,32 @@
+// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-swift-frontend -emit-sil -O %s -verify | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+@TensorFlowGraph
+func add_constant(_ a: Tensor<Float>) -> Tensor<Float> {
+  return a + Tensor<Float>([[5]])
+}
+
+// CHECK-LABEL: @{{.*}}accelerator_only14matmul_and_add{{.*}}
+// CHECK: graph_op "s16accelerator_only14matmul_and_addy10TensorFlow0F0VySfGAF_AFtF.tf_only{{.*}}
+// CHECK: end sil function {{.*}}accelerator_only14matmul_and_add{{.*}}
+@TensorFlowGraph
+@inline(never)
+func matmul_and_add(_ a : Tensor<Float>, _ b : Tensor<Float>) -> Tensor<Float> {
+  return add_constant(a • b)
+}
+
+var acceleratorOnly = TestSuite("AcceleratorOnlyFunctions")
+
+acceleratorOnly.testAllBackends("BasicAcceleratorOnly") {
+  let result = matmul_and_add(Tensor<Float>(shape: [1, 1], scalars: [2.0]),
+                              Tensor(shape: [1, 1], scalars: [3.0]));
+  expectEqual(result.array, ShapedArray(shape: [1, 1], scalars: [11.0]))
+}
+
+runAllTests()


### PR DESCRIPTION
This entails adding a global graph registration at the beginning of main, and
changing convention tensorflow to be still called as a normal swift function later on in IRGen.
Function bodies needed to be preserved throughout TFPartition as well.

This is needed in order to ensure that the graph is still registered when calling TensorFlowGraph in eager mode either as function attributes or directly.

Note: This currently doesn't support calling into convention(tensorflow) functions in other modules.
In addition, This cl contains a very small change to IRGen.cpp where we need tensorflow functions to remain as a normal SIL function so that they can be properly called if they are not inlined rather than being treated as C functions which they are not.