### PR TITLE
[AutoDiff] NFC: Rename SILReverseAutoDiff* to SILAutoDiff*.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -77,7 +77,7 @@ namespace swift {
   enum PointerTypeKind : unsigned;
   struct ValueOwnershipKind;
   // SWIFT_ENABLE_TENSORFLOW
-  struct SILReverseAutoDiffConfig;
+  struct SILAutoDiffConfig;
 
   enum class TypeKind : uint8_t {
 #define TYPE(id, parent) id,
@@ -4072,7 +4072,7 @@ public:
 
   /// SWIFT_ENABLE_TENSORFLOW
   CanSILFunctionType getGradientType(
-    const SILReverseAutoDiffConfig &config, SILModule &M);
+    const SILAutoDiffConfig &config, SILModule &M);
 
   /// If this is a @convention(witness_method) function with a protocol
   /// constrained self parameter, return the protocol constraint for

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -487,7 +487,7 @@ public:
 
   /// SWIFT_ENABLE_TENSORFLOW
   GradientInst *createGradient(SILLocation loc, SILValue original,
-                               const SILReverseAutoDiffConfig &config) {
+                               const SILAutoDiffConfig &config) {
     return insert(GradientInst::create(getModule(), getSILDebugLocation(loc),
                                        original, config));
   }

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -116,20 +116,20 @@ class SILReverseDifferentiableAttr final {
 
 private:
   /// The AD indices.
-  SILReverseAutoDiffIndices indices;
+  SILAutoDiffIndices indices;
   /// The primal and adjoint function names.
   StringRef PrimalName, AdjointName;
   /// Whether the adjoint is primitive.
   bool AdjointIsPrimitive;
 
-  SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
+  SILReverseDifferentiableAttr(const SILAutoDiffIndices &indices,
                                StringRef primalName,
                                StringRef adjointName,
                                bool adjointIsPrimitive);
 
 public:
   static SILReverseDifferentiableAttr *create(
-      SILModule &M, const SILReverseAutoDiffIndices &indices,
+      SILModule &M, const SILAutoDiffIndices &indices,
       StringRef primalName = StringRef(), StringRef adjointName = StringRef(),
       bool adjointIsPrimitive = false);
 
@@ -145,7 +145,7 @@ public:
     AdjointIsPrimitive = primitive;
   }
 
-  const SILReverseAutoDiffIndices &getIndices() const { return indices; }
+  const SILAutoDiffIndices &getIndices() const { return indices; }
 
   void print(llvm::raw_ostream &OS) const;
 };

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7516,26 +7516,26 @@ class GradientInst final
                            SingleValueInstruction> {
 private:
   friend SILBuilder;
-  /// The reverse-mode AD configuration.
-  SILReverseAutoDiffConfig Config;
+  /// The AD configuration.
+  SILAutoDiffConfig Config;
   /// Space for 1 operand: the original function to be differentiated.
   FixedOperandList<1> Operands;
 
   GradientInst(SILModule &module, SILDebugLocation debugLoc, SILValue original,
-               const SILReverseAutoDiffConfig &config);
+               const SILAutoDiffConfig &config);
 
   /// A utility function for computing the SIL type of the gradient of a
   /// function, given the specified differentiation configuration options.
   static SILType getGradientSILType(
       SILModule &module, SILValue original,
-      const SILReverseAutoDiffConfig &config);
+      const SILAutoDiffConfig &config);
 
 public:
   ~GradientInst() {};
 
   static GradientInst *create(SILModule &M, SILDebugLocation debugLoc,
                               SILValue original,
-                              const SILReverseAutoDiffConfig &config);
+                              const SILAutoDiffConfig &config);
 
   SILValue getOriginal() const { return Operands[0].get(); }
 
@@ -7543,11 +7543,11 @@ public:
     return getOriginal()->getType().getAs<SILFunctionType>();
   }
 
-  const SILReverseAutoDiffConfig &getConfig() const {
+  const SILAutoDiffConfig &getConfig() const {
     return Config;
   }
 
-  const SILReverseAutoDiffIndices &getIndices() const {
+  const SILAutoDiffIndices &getIndices() const {
     return Config.indices;
   }
 

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -620,6 +620,10 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   // Automatic differentiation
   SINGLE_VALUE_INST(GradientInst, gradient,
                     SingleValueInstruction, None, DoesNotRelease)
+  SINGLE_VALUE_INST(AutoDiffFunction, autodiff_function,
+                    SingleValueInstruction, None, DoesNotRelease)
+  SINGLE_VALUE_INST(AutoDiffFunctionExtract, autodiff_function_extract,
+                    SingleValueInstruction, None, DoesNotRelease)
 
   // Key paths
   // TODO: The only "side effect" is potentially retaining the returned key path

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -620,10 +620,6 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   // Automatic differentiation
   SINGLE_VALUE_INST(GradientInst, gradient,
                     SingleValueInstruction, None, DoesNotRelease)
-  SINGLE_VALUE_INST(AutoDiffFunction, autodiff_function,
-                    SingleValueInstruction, None, DoesNotRelease)
-  SINGLE_VALUE_INST(AutoDiffFunctionExtract, autodiff_function_extract,
-                    SingleValueInstruction, None, DoesNotRelease)
 
   // Key paths
   // TODO: The only "side effect" is potentially retaining the returned key path

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -17,7 +17,7 @@
 
 using namespace swift;
 
-SILReverseAutoDiffIndices::SILReverseAutoDiffIndices(
+SILAutoDiffIndices::SILAutoDiffIndices(
     unsigned source, ArrayRef<unsigned> parameters) : source(source) {
   if (parameters.empty())
     return;
@@ -32,8 +32,8 @@ SILReverseAutoDiffIndices::SILReverseAutoDiffIndices(
   }
 }
 
-bool SILReverseAutoDiffIndices::operator==(
-    const SILReverseAutoDiffIndices &other) const {
+bool SILAutoDiffIndices::operator==(
+    const SILAutoDiffIndices &other) const {
   if (source != other.source)
     return false;
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2922,7 +2922,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SILValue original = getLocalValue(originalName, originalTy, InstLoc, B);
     if (parseSILDebugLocation(InstLoc, B))
       return true;
-    SILReverseAutoDiffConfig config(
+    SILAutoDiffConfig config(
       {sourceIndex, paramIndices}, existingOptions);
     ResultVal = B.createGradient(InstLoc, original, config);
     break;

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -58,7 +58,7 @@ void SILFunction::addSpecializeAttr(SILSpecializeAttr *Attr) {
 
 /// SWIFT_ENABLE_TENSORFLOW
 SILReverseDifferentiableAttr::
-SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
+SILReverseDifferentiableAttr(const SILAutoDiffIndices &indices,
                              StringRef primalName,
                              StringRef adjointName,
                              bool adjointIsPrimitive)
@@ -67,7 +67,7 @@ SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
 
 SILReverseDifferentiableAttr *
 SILReverseDifferentiableAttr::create(SILModule &M,
-                                     const SILReverseAutoDiffIndices &indices,
+                                     const SILAutoDiffIndices &indices,
                                      StringRef primalName,
                                      StringRef adjointName,
                                      bool adjointIsPrimitive) {

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -101,7 +101,7 @@ CanType SILFunctionType::getSelfInstanceType() const {
 /// SWIFT_ENABLE_TENSORFLOW
 CanSILFunctionType
 SILFunctionType::getGradientType(
-    const SILReverseAutoDiffConfig &config, SILModule &M) {
+    const SILAutoDiffConfig &config, SILModule &M) {
   // FIXME: Handle `Delayed` gradient option.
   auto originalParams = getParameters();
   auto originalResult = getResults()[config.getSourceIndex()];

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -582,14 +582,14 @@ TryApplyInst *TryApplyInst::create(
 /// SWIFT_ENABLE_TENSORFLOW
 GradientInst::GradientInst(SILModule &module, SILDebugLocation debugLoc,
                            SILValue original,
-                           const SILReverseAutoDiffConfig &config)
+                           const SILAutoDiffConfig &config)
   : InstructionBase(debugLoc,
                     getGradientSILType(module, original, config)),
     Config(config), Operands(this, original) {}
 
 SILType GradientInst::getGradientSILType(
     SILModule &module, SILValue original,
-    const SILReverseAutoDiffConfig &config) {
+    const SILAutoDiffConfig &config) {
   // If parameter indices are empty, return an invalid type (empty tuple type).
   // An "empty parameter indices" will be produced during verification.
   if (config.indices.parameters.none()) {
@@ -604,7 +604,7 @@ SILType GradientInst::getGradientSILType(
 GradientInst *
 GradientInst::create(SILModule &M, SILDebugLocation debugLoc,
                      SILValue original,
-                     const SILReverseAutoDiffConfig &config) {
+                     const SILAutoDiffConfig &config) {
   void *buffer = M.allocateInst(sizeof(GradientInst), alignof(GradientInst));
   return ::new (buffer) GradientInst(M, debugLoc, original, config);
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -836,7 +836,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
       auto paramIndices =
           getLoweredAutoDiffParameterIndices(*this, AFD, silOriginalFn,
                                              diffAttr);
-      SILReverseAutoDiffIndices indices(/*source*/ 0, paramIndices);
+      SILAutoDiffIndices indices(/*source*/ 0, paramIndices);
       silOriginalFn->addReverseDifferentiableAttr(
           SILReverseDifferentiableAttr::create(
             M, indices, primName, adjName,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2753,7 +2753,7 @@ static RValue emitGradientInst(RValueEmitter &RVE, const SGFContext &C,
       RVE.SGF.SGM.getLoweredFunctionParameterIndex(param.index, origTy);
     loweredParamIndices.append(silParamIndices.begin(), silParamIndices.end());
   }
-  SILReverseAutoDiffConfig config(
+  SILAutoDiffConfig config(
       {E->getResultIndex(), loweredParamIndices}, options);
   auto gradInst =
     RVE.SGF.B.createGradient(loc, origVal.forward(RVE.SGF), config);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -641,7 +641,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     llvm::SmallBitVector parametersBitVector(parameters.size());
     for (unsigned i = 0; i < parameters.size(); i++)
       parametersBitVector[i] = parameters[i];
-    SILReverseAutoDiffIndices indices(source, parametersBitVector);
+    SILAutoDiffIndices indices(source, parametersBitVector);
 
     auto *attr = SILReverseDifferentiableAttr::create(SILMod, indices,
                                                       primalName, adjointName,
@@ -1478,8 +1478,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     llvm::SmallBitVector paramIndices(ListOfValues.size());
     for (auto i : indices(ListOfValues))
       paramIndices[i] = ListOfValues[i];
-    SILReverseAutoDiffIndices indices(GradResultIndex, paramIndices);
-    SILReverseAutoDiffConfig config(indices, GradOpts);
+    SILAutoDiffIndices indices(GradResultIndex, paramIndices);
+    SILAutoDiffConfig config(indices, GradOpts);
     ResultVal = Builder.createGradient(Loc, Val, config);
     break;
   }

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -2,7 +2,7 @@ add_swift_unittest(SwiftASTTests
   ArithmeticEvaluator.cpp
   DiagnosticConsumerTests.cpp
   # SWIFT_ENABLE_TENSORFLOW
-  SILReverseAutoDiffIndices.cpp
+  SILAutoDiffIndices.cpp
   SourceLocTests.cpp
   TestContext.cpp
   TypeMatchTests.cpp

--- a/unittests/AST/SILAutoDiffIndices.cpp
+++ b/unittests/AST/SILAutoDiffIndices.cpp
@@ -1,4 +1,4 @@
-//===--- SILReverseAutoDiffIndices.cpp - Tests SILReverseAutoDiffIndices --===//
+//===--- SILAutoDiffIndices.cpp - Tests SILAutoDiffIndices ----------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -16,12 +16,12 @@
 
 using namespace swift;
 
-TEST(SILReverseAutoDiffIndices, EqualityAndHash) {
-  using IndicesDenseMapInfo = llvm::DenseMapInfo<SILReverseAutoDiffIndices>;
+TEST(SILAutoDiffIndices, EqualityAndHash) {
+  using IndicesDenseMapInfo = llvm::DenseMapInfo<SILAutoDiffIndices>;
 
   std::array<unsigned, 0> empty;
   // Each example is distinct.
-  SILReverseAutoDiffIndices examples[] = {
+  SILAutoDiffIndices examples[] = {
     {0, empty},
     {1, empty},
     {0, {0}},


### PR DESCRIPTION
As title. No need to differentiate (no pun intended) between forward and reverse.