### PR TITLE
[LangOptions] os(Cygwin) is not true on Cygwin

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -184,10 +184,10 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     addPlatformConditionValue(PlatformConditionKind::OS, "Linux");
   else if (Target.isOSFreeBSD())
     addPlatformConditionValue(PlatformConditionKind::OS, "FreeBSD");
-  else if (Target.isOSWindows())
-    addPlatformConditionValue(PlatformConditionKind::OS, "Windows");
   else if (Target.isWindowsCygwinEnvironment())
     addPlatformConditionValue(PlatformConditionKind::OS, "Cygwin");
+  else if (Target.isOSWindows())
+    addPlatformConditionValue(PlatformConditionKind::OS, "Windows");
   else if (Target.isPS4())
     addPlatformConditionValue(PlatformConditionKind::OS, "PS4");
   else if (Target.isOSHaiku())

--- a/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
@@ -1,8 +1,8 @@
-// RUN: %swift -parse %s -verify -D FOO -D BAR -target x86_64-unknown-windows-cygnus -disable-objc-interop -D FOO -parse-stdlib
+// RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-windows-cygnus -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-cygnus
-#if arch(x86_64) && os(Cygwin) && _runtime(_Native)
+
+#if arch(x86_64) && os(Cygwin) && _runtime(_Native) && _endian(little)
 class C {}
 var x = C()
 #endif
 var y = x
-


### PR DESCRIPTION
`Target.isOSWindows()` and `Target.isWindowsCygwinEnvironment()` are both true in Cygwin.
We should check the `os(Cygwin)` before `os(Windows)`.
