### PR TITLE
Revert "[CSBindings] Detect situations when type variable bindings co…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -424,15 +424,6 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
     case ConstraintKind::ArgumentConversion:
     case ConstraintKind::OperatorArgumentConversion:
     case ConstraintKind::OptionalObject: {
-      // If there is a `bind param` constraint associated with
-      // current type variable, result should be aware of that
-      // fact. Binding set might be incomplete until
-      // this constraint is resolved, because we currently don't
-      // look-through constraints expect to `subtype` to try and
-      // find related bindings.
-      if (constraint->getKind() == ConstraintKind::BindParam)
-        result.PotentiallyIncomplete = true;
-
       auto binding = getPotentialBindingForRelationalConstraint(
           result, constraint, hasDependentMemberRelationalConstraints,
           hasNonDependentMemberRelationalConstraints,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2831,12 +2831,6 @@ private:
     /// Whether the bindings of this type involve other type variables.
     bool InvolvesTypeVariables = false;
 
-    /// Whether the bindings represent (potentially) incomplete set,
-    /// there is no way to say with absolute certainty if that's the
-    /// case, but that could happen when certain constraints like
-    /// `bind param` are present in the system.
-    bool PotentiallyIncomplete = false;
-
     /// Whether this type variable has literal bindings.
     LiteralBindingKind LiteralBinding = LiteralBindingKind::None;
 
@@ -2881,14 +2875,9 @@ private:
       if (formBindingScore(y) < formBindingScore(x))
         return false;
 
-      // If there is a difference in number of default types,
+      // If the only difference is default types,
       // prioritize bindings with fewer of them.
-      if (x.NumDefaultableBindings != y.NumDefaultableBindings)
-        return x.NumDefaultableBindings < y.NumDefaultableBindings;
-
-      // As a last resort, let's check if the bindings are
-      // potentially incomplete, and if so, let's de-prioritize them.
-      return x.PotentiallyIncomplete < y.PotentiallyIncomplete;
+      return x.NumDefaultableBindings < y.NumDefaultableBindings;
     }
 
     void foundLiteralBinding(ProtocolDecl *proto) {
@@ -2921,8 +2910,6 @@ private:
     void dump(llvm::raw_ostream &out,
               unsigned indent = 0) const LLVM_ATTRIBUTE_USED {
       out.indent(indent);
-      if (PotentiallyIncomplete)
-        out << "potentially_incomplete ";
       if (FullyBound)
         out << "fully_bound ";
       if (SubtypeOfExistentialType)

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -798,15 +798,6 @@ func test<Instances : Collection>(
 
 test([1]) { _, _ in fatalError(); () }
 
-// rdar://problem/45659733
-func rdar_45659733() {
-  func foo<T : BinaryInteger>(_: AnyHashable, _: T) {}
-  func bar(_ a: Int, _ b: Int) {
-    _ = (a ..< b).map { i in foo(i, i) } // Ok
-  }
-}
-
-
 // rdar://problem/40537960 - Misleading diagnostic when using closure with wrong type
 
 protocol P_40537960 {}
@@ -831,3 +822,4 @@ func rdar_40537960() {
   var arr: [S] = []
   _ = A(arr, fn: { L($0.v) }) // expected-error {{cannot convert value of type 'L' to closure result type 'R<T>'}}
 }
+


### PR DESCRIPTION
…uld be incomplete"

This reverts commit 4f708890c101dc22516f39ed8dee90888aea75f8.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
