### PR TITLE
[IRGen] Modifications for Cygwin

### DIFF
--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -318,7 +318,9 @@ ClangTypeConverter::reverseBuiltinTypeMapping(IRGenModule &IGM,
   // On 64-bit Windows, no C type is imported as an Int or UInt; CLong is
   // imported as an Int32 and CLongLong as an Int64. Therefore, manually
   // add mappings to C for Int and UInt.
-  if (IGM.Triple.isOSWindows() && IGM.Triple.isArch64Bit()) {
+  // On 64-bit Cygwin, no manual mapping is required.
+  if (IGM.Triple.isOSWindows() && !IGM.Triple.isWindowsCygwinEnvironment() &&
+      IGM.Triple.isArch64Bit()) {
     // Map UInt to uintptr_t
     auto swiftUIntType = getNamedSwiftType(stdlib, "UInt");
     auto clangUIntPtrType = ctx.getCanonicalType(ctx.getUIntPtrType());

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -593,10 +593,17 @@ swift::createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
   }
 
 
+  // On Cygwin 64 bit, dlls are loaded above the max address for 32 bits.
+  // This means that the default CodeModel causes generated code to segfault
+  // when run.
+  Optional<CodeModel::Model> cmodel = None;
+  if (EffectiveTriple.isArch64Bit() && EffectiveTriple.isWindowsCygwinEnvironment())
+    cmodel = CodeModel::Large;
+
   // Create a target machine.
   llvm::TargetMachine *TargetMachine = Target->createTargetMachine(
       EffectiveTriple.str(), CPU, targetFeatures, TargetOpts, Reloc::PIC_,
-      None, OptLevel);
+      cmodel, OptLevel);
   if (!TargetMachine) {
     Ctx.Diags.diagnose(SourceLoc(), diag::no_llvm_target,
                        EffectiveTriple.str(), "no LLVM target machine");


### PR DESCRIPTION
- Cygwin 64 bit uses the LP64 model and differs from the LLP64 model used on Windows 64 bit.
  On Cygwin 64 bit, CLong is imported as Int. Therefore, no manual mapping is required.

- On Cygwin 64 bit, dlls are loaded above the max address for 32 bits.
  This means that the default CodeModel causes generated code to segfault when run.
