### PR TITLE
[Stdlib] Remove SwiftPrivate's dependency on Darwin.

### DIFF
--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftShims
-import SwiftOverlayShims
 
 public struct _FDInputStream {
   public let fd: CInt

--- a/stdlib/public/SwiftShims/LibcOverlayShims.h
+++ b/stdlib/public/SwiftShims/LibcOverlayShims.h
@@ -29,7 +29,6 @@ typedef int mode_t;
 #include <semaphore.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
-#include <unistd.h>
 #endif
 
 #include <errno.h>
@@ -113,32 +112,6 @@ int static inline _swift_stdlib_openat(int fd, const char *path, int oflag,
   return openat(fd, path, oflag, mode);
 }
 #endif
-
-static inline __swift_ssize_t
-_swift_stdlib_read(int fd, void *buf, size_t nbyte) {
-#if defined(_WIN32)
-  return _read(fd, buf, nbyte);
-#else
-  return read(fd, buf, nbyte);
-#endif
-}
-
-static inline __swift_ssize_t
-_swift_stdlib_write(int fd, const void *buf, size_t nbyte) {
-#if defined(_WIN32)
-  return _write(fd, buf, nbyte);
-#else
-  return write(fd, buf, nbyte);
-#endif
-}
-
-static inline int _swift_stdlib_close(int fd) {
-#if defined(_WIN32)
-  return _close(fd);
-#else
-  return close(fd);
-#endif
-}
 
 #if __has_feature(nullability)
 #pragma clang assume_nonnull end

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -62,6 +62,14 @@ static inline void _swift_stdlib_free(void *ptr) {
   free(ptr);
 }
 
+// <unistd.h>
+SWIFT_RUNTIME_STDLIB_SPI
+__swift_ssize_t _swift_stdlib_read(int fd, void *buf, __swift_size_t nbyte);
+SWIFT_RUNTIME_STDLIB_SPI
+__swift_ssize_t _swift_stdlib_write(int fd, const void *buf, __swift_size_t nbyte);
+SWIFT_RUNTIME_STDLIB_SPI
+int _swift_stdlib_close(int fd);
+
 // String handling <string.h>
 SWIFT_READONLY
 static inline __swift_size_t _swift_stdlib_strlen(const char *s) {

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include <type_traits>
 
@@ -49,4 +50,33 @@ __swift_size_t swift::_swift_stdlib_fwrite_stdout(const void *ptr,
                                                   __swift_size_t size,
                                                   __swift_size_t nitems) {
     return fwrite(ptr, size, nitems, stdout);
+}
+
+SWIFT_RUNTIME_STDLIB_SPI
+__swift_ssize_t
+swift::_swift_stdlib_read(int fd, void *buf, __swift_size_t nbyte) {
+#if defined(_WIN32)
+  return _read(fd, buf, nbyte);
+#else
+  return read(fd, buf, nbyte);
+#endif
+}
+
+SWIFT_RUNTIME_STDLIB_SPI
+__swift_ssize_t
+swift::_swift_stdlib_write(int fd, const void *buf, __swift_size_t nbyte) {
+#if defined(_WIN32)
+  return _write(fd, buf, nbyte);
+#else
+  return write(fd, buf, nbyte);
+#endif
+}
+
+SWIFT_RUNTIME_STDLIB_SPI
+int swift::_swift_stdlib_close(int fd) {
+#if defined(_WIN32)
+  return _close(fd);
+#else
+  return close(fd);
+#endif
 }


### PR DESCRIPTION
Cherry-pick #20372 to `swift-5.0-branch`.

Revert #20194, which seems to be more trouble than it's worth. Instead, move the functions that SwiftPrivate needs back into LibcShims.h/cpp as SPI.

rdar://problem/45817565