### PR TITLE
Towards s390x arch support - ConfigureSystemZ changes

### DIFF
--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -134,6 +134,10 @@ static void configureSystemZ(IRGenModule &IGM, const llvm::Triple &triple,
                              SwiftTargetInfo &target) {
   setToMask(target.PointerSpareBits, 64,
             SWIFT_ABI_S390X_SWIFT_SPARE_BITS_MASK);
+  setToMask(target.ObjCPointerReservedBits, 64,
+            SWIFT_ABI_S390X_OBJC_RESERVED_BITS_MASK);
+  setToMask(target.IsObjCPointerBit, 64, SWIFT_ABI_S390X_IS_OBJC_BIT);
+  target.SwiftRetainIgnoresNegativeValues = true;
 }
 
 /// Configure a default target.

--- a/stdlib/public/runtime/WeakReference.h
+++ b/stdlib/public/runtime/WeakReference.h
@@ -91,6 +91,9 @@ class WeakReferenceBits {
 #elif defined(__arm__) || defined(_M_ARM)
     NativeMarkerMask  = SWIFT_ABI_ARM_OBJC_WEAK_REFERENCE_MARKER_MASK,
     NativeMarkerValue = SWIFT_ABI_ARM_OBJC_WEAK_REFERENCE_MARKER_VALUE
+#elif defined(__s390x__)
+    NativeMarkerMask  = SWIFT_ABI_S390X_OBJC_WEAK_REFERENCE_MARKER_MASK,
+    NativeMarkerValue = SWIFT_ABI_S390X_OBJC_WEAK_REFERENCE_MARKER_VALUE
 #elif defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64)
     NativeMarkerMask  = SWIFT_ABI_ARM64_OBJC_WEAK_REFERENCE_MARKER_MASK,
     NativeMarkerValue = SWIFT_ABI_ARM64_OBJC_WEAK_REFERENCE_MARKER_VALUE


### PR DESCRIPTION
This is a continuation of PR https://github.com/apple/swift/pull/19822

This PR modifies SwiftTargetInfo and WeakReference source code to account for s390x architecture.