### PR TITLE
[stdlib] Introduce ContiguousCollection protocol

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1270,16 +1270,6 @@ extension Array: RangeReplaceableCollection {
   //===--- algorithms -----------------------------------------------------===//
 
   @inlinable
-  public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
-    return try withUnsafeMutableBufferPointer {
-      (bufferPointer) -> R in
-      return try body(&bufferPointer)
-    }
-  }
-
-  @inlinable
   public __consuming func _copyToContiguousArray() -> ContiguousArray<Element> {
     if let n = _buffer.requestNativeBuffer() {
       return ContiguousArray(_buffer: n)

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1065,16 +1065,6 @@ extension ArraySlice: RangeReplaceableCollection {
   //===--- algorithms -----------------------------------------------------===//
 
   @inlinable
-  public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
-    return try withUnsafeMutableBufferPointer {
-      (bufferPointer) -> R in
-      return try body(&bufferPointer)
-    }
-  }
-
-  @inlinable
   public __consuming func _copyToContiguousArray() -> ContiguousArray<Element> {
     if let n = _buffer.requestNativeBuffer() {
       return ContiguousArray(_buffer: n)

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SWIFTLIB_ESSENTIAL
   Comparable.swift
   CompilerProtocols.swift
   ContiguousArray.swift
+  ContiguousCollection.swift
   ContiguouslyStored.swift
   ClosedRange.swift
   ContiguousArrayBuffer.swift

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -147,15 +147,10 @@ extension ContiguousArray: _ArrayProtocol {
 }
 
 extension ContiguousArray: RandomAccessCollection, MutableCollection {
-  /// The index type for arrays, `Int`.
   public typealias Index = Int
-
-  /// The type that represents the indices that are valid for subscripting an
-  /// array, in ascending order.
   public typealias Indices = Range<Int>
-
-  /// The type that allows iteration over an array's elements.
   public typealias Iterator = IndexingIterator<ContiguousArray>
+  public typealias SubSequence = ArraySlice<Element>
 
   /// The position of the first element in a nonempty array.
   ///
@@ -418,7 +413,7 @@ extension ContiguousArray: RandomAccessCollection, MutableCollection {
   /// - Parameter bounds: A range of integers. The bounds of the range must be
   ///   valid indices of the array.
   @inlinable
-  public subscript(bounds: Range<Int>) -> ArraySlice<Element> {
+  public subscript(bounds: Range<Int>) -> SubSequence {
     get {
       _checkIndex(bounds.lowerBound)
       _checkIndex(bounds.upperBound)
@@ -912,16 +907,6 @@ extension ContiguousArray: RangeReplaceableCollection {
   }
 
   //===--- algorithms -----------------------------------------------------===//
-
-  @inlinable
-  public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
-    return try withUnsafeMutableBufferPointer {
-      (bufferPointer) -> R in
-      return try body(&bufferPointer)
-    }
-  }
 
   @inlinable
   public __consuming func _copyToContiguousArray() -> ContiguousArray<Element> {

--- a/stdlib/public/core/ContiguousCollection.swift
+++ b/stdlib/public/core/ContiguousCollection.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A collection that supports access to its underlying contiguous storage.
+public protocol ContiguousCollection: Collection
+where SubSequence: ContiguousCollection {
+  func withUnsafeBufferPointer<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R
+}
+
+/// A collection that supports mutable access to its underlying contiguous
+/// storage.
+public protocol MutableContiguousCollection: ContiguousCollection, MutableCollection
+where SubSequence: MutableContiguousCollection {
+  mutating func withUnsafeMutableBufferPointer<R>(
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R
+}
+
+extension Array: MutableContiguousCollection { }
+extension ArraySlice: MutableContiguousCollection { }
+extension ContiguousArray: MutableContiguousCollection { }
+
+extension Slice: ContiguousCollection where Base: ContiguousCollection {
+  @inlinable
+  public func withUnsafeBufferPointer<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R {
+    let i = _base.distance(from: _base.startIndex, to: startIndex)
+    let j = _base.distance(from: _base.startIndex, to: endIndex)
+    return try _base.withUnsafeBufferPointer {
+      return try body(UnsafeBufferPointer(rebasing: $0[i..<j]))
+    }
+  }
+}
+
+extension Slice: MutableContiguousCollection 
+where Base: MutableContiguousCollection {
+  @inlinable
+  public mutating func withUnsafeMutableBufferPointer<R>(
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R {
+    let i = _base.distance(from: _base.startIndex, to: startIndex)
+    let j = _base.distance(from: _base.startIndex, to: endIndex)
+    return try _base.withUnsafeMutableBufferPointer {
+      var buffer = UnsafeMutableBufferPointer(rebasing: $0[i..<j])
+      return try body(&buffer)
+    }
+  }
+}
+
+extension MutableContiguousCollection {
+  @inlinable
+  public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    return try withUnsafeMutableBufferPointer(body)
+  }
+}
+
+extension UnsafeBufferPointer: ContiguousCollection {
+  @inlinable
+  public func withUnsafeBufferPointer<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R {
+    return try body(self)
+  }
+}
+
+extension UnsafeMutableBufferPointer: MutableContiguousCollection {
+  @inlinable
+  public func withUnsafeBufferPointer<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R {
+    return try body(UnsafeBufferPointer(self))
+  }
+
+  @inlinable
+  public mutating func withUnsafeMutableBufferPointer<R>(
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R {
+    return try body(&self)
+  }
+}

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -64,6 +64,7 @@
     "BidirectionalCollection.swift",
     "RandomAccessCollection.swift",
     "MutableCollection.swift",
+    "ContiguousCollection.swift",
     "CollectionAlgorithms.swift",
     "EmptyCollection.swift",
     "Stride.swift",

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -58,8 +58,7 @@
 ///     a[i] = x
 ///     let y = x
 public protocol MutableCollection: Collection
-where SubSequence: MutableCollection
-{
+where SubSequence: MutableCollection {
   // FIXME: Associated type inference requires these.
   override associatedtype Element
   override associatedtype Index

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -408,13 +408,6 @@ extension Unsafe${Mutable}BufferPointer {
     count = other.count
   }
 
-  @inlinable
-  public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
-    return try body(&self)
-  }
-
 %  else:
 
   /// Creates an immutable typed buffer pointer referencing the same memory as the 


### PR DESCRIPTION
A protocol to unify various contiguously-stored collections that offer with-unsafe-buffer capabilities.