### PR TITLE
Require @usableFromInline on witnesses for non-type requirements too

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1322,6 +1322,13 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
     return RequirementCheck(kind, getRequiredAccessScope());
   }
 
+  if (isUsableFromInlineRequired()) {
+    bool witnessIsUsableFromInline = match.Witness->getFormalAccessScope(
+        DC, /*usableFromInlineAsPublic*/true).isPublic();
+    if (!witnessIsUsableFromInline)
+      return CheckKind::UsableFromInline;
+  }
+
   auto requiredAvailability = AvailabilityContext::alwaysAvailable();
   if (checkWitnessAvailability(requirement, match.Witness,
                                &requiredAvailability)) {
@@ -3066,6 +3073,10 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       });
       break;
     }
+
+    case CheckKind::UsableFromInline:
+      diagnoseOrDefer(requirement, false, DiagnoseUsableFromInline(witness));
+      break;
 
     case CheckKind::Availability: {
       diagnoseOrDefer(requirement, false,

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -252,6 +252,9 @@ enum class CheckKind : unsigned {
   /// requirement.
   AccessOfSetter,
 
+  /// The witness needs to be @usableFromInline.
+  UsableFromInline,
+
   /// The witness is less available than the requirement.
   Availability,
 

--- a/test/Compatibility/attr_usableFromInline_protocol.swift
+++ b/test/Compatibility/attr_usableFromInline_protocol.swift
@@ -8,16 +8,19 @@ public protocol PublicProtoWithReqs {
 
 @usableFromInline struct UFIAdopter<T> : PublicProtoWithReqs {}
 // expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+// expected-warning@-2 {{instance method 'foo()' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
 extension UFIAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}
   func foo() {}
+  // expected-note@-1 {{'foo()' declared here}}
 }
 
 @usableFromInline struct UFIAdopterAllInOne<T> : PublicProtoWithReqs {
   typealias Assoc = Int
   // expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
   func foo() {}
+  // expected-warning@-1 {{instance method 'foo()' should be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
 }
 
 internal struct InternalAdopter<T> : PublicProtoWithReqs {}
@@ -34,9 +37,11 @@ extension InternalAdopter {
 
 public struct PublicAdopter<T> : UFIProtoWithReqs {}
 // expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
+// expected-warning@-2 {{instance method 'foo()' should be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
 extension PublicAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}
   func foo() {}
+  // expected-note@-1 {{'foo()' declared here}}
 }
 extension InternalAdopter: UFIProtoWithReqs {} // okay

--- a/test/attr/attr_usableFromInline_protocol.swift
+++ b/test/attr/attr_usableFromInline_protocol.swift
@@ -8,16 +8,19 @@ public protocol PublicProtoWithReqs {
 
 @usableFromInline struct UFIAdopter<T> : PublicProtoWithReqs {}
 // expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+// expected-error@-2 {{instance method 'foo()' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
 extension UFIAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}
   func foo() {}
+  // expected-note@-1 {{'foo()' declared here}}
 }
 
 @usableFromInline struct UFIAdopterAllInOne<T> : PublicProtoWithReqs {
   typealias Assoc = Int
   // expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
   func foo() {}
+  // expected-error@-1 {{instance method 'foo()' must be declared '@usableFromInline' because because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
 }
 
 internal struct InternalAdopter<T> : PublicProtoWithReqs {}
@@ -34,9 +37,11 @@ extension InternalAdopter {
 
 public struct PublicAdopter<T> : UFIProtoWithReqs {}
 // expected-error@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
+// expected-error@-2 {{instance method 'foo()' must be declared '@usableFromInline' because because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
 extension PublicAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}
   func foo() {}
+  // expected-note@-1 {{'foo()' declared here}}
 }
 extension InternalAdopter: UFIProtoWithReqs {} // okay


### PR DESCRIPTION
Follow-up to #20384 for non-type requirements. We use non-type witnesses for optimization purposes, so if we didn't enforce this we might end up with something silently performing worse with parseable interfaces than it would with swiftmodules. There's also a tricky case where the client of the interface infers a different implementation:

```swift
public protocol Foo {
  func foo()
}
extension Foo {
  public func foo() { print("default") }
}
@usableFromInline struct FooImpl: Foo {
  internal func foo() { print("actual") } // not printed
}
```

There might be another solution to this in the future, but for now this is the simplest answer. Like #20384, it'll be a warning in Swift 4 mode and an error in Swift 5 mode.

rdar://problem/43824161
