### PR TITLE
[test] @objc optional should always use a dynamic dispatch

### DIFF
--- a/test/ParseableInterface/Conformances.swiftinterface
+++ b/test/ParseableInterface/Conformances.swiftinterface
@@ -2,10 +2,10 @@
 // swift-module-flags: 
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/Conformances.swiftmodule -enable-resilience -emit-sil -o %t/Conformances.sil %s
+// RUN: %target-swift-frontend -emit-module-path %t/Conformances.swiftmodule -enable-resilience -emit-sil -o %t/Conformances.sil -enable-objc-interop -disable-objc-attr-requires-foundation-module %s
 // RUN: %FileCheck -check-prefix CHECK-MODULE %s < %t/Conformances.sil
 // RUN: %FileCheck -check-prefix NEGATIVE-MODULE %s < %t/Conformances.sil
-// RUN: %target-swift-frontend -emit-sil -I %t %S/Inputs/ConformancesUser.swift -O | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-sil -I %t %S/Inputs/ConformancesUser.swift -O | %FileCheck %s
 
 public protocol MyProto {
   init()
@@ -59,3 +59,24 @@ public struct ResilientStructImpl: MyProto {
 // CHECK: witness_method $ResilientStructImpl, #MyProto.prop!setter.1
 // CHECK: witness_method $ResilientStructImpl, #MyProto.subscript!getter.1
 // CHECK: end sil function '$s16ConformancesUser13testResilientSiyF'
+
+
+@objc public protocol OptionalReqs {
+  @objc optional func method()
+}
+@_fixed_layout
+public final class OptionalReqsPresent: OptionalReqs {
+  public func method () {}
+}
+@_fixed_layout
+public final class OptionalReqsAbsent: OptionalReqs {}
+
+// It would be okay if this one got optimized...
+// CHECK-LABEL: sil @$s16ConformancesUser19testOptionalPresentySb0A00d4ReqsE0CF
+// CHECK: dynamic_method_br %0 : $OptionalReqsPresent, #OptionalReqs.method!1.foreign
+// CHECK: end sil function '$s16ConformancesUser19testOptionalPresentySb0A00d4ReqsE0CF'
+
+// ...but not this one, because the method that's currently absent might get added.
+// CHECK-LABEL: sil @$s16ConformancesUser18testOptionalAbsentySb0A00d4ReqsE0CF
+// CHECK: dynamic_method_br %0 : $OptionalReqsAbsent, #OptionalReqs.method!1.foreign
+// CHECK: end sil function '$s16ConformancesUser18testOptionalAbsentySb0A00d4ReqsE0CF'

--- a/test/ParseableInterface/Inputs/ConformancesUser.swift
+++ b/test/ParseableInterface/Inputs/ConformancesUser.swift
@@ -18,3 +18,16 @@ public func testOpaque() -> Int {
 public func testResilient() -> Int {
   return testGeneric(ResilientStructImpl.self)
 }
+
+
+func testOptionalGeneric<T: OptionalReqs>(_ obj: T) -> Bool {
+  return obj.method?() != nil
+}
+
+public func testOptionalPresent(_ obj: OptionalReqsPresent) -> Bool {
+  return testOptionalGeneric(obj)
+}
+
+public func testOptionalAbsent(_ obj: OptionalReqsAbsent) -> Bool {
+  return testOptionalGeneric(obj)
+}


### PR DESCRIPTION
Right now we're not being careful about 'optional' in witness tables for parseable interfaces; we're listing the requirement as the implementation even if the requirement is optional. As long as we don't optimize based on that information, though, we should be okay.