### PR TITLE
 [Runtime] Cache protocol conformance descriptors, not witness tables.

### DIFF
--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1221,6 +1221,20 @@ void Remangler::mangleEntityContext(Node *node, EntityContext &ctx) {
   // Remember that we're mangling a context.
   EntityContext::ManglingContextRAII raii(ctx);
 
+  // Deal with bound generic types.
+  switch (node->getKind()) {
+    case Node::Kind::BoundGenericStructure:
+    case Node::Kind::BoundGenericEnum:
+    case Node::Kind::BoundGenericClass:
+    case Node::Kind::BoundGenericOtherNominalType:
+    case Node::Kind::BoundGenericTypeAlias:
+      mangleAnyNominalType(node, ctx);
+      return;
+
+    default:
+      break;
+  }
+
   switch (node->getKind()) {
 #define NODE(ID)                                \
   case Node::Kind::ID:
@@ -1731,6 +1745,7 @@ void Remangler::mangleExtension(Node *node, EntityContext &ctx) {
   if (node->getNumChildren() == 3) {
     mangleDependentGenericSignature(node->begin()[2]); // generic sig
   }
+
   mangleEntityContext(node->begin()[1], ctx); // context
 }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -740,7 +740,8 @@ void IRGenModule::emitRuntimeRegistration() {
 /// For any other kind of context, this returns an anonymous context descriptor
 /// for the context.
 ConstantReference
-IRGenModule::getAddrOfParentContextDescriptor(DeclContext *from) {
+IRGenModule::getAddrOfParentContextDescriptor(DeclContext *from,
+                                              bool fromAnonymousContext) {
   // Some types get special treatment.
   if (auto Type = dyn_cast<NominalTypeDecl>(from)) {
     // Use a special module context if we have one.
@@ -757,7 +758,7 @@ IRGenModule::getAddrOfParentContextDescriptor(DeclContext *from) {
 
     // Wrap up private types in an anonymous context for the containing file
     // unit so that the runtime knows they have unstable identity.
-    if (Type->isOutermostPrivateOrFilePrivateScope())
+    if (!fromAnonymousContext && Type->isOutermostPrivateOrFilePrivateScope())
       return {getAddrOfAnonymousContextDescriptor(Type),
               ConstantReference::Direct};
   }
@@ -771,7 +772,8 @@ IRGenModule::getAddrOfParentContextDescriptor(DeclContext *from) {
   case DeclContextKind::TopLevelCodeDecl:
   case DeclContextKind::Initializer:
   case DeclContextKind::SerializedLocal:
-    return {getAddrOfAnonymousContextDescriptor(from),
+    return {getAddrOfAnonymousContextDescriptor(
+              fromAnonymousContext ? parent : from),
             ConstantReference::Direct};
 
   case DeclContextKind::GenericTypeDecl:
@@ -779,7 +781,8 @@ IRGenModule::getAddrOfParentContextDescriptor(DeclContext *from) {
       return {getAddrOfTypeContextDescriptor(nomTy, DontRequireMetadata),
               ConstantReference::Direct};
     }
-    return {getAddrOfAnonymousContextDescriptor(from),
+    return {getAddrOfAnonymousContextDescriptor(
+              fromAnonymousContext ? parent : from),
             ConstantReference::Direct};
 
   case DeclContextKind::ExtensionDecl: {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -513,8 +513,8 @@ namespace {
     }
   
     ConstantReference getParent() {
-      return {IGM.getAddrOfModuleContextDescriptor(DC->getParentModule()),
-              ConstantReference::Direct};
+      return IGM.getAddrOfParentContextDescriptor(
+               DC, /*fromAnonymousContext=*/true);
     }
     
     ContextDescriptorKind getContextKind() {
@@ -565,7 +565,8 @@ namespace {
     }
 
     ConstantReference getParent() {
-      return IGM.getAddrOfParentContextDescriptor(Proto);
+      return IGM.getAddrOfParentContextDescriptor(
+               Proto, /*fromAnonymousContext=*/false);
     }
 
     ContextDescriptorKind getContextKind() {
@@ -1014,7 +1015,8 @@ namespace {
     }
     
     ConstantReference getParent() {
-      return IGM.getAddrOfParentContextDescriptor(Type);
+      return IGM.getAddrOfParentContextDescriptor(
+               Type, /*fromAnonymousContext=*/false);
     }
     
     GenericSignature *getGenericSignature() {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1937,7 +1937,8 @@ namespace {
       auto moduleContext =
         normal->getDeclContext()->getModuleScopeContext();
       ConstantReference moduleContextRef =
-        IGM.getAddrOfParentContextDescriptor(moduleContext);
+        IGM.getAddrOfParentContextDescriptor(moduleContext,
+                                             /*fromAnonymousContext=*/false);
       B.addRelativeAddress(moduleContextRef);
     }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1277,7 +1277,8 @@ public:
                                       ConstantInit definition = ConstantInit());
   llvm::Constant *getAddrOfObjCModuleContextDescriptor();
   llvm::Constant *getAddrOfClangImporterModuleContextDescriptor();
-  ConstantReference getAddrOfParentContextDescriptor(DeclContext *from);
+  ConstantReference getAddrOfParentContextDescriptor(DeclContext *from,
+                                                     bool fromAnonymousContext);
   llvm::Constant *getAddrOfGenericEnvironment(CanGenericSignature signature);
   llvm::Constant *getAddrOfProtocolRequirementsBaseDescriptor(
                                                   ProtocolDecl *proto);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -527,7 +527,7 @@ swift::swift_getGenericMetadata(MetadataRequest request,
   auto &generics = description->getFullGenericContextHeader();
   size_t numGenericArgs = generics.Base.NumKeyArguments;
 
-  auto key = MetadataCacheKey(arguments, numGenericArgs);
+  auto key = MetadataCacheKey(description, arguments, numGenericArgs);
   auto result =
     getCache(generics).getOrInsert(key, request, description, arguments);
 
@@ -4338,7 +4338,7 @@ static Result performOnMetadataCache(const Metadata *metadata,
     reinterpret_cast<const void * const *>(
                                     description->getGenericArguments(metadata));
   size_t numGenericArgs = generics.Base.NumKeyArguments;
-  auto key = MetadataCacheKey(genericArgs, numGenericArgs);
+  auto key = MetadataCacheKey(description, genericArgs, numGenericArgs);
 
   return std::move(callbacks).forGenericMetadata(metadata, description,
                                                  getCache(generics), key);

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -507,6 +507,12 @@ public:
                              const Metadata *type,
                              const ProtocolConformanceDescriptor *conformance);
 
+  /// Determine whether the given type conforms to the given Swift protocol,
+  /// returning the appropriate protocol conformance descriptor when it does.
+  const ProtocolConformanceDescriptor *
+  _conformsToSwiftProtocol(const Metadata * const type,
+                           const ProtocolDescriptor *protocol);
+
   /// Retrieve an associated type witness from the given witness table.
   ///
   /// \param wtable The witness table.

--- a/test/Runtime/Inputs/synthesized_decl_uniqueness.swift
+++ b/test/Runtime/Inputs/synthesized_decl_uniqueness.swift
@@ -1,4 +1,5 @@
 import CoreLocation
+import Foundation
 
 public func getCLError() -> Any.Type {
   return CLError.self
@@ -6,4 +7,8 @@ public func getCLError() -> Any.Type {
 
 public func getCLErrorCode() -> Any.Type {
   return CLError.Code.self
+}
+
+public func getNotificationNameSet() -> Any.Type {
+  return Set<NSNotification.Name>.self
 }

--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -18,6 +18,15 @@ fileprivate struct Foo {
   }
 }
 
+public struct Wibble<T> { }
+
+extension Wibble {
+  fileprivate struct Inner: P {
+    fileprivate struct Innermost { }
+    typealias A = (Innermost, T)
+  }
+}
+
 func getP_A<T: P>(_: T.Type) -> Any.Type {
   return T.A.self
 }
@@ -27,6 +36,7 @@ let AssociatedTypeDemangleTests = TestSuite("AssociatedTypeDemangle")
 
 AssociatedTypeDemangleTests.test("private types") {
   expectEqual(Foo.Inner.Innermost.self, getP_A(Foo.Inner.self))
+  expectEqual((Wibble<Float>.Inner.Innermost, Float).self, getP_A(Wibble<Float>.Inner.self))
 }
 
 private protocol P2 {

--- a/test/Runtime/synthesized_decl_uniqueness.swift
+++ b/test/Runtime/synthesized_decl_uniqueness.swift
@@ -17,6 +17,7 @@ var tests = TestSuite("metadata identity for synthesized types")
 tests.test("synthesized type identity across modules") {
   expectEqual(A.getCLError(), B.getCLError())
   expectEqual(A.getCLErrorCode(), B.getCLErrorCode())
+  expectEqual(A.getNotificationNameSet(), B.getNotificationNameSet())
 }
 
 runAllTests()

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -760,10 +760,9 @@ RuntimeClassNamesTestSuite.test("private class nested in same-type-constrained e
   let util = base.asInner
 
   let clas = unsafeBitCast(type(of: util), to: NSObject.self)
-  // Name should look like _TtC1aP.*Inner
   let desc = clas.description
-  expectEqual("_TtGC1a", desc.prefix(7))
-  expectEqual("Data_", desc.suffix(5))
+  expectEqual("_TtCE1a", desc.prefix(7))
+  expectEqual("Inner", desc.suffix(5))
 }
 
 runAllTests()

--- a/validation-test/stdlib/SetAnyHashableExtensions.swift
+++ b/validation-test/stdlib/SetAnyHashableExtensions.swift
@@ -126,7 +126,10 @@ SetTests.test("insert<Hashable>(_:)") {
   expectEqual(expected, s)
 }
 
-SetTests.test("insert<Hashable>(_:)/FormerCastTrap") {
+SetTests.test("insert<Hashable>(_:)/CastTrap")
+  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
+  .crashOutputMatches("to 'main.TestHashableDerivedB'")
+  .code {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
   ]
@@ -138,6 +141,7 @@ SetTests.test("insert<Hashable>(_:)/FormerCastTrap") {
     expectEqual(1, memberAfterInsert.identity)
   }
 
+  expectCrashLater()
   _ = s.insert(TestHashableDerivedB(1010, identity: 3))
 }
 
@@ -177,7 +181,10 @@ SetTests.test("update<Hashable>(with:)") {
   expectEqual(expected, s)
 }
 
-SetTests.test("update<Hashable>(with:)/FormerCastTrap") {
+SetTests.test("update<Hashable>(with:)/CastTrap")
+  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
+  .crashOutputMatches("to 'main.TestHashableDerivedB'")
+  .code {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
   ]
@@ -187,6 +194,7 @@ SetTests.test("update<Hashable>(with:)/FormerCastTrap") {
     expectEqual(1, old.identity)
   }
 
+  expectCrashLater()
   s.update(with: TestHashableDerivedB(1010, identity: 3))
 }
 
@@ -220,7 +228,10 @@ SetTests.test("remove<Hashable>(_:)") {
   }
 }
 
-SetTests.test("remove<Hashable>(_:)/FormerCastTrap") {
+SetTests.test("remove<Hashable>(_:)/CastTrap")
+  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
+  .crashOutputMatches("to 'main.TestHashableDerivedB'")
+  .code {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
     AnyHashable(TestHashableDerivedA(2020, identity: 1)),
@@ -232,6 +243,7 @@ SetTests.test("remove<Hashable>(_:)/FormerCastTrap") {
     expectEqual(1, old.identity)
   }
 
+  expectCrashLater()
   s.remove(TestHashableDerivedB(2020, identity: 2))
 }
 


### PR DESCRIPTION
The conformance cache was caching the witness table for a conformance
`T: P`, where `T` is a concrete type and `P` is a protocol. However, it
essentially picked one of potentially many witness tables for that
conformance, because retroactive conformances might produce different results
from different modules.

Make the conformance cache what is says it is: a cache of the conformance
descriptor for a given `T: P`. Clients of the conformance cache can choose how to interpret
the protocol conformance descriptor, e.g., by instantiating a witness table with a
particular set of arguments.

We can bring back a specific conformance cache for `swift_conformsToProtocol()`
if it is profitable.