### PR TITLE
[sil] Change all single value instructions with forwarding ownership …

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -121,7 +121,18 @@ class SILBuilder {
   /// Reference to the provided SILBuilderContext.
   SILBuilderContext &C;
 
+  /// The SILFunction that we are currently inserting into if we have one.
+  ///
+  /// If we are building into a block associated with a SILGlobalVariable this
+  /// will be a nullptr.
+  ///
+  /// TODO: This can be made cleaner by using a PointerUnion or the like so we
+  /// can store the SILGlobalVariable here as well.
   SILFunction *F;
+
+  /// If the current block that we are inserting into must assume that
+  /// the current context we are in has ownership.
+  bool hasOwnership;
 
   /// If this is non-null, the instruction is inserted in the specified
   /// basic block, at the specified InsertPt.  If null, created instructions
@@ -133,18 +144,20 @@ class SILBuilder {
 
 public:
   explicit SILBuilder(SILFunction &F, bool isParsing = false)
-      : TempContext(F.getModule()), C(TempContext), F(&F), BB(0) {
+      : TempContext(F.getModule()), C(TempContext), F(&F),
+        hasOwnership(F.hasQualifiedOwnership()), BB(0) {
     C.isParsing = isParsing;
   }
 
   SILBuilder(SILFunction &F, SmallVectorImpl<SILInstruction *> *InsertedInstrs)
       : TempContext(F.getModule(), InsertedInstrs), C(TempContext), F(&F),
-        BB(0) {}
+        hasOwnership(F.hasQualifiedOwnership()), BB(0) {}
 
   explicit SILBuilder(SILInstruction *I,
                       SmallVectorImpl<SILInstruction *> *InsertedInstrs = 0)
       : TempContext(I->getFunction()->getModule(), InsertedInstrs),
-        C(TempContext), F(I->getFunction()) {
+        C(TempContext), F(I->getFunction()),
+        hasOwnership(F->hasQualifiedOwnership()) {
     setInsertionPoint(I);
   }
 
@@ -155,7 +168,8 @@ public:
   explicit SILBuilder(SILBasicBlock *BB,
                       SmallVectorImpl<SILInstruction *> *InsertedInstrs = 0)
       : TempContext(BB->getParent()->getModule(), InsertedInstrs),
-        C(TempContext), F(BB->getParent()) {
+        C(TempContext), F(BB->getParent()),
+        hasOwnership(F->hasQualifiedOwnership()) {
     setInsertionPoint(BB);
   }
 
@@ -165,7 +179,8 @@ public:
   SILBuilder(SILBasicBlock *BB, SILBasicBlock::iterator InsertPt,
              SmallVectorImpl<SILInstruction *> *InsertedInstrs = 0)
       : TempContext(BB->getParent()->getModule(), InsertedInstrs),
-        C(TempContext), F(BB->getParent()) {
+        C(TempContext), F(BB->getParent()),
+        hasOwnership(F->hasQualifiedOwnership()) {
     setInsertionPoint(BB, InsertPt);
   }
 
@@ -174,7 +189,8 @@ public:
   ///
   /// SILBuilderContext must outlive this SILBuilder instance.
   SILBuilder(SILInstruction *I, const SILDebugScope *DS, SILBuilderContext &C)
-      : TempContext(C.getModule()), C(C), F(I->getFunction()) {
+      : TempContext(C.getModule()), C(C), F(I->getFunction()),
+        hasOwnership(F->hasQualifiedOwnership()) {
     assert(DS && "instruction has no debug scope");
     setCurrentDebugScope(DS);
     setInsertionPoint(I);
@@ -185,7 +201,8 @@ public:
   ///
   /// SILBuilderContext must outlive this SILBuilder instance.
   SILBuilder(SILBasicBlock *BB, const SILDebugScope *DS, SILBuilderContext &C)
-      : TempContext(C.getModule()), C(C), F(BB->getParent()) {
+      : TempContext(C.getModule()), C(C), F(BB->getParent()),
+        hasOwnership(F->hasQualifiedOwnership()) {
     assert(DS && "block has no debug scope");
     setCurrentDebugScope(DS);
     setInsertionPoint(BB);
@@ -242,6 +259,16 @@ public:
     auto overriddenLoc = CurDebugLocOverride ? *CurDebugLocOverride : Loc;
     return SILDebugLocation(overriddenLoc, Scope);
   }
+
+  /// Allow for users to override has ownership if necessary.
+  ///
+  /// This is only used in the SILParser since it sets whether or not ownership
+  /// is qualified after the SILBuilder is constructed due to the usage of
+  /// AssumeUnqualifiedOwnershipWhenParsing.
+  ///
+  /// TODO: Once we start printing [ossa] on SILFunctions to indicate ownership
+  /// and get rid of this global option, this can go away.
+  void setHasOwnership(bool newHasOwnership) { hasOwnership = newHasOwnership; }
 
   //===--------------------------------------------------------------------===//
   // Insertion Point Management
@@ -1187,25 +1214,23 @@ public:
   ObjectInst *createObject(SILLocation Loc, SILType Ty,
                            ArrayRef<SILValue> Elements,
                            unsigned NumBaseElements) {
-    return insert(
-        ObjectInst::create(getSILDebugLocation(Loc), Ty, Elements,
-                           NumBaseElements, getModule()));
+    return insert(ObjectInst::create(getSILDebugLocation(Loc), Ty, Elements,
+                                     NumBaseElements, getModule(),
+                                     hasOwnership));
   }
 
   StructInst *createStruct(SILLocation Loc, SILType Ty,
                            ArrayRef<SILValue> Elements) {
     assert(Ty.isLoadableOrOpaque(getModule()));
-    return insert(
-        StructInst::create(getSILDebugLocation(Loc), Ty, Elements,
-                           getModule()));
+    return insert(StructInst::create(getSILDebugLocation(Loc), Ty, Elements,
+                                     getModule(), hasOwnership));
   }
 
   TupleInst *createTuple(SILLocation Loc, SILType Ty,
                          ArrayRef<SILValue> Elements) {
     assert(Ty.isLoadableOrOpaque(getModule()));
-    return insert(
-        TupleInst::create(getSILDebugLocation(Loc), Ty, Elements,
-                          getModule()));
+    return insert(TupleInst::create(getSILDebugLocation(Loc), Ty, Elements,
+                                    getModule(), hasOwnership));
   }
 
   TupleInst *createTuple(SILLocation loc, ArrayRef<SILValue> elts);
@@ -1286,7 +1311,7 @@ public:
     assert(Ty.isLoadableOrOpaque(getModule()));
     return insert(SelectEnumInst::create(
         getSILDebugLocation(Loc), Operand, Ty, DefaultValue, CaseValues,
-        getFunction(), CaseCounts, DefaultCount));
+        getModule(), CaseCounts, DefaultCount, hasOwnership));
   }
 
   SelectEnumAddrInst *createSelectEnumAddr(
@@ -1296,7 +1321,7 @@ public:
       ProfileCounter DefaultCount = ProfileCounter()) {
     return insert(SelectEnumAddrInst::create(
         getSILDebugLocation(Loc), Operand, Ty, DefaultValue, CaseValues,
-        getFunction(), CaseCounts, DefaultCount));
+        getModule(), CaseCounts, DefaultCount));
   }
 
   SelectValueInst *createSelectValue(
@@ -1304,7 +1329,7 @@ public:
       ArrayRef<std::pair<SILValue, SILValue>> CaseValuesAndResults) {
     return insert(SelectValueInst::create(getSILDebugLocation(Loc), Operand, Ty,
                                           DefaultResult, CaseValuesAndResults,
-                                          getFunction()));
+                                          getModule(), hasOwnership));
   }
 
   TupleExtractInst *createTupleExtract(SILLocation Loc, SILValue Operand,
@@ -1491,7 +1516,7 @@ public:
   OpenExistentialRefInst *
   createOpenExistentialRef(SILLocation Loc, SILValue Operand, SILType Ty) {
     auto *I = insert(new (getModule()) OpenExistentialRefInst(
-        getSILDebugLocation(Loc), Operand, Ty));
+        getSILDebugLocation(Loc), Operand, Ty, hasOwnership));
     if (C.OpenedArchetypesTracker)
       C.OpenedArchetypesTracker->registerOpenedArchetypes(I);
     return I;

--- a/include/swift/SIL/ValueUtils.h
+++ b/include/swift/SIL/ValueUtils.h
@@ -1,0 +1,29 @@
+//===--- ValueUtils.h -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_VALUEUTILS_H
+#define SWIFT_SIL_VALUEUTILS_H
+
+#include "swift/SIL/SILValue.h"
+
+namespace swift {
+
+/// Attempt to merge the ValueOwnershipKind of the passed in range's
+/// SILValues. Returns Optional<None> if we found an incompatibility.
+///
+/// NOTE: This assumes that the passed in SILValues are not values used as type
+/// dependent operands.
+Optional<ValueOwnershipKind> mergeSILValueOwnership(ArrayRef<SILValue> values);
+
+} // namespace swift
+
+#endif

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2961,14 +2961,13 @@ IRGenSILFunction::visitSwitchEnumAddrInst(SwitchEnumAddrInst *inst) {
 
 // FIXME: We could lower select_enum directly to LLVM select in a lot of cases.
 // For now, just emit a switch and phi nodes, like a chump.
-template<class C, class T>
+template <class C, class T, class B>
 static llvm::BasicBlock *
-emitBBMapForSelect(IRGenSILFunction &IGF,
-                   Explosion &resultPHI,
-                   SmallVectorImpl<std::pair<T, llvm::BasicBlock*>> &BBs,
+emitBBMapForSelect(IRGenSILFunction &IGF, Explosion &resultPHI,
+                   SmallVectorImpl<std::pair<T, llvm::BasicBlock *>> &BBs,
                    llvm::BasicBlock *&defaultBB,
-                   SelectInstBase<C, T> *inst) {
-  
+                   SelectInstBase<C, T, B> *inst) {
+
   auto origBB = IGF.Builder.GetInsertBlock();
 
   // Set up a continuation BB and phi nodes to receive the result value.
@@ -3099,10 +3098,10 @@ mapTriviallyToInt(IRGenSILFunction &IGF, const EnumImplStrategy &EIS, SelectEnum
   return result;
 }
 
-template <class C, class T>
-static LoweredValue
-getLoweredValueForSelect(IRGenSILFunction &IGF,
-                         Explosion &result, SelectInstBase<C, T> *inst) {
+template <class C, class T, class B>
+static LoweredValue getLoweredValueForSelect(IRGenSILFunction &IGF,
+                                             Explosion &result,
+                                             SelectInstBase<C, T, B> *inst) {
   if (inst->getType().isAddress())
     // FIXME: Loses potentially better alignment info we might have.
     return LoweredValue(Address(result.claimNext(),

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5224,6 +5224,7 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
     F->setUnqualifiedOwnership();
   }
   B.setInsertionPoint(BB);
+  B.setHasOwnership(F->hasQualifiedOwnership());
   do {
     if (parseSILInstruction(B))
       return true;

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -44,6 +44,7 @@ add_swift_host_library(swiftSIL STATIC
   SILWitnessTable.cpp
   TypeLowering.cpp
   ValueOwnership.cpp
+  ValueUtils.cpp
   LINK_LIBRARIES
     swiftSerialization
     swiftSema

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -24,7 +24,7 @@ using namespace swift;
 SILBuilder::SILBuilder(SILGlobalVariable *GlobVar,
                        SmallVectorImpl<SILInstruction *> *InsertedInstrs)
     : TempContext(GlobVar->getModule(), InsertedInstrs), C(TempContext),
-      F(nullptr) {
+      F(nullptr), hasOwnership(false) {
   setInsertionPoint(&GlobVar->StaticInitializerBlock);
 }
 

--- a/lib/SIL/ValueUtils.cpp
+++ b/lib/SIL/ValueUtils.cpp
@@ -1,0 +1,55 @@
+//===--- ValueUtils.cpp ---------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/ValueUtils.h"
+#include "swift/Basic/STLExtras.h"
+#include "swift/SIL/SILFunction.h"
+
+using namespace swift;
+
+Optional<ValueOwnershipKind>
+swift::mergeSILValueOwnership(ArrayRef<SILValue> values) {
+  // A forwarding inst without operands must be trivial.
+  if (values.empty())
+    return Optional<ValueOwnershipKind>(ValueOwnershipKind::Trivial);
+
+  // Find the first index where we have a trivial value.
+  auto iter = find_if(values, [](SILValue v) -> bool {
+    return v.getOwnershipKind() != ValueOwnershipKind::Trivial;
+  });
+  // All trivial.
+  if (iter == values.end()) {
+    return Optional<ValueOwnershipKind>(ValueOwnershipKind::Trivial);
+  }
+
+  // See if we have any Any. If we do, just return that for now.
+  if (any_of(values, [](SILValue v) -> bool {
+        return v.getOwnershipKind() == ValueOwnershipKind::Any;
+      }))
+    return Optional<ValueOwnershipKind>(ValueOwnershipKind::Any);
+
+  unsigned index = std::distance(values.begin(), iter);
+  ValueOwnershipKind base = values[index].getOwnershipKind();
+
+  for (SILValue v : values.slice(index + 1)) {
+    auto opKind = v.getOwnershipKind();
+    if (opKind.merge(ValueOwnershipKind::Trivial))
+      continue;
+
+    auto mergedValue = base.merge(opKind.Value);
+    if (!mergedValue.hasValue()) {
+      return None;
+    }
+  }
+
+  return base;
+}

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2352,10 +2352,8 @@ bb0:
 
 // CHECK-LABEL:   sil @remove_dead_code_after_unreachable
 // CHECK-NEXT:      bb0
-// CHECK-NOT:       integer_literal $Builtin.Int32, -2
 // CHECK-NEXT:      unreachable
-// CHECK-NOT:       integer_literal $Builtin.Int32, -2
-// CHECK-NEXT:      }
+// CHECK-NEXT:      } // end sil function 'remove_dead_code_after_unreachable'
 sil @remove_dead_code_after_unreachable : $@convention(thin) () -> (Int32) {
 bb0:
   unreachable


### PR DESCRIPTION
…to have static ownership.

Previously we would always calculate these instructions ownership dynamically
when asked and rely on the ownership verifier to catch if we made any
mistakes. Instead with this commit we move to a more static model where the
ownership that these instructions can take are frozen on construction. This is a
more static model that simplifies the ownership model.
