### PR TITLE
 [Keypaths] Use mangled names to reference types and witness tables in metadata

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -92,6 +92,7 @@ The following symbolic reference kinds are currently implemented:
 
    associated-conformance-acceess-function ::= '\x07' .{4}  // Reference points directly to associated conformance access function relative to the protocol
    associated-conformance-acceess-function ::= '\x08' .{4}  // Reference points directly to associated conformance access function relative to the conforming type
+   keypath-metadata-access-function ::= '\x09' {.4}  // Reference points directly to keypath type metadata access function
 
 Globals
 ~~~~~~~

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -706,8 +706,14 @@ emitMetadataGeneratorForKeyPath(IRGenModule &IGM,
                                 CanType type,
                                 GenericEnvironment *genericEnv,
                                 ArrayRef<GenericRequirement> requirements) {
-  // TODO: Use a mangled name when we can.
+  // If we have a non-dependent type, use a normal mangled type name.
+  if (!type->hasTypeParameter()) {
+    auto constant = IGM.getTypeRef(type, MangledTypeRefRole::Metadata);
+    auto bitConstant = llvm::ConstantInt::get(IGM.IntPtrTy, 1);
+    return llvm::ConstantExpr::getGetElementPtr(nullptr, constant, bitConstant);
+  }
 
+  // Otherwise, create an accessor.
   CanGenericSignature genericSig;
   if (genericEnv)
     genericSig = genericEnv->getGenericSignature()->getCanonicalSignature();

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -28,6 +28,7 @@
 #include "GenericRequirement.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
+#include "IRGenMangler.h"
 #include "IRGenModule.h"
 #include "MetadataLayout.h"
 #include "ProtocolInfo.h"
@@ -649,53 +650,77 @@ getInitializerForComputedComponent(IRGenModule &IGM,
 /// protocol conformance metadata record.
 /// TODO: It would be much better to emit typeref strings and use runtime
 /// demangling here.
-static llvm::Function *
+static llvm::Constant *
 emitGeneratorForKeyPath(IRGenModule &IGM,
                         StringRef name, CanType type, llvm::Type *returnType,
                         GenericEnvironment *genericEnv,
                         ArrayRef<GenericRequirement> requirements,
                         llvm::function_ref<void(IRGenFunction&,CanType)> emit) {
-  // TODO: Use the standard metadata accessor when there are no arguments
-  // and the metadata accessor is defined.
 
-  // Build a stub that loads the necessary bindings from the key path's
-  // argument buffer then fetches the metadata.
-  auto fnTy = llvm::FunctionType::get(returnType,
-                                      {IGM.Int8PtrTy}, /*vararg*/ false);
-  auto accessorThunk = llvm::Function::Create(fnTy,
-                                          llvm::GlobalValue::PrivateLinkage,
-                                          name, IGM.getModule());
-  accessorThunk->setAttributes(IGM.constructInitialAttributes());
-  {
-    IRGenFunction IGF(IGM, accessorThunk);
-    if (IGM.DebugInfo)
-      IGM.DebugInfo->emitArtificialFunction(IGF, accessorThunk);
-    
-    if (type->hasTypeParameter()) {
-      auto bindingsBufPtr = IGF.collectParameters().claimNext();
-      
-      bindFromGenericRequirementsBuffer(IGF, requirements,
-            Address(bindingsBufPtr, IGM.getPointerAlignment()),
-            MetadataState::Complete,
-            [&](CanType t) {
-              return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
-            });
-      
-      type = genericEnv->mapTypeIntoContext(type)->getCanonicalType();
-    }
-    emit(IGF, type);
-  }
-  return accessorThunk;
+  return IGM.getAddrOfStringForMetadataRef(name,
+      /*shouldSetLowBit=*/true,
+      [&](ConstantInitBuilder &B) {
+        // Build a stub that loads the necessary bindings from the key path's
+        // argument buffer then fetches the metadata.
+        auto fnTy = llvm::FunctionType::get(returnType,
+                                            {IGM.Int8PtrTy}, /*vararg*/ false);
+        auto accessorThunk =
+          llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage,
+                                 name, IGM.getModule());
+        accessorThunk->setAttributes(IGM.constructInitialAttributes());
+        {
+          IRGenFunction IGF(IGM, accessorThunk);
+          if (IGM.DebugInfo)
+            IGM.DebugInfo->emitArtificialFunction(IGF, accessorThunk);
+
+          if (type->hasTypeParameter()) {
+            auto bindingsBufPtr = IGF.collectParameters().claimNext();
+
+            bindFromGenericRequirementsBuffer(IGF, requirements,
+                Address(bindingsBufPtr, IGM.getPointerAlignment()),
+                MetadataState::Complete,
+                [&](CanType t) {
+                  return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
+                });
+
+            type = genericEnv->mapTypeIntoContext(type)->getCanonicalType();
+          }
+          emit(IGF, type);
+        }
+
+        // Form the mangled name with its relative reference.
+        auto S = B.beginStruct();
+        S.setPacked(true);
+        S.add(llvm::ConstantInt::get(IGM.Int8Ty, 9));
+        S.addRelativeAddress(accessorThunk);
+
+        // And a null terminator!
+        S.addInt(IGM.Int8Ty, 0);
+
+        return S.finishAndCreateFuture();
+      });
 }
 
-static llvm::Function *
+static llvm::Constant *
 emitMetadataGeneratorForKeyPath(IRGenModule &IGM,
                                 CanType type,
                                 GenericEnvironment *genericEnv,
                                 ArrayRef<GenericRequirement> requirements) {
+  // TODO: Use a mangled name when we can.
+
+  CanGenericSignature genericSig;
+  if (genericEnv)
+    genericSig = genericEnv->getGenericSignature()->getCanonicalSignature();
+
+  IRGenMangler mangler;
+  std::string symbolName =
+    mangler.mangleSymbolNameForKeyPathMetadata(
+      "keypath_get_type", genericSig, type,
+      ProtocolConformanceRef::forInvalid());
+
   // TODO: Use the standard metadata accessor when there are no arguments
   // and the metadata accessor is defined.
-  return emitGeneratorForKeyPath(IGM, "keypath_get_type", type,
+  return emitGeneratorForKeyPath(IGM, symbolName, type,
     IGM.TypeMetadataPtrTy,
     genericEnv, requirements,
     [&](IRGenFunction &IGF, CanType substType) {
@@ -704,15 +729,24 @@ emitMetadataGeneratorForKeyPath(IRGenModule &IGM,
     });
 };
 
-static llvm::Function *
+static llvm::Constant *
 emitWitnessTableGeneratorForKeyPath(IRGenModule &IGM,
                                     CanType type,
                                     ProtocolConformanceRef conformance,
                                     GenericEnvironment *genericEnv,
                                     ArrayRef<GenericRequirement> requirements) {
+  CanGenericSignature genericSig;
+  if (genericEnv)
+    genericSig = genericEnv->getGenericSignature()->getCanonicalSignature();
+
+  IRGenMangler mangler;
+  std::string symbolName =
+    mangler.mangleSymbolNameForKeyPathMetadata(
+      "keypath_get_witness_table", genericSig, type, conformance);
+
   // TODO: Use the standard conformance accessor when there are no arguments
   // and the conformance accessor is defined.
-  return emitGeneratorForKeyPath(IGM, "keypath_get_witness_table", type,
+  return emitGeneratorForKeyPath(IGM, symbolName, type,
     IGM.WitnessTablePtrTy,
     genericEnv, requirements,
     [&](IRGenFunction &IGF, CanType substType) {

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -198,7 +198,6 @@ llvm::Constant *IRGenModule::getMangledAssociatedConformance(
   // See if we emitted the constant already.
   auto &entry = StringsForTypeRef[symbolName];
   if (entry.second) {
-
     return entry.second;
   }
 

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -257,3 +257,26 @@ std::string IRGenMangler::mangleSymbolNameForAssociatedConformanceWitness(
   appendProtocolName(proto);
   return finalize();
 }
+
+std::string IRGenMangler::mangleSymbolNameForKeyPathMetadata(
+                                           const char *kind,
+                                           CanGenericSignature genericSig,
+                                           CanType type,
+                                           ProtocolConformanceRef conformance) {
+  beginManglingWithoutPrefix();
+  Buffer << kind << " ";
+
+  if (genericSig)
+    appendGenericSignature(genericSig);
+
+  if (type)
+    appendType(type);
+
+  if (conformance.isConcrete())
+    appendConcreteProtocolConformance(conformance.getConcrete());
+  else if (conformance.isAbstract())
+    appendProtocolName(conformance.getAbstract());
+  else
+    assert(conformance.isInvalid() && "Unknown protocol conformance");
+  return finalize();
+}

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -418,6 +418,13 @@ public:
                                   const NormalProtocolConformance *conformance,
                                   CanType associatedType,
                                   const ProtocolDecl *proto);
+
+  std::string mangleSymbolNameForKeyPathMetadata(
+                                           const char *kind,
+                                           CanGenericSignature genericSig,
+                                           CanType type,
+                                           ProtocolConformanceRef conformance);
+
 protected:
   SymbolicMangling
   withSymbolicReferences(IRGenModule &IGM,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -110,6 +110,7 @@ namespace irgen {
   class ClangTypeConverter;
   class ClassMetadataLayout;
   class ConformanceInfo;
+  class ConstantInitBuilder;
   struct ConstantIntegerLiteral;
   class ConstantIntegerLiteralMap;
   class DebugTypeInfo;
@@ -1072,6 +1073,24 @@ public:
                                             MangledTypeRefRole role);
   llvm::Constant *getAddrOfStringForTypeRef(const SymbolicMangling &mangling,
                                             MangledTypeRefRole role);
+
+  /// Retrieve the address of a mangled string used for some kind of metadata
+  /// reference.
+  ///
+  /// \param symbolName The name of the symbol that describes the metadata
+  /// being referenced.
+  /// \param shouldSetLowBit Whether to set the low bit of the result
+  /// constant, which is used by some clients to indicate that the result is
+  /// a mangled name.
+  /// \param body The body of a function that will create the metadata value
+  /// itself, given a constant building and producing a future for the
+  /// initializer.
+  /// \returns the address of the global variable describing this metadata.
+  llvm::Constant *getAddrOfStringForMetadataRef(
+      StringRef symbolName,
+      bool shouldSetLowBit,
+      llvm::function_ref<ConstantInitFuture(ConstantInitBuilder &)> body);
+
   llvm::Constant *getAddrOfFieldName(StringRef Name);
   llvm::Constant *getAddrOfCaptureDescriptor(SILFunction &caller,
                                              CanSILFunctionType origCalleeType,

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2375,8 +2375,47 @@ public func _swift_getKeyPath(pattern: UnsafeMutableRawPointer,
   return UnsafeRawPointer(Unmanaged.passRetained(instance).toOpaque())
 }
 
-internal typealias MetadataAccessor =
-  @convention(c) (UnsafeRawPointer) -> UnsafeRawPointer
+// A reference to metadata, which is a pointer to a mangled name.
+internal typealias MetadataReference = UnsafeRawPointer
+
+// Resolve the given generic argument reference to a generic argument.
+internal func _resolveKeyPathGenericArgReference(_ reference: UnsafeRawPointer,
+                                                 arguments: UnsafeRawPointer)
+    -> UnsafeRawPointer {
+  // If the low bit is clear, it's a direct reference to the argument.
+  if (UInt(bitPattern: reference) & 0x01 == 0) {
+    return reference;
+  }
+
+  // Adjust the reference.
+  let referenceStart = reference - 1
+
+  // If we have a symbolic reference to an accessor, call it.
+  let first = referenceStart.load(as: UInt8.self)
+  if first == 9 {
+    typealias MetadataAccessor =
+      @convention(c) (UnsafeRawPointer) -> UnsafeRawPointer
+
+    // Unaligned load of the offset.
+    var offset: Int32 = 0
+    _memcpy(dest: &offset, src: reference, size: 4)
+
+    let accessorPtr = _resolveRelativeAddress(reference, offset)
+    let accessor = unsafeBitCast(accessorPtr, to: MetadataAccessor.self)
+    return accessor(arguments)
+  }
+
+  fatalError("unhandled keypath metadata reference")
+}
+
+// Resolve the given metadata reference to (type) metadata.
+internal func _resolveKeyPathMetadataReference(_ reference: UnsafeRawPointer,
+                                               arguments: UnsafeRawPointer)
+    -> Any.Type {
+  return unsafeBitCast(
+           _resolveKeyPathGenericArgReference(reference, arguments: arguments),
+           to: Any.Type.self)
+}
 
 internal enum KeyPathStructOrClass {
   case `struct`, `class`
@@ -2394,8 +2433,8 @@ internal struct KeyPathPatternComputedArguments {
 }
 
 internal protocol KeyPathPatternVisitor {
-  mutating func visitHeader(rootAccessor: MetadataAccessor,
-                            leafAccessor: MetadataAccessor,
+  mutating func visitHeader(rootMetadataRef: MetadataReference,
+                            leafMetadataRef: MetadataReference,
                             kvcCompatibilityString: UnsafeRawPointer)
   mutating func visitStoredComponent(kind: KeyPathStructOrClass,
                                      mutable: Bool,
@@ -2413,7 +2452,7 @@ internal protocol KeyPathPatternVisitor {
   mutating func visitOptionalForceComponent()
   mutating func visitOptionalWrapComponent()
 
-  mutating func visitIntermediateComponentType(accessor: MetadataAccessor)
+  mutating func visitIntermediateComponentType(metadataRef: MetadataReference)
 
   mutating func finish()
 }
@@ -2446,15 +2485,15 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
                                   _ pattern: UnsafeRawPointer,
                                   walker: inout W) {
   // Visit the header.
-  let rootAccessor = _loadRelativeAddress(at: pattern,
-                                          as: MetadataAccessor.self)
-  let leafAccessor = _loadRelativeAddress(at: pattern, fromByteOffset: 4,
-                                          as: MetadataAccessor.self)
+  let rootMetadataRef = _loadRelativeAddress(at: pattern,
+                                             as: MetadataReference.self)
+  let leafMetadataRef = _loadRelativeAddress(at: pattern, fromByteOffset: 4,
+                                             as: MetadataReference.self)
   let kvcString = _loadRelativeAddress(at: pattern, fromByteOffset: 8,
                                        as: UnsafeRawPointer.self)
 
-  walker.visitHeader(rootAccessor: rootAccessor,
-                     leafAccessor: leafAccessor,
+  walker.visitHeader(rootMetadataRef: rootMetadataRef,
+                     leafMetadataRef: leafMetadataRef,
                      kvcCompatibilityString: kvcString)
 
   func visitStored(header: RawKeyPathComponent.Header,
@@ -2704,11 +2743,9 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
     // go around again.
     let componentTypeBase = buffer.baseAddress.unsafelyUnwrapped
     let componentTypeOffset = _pop(from: &buffer, as: Int32.self)
-    let componentTypeAccessorRaw = _resolveRelativeAddress(componentTypeBase,
-                                                         componentTypeOffset)
-    let componentTypeAccessor = unsafeBitCast(componentTypeAccessorRaw,
-                                              to: MetadataAccessor.self)
-    walker.visitIntermediateComponentType(accessor: componentTypeAccessor)
+    let componentTypeRef = _resolveRelativeAddress(componentTypeBase,
+                                                   componentTypeOffset)
+    walker.visitIntermediateComponentType(metadataRef: componentTypeRef)
     _sanityCheck(!buffer.isEmpty)
   }
 
@@ -2734,13 +2771,15 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
     size = MemoryLayout<Int>._roundingUpToAlignment(size)
   }
 
-  mutating func visitHeader(rootAccessor: MetadataAccessor,
-                            leafAccessor: MetadataAccessor,
+  mutating func visitHeader(rootMetadataRef: MetadataReference,
+                            leafMetadataRef: MetadataReference,
                             kvcCompatibilityString: UnsafeRawPointer) {
     // Get the root and leaf type metadata so we can form the class type
     // for the entire key path.
-    root = unsafeBitCast(rootAccessor(patternArgs), to: Any.Type.self)
-    leaf = unsafeBitCast(leafAccessor(patternArgs), to: Any.Type.self)
+    root = _resolveKeyPathMetadataReference(rootMetadataRef,
+                                            arguments: patternArgs)
+    leaf = _resolveKeyPathMetadataReference(leafMetadataRef,
+                                            arguments: patternArgs)
   }
 
   mutating func visitStoredComponent(kind: KeyPathStructOrClass,
@@ -2867,7 +2906,8 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
     size += 4
   }
 
-  mutating func visitIntermediateComponentType(accessor _: MetadataAccessor) {
+  mutating
+  func visitIntermediateComponentType(metadataRef _: MetadataReference) {
     // The instantiated component type will be stored in the instantiated
     // object.
     roundUpToPointerAlignment()
@@ -2963,8 +3003,8 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
     return oldValue
   }
 
-  mutating func visitHeader(rootAccessor: MetadataAccessor,
-                            leafAccessor: MetadataAccessor,
+  mutating func visitHeader(rootMetadataRef: MetadataReference,
+                            leafMetadataRef: MetadataReference,
                             kvcCompatibilityString: UnsafeRawPointer) {
   }
 
@@ -3134,9 +3174,9 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
       for i in externalArgs.indices {
         let base = externalArgs.baseAddress.unsafelyUnwrapped + i
         let offset = base.pointee
-        let accessorPtr = UnsafeRawPointer(base) + Int(offset)
-        let accessor = unsafeBitCast(accessorPtr, to: MetadataAccessor.self)
-        let result = accessor(patternArgs)
+        let metadataRef = UnsafeRawPointer(base) + Int(offset)
+        let result = _resolveKeyPathGenericArgReference(metadataRef,
+                                                       arguments: patternArgs)
         pushDest(result)
       }
     }
@@ -3158,9 +3198,10 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
     pushDest(header)
   }
 
-  mutating func visitIntermediateComponentType(accessor: MetadataAccessor) {
-    // Call the accessor to get the metadata for the intermediate type.
-    let metadata = unsafeBitCast(accessor(patternArgs), to: Any.Type.self)
+  mutating func visitIntermediateComponentType(metadataRef: MetadataReference) {
+    // Get the metadata for the intermediate type.
+    let metadata = _resolveKeyPathMetadataReference(metadataRef,
+                                                    arguments: patternArgs)
     pushDest(metadata)
     base = metadata
   }
@@ -3188,14 +3229,14 @@ internal struct ValidatingInstantiateKeyPathBuffer: KeyPathPatternVisitor {
     origDest = self.instantiateVisitor.destData.baseAddress.unsafelyUnwrapped
   }
 
-  mutating func visitHeader(rootAccessor: MetadataAccessor,
-                            leafAccessor: MetadataAccessor,
+  mutating func visitHeader(rootMetadataRef: MetadataReference,
+                            leafMetadataRef: MetadataReference,
                             kvcCompatibilityString: UnsafeRawPointer) {
-    sizeVisitor.visitHeader(rootAccessor: rootAccessor,
-                            leafAccessor: leafAccessor,
+    sizeVisitor.visitHeader(rootMetadataRef: rootMetadataRef,
+                            leafMetadataRef: leafMetadataRef,
                             kvcCompatibilityString: kvcCompatibilityString)
-    instantiateVisitor.visitHeader(rootAccessor: rootAccessor,
-                                 leafAccessor: leafAccessor,
+    instantiateVisitor.visitHeader(rootMetadataRef: rootMetadataRef,
+                                 leafMetadataRef: leafMetadataRef,
                                  kvcCompatibilityString: kvcCompatibilityString)
   }
   mutating func visitStoredComponent(kind: KeyPathStructOrClass,
@@ -3251,9 +3292,9 @@ internal struct ValidatingInstantiateKeyPathBuffer: KeyPathPatternVisitor {
     instantiateVisitor.visitOptionalForceComponent()
     checkSizeConsistency()
   }
-  mutating func visitIntermediateComponentType(accessor: MetadataAccessor) {
-    sizeVisitor.visitIntermediateComponentType(accessor: accessor)
-    instantiateVisitor.visitIntermediateComponentType(accessor: accessor)
+  mutating func visitIntermediateComponentType(metadataRef: MetadataReference) {
+    sizeVisitor.visitIntermediateComponentType(metadataRef: metadataRef)
+    instantiateVisitor.visitIntermediateComponentType(metadataRef: metadataRef)
     checkSizeConsistency()
   }
 

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -47,8 +47,8 @@ sil_vtable C2 {}
 // -- %a: S.x
 // CHECK: [[KP_A:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type 8keypaths1SV
-// CHECK-SAME: @"keypath_get_type Si
+// CHECK-SAME: @"symbolic 8keypaths1SV"
+// CHECK-SAME: @"symbolic Si
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- offset of S.x, mutable
@@ -57,8 +57,8 @@ sil_vtable C2 {}
 // -- %b: S.y
 // CHECK: [[KP_B:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type 8keypaths1SV
-// CHECK-SAME: @"keypath_get_type SS
+// CHECK-SAME: @"symbolic 8keypaths1SV
+// CHECK-SAME: @"symbolic SS
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- offset of S.y, immutable
@@ -68,8 +68,8 @@ sil_vtable C2 {}
 // -- %c: S.z
 // CHECK: [[KP_C:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type 8keypaths1SV
-// CHECK-SAME: @"keypath_get_type 8keypaths1CC
+// CHECK-SAME: @"symbolic 8keypaths1SV
+// CHECK-SAME: @"symbolic 8keypaths1CC
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- offset of S.z, mutable
@@ -79,8 +79,8 @@ sil_vtable C2 {}
 // -- %d: C.x
 // CHECK: [[KP_D:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"symbolic
+// CHECK-SAME: @"symbolic
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- 0x0300_0000 (class) + mutable + offset of C.x
@@ -90,8 +90,8 @@ sil_vtable C2 {}
 // -- %e: C.y
 // CHECK: [[KP_E:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"symbolic
+// CHECK-SAME: @"symbolic
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- 0x0300_0000 (class) + immutable + offset of C.y
@@ -101,8 +101,8 @@ sil_vtable C2 {}
 // -- %f: C.z
 // CHECK: [[KP_F:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"symbolic
+// CHECK-SAME: @"symbolic
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- 0x0300_0000 (class) + mutable offset of C.z
@@ -112,14 +112,14 @@ sil_vtable C2 {}
 // -- %g: S.z.x
 // CHECK: [[KP_G:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"symbolic
+// CHECK-SAME: @"symbolic
 //                  -- instantiable in-line, size 12
 // CHECK-SAME: <i32 0x8000_000c>,
 // -- offset of S.z
 // CHECK-32-SAME: <i32 0x0180_0010>,
 // CHECK-64-SAME: <i32 0x0180_0018>,
-// CHECK: @"keypath_get_type
+// CHECK: @"symbolic
 // -- 0x0300_0000 (class) + offset of C.x
 // CHECK-32-SAME: <i32 0x0380_0008> }>
 // CHECK-64-SAME: <i32 0x0380_0010> }>
@@ -127,21 +127,21 @@ sil_vtable C2 {}
 // -- %h: C.z.x
 // CHECK: [[KP_H:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"symbolic
+// CHECK-SAME: @"symbolic
 // CHECK-SAME: <i32 0x8000_000c>,
 // -- 0x0300_0000 (class) + offset of C.z
 // CHECK-32-SAME: <i32 0x0380_0018>,
 // CHECK-64-SAME: <i32 0x0380_0028>,
-// CHECK: @"keypath_get_type
+// CHECK: @"symbolic
 // -- offset of S.x
 // CHECK-SAME: <i32 0x0180_0000> }>
 
 // -- %k: computed
 // CHECK: [[KP_K:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"symbolic
+// CHECK-SAME: @"symbolic
 //              -- instantiable in-line, size 12
 // CHECK-SAME: <i32 0x8000_000c>,
 // -- computed, get-only, identified by (indirected) function pointer, no args
@@ -152,8 +152,8 @@ sil_vtable C2 {}
 // -- %l: computed
 // CHECK: [[KP_L:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"symbolic
+// CHECK-SAME: @"symbolic
 //              -- instantiable in-line, size 16
 // CHECK-SAME: <i32 0x8000_0010>,
 // -- computed, settable, nonmutating, identified by indirect pointer, no args
@@ -165,8 +165,8 @@ sil_vtable C2 {}
 // -- %m: computed
 // CHECK: [[KP_M:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"symbolic
+// CHECK-SAME: @"symbolic
 //              -- instantiable in-line, size 16
 // CHECK-SAME: <i32 0x8000_0010>,
 // -- computed, settable, nonmutating, identified by property offset, no args

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -47,8 +47,8 @@ sil_vtable C2 {}
 // -- %a: S.x
 // CHECK: [[KP_A:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type 8keypaths1SV
+// CHECK-SAME: @"keypath_get_type Si
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- offset of S.x, mutable
@@ -57,8 +57,8 @@ sil_vtable C2 {}
 // -- %b: S.y
 // CHECK: [[KP_B:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type 8keypaths1SV
+// CHECK-SAME: @"keypath_get_type SS
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- offset of S.y, immutable
@@ -68,8 +68,8 @@ sil_vtable C2 {}
 // -- %c: S.z
 // CHECK: [[KP_C:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type 8keypaths1SV
+// CHECK-SAME: @"keypath_get_type 8keypaths1CC
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- offset of S.z, mutable
@@ -79,8 +79,8 @@ sil_vtable C2 {}
 // -- %d: C.x
 // CHECK: [[KP_D:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- 0x0300_0000 (class) + mutable + offset of C.x
@@ -90,8 +90,8 @@ sil_vtable C2 {}
 // -- %e: C.y
 // CHECK: [[KP_E:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- 0x0300_0000 (class) + immutable + offset of C.y
@@ -101,8 +101,8 @@ sil_vtable C2 {}
 // -- %f: C.z
 // CHECK: [[KP_F:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- 0x0300_0000 (class) + mutable offset of C.z
@@ -112,14 +112,14 @@ sil_vtable C2 {}
 // -- %g: S.z.x
 // CHECK: [[KP_G:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 //                  -- instantiable in-line, size 12
 // CHECK-SAME: <i32 0x8000_000c>,
 // -- offset of S.z
 // CHECK-32-SAME: <i32 0x0180_0010>,
 // CHECK-64-SAME: <i32 0x0180_0018>,
-// CHECK: %swift.type* (i8*)*
+// CHECK: @"keypath_get_type
 // -- 0x0300_0000 (class) + offset of C.x
 // CHECK-32-SAME: <i32 0x0380_0008> }>
 // CHECK-64-SAME: <i32 0x0380_0010> }>
@@ -127,21 +127,21 @@ sil_vtable C2 {}
 // -- %h: C.z.x
 // CHECK: [[KP_H:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 // CHECK-SAME: <i32 0x8000_000c>,
 // -- 0x0300_0000 (class) + offset of C.z
 // CHECK-32-SAME: <i32 0x0380_0018>,
 // CHECK-64-SAME: <i32 0x0380_0028>,
-// CHECK: %swift.type* (i8*)*
+// CHECK: @"keypath_get_type
 // -- offset of S.x
 // CHECK-SAME: <i32 0x0180_0000> }>
 
 // -- %k: computed
 // CHECK: [[KP_K:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 //              -- instantiable in-line, size 12
 // CHECK-SAME: <i32 0x8000_000c>,
 // -- computed, get-only, identified by (indirected) function pointer, no args
@@ -152,8 +152,8 @@ sil_vtable C2 {}
 // -- %l: computed
 // CHECK: [[KP_L:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 //              -- instantiable in-line, size 16
 // CHECK-SAME: <i32 0x8000_0010>,
 // -- computed, settable, nonmutating, identified by indirect pointer, no args
@@ -165,8 +165,8 @@ sil_vtable C2 {}
 // -- %m: computed
 // CHECK: [[KP_M:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: %swift.type* (i8*)*
-// CHECK-SAME: %swift.type* (i8*)*
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 //              -- instantiable in-line, size 16
 // CHECK-SAME: <i32 0x8000_0010>,
 // -- computed, settable, nonmutating, identified by property offset, no args
@@ -183,8 +183,8 @@ sil_vtable C2 {}
 // -- %i: Gen<A>.x
 // CHECK: [[KP_I:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: i32 0
-// CHECK-SAME: %swift.type* (i8*)* [[I_GET_GEN_A_A:@[a-z_.0-9]+]]
-// CHECK-SAME: %swift.type* (i8*)* [[I_GET_A:@[a-z_.0-9]+]]
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 //             -- size 8
 // CHECK-SAME: i32 8,
 //             -- struct with runtime-resolved offset, mutable
@@ -195,8 +195,8 @@ sil_vtable C2 {}
 // -- %j: Gen<A>.y
 // CHECK: [[KP_J:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: i32 0
-// CHECK-SAME: %swift.type* (i8*)* [[J_GET_GEN_A_A:@[a-z_.0-9]+]]
-// CHECK-SAME: %swift.type* (i8*)* [[J_GET_A:@[a-z_.0-9]+]]
+// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"keypath_get_type
 //             -- size 8
 // CHECK-SAME: i32 8,
 //             -- struct with runtime-resolved offset
@@ -206,15 +206,15 @@ sil_vtable C2 {}
 
 // -- %t
 // CHECK: [[KP_T:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 1, {{.*}} @"got.$s8keypaths1GV1xxvpMV"
-// CHECK-SAME:   %swift.type* (i8*)* [[T_GET_TYPE_A:@[A-Za-z0-9._]*]]
+// CHECK-SAME:   @"keypath_get_type
 //            -- computed get-only property, identified by indirect pointer
 // CHECK-SAME:   <i32 0x0208_0002>
 
 // -- %u
 // CHECK: [[KP_U:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 3, {{.*}} @"got.$s8keypaths1GVyxqd__cSHRd__luipMV"
-// CHECK-SAME:   %swift.type* (i8*)* [[U_GET_TYPE_A:@[A-Za-z0-9._]*]]
-// CHECK-SAME:   %swift.type* (i8*)* [[U_GET_TYPE_B:@[A-Za-z0-9._]*]]
-// CHECK-SAME:   i8** (i8*)* [[U_GET_WITNESS_HASHABLE:@[A-Za-z0-9._]*]]
+// CHECK-SAME:   @"keypath_get_type
+// CHECK-SAME:   @"keypath_get_type
+// CHECK-SAME:   @"keypath_get_witness_table
 //            -- computed get-only property, identified by indirect pointer
 // CHECK-SAME:   <i32 0x0208_0002>
 
@@ -308,19 +308,6 @@ entry:
 
   return undef : $()
 }
-
-// CHECK: define private %swift.type* [[I_GET_GEN_A_A]](i8*)
-// CHECK:   [[BUF:%.*]] = bitcast i8* %0
-// CHECK:   [[A:%.*]] = load %swift.type*, %swift.type** [[BUF]]
-// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s8keypaths3GenVMa"([[WORD]] 0, %swift.type* [[A]], %swift.type* [[A]])
-// CHECK:   [[GEN:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// CHECK:   ret %swift.type* [[GEN]]
-
-
-// CHECK: define private %swift.type* [[I_GET_A]](i8*)
-// CHECK:   [[BUF:%.*]] = bitcast i8* %0
-// CHECK:   [[A:%.*]] = load %swift.type*, %swift.type** [[BUF]]
-// CHECK:   ret %swift.type* [[A]]
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @computed_property_generics
 sil @computed_property_generics : $@convention(thin) <T, U> () -> () {


### PR DESCRIPTION
In keypath metadata, use mangled names to reference type metadata and witness tables. There are three cases:

* For non-dependent type metadata, use a mangled type name
* For dependent type metadata, use a fake symbolic reference mangling to an accessor
* For witness tables, use a fake symbolic reference mangling to an accessor

This is the main ABI part of rdar://problem/38038799. We'd still like to use real mangling here instead of fake ones with accessors.