### PR TITLE
[Sema] Emit a diagnostic when extending a protocol with a redundant requirement

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -96,7 +96,7 @@ ERROR(generic_signature_not_minimal,none,
       "generic requirement '%0' is redundant in %1", (StringRef, StringRef))
 
 WARNING(protocol_extension_redundant_requirement,none,
-      "requirement of '%1': '%2' is redundant in an extension of '%0'",
+      "requirement of '%1' to '%2' is redundant in an extension of '%0'",
       (StringRef, StringRef, StringRef))
 
 ERROR(attr_only_on_parameters, none,

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -96,7 +96,8 @@ ERROR(generic_signature_not_minimal,none,
       "generic requirement '%0' is redundant in %1", (StringRef, StringRef))
 
 WARNING(protocol_extension_redundant_requirement,none,
-"requirement of '%1': '%2' is redundant in an extension of '%0'", (StringRef, StringRef, StringRef))
+      "requirement of '%1': '%2' is redundant in an extension of '%0'",
+      (StringRef, StringRef, StringRef))
 
 ERROR(attr_only_on_parameters, none,
       "'%0' may only be used on parameters", (StringRef))

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -96,8 +96,7 @@ ERROR(generic_signature_not_minimal,none,
       "generic requirement '%0' is redundant in %1", (StringRef, StringRef))
 
 WARNING(protocol_extension_redundant_requirement,none,
-      "redundant requirement in extension '%0'. The requirement '%1: %2' is "
-      "redundant as '%0' and '%2' have the same types", (StringRef, StringRef, StringRef))
+"requirement of '%1': '%2' is redundant in an extension of '%0'", (StringRef, StringRef, StringRef))
 
 ERROR(attr_only_on_parameters, none,
       "'%0' may only be used on parameters", (StringRef))

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -95,6 +95,9 @@ NOTE(profile_read_error,none,
 ERROR(generic_signature_not_minimal,none,
       "generic requirement '%0' is redundant in %1", (StringRef, StringRef))
 
+WARNING(extension_redundant_requirement,none,
+"redundant requirement in extension", ())
+
 ERROR(attr_only_on_parameters, none,
       "'%0' may only be used on parameters", (StringRef))
 

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -95,8 +95,9 @@ NOTE(profile_read_error,none,
 ERROR(generic_signature_not_minimal,none,
       "generic requirement '%0' is redundant in %1", (StringRef, StringRef))
 
-WARNING(extension_redundant_requirement,none,
-"redundant requirement in extension", ())
+WARNING(protocol_extension_redundant_requirement,none,
+      "redundant requirement in extension '%0'. The requirement '%1: %2' is "
+      "redundant as '%0' and '%2' have the same types", (StringRef, StringRef, StringRef))
 
 ERROR(attr_only_on_parameters, none,
       "'%0' may only be used on parameters", (StringRef))

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -334,24 +334,6 @@ bool RequirementRequest::visitRequirements(
     // Resolve to a requirement.
     auto req = evaluator(RequirementRequest{owner, index, stage});
     if (req) {
-      
-      // If we're extending a protocol and adding a redundant requirement,
-      // for example, `extension Foo where Self: Foo`, then emit a
-      // diagnostic.
-      
-      // FIXME: Leads to duplicate diagnostic emissions
-      if (auto extDecl = dyn_cast<ExtensionDecl>(owner.dc->getAsDecl())) {
-        auto ownerType = extDecl->getExtendedType();
-        auto selfType = req->getFirstType();
-        auto reqType = req->getSecondType();
-        
-        if (ownerType->isExistentialType() && reqType->isEqual(ownerType)) {
-          auto &ctx = extDecl->getASTContext();
-          ctx.Diags.diagnose(extDecl->getLoc(), diag::protocol_extension_redundant_requirement,
-                             ownerType->getString(), selfType->getString(), reqType->getString());
-        }
-      }
-      
       // Invoke the callback. If it returns true, we're done.
       if (callback(*req, &requirements[index]))
         return true;

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -342,11 +342,13 @@ bool RequirementRequest::visitRequirements(
       // FIXME: Leads to duplicate diagnostic emissions
       if (auto extDecl = dyn_cast<ExtensionDecl>(owner.dc->getAsDecl())) {
         auto ownerType = extDecl->getExtendedType();
+        auto selfType = req->getFirstType();
         auto reqType = req->getSecondType();
         
         if (ownerType->isExistentialType() && reqType->isEqual(ownerType)) {
           auto &ctx = extDecl->getASTContext();
-          ctx.Diags.diagnose(extDecl->getLoc(), diag::protocol_extension_redundant_requirement, ownerType->getString(), req->getFirstType()->getString(), reqType->getString());
+          ctx.Diags.diagnose(extDecl->getLoc(), diag::protocol_extension_redundant_requirement,
+                             ownerType->getString(), selfType->getString(), reqType->getString());
         }
       }
       

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -335,18 +335,18 @@ bool RequirementRequest::visitRequirements(
     auto req = evaluator(RequirementRequest{owner, index, stage});
     if (req) {
       
-      // If we're in an extension declaration and if we are adding a
-      // redundant requirement (for example, `extension Foo where Self: Foo`)
-      // then emit a diagnostic.
+      // If we're extending a protocol and adding a redundant requirement,
+      // for example, `extension Foo where Self: Foo`, then emit a
+      // diagnostic.
       
       // FIXME: Leads to duplicate diagnostic emissions
       if (auto extDecl = dyn_cast<ExtensionDecl>(owner.dc->getAsDecl())) {
         auto ownerType = extDecl->getExtendedType();
         auto reqType = req->getSecondType();
         
-        if (reqType->isEqual(ownerType)) {
+        if (ownerType->isExistentialType() && reqType->isEqual(ownerType)) {
           auto &ctx = extDecl->getASTContext();
-          ctx.Diags.diagnose(extDecl->getLoc(), diag::extension_redundant_requirement);
+          ctx.Diags.diagnose(extDecl->getLoc(), diag::protocol_extension_redundant_requirement, ownerType->getString(), req->getFirstType()->getString(), reqType->getString());
         }
       }
       

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -85,20 +85,20 @@ void checkGenericParamList(TypeChecker &tc,
           
           if (auto decl = owner.dc->getAsDecl()) {
             if (auto extDecl = dyn_cast<ExtensionDecl>(decl)) {
-              auto ownerType = extDecl->getExtendedType();
-              auto ownerSelfType = extDecl->getSelfInterfaceType();
+              auto extType = extDecl->getExtendedType();
+              auto extSelfType = extDecl->getSelfInterfaceType();
               auto reqLHSType = req.getFirstType();
               auto reqRHSType = req.getSecondType();
               
-              if (ownerType->isExistentialType() &&
-                  reqLHSType->isEqual(ownerSelfType)
-                  && reqRHSType->isEqual(ownerType)) {
+              if (extType->isExistentialType() &&
+                  reqLHSType->isEqual(extSelfType)
+                  && reqRHSType->isEqual(extType)) {
                 
                 auto &ctx = extDecl->getASTContext();
                 ctx.Diags.diagnose(extDecl->getLoc(),
                                    diag::protocol_extension_redundant_requirement,
-                                   ownerType->getString(),
-                                   ownerSelfType->getString(),
+                                   extType->getString(),
+                                   extSelfType->getString(),
                                    reqRHSType->getString());
               }
             }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -91,8 +91,8 @@ void checkGenericParamList(TypeChecker &tc,
               auto reqRHSType = req.getSecondType();
               
               if (extType->isExistentialType() &&
-                  reqLHSType->isEqual(extSelfType)
-                  && reqRHSType->isEqual(extType)) {
+                  reqLHSType->isEqual(extSelfType) &&
+                  reqRHSType->isEqual(extType)) {
                 
                 auto &ctx = extDecl->getASTContext();
                 ctx.Diags.diagnose(extDecl->getLoc(),

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -181,12 +181,12 @@ extension S1 {
 // ----------------------------------------------------------------------------
 
 protocol Foo {}
-extension Foo where Self: Foo {} // expected-warning {{redundant requirement in extension}}
+extension Foo where Self: Foo {} // expected-warning {{redundant requirement in extension 'Foo'. The requirement 'Self: Foo' is redundant as 'Foo' and 'Foo' have the same types}}
 
 protocol Bar {}
 protocol Baz {}
 extension Bar where Self: Baz {} // ok
-extension Bar where Self: Bar, Self: Baz {} // expected-warning {{redundant requirement in extension}}
+extension Bar where Self: Bar, Self: Baz {} // expected-warning {{redundant requirement in extension 'Bar'. The requirement 'Self: Bar' is redundant as 'Bar' and 'Bar' have the same types}}
 
 // ----------------------------------------------------------------------------
 // Protocol extensions with additional requirements

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -177,6 +177,18 @@ extension S1 {
 }
 
 // ----------------------------------------------------------------------------
+// Protocol extensions with redundant requirements
+// ----------------------------------------------------------------------------
+
+protocol Foo {}
+extension Foo where Self: Foo {} // expected-warning {{redundant requirement in extension}}
+
+protocol Bar {}
+protocol Baz {}
+extension Bar where Self: Baz {} // ok
+extension Bar where Self: Bar, Self: Baz {} // expected-warning {{redundant requirement in extension}}
+
+// ----------------------------------------------------------------------------
 // Protocol extensions with additional requirements
 // ----------------------------------------------------------------------------
 extension P4 where Self.AssocP4 : P1 {

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -180,13 +180,12 @@ extension S1 {
 // Protocol extensions with redundant requirements
 // ----------------------------------------------------------------------------
 
-protocol Foo {}
-extension Foo where Self: Foo {} // expected-warning {{requirement of 'Self': 'Foo' is redundant in an extension of 'Foo'}}
+protocol FooProtocol {}
+extension FooProtocol where Self: FooProtocol {} // expected-warning {{requirement of 'Self' to 'FooProtocol' is redundant in an extension of 'FooProtocol'}}
 
-protocol Bar {}
-protocol Baz {}
-extension Bar where Self: Baz {} // ok
-extension Bar where Self: Bar, Self: Baz {} // expected-warning {{requirement of 'Self': 'Bar' is redundant in an extension of 'Bar'}}
+protocol AnotherFooProtocol {}
+protocol BazProtocol {}
+extension AnotherFooProtocol where Self: BazProtocol, Self: AnotherFooProtocol {} // expected-warning {{requirement of 'Self' to 'AnotherFooProtocol' is redundant in an extension of 'AnotherFooProtocol'}}
 
 // ----------------------------------------------------------------------------
 // Protocol extensions with additional requirements

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -181,12 +181,12 @@ extension S1 {
 // ----------------------------------------------------------------------------
 
 protocol Foo {}
-extension Foo where Self: Foo {} // expected-warning {{redundant requirement in extension 'Foo'. The requirement 'Self: Foo' is redundant as 'Foo' and 'Foo' have the same types}}
+extension Foo where Self: Foo {} // expected-warning {{requirement of 'Self': 'Foo' is redundant in an extension of 'Foo'}}
 
 protocol Bar {}
 protocol Baz {}
 extension Bar where Self: Baz {} // ok
-extension Bar where Self: Bar, Self: Baz {} // expected-warning {{redundant requirement in extension 'Bar'. The requirement 'Self: Bar' is redundant as 'Bar' and 'Bar' have the same types}}
+extension Bar where Self: Bar, Self: Baz {} // expected-warning {{requirement of 'Self': 'Bar' is redundant in an extension of 'Bar'}}
 
 // ----------------------------------------------------------------------------
 // Protocol extensions with additional requirements

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -187,6 +187,12 @@ protocol AnotherFooProtocol {}
 protocol BazProtocol {}
 extension AnotherFooProtocol where Self: BazProtocol, Self: AnotherFooProtocol {} // expected-warning {{requirement of 'Self' to 'AnotherFooProtocol' is redundant in an extension of 'AnotherFooProtocol'}}
 
+protocol A {
+  associatedtype V
+}
+
+extension A where V: A {} // ok, does not warn because V is not Self
+
 // ----------------------------------------------------------------------------
 // Protocol extensions with additional requirements
 // ----------------------------------------------------------------------------

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -187,11 +187,11 @@ protocol AnotherFooProtocol {}
 protocol BazProtocol {}
 extension AnotherFooProtocol where Self: BazProtocol, Self: AnotherFooProtocol {} // expected-warning {{requirement of 'Self' to 'AnotherFooProtocol' is redundant in an extension of 'AnotherFooProtocol'}}
 
-protocol A {
-  associatedtype V
+protocol AnotherBazProtocol {
+  associatedtype BazValue
 }
 
-extension A where V: A {} // ok, does not warn because V is not Self
+extension AnotherBazProtocol where BazValue: AnotherBazProtocol {} // ok, does not warn because BazValue is not Self
 
 // ----------------------------------------------------------------------------
 // Protocol extensions with additional requirements


### PR DESCRIPTION
This PR adds a change to emit a warning diagnostic when extending a protocol with a redundant requirement.

Resolves [SR-9218](https://bugs.swift.org/browse/SR-9218).