### PR TITLE
Taught graph mode to execute graph_op's with dynamic attributes.

### DIFF
--- a/include/swift/SIL/GraphOperationBuilder.h
+++ b/include/swift/SIL/GraphOperationBuilder.h
@@ -55,9 +55,8 @@ public:
   ArrayRef<GraphOperationAttribute> getAttributes() const { return Attributes; }
 
   /// Build the GraphOperationInst.
-  GraphOperationInst* build(
-      SILBuilder &B, ASTContext &C, SILLocation loc,
-      llvm::ArrayRef<SILType> resultSILTypes) const;
+  GraphOperationInst *build(SILBuilder &B, ASTContext &C, SILLocation loc,
+                            llvm::ArrayRef<SILType> resultSILTypes) const;
 };
 
 } // end namespace tf

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1382,10 +1382,10 @@ public:
   createGraphOperation(SILLocation loc, Identifier name,
                        ArrayRef<SILValue> operands,
                        ArrayRef<GraphOperationAttribute> attrs,
-                       bool runOutOfGraph, ArrayRef<SILType> resultTypes) {
-    return insert(GraphOperationInst::create(
-        getModule(), getSILDebugLocation(loc), name, operands, attrs,
-        runOutOfGraph, resultTypes));
+                       bool noClustering, ArrayRef<SILType> resultTypes) {
+    return insert(
+        GraphOperationInst::create(getModule(), getSILDebugLocation(loc), name,
+                                   operands, attrs, noClustering, resultTypes));
   }
 
   ClassMethodInst *createClassMethod(SILLocation Loc, SILValue Operand,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1378,12 +1378,14 @@ public:
       SILLocation Loc, SILValue Operand,
       llvm::SmallVectorImpl<SILValue> &Result);
 
-  GraphOperationInst *createGraphOperation(
-      SILLocation loc, Identifier name, ArrayRef<SILValue> operands,
-      ArrayRef<GraphOperationAttribute> attrs, ArrayRef<SILType> resultTypes) {
+  GraphOperationInst *
+  createGraphOperation(SILLocation loc, Identifier name,
+                       ArrayRef<SILValue> operands,
+                       ArrayRef<GraphOperationAttribute> attrs,
+                       bool runOutOfGraph, ArrayRef<SILType> resultTypes) {
     return insert(GraphOperationInst::create(
         getModule(), getSILDebugLocation(loc), name, operands, attrs,
-        resultTypes));
+        runOutOfGraph, resultTypes));
   }
 
   ClassMethodInst *createClassMethod(SILLocation Loc, SILValue Operand,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1776,10 +1776,10 @@ void SILCloner<ImplClass>::visitGraphOperationInst(GraphOperationInst *Inst) {
   SmallVector<SILType, 4> resultTypes;
   for (auto result : Inst->getResults())
     resultTypes.push_back(getOpType(result->getType()));
-  recordClonedInstruction(Inst,
-      getBuilder().createGraphOperation(getOpLocation(Inst->getLoc()),
-                                        Inst->getName(), arguments,
-                                        Inst->getAttributes(), resultTypes));
+  recordClonedInstruction(
+      Inst, getBuilder().createGraphOperation(
+                getOpLocation(Inst->getLoc()), Inst->getName(), arguments,
+                Inst->getAttributes(), Inst->getRunOutOfGraph(), resultTypes));
 }
 
 template <typename ImplClass>

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1779,7 +1779,7 @@ void SILCloner<ImplClass>::visitGraphOperationInst(GraphOperationInst *Inst) {
   recordClonedInstruction(
       Inst, getBuilder().createGraphOperation(
                 getOpLocation(Inst->getLoc()), Inst->getName(), arguments,
-                Inst->getAttributes(), Inst->getRunOutOfGraph(), resultTypes));
+                Inst->getAttributes(), Inst->getNoClustering(), resultTypes));
 }
 
 template <typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7771,14 +7771,17 @@ class GraphOperationInst final
   unsigned NumOperands;
   /// The attributes of the graph operation.
   MutableArrayRef<GraphOperationAttribute> Attributes;
-  /// Whether this instruction is to be executed out of graph (via eager op
-  /// dispatch). For an op with dynamic attribute(s), it must run out of graph.
-  bool RunOutOfGraph;
+  /// When true, this instruction is to be executed out-of-graph (via eager op
+  /// dispatch). Otherwise, we attempt to "cluster" this graph op with other
+  /// graph ops into a graph function. For an op with dynamic attribute(s), it
+  /// must run out-of-graph, and thus have this field set to true.
+  // FIXME: Extend parser and printer with this field.
+  bool NoClustering;
 
   GraphOperationInst(SILModule &M, SILDebugLocation loc, Identifier name,
                      ArrayRef<SILValue> arguments,
-                     ArrayRef<GraphOperationAttribute> attrs,
-                     bool runOutOfGraph, ArrayRef<SILType> resultTypes,
+                     ArrayRef<GraphOperationAttribute> attrs, bool noClustering,
+                     ArrayRef<SILType> resultTypes,
                      ArrayRef<ValueOwnershipKind> resultOwnerships);
 
 public:
@@ -7789,7 +7792,7 @@ public:
   static GraphOperationInst *
   create(SILModule &M, SILDebugLocation loc, Identifier name,
          ArrayRef<SILValue> arguments, ArrayRef<GraphOperationAttribute> attrs,
-         bool runOutOfGraph, ArrayRef<SILType> resultTypes);
+         bool noClustering, ArrayRef<SILType> resultTypes);
 
   Identifier getName() const { return Name; }
   unsigned getNumOperands() const { return NumOperands; }
@@ -7822,10 +7825,8 @@ public:
 
   Optional<SymbolicValue> getAttributeNamed(StringRef name);
 
-  void setRunOutOfGraph(bool RunOutOfGraph) {
-    this->RunOutOfGraph = RunOutOfGraph;
-  }
-  bool getRunOutOfGraph() const { return RunOutOfGraph; }
+  void setNoClustering(bool noClustering) { NoClustering = noClustering; }
+  bool getNoClustering() const { return NoClustering; }
 
   static bool classof(const SILNode *N) {
     return N->getKind() == SILNodeKind::GraphOperationInst;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7771,11 +7771,14 @@ class GraphOperationInst final
   unsigned NumOperands;
   /// The attributes of the graph operation.
   MutableArrayRef<GraphOperationAttribute> Attributes;
+  /// Whether this instruction is to be executed out of graph (via eager op
+  /// dispatch). For an op with dynamic attribute(s), it must run out of graph.
+  bool RunOutOfGraph;
 
   GraphOperationInst(SILModule &M, SILDebugLocation loc, Identifier name,
                      ArrayRef<SILValue> arguments,
                      ArrayRef<GraphOperationAttribute> attrs,
-                     ArrayRef<SILType> resultTypes,
+                     bool runOutOfGraph, ArrayRef<SILType> resultTypes,
                      ArrayRef<ValueOwnershipKind> resultOwnerships);
 
 public:
@@ -7783,11 +7786,10 @@ public:
   using MultipleValueInstructionTrailingObjects::totalSizeToAlloc;
 
   ~GraphOperationInst();
-  static GraphOperationInst *create(SILModule &M, SILDebugLocation loc,
-                                    Identifier name,
-                                    ArrayRef<SILValue> arguments,
-                                    ArrayRef<GraphOperationAttribute> attrs,
-                                    ArrayRef<SILType> resultTypes);
+  static GraphOperationInst *
+  create(SILModule &M, SILDebugLocation loc, Identifier name,
+         ArrayRef<SILValue> arguments, ArrayRef<GraphOperationAttribute> attrs,
+         bool runOutOfGraph, ArrayRef<SILType> resultTypes);
 
   Identifier getName() const { return Name; }
   unsigned getNumOperands() const { return NumOperands; }
@@ -7819,6 +7821,11 @@ public:
   }
 
   Optional<SymbolicValue> getAttributeNamed(StringRef name);
+
+  void setRunOutOfGraph(bool RunOutOfGraph) {
+    this->RunOutOfGraph = RunOutOfGraph;
+  }
+  bool getRunOutOfGraph() const { return RunOutOfGraph; }
 
   static bool classof(const SILNode *N) {
     return N->getKind() == SILNodeKind::GraphOperationInst;

--- a/lib/AST/GraphOperationBuilder.cpp
+++ b/lib/AST/GraphOperationBuilder.cpp
@@ -65,7 +65,7 @@ GraphOperationInst* GraphOperationBuilder::build(
     SILBuilder &B, ASTContext &C, SILLocation loc,
     ArrayRef<SILType> resultSILTypes) const {
   return B.createGraphOperation(loc, C.getIdentifier(MangledName), Operands,
-                                Attributes, /*runOutOfGraph*/ false,
+                                Attributes, /*noClustering*/ false,
                                 resultSILTypes);
 }
 

--- a/lib/AST/GraphOperationBuilder.cpp
+++ b/lib/AST/GraphOperationBuilder.cpp
@@ -65,7 +65,8 @@ GraphOperationInst* GraphOperationBuilder::build(
     SILBuilder &B, ASTContext &C, SILLocation loc,
     ArrayRef<SILType> resultSILTypes) const {
   return B.createGraphOperation(loc, C.getIdentifier(MangledName), Operands,
-                                Attributes, resultSILTypes);
+                                Attributes, /*runOutOfGraph*/ false,
+                                resultSILTypes);
 }
 
 } // end namespace tf

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -2427,11 +2427,11 @@ DestructureTupleInst *DestructureTupleInst::create(SILModule &M,
 GraphOperationInst::GraphOperationInst(
     SILModule &M, SILDebugLocation loc, Identifier name,
     ArrayRef<SILValue> arguments, ArrayRef<GraphOperationAttribute> attrs,
-    bool runOutOfGraph, ArrayRef<SILType> resultTypes,
+    bool noClustering, ArrayRef<SILType> resultTypes,
     ArrayRef<ValueOwnershipKind> resultOwnerships)
     : InstructionBase(loc), MultipleValueInstructionTrailingObjects(
                                 this, resultTypes, resultOwnerships),
-      Name(name), NumOperands(arguments.size()), RunOutOfGraph(runOutOfGraph) {
+      Name(name), NumOperands(arguments.size()), NoClustering(noClustering) {
   auto allOperands = getAllOperands();
   for (unsigned i : indices(arguments))
     new (&allOperands[i]) Operand(this, arguments[i]);
@@ -2451,7 +2451,7 @@ GraphOperationInst *
 GraphOperationInst::create(SILModule &M, SILDebugLocation loc, Identifier name,
                            ArrayRef<SILValue> arguments,
                            ArrayRef<GraphOperationAttribute> attributes,
-                           bool runOutOfGraph, ArrayRef<SILType> resultTypes) {
+                           bool noClustering, ArrayRef<SILType> resultTypes) {
   llvm::SmallVector<ValueOwnershipKind, 4> resultOwnerships;
   for (auto resultType : resultTypes) {
     auto ownership = resultType.isTrivial(M)
@@ -2464,7 +2464,7 @@ GraphOperationInst::create(SILModule &M, SILDebugLocation loc, Identifier name,
       1, resultTypes.size(), arguments.size());
   void *buffer = M.allocateInst(size, alignof(GraphOperationInst));
   return ::new (buffer)
-      GraphOperationInst(M, loc, name, arguments, attributes, runOutOfGraph,
+      GraphOperationInst(M, loc, name, arguments, attributes, noClustering,
                          resultTypes, resultOwnerships);
 }
 

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2279,7 +2279,7 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
   };
 
   GraphOperationBuilder opBuilder(opInfo.getOperationName());
-  bool runOutOfGraph = false;
+  bool noClustering = false;
 
   // Find the device attribute specified for the instruction if present.
   StringRef opDevice;
@@ -2411,10 +2411,8 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
       LLVM_DEBUG(llvm::dbgs() << "  graph_op " << *origInst
                               << " has a dynamic attr: " << argumentValue
                               << " and will be evaluated out-of-graph.\n");
-      runOutOfGraph = true;
-      opBuilder.addArgument(
-          argumentValue,
-          attrIdentifier.str() /*std::get<0>(argumentNameAndLowering)*/);
+      noClustering = true;
+      opBuilder.addArgument(argumentValue, attrIdentifier.str());
       continue;
     }
 
@@ -2661,7 +2659,7 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
         return SILType::getPrimitiveObjectType(ty->getCanonicalType()); });
 
     auto op = opBuilder.build(B, context, loc, resultSILTypes);
-    op->setRunOutOfGraph(runOutOfGraph);
+    op->setNoClustering(noClustering);
 
     // Recursively pack results to a value with the user-specified aggregate type.
     auto resultIt = op->getResults().begin();
@@ -2699,7 +2697,7 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
       assert(isTensorFlowValue(resultType) &&
              "when there are multiple results, they should be tf types");
     auto op = opBuilder.build(B, context, loc, origResultTypes);
-    op->setRunOutOfGraph(runOutOfGraph);
+    op->setNoClustering(noClustering);
     origInst->replaceAllUsesPairwiseWith(op);
   }
 

--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -227,8 +227,9 @@ void DevicePartitionCloner::visitGraphOperationInst(GraphOperationInst *inst) {
   for (auto r : inst->getResults())
     resultTypes.push_back(r->getType());
 
-  auto newOp = B.createGraphOperation(loc, inst->getName(), args,
-                                      inst->getAttributes(), resultTypes);
+  auto newOp =
+      B.createGraphOperation(loc, inst->getName(), args, inst->getAttributes(),
+                             /*runOutOfGraph*/ false, resultTypes);
 
   for (unsigned i = 0, e = inst->getNumResults(); i != e; ++i)
     ValueMap[inst->getResult(i)] = newOp->getResult(i);

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -643,7 +643,10 @@ public:
   DominanceInfo &DI;
   BlocksReachingTensorCode tensorCodeBlocks;
 
-  /// These are all the tensor ops found in the initial scan over the function.
+  /// These are the tensor ops to be executed in the extracted graph function.
+  // They are found in the initial scan over the function.
+  // Note when a graphOp inst is marked to run out-of-graph
+  // (graphOp->getRunOutOfGraph() is true), it will not be included here.
   SmallPtrSet<SILInstruction *, 8> tensorOpsSet;
 
   /// This keeps track of the set of blocks that are marked as needing to be
@@ -2029,6 +2032,10 @@ bool TFFunctionPartition::markFunction(bool &hasTensorOps) {
       if (!graphOp)
         continue;
       logInput();
+
+      if (graphOp->getRunOutOfGraph())
+        continue;
+
       tensorOps.push_back(inst);
       tensorOpsSet.insert(inst);
 

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2033,7 +2033,9 @@ bool TFFunctionPartition::markFunction(bool &hasTensorOps) {
         continue;
       logInput();
 
-      if (graphOp->getRunOutOfGraph())
+      // If we need to run this op out-of-graph (e.g. because it has a dynamic
+      // attribute), do not add it to `tensorOps`.
+      if (graphOp->getNoClustering())
         continue;
 
       tensorOps.push_back(inst);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1501,10 +1501,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
                            (SILValueCategory)(unsigned)ListOfValues[i+1]);
       ResultSILTypes.push_back(Ty);
     }
-    // TODO: deserialize `runOutOfGraph`.
+    // TODO: deserialize `noClustering`.
     ResultVal =
         Builder.createGraphOperation(Loc, MangledName, Args, {},
-                                     /*runOutOfGraph*/ false, ResultSILTypes);
+                                     /*noClustering*/ false, ResultSILTypes);
     break;
   }
   case SILInstructionKind::AllocGlobalInst: {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1501,8 +1501,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
                            (SILValueCategory)(unsigned)ListOfValues[i+1]);
       ResultSILTypes.push_back(Ty);
     }
-    ResultVal = Builder.createGraphOperation(Loc, MangledName, Args, {},
-                                             ResultSILTypes);
+    // TODO: deserialize `runOutOfGraph`.
+    ResultVal =
+        Builder.createGraphOperation(Loc, MangledName, Args, {},
+                                     /*runOutOfGraph*/ false, ResultSILTypes);
     break;
   }
   case SILInstructionKind::AllocGlobalInst: {

--- a/test/TensorFlow/deabstraction_crashers.swift
+++ b/test/TensorFlow/deabstraction_crashers.swift
@@ -1,11 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
 import TensorFlow
 
-public func SR8299(a: Tensor<Float>) {
-   // expected-error @+1 {{attribute 'someAttr' requires a constant argument}}
-   () = #tfop("foo", someAttr: a)
-}
-
 // @constExpr
 func one() -> Int {
   return 1

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -276,3 +276,11 @@ public func getTensorAndAddOneFunction() -> (Tensor<Float>, (Tensor<Float>) -> T
 // CHECK-NOT: --- TFPartition Accelerator Result: {{.*}}getZero{{.*}}
 // CHECK: --- TFPartition Accelerator Result: {{.*}}getTensorAndAddOneFunction{{.*}}
 
+// This test can still compile in graph mode, especially of the dynamic
+// attribute `padding`, since we will run the conv2D op out-of-graph (via eager
+// op dispatch).
+public func nonConstantAttribute(x: Tensor<Float>, padding: Padding) {
+  _hostOp(x.convolved2D(withFilter: Tensor<Float>(ones: [1, 3, 3, 1]),
+                        strides: (1, 1, 1, 1),
+                        padding: padding))
+}

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -27,17 +27,6 @@ public func resultPacking() {
   let _: Foo = #tfop("SomeOp")
 }
 
-// This shows passing a non-constant value into an attribute.
-// TODO: Improve the diagnostic to display the Swift parameter name instead of
-// the internal TensorFlow attribute name. (In this example, it's hard to tell
-// because both Swift/TensorFlow use the same name "padding".)
-public func nonConstantAttribute(x: Tensor<Float>, padding: Padding) {
-  // expected-error @+1 {{attribute 'padding' requires a constant argument}}
-  _hostOp(x.convolved2D(withFilter: Tensor<Float>(ones: [1, 3, 3, 1]),
-                        strides: (1, 1, 1, 1),
-                        padding: padding))
-}
-
 public enum X {
   case A, B
 }
@@ -45,11 +34,6 @@ public enum X {
 public func invalidAttributeArg() -> TensorHandle<Int32> {
   // expected-error@+1 {{attribute 'someAttr' cannot be an enum, struct, or tuple}}
   return #tfop("bar", someAttr: X.A)
-}
-
-public func invalidAttrTensor(a: Tensor<Float>) {
-   // expected-error @+1 {{attribute 'someAttr' requires a constant argument}}
-   () = #tfop("foo", someAttr: a)
 }
 
 public func noTensorShape() -> Tensor<Float> {

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-dynamic-compilation-swift
+// UN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: tensorflow
 

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -1,5 +1,5 @@
-// UN: %target-run-dynamic-compilation-swift
 // RUN: %target-run-simple-swift
+// RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 // REQUIRES: tensorflow
 


### PR DESCRIPTION
This involves a simple change in the deabstraction and partition passes. In the
former pass, we mark the graph_op with a new bit indicating it will run "out of
graph" (i.e., via eager op dispatch), when we fail to const-evaluate any
attribute of it. In the latter pass, we exclude those graph_op's marked
out-of-graph from tensorOpSet, so that they are not considered when extracting
the graph function. Effectively, they are treated like host functions such as
`atariSimulator()`.

Extended the graph_op infra to support instruction creation and mutation with this new "out-of-graph" bit. We chose not to extend `GraphOperationBuilder::Builder` accordingly in order to avoid unnecessary interface complexity, because its many existing callers do not care about this bit.

Adjusted some compiler tests, and turned on the entire runtime test suite on
dynamic attrs in graph mode!
