### PR TITLE
[stdlib] Unexport shadow protocols

### DIFF
--- a/stdlib/public/SDK/Foundation/NSArray.swift
+++ b/stdlib/public/SDK/Foundation/NSArray.swift
@@ -43,9 +43,7 @@ extension Array : _ObjectiveCBridgeable {
     //
     // The bug is fixed in: OS X 10.11.0, iOS 9.0, all versions of tvOS
     // and watchOS.
-    self = Array(
-      _immutableCocoaArray:
-        unsafeBitCast(_cocoaArray.copy() as AnyObject, to: _NSArrayCore.self))
+    self = Array(_immutableCocoaArray: _cocoaArray.copy() as AnyObject)
   }
 
   @_semantics("convertToObjectiveC")

--- a/stdlib/public/SDK/Foundation/NSDictionary.swift
+++ b/stdlib/public/SDK/Foundation/NSDictionary.swift
@@ -49,7 +49,7 @@ extension Dictionary {
     // The bug is fixed in: OS X 10.11.0, iOS 9.0, all versions of tvOS
     // and watchOS.
     self = Dictionary(
-      _immutableCocoaDictionary: _cocoaDictionary.copy(with: nil))
+      _immutableCocoaDictionary: _cocoaDictionary.copy(with: nil) as AnyObject)
   }
 }
 

--- a/stdlib/public/SDK/Foundation/NSDictionary.swift
+++ b/stdlib/public/SDK/Foundation/NSDictionary.swift
@@ -34,7 +34,7 @@ extension Dictionary {
   ///
   /// The provided `NSDictionary` will be copied to ensure that the copy can
   /// not be mutated by other code.
-  fileprivate init(_cocoaDictionary: __shared _NSDictionary) {
+  fileprivate init(_cocoaDictionary: __shared AnyObject) {
     assert(
       _isBridgedVerbatimToObjectiveC(Key.self) &&
       _isBridgedVerbatimToObjectiveC(Value.self),
@@ -49,9 +49,7 @@ extension Dictionary {
     // The bug is fixed in: OS X 10.11.0, iOS 9.0, all versions of tvOS
     // and watchOS.
     self = Dictionary(
-      _immutableCocoaDictionary:
-        unsafeBitCast(_cocoaDictionary.copy(with: nil) as AnyObject,
-                      to: _NSDictionary.self))
+      _immutableCocoaDictionary: _cocoaDictionary.copy(with: nil))
   }
 }
 
@@ -75,8 +73,7 @@ extension Dictionary : _ObjectiveCBridgeable {
 
     if _isBridgedVerbatimToObjectiveC(Key.self) &&
        _isBridgedVerbatimToObjectiveC(Value.self) {
-      result = [Key : Value](
-        _cocoaDictionary: unsafeBitCast(d as AnyObject, to: _NSDictionary.self))
+      result = [Key : Value](_cocoaDictionary: d)
       return
     }
 

--- a/stdlib/public/SDK/Foundation/NSSet.swift
+++ b/stdlib/public/SDK/Foundation/NSSet.swift
@@ -29,7 +29,7 @@ extension Set {
     //
     // The bug is fixed in: OS X 10.11.0, iOS 9.0, all versions of tvOS
     // and watchOS.
-    self = Set(_immutableCocoaSet: _cocoaSet.copy(with: nil))
+    self = Set(_immutableCocoaSet: _cocoaSet.copy(with: nil) as AnyObject)
   }
 }
 

--- a/stdlib/public/SDK/Foundation/NSSet.swift
+++ b/stdlib/public/SDK/Foundation/NSSet.swift
@@ -17,7 +17,7 @@ extension Set {
   ///
   /// The provided `NSSet` will be copied to ensure that the copy can
   /// not be mutated by other code.
-  fileprivate init(_cocoaSet: __shared _NSSet) {
+  fileprivate init(_cocoaSet: __shared AnyObject) {
     assert(_isBridgedVerbatimToObjectiveC(Element.self),
       "Set can be backed by NSSet _variantStorage only when the member type can be bridged verbatim to Objective-C")
     // FIXME: We would like to call CFSetCreateCopy() to avoid doing an
@@ -29,9 +29,7 @@ extension Set {
     //
     // The bug is fixed in: OS X 10.11.0, iOS 9.0, all versions of tvOS
     // and watchOS.
-    self = Set(
-      _immutableCocoaSet:
-        unsafeBitCast(_cocoaSet.copy(with: nil) as AnyObject, to: _NSSet.self))
+    self = Set(_immutableCocoaSet: _cocoaSet.copy(with: nil))
   }
 }
 
@@ -69,7 +67,7 @@ extension Set : _ObjectiveCBridgeable {
     }
 
     if _isBridgedVerbatimToObjectiveC(Element.self) {
-      result = Set<Element>(_cocoaSet: unsafeBitCast(s, to: _NSSet.self))
+      result = Set<Element>(_cocoaSet: s)
       return
     }
 

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1728,7 +1728,7 @@ extension Array {
 // to do the bridging in an ABI safe way. Even though this looks useless,
 // DO NOT DELETE!
 @usableFromInline internal
-func _bridgeCocoaArray<T>(_ _immutableCocoaArray: _NSArrayCore) -> Array<T> {
+func _bridgeCocoaArray<T>(_ _immutableCocoaArray: AnyObject) -> Array<T> {
   return Array(_buffer: _ArrayBuffer(nsArray: _immutableCocoaArray))
 }
 
@@ -1764,7 +1764,7 @@ extension Array {
   /// * `Element` is bridged verbatim to Objective-C (i.e.,
   ///   is a reference type).
   @inlinable
-  public init(_immutableCocoaArray: _NSArrayCore) {
+  public init(_immutableCocoaArray: AnyObject) {
     self = _bridgeCocoaArray(_immutableCocoaArray)
   }
 }

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -20,7 +20,7 @@ import SwiftShims
 
 @usableFromInline
 internal typealias _ArrayBridgeStorage
-  = _BridgeStorage<__ContiguousArrayStorageBase, AnyObject>
+  = _BridgeStorage<__ContiguousArrayStorageBase>
 
 @usableFromInline
 @_fixed_layout

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -13,7 +13,7 @@
 //  Types that are bridged to Objective-C need to manage an object
 //  that may be either some native class or the @objc Cocoa
 //  equivalent.  _BridgeStorage discriminates between these two
-//  possibilities and stores a few extra bits when the stored type is
+//  possibilities and stores a single extra bit when the stored type is
 //  native.  It is assumed that the @objc class instance may in fact
 //  be a tagged pointer, and thus no extra bits may be available.
 //
@@ -22,15 +22,12 @@ import SwiftShims
 
 @_fixed_layout
 @usableFromInline
-internal struct _BridgeStorage<
-  NativeClass: AnyObject,
-  ObjCClass: AnyObject
-> {
+internal struct _BridgeStorage<NativeClass: AnyObject> {
   @usableFromInline
   internal typealias Native = NativeClass
 
   @usableFromInline
-  internal typealias ObjC = ObjCClass
+  internal typealias ObjC = AnyObject
 
   // rawValue is passed inout to _isUnique.  Although its value
   // is unchanged, it must appear mutable to the optimizer.

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -21,29 +21,76 @@
 #if _runtime(_ObjC)
 import SwiftShims
 
-/// A wrapper around any `_NSArrayCore` that gives it
-/// `Collection` conformance.  Why not make
-/// `_NSArrayCore` conform directly?  It's a class, and I
-/// don't want to pay for the dynamic dispatch overhead.
+/// A wrapper around any `_NSArrayCore` (represented as AnyObject) that gives it
+/// `Collection` conformance.  Why not make `_NSArrayCore` conform directly?
+/// It's a class, and I don't want to pay for the dynamic dispatch overhead.
 @usableFromInline
 @_fixed_layout
 internal struct _CocoaArrayWrapper : RandomAccessCollection {
   @usableFromInline
   typealias Indices = Range<Int>
 
+  @usableFromInline
+  internal var buffer: AnyObject
+
+  @usableFromInline @_transparent
+  internal init(_ buffer: AnyObject) {
+    self.buffer = buffer
+  }
+
+  internal var core: _NSArrayCore {
+    @inline(__always) get {
+      return unsafeBitCast(buffer, to: _NSArrayCore.self)
+    }
+  }
+
   @inlinable
   internal var startIndex: Int {
     return 0
   }
 
-  @inlinable
+  @usableFromInline
   internal var endIndex: Int {
-    return buffer.count
+    return core.count
   }
 
-  @inlinable
+  @usableFromInline
   internal subscript(i: Int) -> AnyObject {
-    return buffer.objectAt(i)
+    return core.objectAt(i)
+  }
+
+  @usableFromInline
+  internal subscript(bounds: Range<Int>) -> _SliceBuffer<AnyObject> {
+    let boundsCount = bounds.count
+    if boundsCount == 0 {
+      return _SliceBuffer(
+        _buffer: _ContiguousArrayBuffer<AnyObject>(),
+        shiftedToStartIndex: bounds.lowerBound)
+    }
+
+    // Look for contiguous storage in the NSArray
+    let cocoaStorageBaseAddress = self.contiguousStorage(self.indices)
+
+    if let cocoaStorageBaseAddress = cocoaStorageBaseAddress {
+      return _SliceBuffer(
+        owner: self.buffer,
+        subscriptBaseAddress: cocoaStorageBaseAddress,
+        indices: bounds,
+        hasNativeBuffer: false)
+    }
+
+    // No contiguous storage found; we must allocate
+    let result = _ContiguousArrayBuffer<AnyObject>(
+      _uninitializedCount: boundsCount,
+      minimumCapacity: 0)
+
+    // Tell Cocoa to copy the objects into our storage
+    core.getObjects(
+      UnsafeMutableRawPointer(result.firstElementAddress)
+      .assumingMemoryBound(to: AnyObject.self),
+      range: _SwiftNSRange(location: bounds.lowerBound, length: boundsCount))
+
+    return _SliceBuffer(_buffer: result, shiftedToStartIndex: bounds.lowerBound)
   }
 
   /// Returns a pointer to the first element in the given non-empty `subRange`
@@ -56,7 +103,6 @@ internal struct _CocoaArrayWrapper : RandomAccessCollection {
   ///   is sometimes conservative and may return `nil` even when
   ///   contiguous storage exists, e.g., if array doesn't have a smart
   /// implementation of countByEnumerating.
-  @inlinable
   internal func contiguousStorage(
     _ subRange: Range<Int>
   ) -> UnsafeMutablePointer<AnyObject>?
@@ -69,9 +115,9 @@ internal struct _CocoaArrayWrapper : RandomAccessCollection {
     // acceptable conservative behavior, but could potentially be
     // optimized for other cases.
     let contiguousCount = withUnsafeMutablePointer(to: &enumerationState) {
-      self.buffer.countByEnumerating(with: $0, objects: nil, count: 0)
+      core.countByEnumerating(with: $0, objects: nil, count: 0)
     }
-    
+
     return contiguousCount >= subRange.upperBound
       ? UnsafeMutableRawPointer(enumerationState.itemsPtr!)
           .assumingMemoryBound(to: AnyObject.self)
@@ -79,12 +125,25 @@ internal struct _CocoaArrayWrapper : RandomAccessCollection {
       : nil
   }
 
-  @usableFromInline @_transparent
-  internal init(_ buffer: _NSArrayCore) {
-    self.buffer = buffer
-  }
-
   @usableFromInline
-  internal var buffer: _NSArrayCore
+  __consuming internal func _copyContents(
+    subRange bounds: Range<Int>,
+    initializing target: UnsafeMutablePointer<AnyObject>
+  ) -> UnsafeMutablePointer<AnyObject> {
+    let nsSubRange = SwiftShims._SwiftNSRange(
+      location: bounds.lowerBound,
+      length: bounds.upperBound - bounds.lowerBound)
+
+    // Copies the references out of the NSArray without retaining them
+    core.getObjects(target, range: nsSubRange)
+
+    // Make another pass to retain the copied objects
+    var result = target
+    for _ in bounds {
+      result.initialize(to: result.pointee)
+      result += 1
+    }
+    return result
+  }
 }
 #endif

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -431,7 +431,7 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   ///
   /// - Complexity: O(1).
   @inlinable
-  internal __consuming func _asCocoaArray() -> _NSArrayCore {
+  internal __consuming func _asCocoaArray() -> AnyObject {
     if count == 0 {
       return _emptyArrayStorage
     }

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -414,7 +414,7 @@ public struct Dictionary<Key: Hashable, Value> {
   ///   are reference types).
   @inlinable
   public // SPI(Foundation)
-  init(_immutableCocoaDictionary: __owned _NSDictionary) {
+  init(_immutableCocoaDictionary: __owned AnyObject) {
     _sanityCheck(
       _isBridgedVerbatimToObjectiveC(Key.self) &&
       _isBridgedVerbatimToObjectiveC(Value.self),

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -35,7 +35,7 @@ extension Dictionary {
   @_fixed_layout
   internal struct _Variant {
     @usableFromInline
-    internal var object: _BridgeStorage<_RawDictionaryStorage, AnyObject>
+    internal var object: _BridgeStorage<_RawDictionaryStorage>
 
     @inlinable
     @inline(__always)

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -34,13 +34,8 @@ extension Dictionary {
   @usableFromInline
   @_fixed_layout
   internal struct _Variant {
-#if _runtime(_ObjC)
-    @usableFromInline
-    internal var object: _BridgeStorage<_RawDictionaryStorage, _NSDictionary>
-#else
     @usableFromInline
     internal var object: _BridgeStorage<_RawDictionaryStorage, AnyObject>
-#endif
 
     @inlinable
     @inline(__always)

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -187,7 +187,7 @@ public struct Set<Element: Hashable> {
   ///   is a reference type).
   @inlinable
   public // SPI(Foundation)
-  init(_immutableCocoaSet: __owned _NSSet) {
+  init(_immutableCocoaSet: __owned AnyObject) {
     _sanityCheck(_isBridgedVerbatimToObjectiveC(Element.self),
       "Set can be backed by NSSet _variant only when the member type can be bridged verbatim to Objective-C")
     self.init(_cocoa: _CocoaSet(_immutableCocoaSet))

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -30,13 +30,8 @@ extension Set {
   @usableFromInline
   @_fixed_layout
   internal struct _Variant {
-#if _runtime(_ObjC)
-    @usableFromInline
-    internal var object: _BridgeStorage<_RawSetStorage, _NSSet>
-#else
     @usableFromInline
     internal var object: _BridgeStorage<_RawSetStorage, AnyObject>
-#endif
 
     @inlinable
     @inline(__always)

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -31,7 +31,7 @@ extension Set {
   @_fixed_layout
   internal struct _Variant {
     @usableFromInline
-    internal var object: _BridgeStorage<_RawSetStorage, AnyObject>
+    internal var object: _BridgeStorage<_RawSetStorage>
 
     @inlinable
     @inline(__always)

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -177,7 +177,7 @@ internal protocol _NSSet: _NSSetCore {
 /// A shadow for the API of NSNumber we will use in the core
 /// stdlib.
 @objc
-public protocol _NSNumber {
+internal protocol _NSNumber {
   var doubleValue: Double { get }
   var floatValue: Float { get }
   var unsignedLongLongValue: UInt64 { get }

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -58,8 +58,7 @@ public protocol _NSCopying : _ShadowProtocol {
 /// Covers a set of operations everyone needs to implement in order to
 /// be a useful `NSArray` subclass.
 @unsafe_no_objc_tagged_pointer @objc
-public protocol _NSArrayCore :
-    _NSCopying, _NSFastEnumeration {
+internal protocol _NSArrayCore: _NSCopying, _NSFastEnumeration {
 
   @objc(objectAtIndex:)
   func objectAt(_ index: Int) -> AnyObject
@@ -184,9 +183,5 @@ internal protocol _NSNumber {
   var longLongValue: Int64 { get }
   var objCType: UnsafePointer<Int8> { get }
 }
-
-#else
-
-public protocol _NSArrayCore {}
 
 #endif

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -24,11 +24,11 @@
 import SwiftShims
 
 @objc
-public protocol _ShadowProtocol {}
+internal protocol _ShadowProtocol {}
 
 /// A shadow for the `NSFastEnumeration` protocol.
 @objc
-public protocol _NSFastEnumeration : _ShadowProtocol {
+internal protocol _NSFastEnumeration: _ShadowProtocol {
   @objc(countByEnumeratingWithState:objects:count:)
   func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
@@ -38,17 +38,17 @@ public protocol _NSFastEnumeration : _ShadowProtocol {
 
 /// A shadow for the `NSEnumerator` class.
 @objc
-public protocol _NSEnumerator : _ShadowProtocol {
+internal protocol _NSEnumerator: _ShadowProtocol {
   init()
   func nextObject() -> AnyObject?
 }
 
 /// A token that can be used for `NSZone*`.
-public typealias _SwiftNSZone = OpaquePointer
+internal typealias _SwiftNSZone = OpaquePointer
 
 /// A shadow for the `NSCopying` protocol.
 @objc
-public protocol _NSCopying : _ShadowProtocol {
+internal protocol _NSCopying: _ShadowProtocol {
   @objc(copyWithZone:)
   func copy(with zone: _SwiftNSZone?) -> AnyObject
 }

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -138,8 +138,7 @@ internal protocol _NSDictionary: _NSDictionaryCore {
 /// Covers a set of operations everyone needs to implement in order to
 /// be a useful `NSSet` subclass.
 @objc
-public protocol _NSSetCore :
-    _NSCopying, _NSFastEnumeration {
+internal protocol _NSSetCore: _NSCopying, _NSFastEnumeration {
 
   // The following methods should be overridden when implementing an
   // NSSet subclass.
@@ -172,7 +171,7 @@ public protocol _NSSetCore :
 /// forced to implement operations that `NSSet` already
 /// supplies.
 @unsafe_no_objc_tagged_pointer @objc
-public protocol _NSSet : _NSSetCore {
+internal protocol _NSSet: _NSSetCore {
 }
 
 /// A shadow for the API of NSNumber we will use in the core
@@ -189,6 +188,5 @@ public protocol _NSNumber {
 #else
 
 public protocol _NSArrayCore {}
-public protocol _NSSetCore {}
 
 #endif

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -184,4 +184,9 @@ internal protocol _NSNumber {
   var objCType: UnsafePointer<Int8> { get }
 }
 
+#else
+
+internal protocol _NSSetCore {}
+internal protocol _NSDictionaryCore {}
+
 #endif

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -80,9 +80,7 @@ public protocol _NSArrayCore :
 /// Covers a set of operations everyone needs to implement in order to
 /// be a useful `NSDictionary` subclass.
 @objc
-public protocol _NSDictionaryCore :
-    _NSCopying, _NSFastEnumeration {
-
+internal protocol _NSDictionaryCore: _NSCopying, _NSFastEnumeration {
   // The following methods should be overridden when implementing an
   // NSDictionary subclass.
 
@@ -126,7 +124,7 @@ public protocol _NSDictionaryCore :
 /// forced to implement operations that `NSDictionary` already
 /// supplies.
 @unsafe_no_objc_tagged_pointer @objc
-public protocol _NSDictionary : _NSDictionaryCore {
+internal protocol _NSDictionary: _NSDictionaryCore {
   // Note! This API's type is different from what is imported by the clang
   // importer.
   override func getObjects(
@@ -191,7 +189,6 @@ public protocol _NSNumber {
 #else
 
 public protocol _NSArrayCore {}
-public protocol _NSDictionaryCore {}
 public protocol _NSSetCore {}
 
 #endif

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -64,7 +64,7 @@ bb0(%0 : $TrivialDestructor):
   store %0 to %10 : $*TrivialDestructor
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
   strong_retain %0 : $TrivialDestructor
   strong_release %15 : $Builtin.BridgeObject
 // CHECK-NEXT: tuple ()
@@ -91,7 +91,7 @@ bb0(%0 : $TrivialDestructor):
   %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*TrivialDestructor
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
   strong_retain %0 : $TrivialDestructor
   strong_release %15 : $Builtin.BridgeObject
 
@@ -121,7 +121,7 @@ bb0(%0 : $TrivialDestructor):
   %6 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 1
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
   cond_br undef, bb1, bb2
 
 bb1:
@@ -159,7 +159,7 @@ bb1:
   %5 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 0
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
   strong_release %15 : $Builtin.BridgeObject
   %18 = tuple ()
   return %18 : $()
@@ -190,7 +190,7 @@ bb0(%0 : $TrivialDestructor):
   %12 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 0
   %13 = struct_extract %12 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
   strong_release %15 : $Builtin.BridgeObject
 
   return %22 : $TrivialDestructor
@@ -217,7 +217,7 @@ bb0(%0 : $TrivialDestructor, %1 : $TrivialDestructor):
   %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*TrivialDestructor
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
   cond_br undef, bb1, bb2
 
 bb1:
@@ -260,7 +260,7 @@ bb1:
   %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*TrivialDestructor
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
   strong_retain %0 : $TrivialDestructor
   store %0 to %7 : $*TrivialDestructor
   strong_release %15 : $Builtin.BridgeObject

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -64,7 +64,7 @@ bb0(%0 : $TrivialDestructor):
   store %0 to %10 : $*TrivialDestructor
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
   strong_retain %0 : $TrivialDestructor
   strong_release %15 : $Builtin.BridgeObject
 // CHECK-NEXT: tuple ()
@@ -91,7 +91,7 @@ bb0(%0 : $TrivialDestructor):
   %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*TrivialDestructor
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
   strong_retain %0 : $TrivialDestructor
   strong_release %15 : $Builtin.BridgeObject
 
@@ -121,7 +121,7 @@ bb0(%0 : $TrivialDestructor):
   %6 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 1
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
   cond_br undef, bb1, bb2
 
 bb1:
@@ -159,7 +159,7 @@ bb1:
   %5 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 0
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
   strong_release %15 : $Builtin.BridgeObject
   %18 = tuple ()
   return %18 : $()
@@ -190,7 +190,7 @@ bb0(%0 : $TrivialDestructor):
   %12 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 0
   %13 = struct_extract %12 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
   strong_release %15 : $Builtin.BridgeObject
 
   return %22 : $TrivialDestructor
@@ -217,7 +217,7 @@ bb0(%0 : $TrivialDestructor, %1 : $TrivialDestructor):
   %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*TrivialDestructor
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
   cond_br undef, bb1, bb2
 
 bb1:
@@ -260,7 +260,7 @@ bb1:
   %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*TrivialDestructor
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
-  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  %15 = struct_extract %14 : $_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
   strong_retain %0 : $TrivialDestructor
   store %0 to %7 : $*TrivialDestructor
   strong_release %15 : $Builtin.BridgeObject

--- a/test/SILOptimizer/licm_multiend.sil
+++ b/test/SILOptimizer/licm_multiend.sil
@@ -55,7 +55,7 @@ bb0:
   %1 = struct_element_addr %0 : $*ReversedCollection<Array<Int>>, #ReversedCollection._base
   %2 = struct_element_addr %1 : $*Array<Int>, #Array._buffer
   %3 = struct_element_addr %2 : $*_ArrayBuffer<Int>, #_ArrayBuffer._storage
-  %4 = struct_element_addr %3 : $*_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
+  %4 = struct_element_addr %3 : $*_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
   %5 = load %4 : $*Builtin.BridgeObject
   %6 = unchecked_ref_cast %5 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
   %7 = ref_element_addr %6 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
@@ -140,7 +140,7 @@ bb0:
   %1 = struct_element_addr %0 : $*ReversedCollection<Array<Int>>, #ReversedCollection._base
   %2 = struct_element_addr %1 : $*Array<Int>, #Array._buffer
   %3 = struct_element_addr %2 : $*_ArrayBuffer<Int>, #_ArrayBuffer._storage
-  %4 = struct_element_addr %3 : $*_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
+  %4 = struct_element_addr %3 : $*_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
   %5 = load %4 : $*Builtin.BridgeObject
   %6 = unchecked_ref_cast %5 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
   %7 = ref_element_addr %6 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity

--- a/test/SILOptimizer/licm_multiend.sil
+++ b/test/SILOptimizer/licm_multiend.sil
@@ -55,7 +55,7 @@ bb0:
   %1 = struct_element_addr %0 : $*ReversedCollection<Array<Int>>, #ReversedCollection._base
   %2 = struct_element_addr %1 : $*Array<Int>, #Array._buffer
   %3 = struct_element_addr %2 : $*_ArrayBuffer<Int>, #_ArrayBuffer._storage
-  %4 = struct_element_addr %3 : $*_BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  %4 = struct_element_addr %3 : $*_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
   %5 = load %4 : $*Builtin.BridgeObject
   %6 = unchecked_ref_cast %5 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
   %7 = ref_element_addr %6 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
@@ -140,7 +140,7 @@ bb0:
   %1 = struct_element_addr %0 : $*ReversedCollection<Array<Int>>, #ReversedCollection._base
   %2 = struct_element_addr %1 : $*Array<Int>, #Array._buffer
   %3 = struct_element_addr %2 : $*_ArrayBuffer<Int>, #_ArrayBuffer._storage
-  %4 = struct_element_addr %3 : $*_BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  %4 = struct_element_addr %3 : $*_BridgeStorage<__ContiguousArrayStorageBase, AnyObject>, #_BridgeStorage.rawValue
   %5 = load %4 : $*Builtin.BridgeObject
   %6 = unchecked_ref_cast %5 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
   %7 = ref_element_addr %6 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3509,6 +3509,8 @@ bb0(%0 : $*Builtin.Int64, %1 : $B):
   return %4 : $Builtin.Int64
 }
 
+protocol _NSArrayCore {}
+
 // CHECK-LABEL: sil @mark_dependence_base2
 // CHECK: bb0(
 // CHECK-NOT: open_existential_ref

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -291,3 +291,15 @@ Protocol _NSDictionary has been removed
 Protocol _NSDictionaryCore has been removed
 Var Dictionary._Variant.object has declared type change from _BridgeStorage<_RawDictionaryStorage, _NSDictionary> to _BridgeStorage<_RawDictionaryStorage, AnyObject>
 Var _CocoaDictionary.object has declared type change from _NSDictionary to AnyObject
+
+Class _EmptySetSingleton has removed conformance to _NSSetCore
+Class _SetStorage has removed conformance to _NSSetCore
+Constructor Set.init(_immutableCocoaSet:) has parameter 0 type change from _NSSet to AnyObject
+Constructor _CocoaSet.init(_:) has parameter 0 type change from _NSSet to AnyObject
+Func Set._bridgeToObjectiveCImpl() has return type change from _NSSetCore to AnyObject
+Func _NativeSet.bridged() has return type change from _NSSet to AnyObject
+Func _stdlib_CFSetGetValues(_:_:) has been removed
+Protocol _NSSet has been removed
+Protocol _NSSetCore has been removed
+Var Set._Variant.object has declared type change from _BridgeStorage<_RawSetStorage, _NSSet> to _BridgeStorage<_RawSetStorage, AnyObject>
+Var _CocoaSet.object has declared type change from _NSSet to AnyObject

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -280,3 +280,14 @@ Func _BidirectionalCollectionBox.__preprocessingPass(_:) has been removed
 Func _CollectionBox.__preprocessingPass(_:) has been removed
 Func _RandomAccessCollectionBox.__preprocessingPass(_:) has been removed
 Func _SequenceBox.__preprocessingPass(_:) has been removed
+
+Class _DictionaryStorage has removed conformance to _NSDictionaryCore
+Class _EmptyDictionarySingleton has removed conformance to _NSDictionaryCore
+Constructor Dictionary.init(_immutableCocoaDictionary:) has parameter 0 type change from _NSDictionary to AnyObject
+Constructor _CocoaDictionary.init(_:) has parameter 0 type change from _NSDictionary to AnyObject
+Func Dictionary._bridgeToObjectiveCImpl() has return type change from _NSDictionaryCore to AnyObject
+Func _NativeDictionary.bridged() has return type change from _NSDictionary to AnyObject
+Protocol _NSDictionary has been removed
+Protocol _NSDictionaryCore has been removed
+Var Dictionary._Variant.object has declared type change from _BridgeStorage<_RawDictionaryStorage, _NSDictionary> to _BridgeStorage<_RawDictionaryStorage, AnyObject>
+Var _CocoaDictionary.object has declared type change from _NSDictionary to AnyObject

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -303,3 +303,5 @@ Protocol _NSSet has been removed
 Protocol _NSSetCore has been removed
 Var Set._Variant.object has declared type change from _BridgeStorage<_RawSetStorage, _NSSet> to _BridgeStorage<_RawSetStorage, AnyObject>
 Var _CocoaSet.object has declared type change from _NSSet to AnyObject
+
+Protocol _NSNumber has been removed

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -305,3 +305,25 @@ Var Set._Variant.object has declared type change from _BridgeStorage<_RawSetStor
 Var _CocoaSet.object has declared type change from _NSSet to AnyObject
 
 Protocol _NSNumber has been removed
+
+Class _ContiguousArrayStorage has removed conformance to _NSArrayCore
+Class __ContiguousArrayStorageBase has removed conformance to _NSArrayCore
+Class __EmptyArrayStorage has removed conformance to _NSArrayCore
+Class __SwiftDeferredNSArray has removed conformance to _NSArrayCore
+Class __SwiftNativeNSArrayWithContiguousStorage has removed conformance to _NSArrayCore
+Constructor Array.init(_immutableCocoaArray:) has parameter 0 type change from _NSArrayCore to AnyObject
+Constructor _ArrayBuffer.init(nsArray:) has parameter 0 type change from _NSArrayCore to AnyObject
+Constructor _ArrayBuffer.init(storage:) has parameter 0 type change from _BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore> to _BridgeStorage<__ContiguousArrayStorageBase, AnyObject>
+Constructor _CocoaArrayWrapper.init(_:) has parameter 0 type change from _NSArrayCore to AnyObject
+Func _ArrayBuffer._asCocoaArray() has return type change from _NSArrayCore to AnyObject
+Func _CocoaArrayWrapper.contiguousStorage(_:) has been removed
+Func _ContiguousArrayBuffer._asCocoaArray() has return type change from _NSArrayCore to AnyObject
+Func _bridgeCocoaArray(_:) has parameter 0 type change from _NSArrayCore to AnyObject
+Protocol _NSArrayCore has been removed
+Struct _CocoaArrayWrapper has type witness type for BidirectionalCollection.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
+Struct _CocoaArrayWrapper has type witness type for Collection.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
+Struct _CocoaArrayWrapper has type witness type for RandomAccessCollection.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
+Struct _CocoaArrayWrapper has type witness type for Sequence.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
+Var _ArrayBuffer._nonNative has declared type change from _NSArrayCore to _CocoaArrayWrapper
+Var _ArrayBuffer._storage has declared type change from _BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore> to _BridgeStorage<__ContiguousArrayStorageBase, AnyObject>
+Var _CocoaArrayWrapper.buffer has declared type change from _NSArrayCore to AnyObject

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -289,7 +289,7 @@ Func Dictionary._bridgeToObjectiveCImpl() has return type change from _NSDiction
 Func _NativeDictionary.bridged() has return type change from _NSDictionary to AnyObject
 Protocol _NSDictionary has been removed
 Protocol _NSDictionaryCore has been removed
-Var Dictionary._Variant.object has declared type change from _BridgeStorage<_RawDictionaryStorage, _NSDictionary> to _BridgeStorage<_RawDictionaryStorage, AnyObject>
+Var Dictionary._Variant.object has declared type change from _BridgeStorage<_RawDictionaryStorage, _NSDictionary> to _BridgeStorage<_RawDictionaryStorage>
 Var _CocoaDictionary.object has declared type change from _NSDictionary to AnyObject
 
 Class _EmptySetSingleton has removed conformance to _NSSetCore
@@ -301,7 +301,7 @@ Func _NativeSet.bridged() has return type change from _NSSet to AnyObject
 Func _stdlib_CFSetGetValues(_:_:) has been removed
 Protocol _NSSet has been removed
 Protocol _NSSetCore has been removed
-Var Set._Variant.object has declared type change from _BridgeStorage<_RawSetStorage, _NSSet> to _BridgeStorage<_RawSetStorage, AnyObject>
+Var Set._Variant.object has declared type change from _BridgeStorage<_RawSetStorage, _NSSet> to _BridgeStorage<_RawSetStorage>
 Var _CocoaSet.object has declared type change from _NSSet to AnyObject
 
 Protocol _NSNumber has been removed
@@ -313,7 +313,7 @@ Class __SwiftDeferredNSArray has removed conformance to _NSArrayCore
 Class __SwiftNativeNSArrayWithContiguousStorage has removed conformance to _NSArrayCore
 Constructor Array.init(_immutableCocoaArray:) has parameter 0 type change from _NSArrayCore to AnyObject
 Constructor _ArrayBuffer.init(nsArray:) has parameter 0 type change from _NSArrayCore to AnyObject
-Constructor _ArrayBuffer.init(storage:) has parameter 0 type change from _BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore> to _BridgeStorage<__ContiguousArrayStorageBase, AnyObject>
+Constructor _ArrayBuffer.init(storage:) has parameter 0 type change from _BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore> to _BridgeStorage<__ContiguousArrayStorageBase>
 Constructor _CocoaArrayWrapper.init(_:) has parameter 0 type change from _NSArrayCore to AnyObject
 Func _ArrayBuffer._asCocoaArray() has return type change from _NSArrayCore to AnyObject
 Func _CocoaArrayWrapper.contiguousStorage(_:) has been removed
@@ -325,8 +325,22 @@ Struct _CocoaArrayWrapper has type witness type for Collection.SubSequence chang
 Struct _CocoaArrayWrapper has type witness type for RandomAccessCollection.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
 Struct _CocoaArrayWrapper has type witness type for Sequence.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
 Var _ArrayBuffer._nonNative has declared type change from _NSArrayCore to _CocoaArrayWrapper
-Var _ArrayBuffer._storage has declared type change from _BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore> to _BridgeStorage<__ContiguousArrayStorageBase, AnyObject>
+Var _ArrayBuffer._storage has declared type change from _BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore> to _BridgeStorage<__ContiguousArrayStorageBase>
 Var _CocoaArrayWrapper.buffer has declared type change from _NSArrayCore to AnyObject
 
 Var _SliceBuffer.endIndexAndFlags in a non-resilient type changes position from 2 to 3
 Var _SliceBuffer.startIndex in a non-resilient type changes position from 3 to 2
+
+Constructor _BridgeStorage.init(native:) has generic signature change from <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> to <τ_0_0 where τ_0_0 : AnyObject>
+Constructor _BridgeStorage.init(native:) has return type change from _BridgeStorage<τ_0_0, τ_0_1> to _BridgeStorage<τ_0_0>
+Constructor _BridgeStorage.init(native:isFlagged:) has generic signature change from <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> to <τ_0_0 where τ_0_0 : AnyObject>
+Constructor _BridgeStorage.init(native:isFlagged:) has return type change from _BridgeStorage<τ_0_0, τ_0_1> to _BridgeStorage<τ_0_0>
+Constructor _BridgeStorage.init(objC:) has generic signature change from <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> to <τ_0_0 where τ_0_0 : AnyObject>
+Constructor _BridgeStorage.init(objC:) has parameter 0 type change from τ_0_1 to AnyObject
+Constructor _BridgeStorage.init(objC:) has return type change from _BridgeStorage<τ_0_0, τ_0_1> to _BridgeStorage<τ_0_0>
+Constructor _BridgeStorage.init(taggedPayload:) has generic signature change from <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> to <τ_0_0 where τ_0_0 : AnyObject>
+Constructor _BridgeStorage.init(taggedPayload:) has return type change from _BridgeStorage<τ_0_0, τ_0_1> to _BridgeStorage<τ_0_0>
+Func _BridgeStorage.isUniquelyReferencedNative() has generic signature change from <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> to <τ_0_0 where τ_0_0 : AnyObject>
+Func _BridgeStorage.isUniquelyReferencedUnflaggedNative() has generic signature change from <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> to <τ_0_0 where τ_0_0 : AnyObject>
+Struct _BridgeStorage has generic signature change from <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> to <τ_0_0 where τ_0_0 : AnyObject>
+Var _BridgeStorage.objCInstance has declared type change from τ_0_1 to AnyObject

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -327,3 +327,6 @@ Struct _CocoaArrayWrapper has type witness type for Sequence.SubSequence changin
 Var _ArrayBuffer._nonNative has declared type change from _NSArrayCore to _CocoaArrayWrapper
 Var _ArrayBuffer._storage has declared type change from _BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore> to _BridgeStorage<__ContiguousArrayStorageBase, AnyObject>
 Var _CocoaArrayWrapper.buffer has declared type change from _NSArrayCore to AnyObject
+
+Var _SliceBuffer.endIndexAndFlags in a non-resilient type changes position from 2 to 3
+Var _SliceBuffer.startIndex in a non-resilient type changes position from 3 to 2

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -344,3 +344,39 @@ Func _BridgeStorage.isUniquelyReferencedNative() has generic signature change fr
 Func _BridgeStorage.isUniquelyReferencedUnflaggedNative() has generic signature change from <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> to <τ_0_0 where τ_0_0 : AnyObject>
 Struct _BridgeStorage has generic signature change from <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> to <τ_0_0 where τ_0_0 : AnyObject>
 Var _BridgeStorage.objCInstance has declared type change from τ_0_1 to AnyObject
+
+Class _ContiguousArrayStorage has removed conformance to _NSCopying
+Class _ContiguousArrayStorage has removed conformance to _NSFastEnumeration
+Class _ContiguousArrayStorage has removed conformance to _ShadowProtocol
+Class _DictionaryStorage has removed conformance to _NSCopying
+Class _DictionaryStorage has removed conformance to _NSFastEnumeration
+Class _DictionaryStorage has removed conformance to _ShadowProtocol
+Class _EmptyDictionarySingleton has removed conformance to _NSCopying
+Class _EmptyDictionarySingleton has removed conformance to _NSFastEnumeration
+Class _EmptyDictionarySingleton has removed conformance to _ShadowProtocol
+Class _EmptySetSingleton has removed conformance to _NSCopying
+Class _EmptySetSingleton has removed conformance to _NSFastEnumeration
+Class _EmptySetSingleton has removed conformance to _ShadowProtocol
+Class _SetStorage has removed conformance to _NSCopying
+Class _SetStorage has removed conformance to _NSFastEnumeration
+Class _SetStorage has removed conformance to _ShadowProtocol
+Class _SharedStringStorage has removed conformance to _NSCopying
+Class _SharedStringStorage has removed conformance to _ShadowProtocol
+Class _StringStorage has removed conformance to _NSCopying
+Class _StringStorage has removed conformance to _ShadowProtocol
+Class __ContiguousArrayStorageBase has removed conformance to _NSCopying
+Class __ContiguousArrayStorageBase has removed conformance to _NSFastEnumeration
+Class __ContiguousArrayStorageBase has removed conformance to _ShadowProtocol
+Class __EmptyArrayStorage has removed conformance to _NSCopying
+Class __EmptyArrayStorage has removed conformance to _NSFastEnumeration
+Class __EmptyArrayStorage has removed conformance to _ShadowProtocol
+Class __SwiftDeferredNSArray has removed conformance to _NSCopying
+Class __SwiftDeferredNSArray has removed conformance to _NSFastEnumeration
+Class __SwiftDeferredNSArray has removed conformance to _ShadowProtocol
+Class __SwiftNativeNSArrayWithContiguousStorage has removed conformance to _NSCopying
+Class __SwiftNativeNSArrayWithContiguousStorage has removed conformance to _NSFastEnumeration
+Class __SwiftNativeNSArrayWithContiguousStorage has removed conformance to _ShadowProtocol
+Protocol _NSCopying has been removed
+Protocol _NSEnumerator has been removed
+Protocol _NSFastEnumeration has been removed
+Protocol _ShadowProtocol has been removed

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -323,7 +323,6 @@ Protocol _NSArrayCore has been removed
 Struct _CocoaArrayWrapper has type witness type for BidirectionalCollection.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
 Struct _CocoaArrayWrapper has type witness type for Collection.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
 Struct _CocoaArrayWrapper has type witness type for RandomAccessCollection.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
-Struct _CocoaArrayWrapper has type witness type for Sequence.SubSequence changing from Slice<_CocoaArrayWrapper> to _SliceBuffer<AnyObject>
 Var _ArrayBuffer._nonNative has declared type change from _NSArrayCore to _CocoaArrayWrapper
 Var _ArrayBuffer._storage has declared type change from _BridgeStorage<__ContiguousArrayStorageBase, _NSArrayCore> to _BridgeStorage<__ContiguousArrayStorageBase>
 Var _CocoaArrayWrapper.buffer has declared type change from _NSArrayCore to AnyObject

--- a/test/stdlib/BridgeStorage.swift
+++ b/test/stdlib/BridgeStorage.swift
@@ -116,10 +116,10 @@ var unTaggedNSString : NSString {
 }
 
 allTests.test("_BridgeStorage") {
-  typealias B = _BridgeStorage<C, NSString>
+  typealias B = _BridgeStorage<C>
 
   let oy: NSString = "oy"
-  expectTrue(B(objC: oy).objCInstance == oy)
+  expectTrue(B(objC: oy).objCInstance === oy)
 
   for flag in [false, true] {
     do {


### PR DESCRIPTION
We redefine some Cocoa interfaces in a set of shadow protocols to make select Cocoa APIs available to the stdlib.  These protocols don't meaningfully increase type safety, but having them part of the ABI forces collection storage classes to expose their implementations as Swift entry points. This is unfortunate; these are internal implementation details that we may want to tweak later. (Also, the Swift names / argument types don't always match how ClangImporter imports these APIs to Swift.)

This was uncovered by @jrose-apple's improved diagnostics in #20485.