### PR TITLE
[NFC] Rename @sil_stored to @_hasStorage

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -245,9 +245,9 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(override, Override,
   OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor | OnAssociatedType |
   DeclModifier |
   NotSerialized, 44)
-SIMPLE_DECL_ATTR(sil_stored, SILStored,
+SIMPLE_DECL_ATTR(_hasStorage, HasStorage,
   OnVar |
-  SILOnly |
+  UserInaccessible |
   NotSerialized, 45)
 DECL_ATTR(private, AccessControl,
   OnFunc | OnAccessor | OnExtension | OnGenericType | OnVar | OnSubscript |

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2355,12 +2355,12 @@ static void printParameterFlags(ASTPrinter &printer, PrintOptions options,
 
 void PrintAST::visitVarDecl(VarDecl *decl) {
   printDocumentationComment(decl);
-  // Print @sil_stored when the attribute is not already
+  // Print @_hasStorage when the attribute is not already
   // on, decl has storage and it is on a class.
   if (Options.PrintForSIL && decl->hasStorage() &&
       isStructOrClassContext(decl->getDeclContext()) &&
-      !decl->getAttrs().hasAttribute<SILStoredAttr>())
-    Printer << "@sil_stored ";
+      !decl->getAttrs().hasAttribute<HasStorageAttr>())
+    Printer << "@_hasStorage ";
   printAttributes(decl);
   printAccess(decl);
   if (!Options.SkipIntroducerKeywords) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4672,7 +4672,7 @@ Parser::parseDeclVarGetSet(Pattern *pattern, ParseDeclOptions Flags,
   }
 
   // Reject accessors on 'let's after parsing them (for better recovery).
-  if (PrimaryVar->isLet() && !Attributes.hasAttribute<SILStoredAttr>()) {
+  if (PrimaryVar->isLet() && !Attributes.hasAttribute<HasStorageAttr>()) {
     Diag<> DiagID;
     if (accessors.WillSet || accessors.DidSet)
       DiagID = diag::let_cannot_be_observing_property;
@@ -4935,9 +4935,9 @@ Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
     readWriteImpl = ReadWriteImplKind::Immutable;
   }
 
-  // Allow the sil_stored attribute to override all the accessors we parsed
+  // Allow the _hasStorage attribute to override all the accessors we parsed
   // when making the final classification.
-  if (attrs.hasAttribute<SILStoredAttr>()) {
+  if (attrs.hasAttribute<HasStorageAttr>()) {
     return StorageImplInfo::getSimpleStored(StorageIsMutable_t(Set != nullptr));
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -285,7 +285,7 @@ public:
   void visitAccessControlAttr(AccessControlAttr *attr);
   void visitSetterAccessAttr(SetterAccessAttr *attr);
   bool visitAbstractAccessControlAttr(AbstractAccessControlAttr *attr);
-  void visitSILStoredAttr(SILStoredAttr *attr);
+  void visitHasStorageAttr(HasStorageAttr *attr);
   void visitObjCMembersAttr(ObjCMembersAttr *attr);
 };
 } // end anonymous namespace
@@ -428,7 +428,7 @@ void AttributeEarlyChecker::visitGKInspectableAttr(GKInspectableAttr *attr) {
                                  attr->getAttrName());
 }
 
-void AttributeEarlyChecker::visitSILStoredAttr(SILStoredAttr *attr) {
+void AttributeEarlyChecker::visitHasStorageAttr(HasStorageAttr *attr) {
   auto *VD = cast<VarDecl>(D);
   if (VD->getDeclContext()->getSelfClassDecl())
     return;
@@ -819,6 +819,7 @@ public:
     IGNORED_ATTR(Exported)
     IGNORED_ATTR(ForbidSerializingReference)
     IGNORED_ATTR(GKInspectable)
+    IGNORED_ATTR(HasStorage)
     IGNORED_ATTR(IBDesignable)
     IGNORED_ATTR(IBInspectable)
     IGNORED_ATTR(IBOutlet) // checked early.
@@ -846,7 +847,6 @@ public:
     IGNORED_ATTR(Semantics)
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(SILGenName)
-    IGNORED_ATTR(SILStored)
     IGNORED_ATTR(StaticInitializeObjCMetadata)
     IGNORED_ATTR(SynthesizedProtocol)
     IGNORED_ATTR(Testable)

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1224,7 +1224,7 @@ namespace  {
     UNINTERESTING_ATTR(SynthesizedProtocol)
     UNINTERESTING_ATTR(RequiresStoredPropertyInits)
     UNINTERESTING_ATTR(Transparent)
-    UNINTERESTING_ATTR(SILStored)
+    UNINTERESTING_ATTR(HasStorage)
     UNINTERESTING_ATTR(Testable)
 
     UNINTERESTING_ATTR(WarnUnqualifiedAccess)

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -4,8 +4,8 @@ import Builtin
 import Swift
 
 class A {
-  @sil_stored var property: Int { get set }
-  @sil_stored var exProperty: Any { get set }
+  @_hasStorage var property: Int { get set }
+  @_hasStorage var exProperty: Any { get set }
   deinit
   init()
 }

--- a/test/IRGen/class_stack_alloc.sil
+++ b/test/IRGen/class_stack_alloc.sil
@@ -4,24 +4,24 @@ import Builtin
 import Swift
 
 class TestClass {
-  @sil_stored var a : Int64
+  @_hasStorage var a : Int64
   init()
 }
 
 struct TestStruct {
-  @sil_stored var a : Int64
-  @sil_stored var b : Int64
-  @sil_stored var c : Int64
+  @_hasStorage var a : Int64
+  @_hasStorage var b : Int64
+  @_hasStorage var c : Int64
 }
 
 class BigClass {
-  @sil_stored var a : Int64
-  @sil_stored var b : Int64
-  @sil_stored var c : Int64
-  @sil_stored var d : Int64
-  @sil_stored var e : Int64
-  @sil_stored var f : Int64
-  @sil_stored var g : Int64
+  @_hasStorage var a : Int64
+  @_hasStorage var b : Int64
+  @_hasStorage var c : Int64
+  @_hasStorage var d : Int64
+  @_hasStorage var e : Int64
+  @_hasStorage var f : Int64
+  @_hasStorage var g : Int64
   init()
 }
 

--- a/test/IRGen/constant_struct_with_padding.sil
+++ b/test/IRGen/constant_struct_with_padding.sil
@@ -6,8 +6,8 @@ import Builtin
 import Swift
 
 struct T {
-  @sil_stored var a: Builtin.Int1 { get set }
-  @sil_stored var b: Builtin.Int32 { get set }
+  @_hasStorage var a: Builtin.Int1 { get set }
+  @_hasStorage var b: Builtin.Int32 { get set }
 }
 
 // CHECK: @global = hidden global %T4main1TV <{ i1 false, [3 x i8] undef, i32 0 }>, align 4

--- a/test/IRGen/exactcast.sil
+++ b/test/IRGen/exactcast.sil
@@ -9,7 +9,7 @@ import Swift
 import SwiftShims
 
 class Node {
-  @sil_stored var index: Int { get set }
+  @_hasStorage var index: Int { get set }
   init(index: Int)
   func check() -> Int
   @objc deinit

--- a/test/IRGen/exclusivity.sil
+++ b/test/IRGen/exclusivity.sil
@@ -5,7 +5,7 @@ sil_stage canonical
 import Swift
 
 class A {
-   @sil_stored final var x: Int { get set }
+   @_hasStorage final var x: Int { get set }
    init(x: Int)
 }
 sil_vtable A {}

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -186,7 +186,7 @@ protocol TestP : AnyObject {}
 class NSObject {}
 
 class TestC {
-  @sil_stored unowned final let t: @sil_unowned NSObject & TestP
+  @_hasStorage unowned final let t: @sil_unowned NSObject & TestP
   init(t: NSObject & TestP)
 }
 

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -9,7 +9,7 @@ import Foundation
 
 class C: NSObject {
   @objc dynamic var x: NSString { get }
-  @sil_stored final var stored: Int
+  @_hasStorage final var stored: Int
   override init()
 }
 

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -7,8 +7,8 @@ sil_stage canonical
 import Swift
 
 public struct ExternalGeneric<T: Comparable> {
-  @sil_stored public var ro: T { get }
-  @sil_stored public var rw: T { get set }
+  @_hasStorage public var ro: T { get }
+  @_hasStorage public var rw: T { get set }
 
   public var computedRO: T { get }
   public var computedRW: T { get set }
@@ -21,8 +21,8 @@ public struct ExternalGeneric<T: Comparable> {
 }
 
 public struct External {
-  @sil_stored public var ro: Int { get }
-  @sil_stored public var rw: Int { get set }
+  @_hasStorage public var ro: Int { get }
+  @_hasStorage public var rw: Int { get set }
 
   public var computedRO: Int { get }
   public var computedRW: Int { get set }
@@ -35,8 +35,8 @@ public struct External {
 }
 
 public struct ExternalReabstractions<T> {
-  @sil_stored public var ro: T { get }
-  @sil_stored public var reabstracted: () -> () { get set }
+  @_hasStorage public var ro: T { get }
+  @_hasStorage public var reabstracted: () -> () { get set }
 }
 
 // -- struct property, offset resolved from field offset vector in metadata

--- a/test/IRGen/reference_storage_extra_inhabitants.sil
+++ b/test/IRGen/reference_storage_extra_inhabitants.sil
@@ -9,7 +9,7 @@ class C { }
 sil_vtable C { }
 
 struct S {
-  @sil_stored unowned(unsafe) var uu: @sil_unmanaged C? { get set }
+  @_hasStorage unowned(unsafe) var uu: @sil_unmanaged C? { get set }
 }
 
 func example(_ os: S?)

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -47,7 +47,7 @@ sil_global @$s6nested1xAA2S2Vv : $S2 = {
 // CHECK: @"$s6nested1xAA2S2Vv" = {{(protected )?}}global %T18static_initializer2S2V <{ %Ts5Int32V <{ i32 2 }>, %Ts5Int32V <{ i32 3 }>, %T18static_initializer1SV <{ %Ts5Int32V <{ i32 4 }> }> }>, align 4
 
 final class TestArrayStorage {
-  @sil_stored var count: Int32
+  @_hasStorage var count: Int32
   init()
 }
 
@@ -78,8 +78,8 @@ sil_global @static_aligned_array : $TestArrayStorage = {
 // CHECK: @static_aligned_array = {{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [2 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [12 x i8] undef, %Ts7Float80V <{ x86_fp80 0xK3FFE8000000000000000 }> }> }, align 16
 
 final class ClassWithEmptyField {
-  @sil_stored var x: Int32
-  @sil_stored var y: ()
+  @_hasStorage var x: Int32
+  @_hasStorage var y: ()
   init()
 }
 

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -9,7 +9,7 @@ import Swift
 
 // sizeof(TestClass) = 16 bytes header + 1 byte = 17 bytes
 class TestClass {
-  @sil_stored var a : Int8
+  @_hasStorage var a : Int8
   init()
 }
 

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -9,7 +9,7 @@ import Swift
 sil_global private @globalinit_token0 : $Builtin.Word
 
 class TestArrayStorage {
-  @sil_stored var count: Int32
+  @_hasStorage var count: Int32
   init()
 }
 
@@ -1622,7 +1622,7 @@ bb0(%0 : $(Builtin.NativeObject, Builtin.Int32), %1 : $TestArray2):
 }
 
 class A {
-  @sil_stored var property: Any { get set }
+  @_hasStorage var property: Any { get set }
   deinit
   init()
 }

--- a/test/SIL/Parser/final.swift
+++ b/test/SIL/Parser/final.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
 
 // CHECK: final class Rect
-// CHECK: @sil_stored @_hasInitialValue final var orgx: Double
+// CHECK: @_hasStorage @_hasInitialValue final var orgx: Double
 final class Rect {
   var orgx = 0.0
 }
 
 protocol P { }
 // CHECK: struct Rect2 : P {
-// CHECK: @sil_stored @_hasInitialValue var orgx: Double
+// CHECK: @_hasStorage @_hasInitialValue var orgx: Double
 struct Rect2 : P {
   var orgx = 0.0
 }

--- a/test/SIL/Parser/stored_property.sil
+++ b/test/SIL/Parser/stored_property.sil
@@ -2,9 +2,9 @@
 
 import Swift
 
-// CHECK: @sil_stored var orgx
+// CHECK: @_hasStorage var orgx
 class Rect {
-  @sil_stored var orgx: Double { get }
+  @_hasStorage var orgx: Double { get }
   init(orgx: Double)
 }
 

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -23,7 +23,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 }
 
 class TestArrayStorage {
-  @sil_stored var count: Int32
+  @_hasStorage var count: Int32
   init()
 }
 

--- a/test/SIL/ownership-verifier/definite_init.sil
+++ b/test/SIL/ownership-verifier/definite_init.sil
@@ -529,7 +529,7 @@ bb0(%0 : @owned $DerivedClassWithIVars, %i : @trivial $Builtin.Int32):
 
 
 struct MyStruct3 {
-  @sil_stored var c: C
+  @_hasStorage var c: C
 }
 sil @selfinit_mystruct3 : $@convention(thin) () -> @owned MyStruct3
 

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -5,7 +5,7 @@ final class Final<T> {
     init(x: T) { self.x = x }
 }
 // CHECK-LABEL: final class Final<T> {
-// CHECK:   @sil_stored final var x: T { get set }
+// CHECK:   @_hasStorage final var x: T { get set }
 // CHECK:   init(x: T)
 // CHECK:   deinit
 // CHECK:   enum CodingKeys : CodingKey {
@@ -25,7 +25,7 @@ class Nonfinal<T> {
     init(x: T) { self.x = x }
 }
 // CHECK-LABEL: class Nonfinal<T> {
-// CHECK:   @sil_stored var x: T { get set }
+// CHECK:   @_hasStorage var x: T { get set }
 // CHECK:   init(x: T)
 // CHECK:   deinit
 // CHECK:   enum CodingKeys : CodingKey {

--- a/test/SILGen/synthesized_conformance_struct.swift
+++ b/test/SILGen/synthesized_conformance_struct.swift
@@ -6,7 +6,7 @@ struct Struct<T> {
 }
 
 // CHECK-LABEL: struct Struct<T> {
-// CHECK:   @sil_stored var x: T { get set }
+// CHECK:   @_hasStorage var x: T { get set }
 // CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -13,7 +13,7 @@ struct ArrayIntBuffer {
 }
 
 final class StorageBase {
-  @sil_stored var header: Int64
+  @_hasStorage var header: Int64
 }
 
 struct ArrayInt{

--- a/test/SILOptimizer/access_dom.sil
+++ b/test/SILOptimizer/access_dom.sil
@@ -11,7 +11,7 @@ import Swift
 import SwiftShims
 
 struct X {
-  @sil_stored var i: Int64 { get set }
+  @_hasStorage var i: Int64 { get set }
   init(i: Int64)
   init()
 }

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -9,7 +9,7 @@ import c_layout
 
 
 struct X {
-  @sil_stored var i: Int64 { get set }
+  @_hasStorage var i: Int64 { get set }
   init(i: Int64)
   init()
 }

--- a/test/SILOptimizer/access_marker_elim.sil
+++ b/test/SILOptimizer/access_marker_elim.sil
@@ -8,7 +8,7 @@ import Swift
 import SwiftShims
 
 public struct S {
-  @sil_stored var i: Builtin.Int64 { get set }
+  @_hasStorage var i: Builtin.Int64 { get set }
   init(i: Int)
 }
 

--- a/test/SILOptimizer/access_sink.sil
+++ b/test/SILOptimizer/access_sink.sil
@@ -11,7 +11,7 @@ import Swift
 import SwiftShims
 
 struct X {
-  @sil_stored var i: Int64 { get set }
+  @_hasStorage var i: Int64 { get set }
   init(i: Int64)
   init()
 }

--- a/test/SILOptimizer/access_summary_analysis.sil
+++ b/test/SILOptimizer/access_summary_analysis.sil
@@ -7,13 +7,13 @@ import Swift
 import SwiftShims
 
 struct StructWithStoredProperties {
-  @sil_stored var f: Int
-  @sil_stored var g: Int
+  @_hasStorage var f: Int
+  @_hasStorage var g: Int
 }
 
 struct StructWithStructWithStoredProperties {
-  @sil_stored var a: StructWithStoredProperties
-  @sil_stored var b: StructWithStoredProperties
+  @_hasStorage var a: StructWithStoredProperties
+  @_hasStorage var b: StructWithStoredProperties
 }
 
 // CHECK-LABEL: @assignsToCapture

--- a/test/SILOptimizer/access_wmo.sil
+++ b/test/SILOptimizer/access_wmo.sil
@@ -16,13 +16,13 @@ var internalGlobal: Int64
 public var publicGlobal: Int64
 
 public class C {
-  @sil_stored var setterProp: Int64 { get set }
-  @sil_stored final var finalProp: Int64 { get set }
-  @sil_stored var inlinedProp: Int64 { get set }
-  @sil_stored var internalProp: Int64 { get set }
-  @sil_stored var keyPathProp: Int64 { get set }
-  @sil_stored final var finalKeyPathProp: Int64 { get set }
-  @sil_stored public var publicProp: Int64 { get set }
+  @_hasStorage var setterProp: Int64 { get set }
+  @_hasStorage final var finalProp: Int64 { get set }
+  @_hasStorage var inlinedProp: Int64 { get set }
+  @_hasStorage var internalProp: Int64 { get set }
+  @_hasStorage var keyPathProp: Int64 { get set }
+  @_hasStorage final var finalKeyPathProp: Int64 { get set }
+  @_hasStorage public var publicProp: Int64 { get set }
   init()
   deinit
 }

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -333,14 +333,14 @@ bb0:
 }
 
 class C {
-  @sil_stored var property: Int
+  @_hasStorage var property: Int
   deinit
   init()
 }
 
 // CHECK-LABEL: @readIdentifiedClass
 // CHECK: [read] Class %0 = argument of bb0 : $C
-// CHECK: Field: @sil_stored var property: Int
+// CHECK: Field: @_hasStorage var property: Int
 sil @readIdentifiedClass : $@convention(thin) (@guaranteed C) -> Int {
 bb0(%0 : $C):
   %1 = ref_element_addr %0 : $C, #C.property
@@ -352,7 +352,7 @@ bb0(%0 : $C):
 
 // CHECK-LABEL: @writeIdentifiedClass
 // CHECK: [modify] Class %0 = argument of bb0 : $C
-// CHECK: Field: @sil_stored var property: Int
+// CHECK: Field: @_hasStorage var property: Int
 sil @writeIdentifiedClass : $@convention(thin) (@guaranteed C, Int) -> () {
 bb0(%0 : $C, %1 : $Int):
   %2 = ref_element_addr %0 : $C, #C.property
@@ -365,7 +365,7 @@ bb0(%0 : $C, %1 : $Int):
 
 // CHECK-LABEL: @readWriteIdentifiedClass
 // CHECK: [modify] Class   %1 = alloc_ref $C
-// CHECK: Field: @sil_stored var property: Int
+// CHECK: Field: @_hasStorage var property: Int
 sil @readWriteIdentifiedClass : $@convention(thin) (Int) -> (Int) {
 bb0(%0 : $Int):
   %1 = alloc_ref $C
@@ -380,7 +380,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: @readIdentifiedNestedClass
 // CHECK: [read] Class %0 = argument of bb0 : $C
-// CHECK: Field: @sil_stored var property: Int
+// CHECK: Field: @_hasStorage var property: Int
 sil @readIdentifiedNestedClass : $@convention(thin) (@guaranteed C) -> Int {
 bb0(%0 : $C):
   %1 = ref_element_addr %0 : $C, #C.property
@@ -394,7 +394,7 @@ bb0(%0 : $C):
 
 // CHECK-LABEL: @writeIdentifiedNestedClass
 // CHECK: [modify] Class %0 = argument of bb0 : $C
-// CHECK: Field: @sil_stored var property: Int
+// CHECK: Field: @_hasStorage var property: Int
 sil @writeIdentifiedNestedClass : $@convention(thin) (@guaranteed C, Int) -> () {
 bb0(%0 : $C, %1 : $Int):
   %2 = ref_element_addr %0 : $C, #C.property
@@ -409,7 +409,7 @@ bb0(%0 : $C, %1 : $Int):
 
 // CHECK-LABEL: @readWriteIdentifiedNestedClass
 // CHECK: [modify] Class   %1 = alloc_ref $C
-// CHECK: Field: @sil_stored var property: Int
+// CHECK: Field: @_hasStorage var property: Int
 sil @readWriteIdentifiedNestedClass : $@convention(thin) (Int) -> (Int) {
 bb0(%0 : $Int):
   %1 = alloc_ref $C
@@ -541,7 +541,7 @@ bb0(%0 : $*Int, %1 : $*Int):
 // Test directly recursive argument access.
 // CHECK-LABEL: @readRecursiveArgument
 // CHECK:   [read] Class %0 = argument of bb0 : $C
-// CHECK:   Field: @sil_stored var property: Int
+// CHECK:   Field: @_hasStorage var property: Int
 sil @readRecursiveArgument : $@convention(thin) (@guaranteed C, Int) -> Int {
 bb0(%0 : $C, %1 : $Int):
   %propaddr = ref_element_addr %0 : $C, #C.property
@@ -556,7 +556,7 @@ bb0(%0 : $C, %1 : $Int):
 // Test a class argument access from an optional caller value.
 // CHECK-LABEL: @readOptionalArgumentInCallee
 // CHECK:   [read] Class   %1 = unchecked_enum_data %0 : $Optional<C>, #Optional.some!enumelt.1
-// CHECK:   Field: @sil_stored var property: Int
+// CHECK:   Field: @_hasStorage var property: Int
 sil @readOptionalArgumentInCallee : $@convention(thin) (@guaranteed Optional<C>) -> Int {
 bb0(%0 : $Optional<C>):
   %c = unchecked_enum_data %0 : $Optional<C>, #Optional.some!enumelt.1
@@ -567,7 +567,7 @@ bb0(%0 : $Optional<C>):
 
 // CHECK-LABEL: @readOptionalArgumentInCalleeHelper
 // CHECK:   [read] Class %0 = argument of bb0 : $C
-// CHECK:   Field: @sil_stored var property: Int
+// CHECK:   Field: @_hasStorage var property: Int
 sil private @readOptionalArgumentInCalleeHelper : $@convention(thin) (@guaranteed C) -> Int {
 bb0(%0 : $C):
   %propaddr = ref_element_addr %0 : $C, #C.property

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -537,7 +537,7 @@ struct Q : Count {
 }
 
 struct S<T : Count> {
-  @sil_stored var t: T
+  @_hasStorage var t: T
   var count: Int { get }
   func test(i: Int) -> Bool
   init(t: T)

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -533,7 +533,7 @@ struct Q : Count {
 }
 
 struct S<T : Count> {
-  @sil_stored var t: T
+  @_hasStorage var t: T
   var count: Int { get }
   func test(i: Int) -> Bool
   init(t: T)

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -50,7 +50,7 @@ class C {
 sil @cls_use : $@convention(thin) (@owned Cls) -> ()
 
 class Container {
-  @sil_stored var c : Cls
+  @_hasStorage var c : Cls
   init()
 }
 

--- a/test/SILOptimizer/array_count_propagation.sil
+++ b/test/SILOptimizer/array_count_propagation.sil
@@ -6,22 +6,22 @@ import Builtin
 import Swift
 
 struct MyInt {
-  @sil_stored var _value: Builtin.Int64
+  @_hasStorage var _value: Builtin.Int64
 }
 
 struct MyBool {}
 
 struct _MyBridgeStorage {
-  @sil_stored var rawValue : Builtin.BridgeObject
+  @_hasStorage var rawValue : Builtin.BridgeObject
 }
 
 struct _MyArrayBuffer<T> {
-  @sil_stored var _storage : _MyBridgeStorage
+  @_hasStorage var _storage : _MyBridgeStorage
 }
 
 
 struct MyArray<T> {
-  @sil_stored var _buffer : _MyArrayBuffer<T>
+  @_hasStorage var _buffer : _MyArrayBuffer<T>
 }
 
 sil @swift_bufferAllocate : $@convention(thin)() -> @owned AnyObject

--- a/test/SILOptimizer/array_element_propagation.sil
+++ b/test/SILOptimizer/array_element_propagation.sil
@@ -6,23 +6,23 @@ import Builtin
 import Swift
 
 struct MyInt {
-  @sil_stored var _value: Builtin.Int64
+  @_hasStorage var _value: Builtin.Int64
 }
 
 struct MyBool {}
 struct _MyDependenceToken {}
 
 struct _MyBridgeStorage {
-  @sil_stored var rawValue : Builtin.BridgeObject
+  @_hasStorage var rawValue : Builtin.BridgeObject
 }
 
 struct _MyArrayBuffer<T> {
-  @sil_stored var _storage : _MyBridgeStorage
+  @_hasStorage var _storage : _MyBridgeStorage
 }
 
 
 struct MyArray<T> {
-  @sil_stored var _buffer : _MyArrayBuffer<T>
+  @_hasStorage var _buffer : _MyArrayBuffer<T>
 }
 
 sil @swift_bufferAllocate : $@convention(thin)() -> @owned AnyObject

--- a/test/SILOptimizer/basic-aa.sil
+++ b/test/SILOptimizer/basic-aa.sil
@@ -509,8 +509,8 @@ sil @different_fields : $@convention(thin) () -> () {
 }
 
 public final class C {
-  @sil_stored final var a: Int { get set }
-  @sil_stored final var b: Int { get set }
+  @_hasStorage final var a: Int { get set }
+  @_hasStorage final var b: Int { get set }
    deinit
   init()
 }

--- a/test/SILOptimizer/basic-instruction-properties.sil
+++ b/test/SILOptimizer/basic-instruction-properties.sil
@@ -5,8 +5,8 @@
 import Builtin
 
 class X {
-  @sil_stored var a: Builtin.Int32
-  @sil_stored var x: X
+  @_hasStorage var a: Builtin.Int32
+  @_hasStorage var x: X
 
   init()
   func foo()

--- a/test/SILOptimizer/closure_specialize_consolidated.sil
+++ b/test/SILOptimizer/closure_specialize_consolidated.sil
@@ -16,12 +16,12 @@ protocol Q {
 }
 
 public class C {
-  @sil_stored var c: C? { get set }
+  @_hasStorage var c: C? { get set }
   init()
 }
 
 public struct S: Q {
-  @sil_stored var c: C? { get set }
+  @_hasStorage var c: C? { get set }
   init(c: C?)
   init()
 }

--- a/test/SILOptimizer/conditionforwarding.sil
+++ b/test/SILOptimizer/conditionforwarding.sil
@@ -10,7 +10,7 @@ enum E { case A, B }
 enum E3 { case A, B, C }
 
 class C {
-  @sil_stored var x : Builtin.Int64
+  @_hasStorage var x : Builtin.Int64
   init()
 }
 

--- a/test/SILOptimizer/copyforward.sil
+++ b/test/SILOptimizer/copyforward.sil
@@ -604,8 +604,8 @@ bb0(%0 : $*P, %1 : $*T):
 }
 
 public struct S<T> {
-  @sil_stored var f: T { get set }
-  @sil_stored var g: T { get set }
+  @_hasStorage var f: T { get set }
+  @_hasStorage var g: T { get set }
   init(f: T, g: T)
 }
 

--- a/test/SILOptimizer/cowarray_opt.sil
+++ b/test/SILOptimizer/cowarray_opt.sil
@@ -39,7 +39,7 @@ struct ContainerContainer {
 }
 
 class MyArrayStorage {
-  @sil_stored var header: Int
+  @_hasStorage var header: Int
 
   init()
   deinit
@@ -478,7 +478,7 @@ struct My2dArray<T> {
 
 
 struct MyInt {
-  @sil_stored var _value: Builtin.Int64
+  @_hasStorage var _value: Builtin.Int64
   init(_ value: Int16)
 }
 

--- a/test/SILOptimizer/definite_init_crashes.sil
+++ b/test/SILOptimizer/definite_init_crashes.sil
@@ -85,13 +85,13 @@ protocol Error {}
 public struct MyErrorType : Error {}
 
 public struct NonTrivial {
-  @sil_stored let ptr: Builtin.NativeObject
+  @_hasStorage let ptr: Builtin.NativeObject
 }
 
 public struct AStruct {
-  @sil_stored public let name: NonTrivial
-  @sil_stored public let foobar: NonTrivial
-  @sil_stored public let protoType: Proto.Type
+  @_hasStorage public let name: NonTrivial
+  @_hasStorage public let foobar: NonTrivial
+  @_hasStorage public let protoType: Proto.Type
 }
 
 sil @mayThrow : $@convention(thin) () -> (@owned NonTrivial, @error Error)

--- a/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
@@ -79,7 +79,7 @@ bb0(%0 : @trivial $*MyStruct2, %1 : @trivial $@thin MyStruct2.Type):
 
 // <rdar://problem/20608881> DI miscompiles this testcase into a memory leak
 struct MyStruct3 {
-  @sil_stored var c: C
+  @_hasStorage var c: C
 }
 sil @selfinit_mystruct3 : $@convention(thin) () -> @owned MyStruct3
 

--- a/test/SILOptimizer/destructor_analysis.sil
+++ b/test/SILOptimizer/destructor_analysis.sil
@@ -14,7 +14,7 @@ struct ArrayOf<T> : _DestructorSafeContainer {
 }
 
 struct Foo {
-  @sil_stored var subFoos: ArrayOf<Foo>
+  @_hasStorage var subFoos: ArrayOf<Foo>
   init()
 }
 

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -17,7 +17,7 @@ class Bar {
 }
 
 public class FooClass {
-  @sil_stored var value: Int32 { get set }
+  @_hasStorage var value: Int32 { get set }
   @inline(never) func foo(x: Int32) -> Int32
   init(value: Int32)
    deinit

--- a/test/SILOptimizer/devirtualize.sil
+++ b/test/SILOptimizer/devirtualize.sil
@@ -57,7 +57,7 @@ sil_vtable Bar {
 }
 
 private class Node {
-  @sil_stored var index: Int { get set }
+  @_hasStorage var index: Int { get set }
   init(index: Int)
    deinit
 }

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -18,13 +18,13 @@ public protocol HasElt {
 }
 
 struct X : AnElt {
-  @sil_stored var i: Int { get set }
+  @_hasStorage var i: Int { get set }
   init(i: Int)
 }
 
 struct S : HasElt {
   typealias Elt = X
-  @sil_stored var e: X { get set }
+  @_hasStorage var e: X { get set }
   init(e: Elt)
 }
 

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -21,13 +21,13 @@ class Derived : X {
 }
 
 class Y {
-  @sil_stored var x: X
+  @_hasStorage var x: X
 
   init(newx: X)
 }
 
 class Z {
-  @sil_stored var x: X
+  @_hasStorage var x: X
   init(newx: X)
   deinit
 }
@@ -52,7 +52,7 @@ enum PointerEnum2 {
 }
 
 class LinkedNode {
-  @sil_stored var next: LinkedNode;
+  @_hasStorage var next: LinkedNode;
 
   init(_ n: LinkedNode)
 }

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -230,7 +230,7 @@ bb0(%0 : @trivial $Int):
 
 
 class ClassWithStoredProperty {
-  @sil_stored var f: Int
+  @_hasStorage var f: Int
   init()
 }
 // CHECK-LABEL: sil hidden @classStoredProperty

--- a/test/SILOptimizer/existential_type_propagation.sil
+++ b/test/SILOptimizer/existential_type_propagation.sil
@@ -21,7 +21,7 @@ public protocol ReaderWriterType {
 }
 
 public final class ArrayClassReaderWriter : ReaderWriterType {
-  @sil_stored private final var elements: [Int32] { get set }
+  @_hasStorage private final var elements: [Int32] { get set }
   @inline(never) public init()
   @inline(never) public final func read(index: Int32) -> Int32
   public final func write(index: Int32, value: Int32)

--- a/test/SILOptimizer/inline_heuristics.sil
+++ b/test/SILOptimizer/inline_heuristics.sil
@@ -438,7 +438,7 @@ bb0(%0 : $*U):
 // CHECK: end sil function 'testExclusivity' 
 
 struct X {
-  @sil_stored var i: Int64 { get set }
+  @_hasStorage var i: Int64 { get set }
   init(i: Int64)
   init()
 }

--- a/test/SILOptimizer/licm_exclusivity.sil
+++ b/test/SILOptimizer/licm_exclusivity.sil
@@ -7,7 +7,7 @@ import Builtin
 import Swift
 
 struct X {
-  @sil_stored var i: Int64 { get set }
+  @_hasStorage var i: Int64 { get set }
   init(i: Int64)
   init()
 }

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -17,7 +17,7 @@ extension P2 {
 
 struct L {
   var start: Int32 { get }
-  @sil_stored let o: P2
+  @_hasStorage let o: P2
   init(o: P2)
 }
 

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -6,8 +6,8 @@ import Builtin
 import Swift
 
 class X {
-  @sil_stored var a: Int32
-  @sil_stored var x: X
+  @_hasStorage var a: Int32
+  @_hasStorage var x: X
 
   init()
 }

--- a/test/SILOptimizer/objectoutliner.sil
+++ b/test/SILOptimizer/objectoutliner.sil
@@ -7,7 +7,7 @@ import Builtin
 import Swift
 
 class Obj {
-  @sil_stored var value: Int64
+  @_hasStorage var value: Int64
   init()
 }
 

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -72,7 +72,7 @@ class DynamicStorage {
 }
 
 final class ItemStorage<V> : DynamicStorage where V : View {
-  @sil_stored final let content: V
+  @_hasStorage final let content: V
   init(content: V)
   deinit
   override init()
@@ -83,7 +83,7 @@ extension View {
 }
 
 public struct DynamicItem {
-  @sil_stored private var storage: DynamicStorage { get set }
+  @_hasStorage private var storage: DynamicStorage { get set }
   public init(view: View)
 }
 
@@ -136,8 +136,8 @@ func use<T>(_ t: T)
 
 final class Foo<T> where T : P {
   init(_ x: T)
-  @sil_stored final var x: T { get set }
-  @sil_stored final var y: T { get set }
+  @_hasStorage final var x: T { get set }
+  @_hasStorage final var y: T { get set }
   deinit
 }
 

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -232,7 +232,7 @@ bb3:
 }
 
 class TestArrayStorage {
-  @sil_stored var count: Builtin.Int32
+  @_hasStorage var count: Builtin.Int32
   init()
 }
 

--- a/test/SILOptimizer/redundant_load_elim_with_casts.sil
+++ b/test/SILOptimizer/redundant_load_elim_with_casts.sil
@@ -362,7 +362,7 @@ bb0:
 }
 
 class Empty {}
-struct HoldsRef { @sil_stored var c: Empty }
+struct HoldsRef { @_hasStorage var c: Empty }
 
 sil @mutator : $@convention(method) (@inout HoldsRef) -> ()
 

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -62,7 +62,7 @@ enum Optional<T> {
 }
 
 struct Unowned {
-  @sil_stored unowned let x: @sil_unowned Builtin.NativeObject
+  @_hasStorage unowned let x: @sil_unowned Builtin.NativeObject
 }
 
 sil @createS : $@convention(thin) () -> @owned S
@@ -265,7 +265,7 @@ bb3:
 }
 
 final class MyArrayBuffer {
-  @sil_stored var dummyElements: Int32
+  @_hasStorage var dummyElements: Int32
   init()
 }
 

--- a/test/SILOptimizer/side-effect.sil
+++ b/test/SILOptimizer/side-effect.sil
@@ -27,8 +27,8 @@ struct UnsafeMutablePointer<T> {
 }
 
 class X {
-  @sil_stored var a: Int32
-  @sil_stored var x: X
+  @_hasStorage var a: Int32
+  @_hasStorage var x: X
 
   init()
 }

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3215,7 +3215,7 @@ extension PM {
 
 
 public final class VV {
-  @sil_stored final var m: PM { get set }
+  @_hasStorage final var m: PM { get set }
   init()
   deinit
 }

--- a/test/SILOptimizer/sil_combine_enums.sil
+++ b/test/SILOptimizer/sil_combine_enums.sil
@@ -423,8 +423,8 @@ bb3:
 public class C {}
 public struct S {}
 public struct T {
-  @sil_stored let c: C
-  @sil_stored let s: S
+  @_hasStorage let c: C
+  @_hasStorage let s: S
 }
 public enum X {
   case none

--- a/test/SILOptimizer/sil_combine_objc_bridge.sil
+++ b/test/SILOptimizer/sil_combine_objc_bridge.sil
@@ -20,7 +20,7 @@ class AnNSArray {
 }
 
 struct AnArray<T> : _ObjectiveCBridgeable {
-  @sil_stored var Buffer : Builtin.NativeObject
+  @_hasStorage var Buffer : Builtin.NativeObject
 
   func _bridgeToObjectiveC() -> AnNSArray {
     return AnNSArray()

--- a/test/SILOptimizer/sil_simplify_instrs.sil
+++ b/test/SILOptimizer/sil_simplify_instrs.sil
@@ -130,7 +130,7 @@ bb0(%x : $Builtin.Int64):
 }
 
 class IntClass {
-  @sil_stored var value: Builtin.Int32 { get set }
+  @_hasStorage var value: Builtin.Int32 { get set }
   init(value: Builtin.Int32)
   @objc deinit
 }

--- a/test/SILOptimizer/simplify_cfg_args_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_args_crash.sil
@@ -36,13 +36,13 @@ bb3:                                            // Preds: bb0 bb409
 // Verify that we do not crash in argument splitting (rdar://problem/25008398).
 
 class C {
-  @sil_stored let x: Builtin.Int32
+  @_hasStorage let x: Builtin.Int32
   init()
 }
 
 struct Pair {
-  @sil_stored let first: C
-  @sil_stored let second: C
+  @_hasStorage let first: C
+  @_hasStorage let second: C
 }
 
 // CHECK-LABEL: @simplify_args_crash

--- a/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
@@ -50,8 +50,8 @@ sil @get_condition : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
 public final class AA {
 }
 public final class BB {
-  @sil_stored internal weak final var n:  BB!
-  @sil_stored internal final var o: AA!
+  @_hasStorage internal weak final var n:  BB!
+  @_hasStorage internal final var o: AA!
 }
 
 // Test that SimplifyCFG does not hang when compiling an infinite loop with switch_enum.

--- a/test/SILOptimizer/sr-5068.sil
+++ b/test/SILOptimizer/sr-5068.sil
@@ -42,7 +42,7 @@ var events: [String]
 var currentModel: Model { get }
 
 public class Model : Object {
-  @sil_stored var id: Int { get set }
+  @_hasStorage var id: Int { get set }
   override init()
   init(value: Any)
   deinit

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -7,20 +7,20 @@ import Swift
 import SwiftShims
 
 class XX {
-	@sil_stored var x: Int32
+	@_hasStorage var x: Int32
 
 	init()
 }
 
 class YY {
-	@sil_stored var xx: XX
+	@_hasStorage var xx: XX
 
 	init(newx: XX)
 }
 
 class DummyArrayStorage<Element> {
-  @sil_stored var count : Int
-  @sil_stored var capacity : Int
+  @_hasStorage var count : Int
+  @_hasStorage var capacity : Int
   init()
 }
 

--- a/test/SILOptimizer/unsafe_guaranteed_peephole.sil
+++ b/test/SILOptimizer/unsafe_guaranteed_peephole.sil
@@ -375,7 +375,7 @@ bb0(%0 : $Foo):
 }
 
 struct MyInt {
-  @sil_stored var val: Builtin.Int32
+  @_hasStorage var val: Builtin.Int32
 }
 
 // CHECK-LABEL: sil @testUnsafeGuaranteed_sideeffectfree_inst

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -1223,8 +1223,8 @@ sil [transparent] [serialized] [thunk] @a_regular_thunk : $@convention(thin) () 
 }
 
 public class WeakUnownedTest {
-  @sil_stored public unowned var unownedVal: @sil_unowned AnyObject { get set }
-  @sil_stored public weak var weakVal: @sil_weak AnyObject? { get set }
+  @_hasStorage public unowned var unownedVal: @sil_unowned AnyObject { get set }
+  @_hasStorage public weak var weakVal: @sil_weak AnyObject? { get set }
   public init(protoVal: AnyObject)
   deinit
 }
@@ -1249,7 +1249,7 @@ bb0(%0 : $WeakUnownedTest, %1 : $AnyObject):
 
 
 class A {
-  @sil_stored var property: Any { get set }
+  @_hasStorage var property: Any { get set }
   deinit
   init()
 }

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -262,8 +262,8 @@ class C {
   @_optimize(size) var c : Int // expected-error {{'@_optimize(size)' attribute cannot be applied to stored properties}}
 }
 
-class SILStored {
-  @sil_stored var x : Int = 42  // expected-error {{'sil_stored' only allowed in SIL modules}}
+class HasStorage {
+  @_hasStorage var x : Int = 42  // ok, _hasStorage is allowed here
 }
 
 @_show_in_interface protocol _underscored {}

--- a/validation-test/SIL/crashers_fixed/007-swift-abstractstoragedecl-makecomputed.sil
+++ b/validation-test/SIL/crashers_fixed/007-swift-abstractstoragedecl-makecomputed.sil
@@ -1,2 +1,2 @@
 // RUN: not %target-sil-opt %s
-protocol a{@sil_stored var e:a{get
+protocol a{@_hasStorage var e:a{get


### PR DESCRIPTION
This is split off from #20250. Because we're going to start using this attribute outside of SIL (in `.swiftinterface` files), rename it.