### PR TITLE
build: allow building tools and stdlib separately

### DIFF
--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -25,22 +25,25 @@ if(SWIFT_BUILD_STDLIB)
     C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}
     LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
     INSTALL_IN_COMPONENT dev)
-else()
-  add_custom_target(swiftReflection-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})
 endif()
 
 # Build a specific version for the host with the host toolchain.  This is going
 # to be used by tools (e.g. lldb)
+if(SWIFT_INCLUDE_TOOLS)
+  if(NOT SWIFT_BUILD_STDLIB)
+    add_custom_target(swiftReflection-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})
+  endif()
 
-if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
-  set(CMAKE_C_COMPILER ${HOST_CMAKE_C_COMPILER})
-  set(CMAKE_CXX_COMPILER ${HOST_CMAKE_CXX_COMPILER})
+  if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
+    set(CMAKE_C_COMPILER ${HOST_CMAKE_C_COMPILER})
+    set(CMAKE_CXX_COMPILER ${HOST_CMAKE_CXX_COMPILER})
+  endif()
+
+  add_swift_host_library(swiftReflection STATIC
+    ${swiftReflection_SOURCES})
+  target_compile_options(swiftReflection PRIVATE
+    ${SWIFT_RUNTIME_CXX_FLAGS})
+  set_property(TARGET swiftReflection
+    APPEND_STRING PROPERTY LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS})
 endif()
-
-add_swift_host_library(swiftReflection STATIC
-  ${swiftReflection_SOURCES})
-target_compile_options(swiftReflection PRIVATE
-  ${SWIFT_RUNTIME_CXX_FLAGS})
-set_property(TARGET swiftReflection
-  APPEND_STRING PROPERTY LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS})
 


### PR DESCRIPTION
This restores the ability to build the standard library and the tools in two
separate build invocations.  This is required to cross-compile the standard
library on various targets without building complete toolchains.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
