### PR TITLE
[CSDiag] Diagnose KeyPath tuple access as unsupported even when sugared

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6697,8 +6697,8 @@ static bool diagnoseKeyPathComponents(ConstraintSystem &CS, KeyPathExpr *KPE,
                                            : defaultUnqualifiedLookupOptions),
                                corrections);
 
-      if (currentType)
-        if (isa<TupleType>(currentType.getPointer())) {
+      if (currentType) {
+        if (currentType->is<TupleType>()) {
           TC.diagnose(KPE->getLoc(), diag::expr_keypath_unimplemented_tuple);
           isInvalid = true;
           break;
@@ -6706,7 +6706,7 @@ static bool diagnoseKeyPathComponents(ConstraintSystem &CS, KeyPathExpr *KPE,
         else
           TC.diagnose(componentNameLoc, diag::could_not_find_type_member,
                       currentType, componentName);
-      else
+      } else
         TC.diagnose(componentNameLoc, diag::use_unresolved_identifier,
                     componentName, false);
 

--- a/test/expr/unary/keypath/keypath-unimplemented.swift
+++ b/test/expr/unary/keypath/keypath-unimplemented.swift
@@ -22,3 +22,14 @@ let _: KeyPath<TupleKeypath, Int> = \TupleKeypath.labeled.foo // expected-error 
 let _: KeyPath<TupleKeypath, String> = \TupleKeypath.labeled.bar // expected-error {{key path support for tuples is not implemented}}
 let _: KeyPath<TupleKeypath, Int> = \TupleKeypath.unlabeled.0 // expected-error {{key path support for tuples is not implemented}}
 let _: KeyPath<TupleKeypath, String> = \TupleKeypath.unlabeled.1 // expected-error {{key path support for tuples is not implemented}}
+
+struct S {
+  typealias X = (lhs: Int, rhs: Int)
+  typealias Y = (Int, Int)
+
+  let x: X
+  let y: Y
+}
+
+let _: KeyPath<S, Int> = \S.x.lhs // expected-error {{key path support for tuples is not implemented}}
+let _: KeyPath<S, Int> = \S.y.0   // expected-error {{key path support for tuples is not implemented}}


### PR DESCRIPTION
Follow-up for [SR-9213](https://bugs.swift.org/browse/SR-9213)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
