### PR TITLE
[stdib] Audit @_fixed_layout on collection storage classes

### DIFF
--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -192,7 +192,6 @@ extension _RawDictionaryStorage {
   }
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 final internal class _DictionaryStorage<Key: Hashable, Value>
   : _RawDictionaryStorage, _NSDictionaryCore {

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -16,7 +16,7 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout
 @usableFromInline
 @_objc_non_lazy_realization
 internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -312,57 +312,50 @@ internal func _rawPointerToString(_ value: Builtin.RawPointer) -> String {
 // coexist, so they were renamed. The old names must not be used in the
 // new runtime.
 
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout
+@usableFromInline
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSArrayBase)
 internal class __SwiftNativeNSArray {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @nonobjc
   internal init() {}
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   deinit {}
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout
+@usableFromInline
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSDictionaryBase)
 internal class __SwiftNativeNSDictionary {
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal init() {}
-  @inlinable // FIXME(sil-serialize-all)
   deinit {}
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout
+@usableFromInline
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSSetBase)
 internal class __SwiftNativeNSSet {
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal init() {}
-  @inlinable // FIXME(sil-serialize-all)
   deinit {}
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
-@objc @_swift_native_objc_runtime_base(__SwiftNativeNSEnumeratorBase)
+@objc
+@_swift_native_objc_runtime_base(__SwiftNativeNSEnumeratorBase)
 internal class __SwiftNativeNSEnumerator {
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal init() {}
-  @inlinable // FIXME(sil-serialize-all)
   deinit {}
 }
 
 // FIXME(ABI)#60 : move into the Foundation overlay and remove 'open'
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSDataBase)
 open class __SwiftNativeNSData {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @objc public init() {}
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   deinit {}
 }
 
@@ -405,28 +398,28 @@ public func _stdlib_initializeReturnAutoreleased() {
 }
 #else
 
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout
+@usableFromInline
 internal class __SwiftNativeNSArray {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   internal init() {}
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   deinit {}
 }
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout
+@usableFromInline
 internal class __SwiftNativeNSDictionary {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   internal init() {}
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   deinit {}
 }
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_fixed_layout
+@usableFromInline
 internal class __SwiftNativeNSSet {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   internal init() {}
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   deinit {}
 }
 

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -16,7 +16,7 @@ import SwiftShims
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout
 @usableFromInline
 @_objc_non_lazy_realization
 internal class _RawSetStorage: __SwiftNativeNSSet {

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -175,7 +175,6 @@ extension _EmptySetSingleton: _NSSetCore {
 #endif
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 final internal class _SetStorage<Element: Hashable>
   : _RawSetStorage, _NSSetCore {

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -41,15 +41,15 @@ internal func _isValidArraySubscript(_ index: Int, count: Int) -> Bool {
 /// NOTE: older runtimes called this
 /// _SwiftNativeNSArrayWithContiguousStorage. The two must coexist, so
 /// it was renamed. The old name must not be used in the new runtime.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout
 @usableFromInline
 internal class __SwiftNativeNSArrayWithContiguousStorage
   : __SwiftNativeNSArray { // Provides NSArray inheritance and native refcounting
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @nonobjc internal override init() {}
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   deinit {}
 
   // Operate on our contiguous storage

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -161,6 +161,14 @@ Func SystemRandomNumberGenerator._fill(bytes:) has been removed
 Func _createStringTableCache(_:) has been removed
 Struct _StringSwitchContext has been removed
 
+Class __SwiftNativeNSEnumerator has been removed
+Constructor _RawDictionaryStorage.init() has been removed
+Constructor _RawSetStorage.init() has been removed
+Constructor __SwiftNativeNSDictionary.init() has been removed
+Constructor __SwiftNativeNSSet.init() has been removed
+Class _DictionaryStorage is now without @_fixed_layout
+Class _SetStorage is now without @_fixed_layout
+
 Protocol Numeric has generic signature change from <τ_0_0 : Equatable, τ_0_0 : ExpressibleByIntegerLiteral, τ_0_0.Magnitude : Comparable, τ_0_0.Magnitude : Numeric> to <τ_0_0 : AdditiveArithmetic, τ_0_0 : ExpressibleByIntegerLiteral, τ_0_0.Magnitude : Comparable, τ_0_0.Magnitude : Numeric>
 Func Numeric.+(_:) has been removed
 Func Numeric.+(_:_:) has been removed


### PR DESCRIPTION
- Remove `__SwiftNativeNSEnumerator` from the ABI. (It’s only used in internal classes and in the Objective-C runtime.)
- Remove inlinability of `init()` and `deinit` for all the `__SwiftNativeNSFoo` superclasses except Array’s and Data’s.
- As an experiment, let’s try removing `@_fixed_layout` from `_SetStorage` and `_DictionaryStorage`. Their current ivars are all defined in their respective superclasses, so (if my mental model of how this works is correct), this will have little effect on benchmarks, but it adds a little bit of flexibility. Maybe.
