### PR TITLE
Make sure the code completion takes both private imports and testable

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -990,7 +990,18 @@ public:
 
   void addImports(ArrayRef<ImportedModuleDesc> IM);
 
-  bool hasTestableOrPrivateImport(AccessLevel accessLevel, const ValueDecl *ofDecl) const;
+  enum ImportQueryKind {
+    /// Return the resuls for testable or private imports.
+    TestableAndPrivate,
+    /// Return the results only for testable imports.
+    TestableOnly,
+    /// Return the results only for private imports.
+    PrivateOnly
+  };
+
+  bool
+  hasTestableOrPrivateImport(AccessLevel accessLevel, const ValueDecl *ofDecl,
+                             ImportQueryKind kind = TestableAndPrivate) const;
 
   void clearLookupCache();
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -991,7 +991,7 @@ public:
   void addImports(ArrayRef<ImportedModuleDesc> IM);
 
   enum ImportQueryKind {
-    /// Return the resuls for testable or private imports.
+    /// Return the results for testable or private imports.
     TestableAndPrivate,
     /// Return the results only for testable imports.
     TestableOnly,

--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -41,6 +41,7 @@ public:
     std::vector<std::string> AccessPath;
     bool ResultsHaveLeadingDot;
     bool ForTestableLookup;
+    bool ForPrivateImportLookup;
     bool CodeCompleteInitsInPostfixExpr;
 
     friend bool operator==(const Key &LHS, const Key &RHS) {
@@ -49,6 +50,7 @@ public:
         LHS.AccessPath == RHS.AccessPath &&
         LHS.ResultsHaveLeadingDot == RHS.ResultsHaveLeadingDot &&
         LHS.ForTestableLookup == RHS.ForTestableLookup &&
+        LHS.ForPrivateImportLookup == RHS.ForPrivateImportLookup &&
         LHS.CodeCompleteInitsInPostfixExpr == RHS.CodeCompleteInitsInPostfixExpr;
     }
   };
@@ -106,10 +108,10 @@ template<>
 struct DenseMapInfo<swift::ide::CodeCompletionCache::Key> {
   using KeyTy = swift::ide::CodeCompletionCache::Key;
   static inline KeyTy getEmptyKey() {
-    return KeyTy{"", "", {}, false, false, false};
+    return KeyTy{"", "", {}, false, false, false, false};
   }
   static inline KeyTy getTombstoneKey() {
-    return KeyTy{"", "", {}, true, false, false};
+    return KeyTy{"", "", {}, true, false, false, false};
   }
   static unsigned getHashValue(const KeyTy &Val) {
     size_t H = 0;
@@ -119,6 +121,7 @@ struct DenseMapInfo<swift::ide::CodeCompletionCache::Key> {
       H ^= std::hash<std::string>()(Piece);
     H ^= std::hash<bool>()(Val.ResultsHaveLeadingDot);
     H ^= std::hash<bool>()(Val.ForTestableLookup);
+    H ^= std::hash<bool>()(Val.ForPrivateImportLookup);
     return static_cast<unsigned>(H);
   }
   static bool isEqual(const KeyTy &LHS, const KeyTy &RHS) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5946,12 +5946,15 @@ void CodeCompletionCallbacksImpl::doneParsing() {
       if (!ModuleFilename.empty()) {
         auto &Ctx = TheModule->getASTContext();
         CodeCompletionCache::Key K{
-            ModuleFilename,
-            TheModule->getName().str(),
-            AccessPath,
-            Request.NeedLeadingDot,
-            SF.hasTestableOrPrivateImport(AccessLevel::Internal, TheModule),
-            Ctx.LangOpts.CodeCompleteInitsInPostfixExpr};
+          ModuleFilename, TheModule->getName().str(), AccessPath,
+              Request.NeedLeadingDot,
+              SF.hasTestableOrPrivateImport(
+                  AccessLevel::Internal, TheModule,
+                  SourceFile::ImportQueryKind::TestableOnly),
+              SF.hasTestableOrPrivateImport(
+                  AccessLevel::Internal, TheModule,
+                  SourceFile::ImportQueryKind::PrivateOnly),
+          Ctx.LangOpts.CodeCompleteInitsInPostfixExpr};
 
         using PairType = llvm::DenseSet<swift::ide::CodeCompletionCache::Key,
             llvm::DenseMapInfo<CodeCompletionCache::Key>>::iterator;

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -488,7 +488,8 @@ OnDiskCodeCompletionCache::getFromFile(StringRef filename) {
     return None;
 
   // Make up a key for readCachedModule.
-  CodeCompletionCache::Key K{filename, "<module-name>", {}, false, false, false};
+  CodeCompletionCache::Key K{filename, "<module-name>", {},   false,
+                             false,    false,           false};
 
   // Read the cached results.
   auto V = CodeCompletionCache::createValue();

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -312,6 +312,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
       OSS << p << "\0";
     OSSLE.write(K.ResultsHaveLeadingDot);
     OSSLE.write(K.ForTestableLookup);
+    OSSLE.write(K.ForPrivateImportLookup);
     OSSLE.write(K.CodeCompleteInitsInPostfixExpr);
     LE.write(static_cast<uint32_t>(OSS.tell()));   // Size of debug info
     out.write(OSS.str().data(), OSS.str().size()); // Debug info blob
@@ -423,6 +424,8 @@ static std::string getName(StringRef cacheDirectory,
   // name[-dot][-testable][-inits]
   OSS << (K.ResultsHaveLeadingDot ? "-dot" : "")
       << (K.ForTestableLookup ? "-testable" : "")
+      << (K.ForPrivateLookup ? "-private" : "")
+      << (K.CodeCompleteInitsInPostfixExpr ? "-inits" : "");
       << (K.CodeCompleteInitsInPostfixExpr ? "-inits" : "");
 
   // name[-access-path-components]

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -424,8 +424,7 @@ static std::string getName(StringRef cacheDirectory,
   // name[-dot][-testable][-inits]
   OSS << (K.ResultsHaveLeadingDot ? "-dot" : "")
       << (K.ForTestableLookup ? "-testable" : "")
-      << (K.ForPrivateLookup ? "-private" : "")
-      << (K.CodeCompleteInitsInPostfixExpr ? "-inits" : "");
+      << (K.ForPrivateImportLookup ? "-private" : "")
       << (K.CodeCompleteInitsInPostfixExpr ? "-inits" : "");
 
   // name[-access-path-components]

--- a/test/IDE/complete_cache.swift
+++ b/test/IDE/complete_cache.swift
@@ -39,13 +39,20 @@
 // Check the individual cache item.
 // RUN: %target-swift-ide-test -dump-completion-cache %t.ccp/macros-dot-* | %FileCheck %s -check-prefix=CLANG_QUAL_MACROS_2
 
+// Qualified private with dot.
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=CLANG_QUAL_STRING -completion-cache-path=%t.ccp > %t.string.ccp1.compl.txt
+// RUN: %FileCheck %s -check-prefix=CLANG_QUAL_STRING  < %t.string.ccp1.compl.txt
+
+
 // Ensure the testable import showed up mangled correctly.
 // RUN: ls %t.ccp/Darwin-testable*
+// RUN: ls %t.ccp/AppKit-private*
 // REQUIRES: executable_test
 
 import macros
 import ctypes
 @testable import Darwin
+@_private(sourceFile: "AppKit.swift") import AppKit
 
 // CLANG_CTYPES: Begin completions
 // CLANG_CTYPES-DAG: Decl[Struct]/OtherModule[ctypes]/keyword[Foo1, Struct1]:    FooStruct1[#FooStruct1#]{{; name=.+$}}
@@ -105,4 +112,11 @@ func testCompleteModuleQualifiedMacros2() {
 // CLANG_QUAL_MACROS_2-DAG: Decl[GlobalVar]/OtherModule[macros]: .UTF8_STRING[#String#]{{; name=.+$}}
 // CLANG_QUAL_MACROS_2-DAG: Decl[GlobalVar]/OtherModule[macros]: .VERSION_STRING[#String#]{{; name=.+$}}
 // CLANG_QUAL_MACROS_2: End completions
+}
+
+func testPrivate() {
+  String.#^CLANG_QUAL_STRING^#
+// CLANG_QUAL_STRING: Begin completions
+// CLANG_QUAL_STRING: name=someMethod()
+// CLANG_QUAL_STRING: End completions
 }

--- a/test/Inputs/clang-importer-sdk/swift-modules/AppKit.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/AppKit.swift
@@ -3,3 +3,7 @@
 extension String {
   public static func someFactoryMethod() -> Int { return 0 }
 }
+
+extension String {
+  static func someMethod() -> Int { return 0 }
+}


### PR DESCRIPTION
imports into account separately.