### PR TITLE
Adding Tensor->ndarray conversion.

### DIFF
--- a/stdlib/public/TensorFlow/NumpyConversion.swift
+++ b/stdlib/public/TensorFlow/NumpyConversion.swift
@@ -108,4 +108,18 @@ extension Tensor : ConvertibleFromNumpyArray
     self.init(shape: shape, scalars: buffPtr)
   }
 }
+
+extension ShapedArray where Scalar : NumpyScalarCompatible {
+  /// Creates a NumPy array with the same elements.
+  ///
+  /// - Precondition: The `numpy` Python package must have been installed.
+  public func makeNumpyArray() -> PythonObject {
+    return scalars.makeNumpyArray().reshape(shape)
+  }
+}
+
+extension Tensor where Scalar : NumpyScalarCompatible {
+  public func makeNumpyArray() -> PythonObject { return array.makeNumpyArray() }
+}
+
 #endif

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -18,6 +18,7 @@ var NumpyConversionTests = TestSuite("NumpyConversion")
 import Python
 
 let numpyModule = try? Python.attemptImport("numpy")
+let ctypesModule = try? Python.attemptImport("ctypes")
 
 NumpyConversionTests.test("shaped-array-conversion") {
   guard let np = numpyModule else { return }
@@ -102,6 +103,20 @@ NumpyConversionTests.test("tensor-conversion") {
   if let tensor = expectNotNil(Tensor<Int32>(numpyArray: numpyArrayStrided)) {
     expectEqual(ShapedArray(shape: [2], scalars: [2, 2]), tensor.array)
   }
+}
+
+NumpyConversionTests.test("tensor-round-trip") {
+  guard numpyModule != nil else { return }
+  guard ctypesModule != nil else { return }
+
+  let t1 = Tensor<Float>(shape: [1,2,3,4], repeating: 3.0)
+  expectEqual(t1, Tensor<Float>(numpyArray: t1.makeNumpyArray())!)
+
+  let t2 = Tensor<UInt8>(shape: [2,3], scalars: [1, 2, 3, 4, 5, 6])
+  expectEqual(t2, Tensor<UInt8>(numpyArray: t2.makeNumpyArray())!)
+
+  let t3 = Tensor<Int32>(shape: [8,5,4], repeating: 30)
+  expectEqual(t3, Tensor<Int32>(numpyArray: t3.makeNumpyArray())!)
 }
 #endif
 


### PR DESCRIPTION
Adding helper method attached to Tensor that gives you a numpy array. This was useful to be able to use python code that operated over ndarray.