### PR TITLE
[ClangImporter] NS_ERROR_ENUMs can be redefined in separate modules

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2021,7 +2021,7 @@ getClangTopLevelOwningModule(ClangNode Node,
 }
 
 static bool isVisibleFromModule(const ClangModuleUnit *ModuleFilter,
-                                const ValueDecl *VD) {
+                                ValueDecl *VD) {
   assert(ModuleFilter);
 
   auto ContainingUnit = VD->getDeclContext()->getModuleScopeContext();
@@ -2036,24 +2036,34 @@ static bool isVisibleFromModule(const ClangModuleUnit *ModuleFilter,
 
   auto ClangNode = VD->getClangNode();
   if (!ClangNode) {
-    // If we synthesized a ValueDecl, it won't have a Clang node. But so far
-    // all the situations where we synthesize top-level declarations are
-    // situations where we don't have to worry about C redeclarations.
-    // We should only consider the declaration visible from its owning module.
+    // If we synthesized a ValueDecl, it won't have a Clang node. Find the
+    // associated declaration that /does/ have a Clang node, and use that.
     auto *SynthesizedTypeAttr =
         VD->getAttrs().getAttribute<ClangImporterSynthesizedTypeAttr>();
     assert(SynthesizedTypeAttr);
 
-    // When adding new ClangImporterSynthesizedTypeAttr::Kinds, make sure that
-    // the above statement still holds: "we don't want to allow these
-    // declarations to be treated as present in multiple modules".
     switch (SynthesizedTypeAttr->getKind()) {
     case ClangImporterSynthesizedTypeAttr::Kind::NSErrorWrapper:
-    case ClangImporterSynthesizedTypeAttr::Kind::NSErrorWrapperAnon:
+    case ClangImporterSynthesizedTypeAttr::Kind::NSErrorWrapperAnon: {
+      ASTContext &Ctx = ContainingUnit->getASTContext();
+      auto LookupFlags =
+          NominalTypeDecl::LookupDirectFlags::IgnoreNewExtensions;
+      auto WrapperStruct = cast<StructDecl>(VD);
+      TinyPtrVector<ValueDecl *> LookupResults =
+          WrapperStruct->lookupDirect(Ctx.Id_Code, LookupFlags);
+      assert(!LookupResults.empty() && "imported error enum without Code");
+
+      auto CodeEnumIter = llvm::find_if(LookupResults,
+                                        [&](ValueDecl *Member) -> bool {
+        return Member->getDeclContext() == WrapperStruct;
+      });
+      assert(CodeEnumIter != LookupResults.end() &&
+             "could not find Code enum in wrapper struct");
+      assert((*CodeEnumIter)->hasClangNode());
+      ClangNode = (*CodeEnumIter)->getClangNode();
       break;
     }
-
-    return false;
+    }
   }
 
   // Macros can be "redeclared" by putting an equivalent definition in two

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredErrorEnum/Redeclared.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredErrorEnum/Redeclared.h
@@ -1,7 +1,16 @@
 @import Foundation;
+#ifndef NO_IMPORT_BASE_FROM_REDECLARED
 @import Base;
+#endif
 
 extern NSString * const SomeErrorDomain;
 // typedef NS_ERROR_ENUM(SomeErrorDomain, SomeErrorCode);
 typedef enum SomeErrorCode : long SomeErrorCode;
-enum __attribute__((ns_error_domain(SomeErrorDomain))) SomeErrorCode : long;
+enum __attribute__((ns_error_domain(SomeErrorDomain))) SomeErrorCode : long
+#ifdef NO_IMPORT_BASE_FROM_REDECLARED
+{
+  SomeErrorX,
+  SomeErrorY
+}
+#endif
+;

--- a/test/ClangImporter/enum-error-redeclared.swift
+++ b/test/ClangImporter/enum-error-redeclared.swift
@@ -1,4 +1,10 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -enable-objc-interop -I %S/Inputs/custom-modules/RedeclaredErrorEnum
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -enable-objc-interop -I %S/Inputs/custom-modules/RedeclaredErrorEnum -DIMPORT_BASE
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -enable-objc-interop -I %S/Inputs/custom-modules/RedeclaredErrorEnum -DIMPORT_BASE -Xcc -DNO_IMPORT_BASE_FROM_REDECLARED
+
+#if IMPORT_BASE
+import Base
+#endif
 
 import Redeclared
 


### PR DESCRIPTION
It's not something that *ought* to happen, but when modules aren't quite set up properly (often by accident, thanks to header maps), we can get into basically this situation by having the definition end up in a header that's textually included into two different modules, or into a module and a bridging header. Handle that the same way we handle other redeclarations: have it show up in both modules.

rdar://problem/45646620