### PR TITLE
[Runtime] Demangle generic types with their instantiation arguments.

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -98,23 +98,14 @@ internal func _getTypeByMangledName(
 /// up this functionality.
 public  // TEMPORARY
 func _typeByMangledName(_ name: String,
-                        substitutions: [[Any.Type]] = []) -> Any.Type? {
-  // Map the substitutions to a flat representation that's easier to thread
-  // through to the runtime.
-  let numberOfLevels = UInt(substitutions.count)
-  var parametersPerLevel = [UInt]()
-  var flatSubstitutions = [Any.Type]()
-  for level in substitutions {
-    parametersPerLevel.append(UInt(level.count))
-    flatSubstitutions.append(contentsOf: level)
-  }
-
+                        rawSubstitutions: [Any.Type] = []) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)
+  let parametersPerLevel: [UInt] = []
   return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
     return  _getTypeByMangledName(nameUTF8.baseAddress!,
                                   UInt(nameUTF8.endIndex),
-                                  numberOfLevels,
+                                  0,
                                   parametersPerLevel,
-                                  flatSubstitutions)
+                                  rawSubstitutions)
   }
 }

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -178,12 +178,21 @@ extension S: P4 {
 DemangleToMetadataTests.test("substitutions") {
   // Type parameter substitutions.
   expectEqual(type(of: (1, 3.14159, "Hello")),
-    _typeByMangledName("yyx_q_qd__t",
-      substitutions: [[Int.self, Double.self], [String.self]])!)
+    _typeByMangledName("x_q_qd__tr0__lu",
+      rawSubstitutions: [Int.self, Double.self, String.self])!)
 
   // Associated type substitutions
+  // FIXME: When _typeByMangledName with raw substitutions starts looking at
+  // the witness tables passed along here, this test will fail.
   expectEqual(type(of: (S(), 1, "Hello")),
-    _typeByMangledName("x_6Assoc14main2P4PQz6Assoc24main2P4PQzt", substitutions: [[S.self]])!)
+    _typeByMangledName("x_6Assoc14main2P4PQz6Assoc24main2P4PQztlu",
+      rawSubstitutions: [S.self])!)
+
+  // Same-type constraints.
+  expectEqual(type(of: (1, 3.1415, 17, 2.71 as Float, "hello", "a" as Character, S())),
+    _typeByMangledName("x_q_q0_qd__qd_0_qd_1_qd0__tq0_Rsz6Assoc24main2P4PQyd0__Rsd_0_r1_1__lu",
+      rawSubstitutions: [Int.self, Double.self, Float.self, Character.self, S.self])!)
+  
 }
 
 enum EG<T, U> { case a }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -52,7 +52,6 @@ Func _swift_stdlib_atomicStoreInt32(object:desired:) has been removed
 Func _swift_stdlib_atomicStoreInt64(object:desired:) has been removed
 Func _swift_stdlib_atomicStoreUInt32(object:desired:) has been removed
 Func _swift_stdlib_atomicStoreUInt64(object:desired:) has been removed
-
 Var _FixedArray16._count has been removed
 Var _FixedArray16.capacity has been removed
 Var _FixedArray16.count has been removed
@@ -117,7 +116,8 @@ Constructor _FixedArray4.init(count:) has been removed
 Constructor _FixedArray8.init() has been removed
 Constructor _FixedArray8.init(allZeros:) has been removed
 Constructor _FixedArray8.init(count:) has been removed
-
+Func _typeByMangledName(_:substitutions:) has been renamed to Func _typeByMangledName(_:rawSubstitutions:)
+Func _typeByMangledName(_:substitutions:) has parameter 1 type change from Array<Array<Any.Type>> to Array<Any.Type>
 Struct Hasher._Core has removed conformance to _HasherCore
 Protocol _HasherCore has been removed
 Struct _BufferingHasher has been removed


### PR DESCRIPTION
Introduce logic to demangle a generic type involving generic parameters,
using its mangled generic signature to interpret the corresponding
instantiation arguments.
