### PR TITLE
[runtime] Register a hook for class name lookup from libobjc.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -464,6 +464,11 @@ SWIFT_RUNTIME_EXPORT
 const ClassMetadata *
 swift_getObjCClassFromMetadata(const Metadata *theClass);
 
+// Get the ObjC class object from class type metadata,
+// or nullptr if the type isn't an ObjC class.
+const ClassMetadata *
+swift_getObjCClassFromMetadataConditional(const Metadata *theClass);
+
 SWIFT_RUNTIME_EXPORT
 const ClassMetadata *
 swift_getObjCClassFromObject(HeapObject *object);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -756,6 +756,22 @@ swift::swift_getObjCClassFromMetadata(const Metadata *theMetadata) {
   return theClass;
 }
 
+const ClassMetadata *
+swift::swift_getObjCClassFromMetadataConditional(const Metadata *theMetadata) {
+  // If it's an ordinary class, return it.
+  if (auto theClass = dyn_cast<ClassMetadata>(theMetadata)) {
+    return theClass;
+  }
+
+  // Unwrap ObjC class wrappers.
+  if (auto wrapper = dyn_cast<ObjCClassWrapperMetadata>(theMetadata)) {
+    return wrapper->Class;
+  }
+
+  // Not an ObjC class after all.
+  return nil;
+}
+
 #endif
 
 /***************************************************************************/

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -47,6 +47,7 @@ using namespace reflection;
 #include <objc/runtime.h>
 #include <objc/message.h>
 #include <objc/objc.h>
+#include <dlfcn.h>
 #endif
 
 /// Produce a Demangler value suitable for resolving runtime type metadata
@@ -1294,6 +1295,63 @@ swift_getTypeByMangledNameImpl(const char *typeNameStart, size_t typeNameLength,
 
   return swift_checkMetadataState(MetadataState::Complete, metadata).Value;
 }
+
+#if SWIFT_OBJC_INTEROP
+
+// Return the ObjC class for the given type name.
+// This gets installed as a callback from libobjc.
+
+// FIXME: delete this #if and dlsym once we don't
+// need to build with older libobjc headers
+#if !OBJC_GETCLASSHOOK_DEFINED
+using objc_hook_getClass =  BOOL(*)(const char * _Nonnull name,
+                                    Class _Nullable * _Nonnull outClass);
+#endif
+static objc_hook_getClass OldGetClassHook;
+
+static BOOL
+getObjCClassByMangledName(const char * _Nonnull typeName,
+                          Class _Nullable * _Nonnull outClass) {
+  auto metadata = swift_getTypeByMangledNameImpl(typeName, strlen(typeName),
+                                                 /* no substitutions */
+                                                 0, nullptr, nullptr);
+  if (metadata) {
+    auto objcClass =
+      reinterpret_cast<Class>(
+        const_cast<ClassMetadata *>(
+          swift_getObjCClassFromMetadataConditional(metadata)));
+
+    if (objcClass) {
+      *outClass = objcClass;
+      return YES;
+    }
+  }
+
+  return OldGetClassHook(typeName, outClass);
+}
+
+__attribute__((constructor))
+static void installGetClassHook() {
+  // FIXME: delete this #if and dlsym once we don't
+  // need to build with older libobjc headers
+#if !OBJC_GETCLASSHOOK_DEFINED
+  using objc_hook_getClass =  BOOL(*)(const char * _Nonnull name,
+                                      Class _Nullable * _Nonnull outClass);
+  auto objc_setHook_getClass =
+    (void(*)(objc_hook_getClass _Nonnull,
+             objc_hook_getClass _Nullable * _Nonnull))
+    dlsym(RTLD_DEFAULT, "objc_setHook_getClass");
+#endif
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+  if (&objc_setHook_getClass) {
+    objc_setHook_getClass(getObjCClassByMangledName, &OldGetClassHook);
+  }
+#pragma clang diagnostic pop
+}
+
+#endif
 
 unsigned SubstGenericParametersFromMetadata::
 buildDescriptorPath(const ContextDescriptor *context) const {

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -1,0 +1,142 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// Test Swift's hook for objc_getClass()
+
+import StdlibUnittest
+import ObjectiveC
+import Foundation
+
+// Old OS versions do not have this hook.
+let getClassHookMissing = {
+  nil == dlsym(UnsafeMutableRawPointer(bitPattern: -2),
+    "objc_setHook_getClass")
+}()
+
+var testSuite = TestSuite("objc_getClass")
+
+
+class SwiftSuperclass { }
+class SwiftSubclass : SwiftSuperclass { }
+
+class ObjCSuperclass : NSObject { }
+class ObjCSubclass : ObjCSuperclass { }
+
+
+class MangledSwiftSuperclass { }
+class MangledSwiftSubclass : MangledSwiftSuperclass { }
+
+class MangledObjCSuperclass : NSObject { }
+class MangledObjCSubclass : MangledObjCSuperclass { }
+
+
+class GenericSwiftClass<Value> {
+  let value: Value
+  init(value: Value) { self.value = value }
+}
+class ConstrainedSwiftSuperclass : GenericSwiftClass<String> {
+  init() { super.init(value:"") }
+}
+class ConstrainedSwiftSubclass : ConstrainedSwiftSuperclass { }
+
+
+class MangledGenericSwiftClass<Value> {
+  let value: Value
+  init(value: Value) { self.value = value }
+}
+class MangledConstrainedSwiftSuperclass : MangledGenericSwiftClass<String> {
+  init() { super.init(value:"") }
+}
+class MangledConstrainedSwiftSubclass : MangledConstrainedSwiftSuperclass { }
+
+
+class GenericObjCClass<Value> : NSObject {
+  let value: Value
+  init(value: Value) { self.value = value }
+}
+class ConstrainedObjCSuperclass : GenericObjCClass<String> {
+  init() { super.init(value:"") }
+}
+class ConstrainedObjCSubclass : ConstrainedObjCSuperclass { }
+
+
+class MangledGenericObjCClass<Value> : NSObject {
+  let value: Value
+  init(value: Value) { self.value = value }
+}
+class MangledConstrainedObjCSuperclass : MangledGenericObjCClass<String> {
+  init() { super.init(value:"") }
+}
+class MangledConstrainedObjCSubclass : MangledConstrainedObjCSuperclass { }
+
+
+func requireClass(named name: String, demangledName: String) {
+  for _ in 1...2 {
+    let cls: AnyClass? = NSClassFromString(name)
+    expectNotNil(cls, "class named \(name) unexpectedly not found")
+    expectEqual(NSStringFromClass(cls!), demangledName,
+                "class named \(name) has the wrong name");
+  }
+}
+
+func requireClass(named name: String) {
+  return requireClass(named: name, demangledName: name)
+}
+
+testSuite.test("Basic") {
+  requireClass(named: "main.SwiftSubclass")
+  requireClass(named: "main.SwiftSuperclass")
+  requireClass(named: "main.ObjCSubclass")
+  requireClass(named: "main.ObjCSuperclass")
+}
+
+testSuite.test("BasicMangled") {
+  requireClass(named:   "_TtC4main20MangledSwiftSubclass",
+               demangledName: "main.MangledSwiftSubclass")
+  requireClass(named:   "_TtC4main22MangledSwiftSuperclass",
+               demangledName: "main.MangledSwiftSuperclass")
+  requireClass(named:   "_TtC4main19MangledObjCSubclass",
+               demangledName: "main.MangledObjCSubclass")
+  requireClass(named:   "_TtC4main21MangledObjCSuperclass",
+               demangledName: "main.MangledObjCSuperclass")
+}
+
+testSuite.test("Generic")
+  .skip(.custom({ getClassHookMissing },
+                reason: "objc_getClass hook not present"))
+  .code {
+  requireClass(named: "main.ConstrainedSwiftSubclass")
+  requireClass(named: "main.ConstrainedSwiftSuperclass")
+  requireClass(named: "main.ConstrainedObjCSubclass")
+  requireClass(named: "main.ConstrainedObjCSuperclass")
+}
+
+testSuite.test("GenericMangled")
+  .skip(.custom({ getClassHookMissing },
+                reason: "objc_getClass hook not present"))
+  .code {
+  requireClass(named:   "_TtC4main24ConstrainedSwiftSubclass",
+               demangledName: "main.ConstrainedSwiftSubclass")
+  requireClass(named:   "_TtC4main26ConstrainedSwiftSuperclass",
+               demangledName: "main.ConstrainedSwiftSuperclass")
+  requireClass(named:   "_TtC4main23ConstrainedObjCSubclass",
+               demangledName: "main.ConstrainedObjCSubclass")
+  requireClass(named:   "_TtC4main25ConstrainedObjCSuperclass",
+               demangledName: "main.ConstrainedObjCSuperclass")
+}
+
+
+testSuite.test("NotPresent") {
+  // This class does not exist.
+  expectNil(NSClassFromString("main.ThisClassDoesNotExist"));
+
+  // This name is improperly mangled
+  expectNil(NSClassFromString("_TtC5main"));
+
+  // Swift.Int is not a class type.
+  expectNil(NSClassFromString("Si"))
+}
+
+runAllTests()
+


### PR DESCRIPTION
libobjc needs to look up classes by name. Some Swift classes, such as
instantiated generics and their subclasses, are created only on demand.
Now a by-name lookup from libobjc counts as a demand for those classes.

rdar://problem/27808571
