### PR TITLE
Allow function attributes when -tf-dynamic-compilation is set.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -3754,7 +3754,8 @@ void TFFunctionPartition::insertReplacementGraphOp(
     SILValue newTH = opResult->getResult(resultNumber);
     // Manually walk the use list in a custom way to avoid invalidating the
     // iterator as we potentially change it.
-    for (auto *operand : result->getUses()) {
+    for (auto UI = result->use_begin(), UE = result->use_end(); UI != UE;) {
+      auto *operand = *UI++;
       auto user = operand->getUser();
 
       // Users may be either inside (e.g. another tensor op, or a non-tensor op
@@ -3764,7 +3765,6 @@ void TFFunctionPartition::insertReplacementGraphOp(
       // balance, and then nuke it later.
       if (DI.dominates(tensorEndPoint, user)) {
         operand->set(newTH);
-        continue;
       }
     }
   }

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -26,9 +26,6 @@ import StdlibUnittest
 
 var DatasetTests = TestSuite("Dataset")
 
-// TODO: This test uses function attributes, which dynamic compilation does not
-// support yet.
-#if !TF_DYNAMIC_COMPILATION
 // Creates a dataset, which produces one float scalar value in each get next
 // call.
 @TensorFlowGraph
@@ -101,7 +98,6 @@ public func model() {
 DatasetTests.testAllBackends("Basic") {
   model()
 }
-#endif // !TF_DYNAMIC_COMPILATION
 
 DatasetTests.testAllBackends("MultiValue") {
   enableCPU()

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -52,9 +52,6 @@ DatasetAPITests.testAllBackends("SingleValueTransformations") {
   expectEqual([0, 4, 1, 3, 2], shuffled.map { $0.scalar! })
 }
 
-// TODO: This test uses function attributes, which dynamic compilation does not
-// support yet.
-#if !TF_DYNAMIC_COMPILATION
 DatasetAPITests.testAllBackends("SingleValueHOFs") {
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
   let dataset = Dataset(elements: scalars)
@@ -63,7 +60,6 @@ DatasetAPITests.testAllBackends("SingleValueHOFs") {
   let evens: Dataset = dataset.filter { Tensor($0 % 2 == Tensor(0)) }
   expectEqual([0, 2, 4], evens.flatMap { $0.scalars })
 }
-#endif // !TF_DYNAMIC_COMPILATION
 
 DatasetAPITests.testAllBackends("SingleValueBatched") {
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)


### PR DESCRIPTION
Address TODOs to allow function attributes for ops that reach IRGen.

In addition fix a bug introduced into TFPartition from a previous PR.