### PR TITLE
[semantic-sil] Enable the mandatory sil ownership optimization on all…

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -243,6 +243,7 @@ function(_compile_swift_files
 
   if(SWIFTFILE_IS_STDLIB)
     list(APPEND swift_flags "-Xfrontend" "-enable-sil-ownership")
+    list(APPEND swift_flags "-Xfrontend" "-enable-mandatory-semantic-arc-opts")
   endif()
 
   if(NOT SWIFT_ENABLE_STDLIBCORE_EXCLUSIVITY_CHECKING AND SWIFTFILE_IS_STDLIB)

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -304,8 +304,8 @@ def enable_sil_ownership : Flag<["-"], "enable-sil-ownership">,
 def disable_guaranteed_normal_arguments : Flag<["-"], "disable-guaranteed-normal-arguments">,
   HelpText<"If set to true, all normal parameters (except to inits/setters) will be passed at +1">;
 
-def disable_mandatory_semantic_arc_opts : Flag<["-"], "disable-mandatory-semantic-arc-opts">,
-  HelpText<"Disable the mandatory semantic arc optimizer">;
+def enable_mandatory_semantic_arc_opts : Flag<["-"], "enable-mandatory-semantic-arc-opts">,
+  HelpText<"Enable the mandatory semantic arc optimizer">;
 
 def assume_parsing_unqualified_ownership_sil : Flag<["-"], "assume-parsing-unqualified-ownership-sil">,
   HelpText<"Assume unqualified SIL ownership when parsing SIL">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -743,7 +743,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.AssumeUnqualifiedOwnershipWhenParsing
     |= Args.hasArg(OPT_assume_parsing_unqualified_ownership_sil);
   Opts.EnableMandatorySemanticARCOpts |=
-      !Args.hasArg(OPT_disable_mandatory_semantic_arc_opts);
+      Args.hasArg(OPT_enable_mandatory_semantic_arc_opts);
   Opts.EnableLargeLoadableTypes |= Args.hasArg(OPT_enable_large_loadable_types);
 
   if (const Arg *A = Args.getLastArg(OPT_save_optimization_record_path))

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -180,11 +180,11 @@ namespace {
 struct SemanticARCOpts : SILFunctionTransform {
   void run() override {
     SILFunction &f = *getFunction();
-    // Do not run the semantic arc opts unless we are running on the
-    // standard library. This is because this is the only module that
-    // passes the ownership verifier.
-    if (!f.getModule().isStdlibModule())
-      return;
+
+    // Make sure we are running with ownership verification enabled.
+    assert(f.getModule().getOptions().EnableSILOwnership &&
+           "Can not perform semantic arc optimization unless ownership "
+           "verification is enabled");
 
     // Iterate over all of the arguments, performing small peephole
     // ARC optimizations.

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -172,3 +172,19 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
+
+// Do not eliminate a copy from an unowned value. This will cause us to pass the
+// unowned value as guaranteed... =><=.
+//
+// CHECK-LABEL: sil @unowned_arg_copy : $@convention(thin) (Builtin.NativeObject) -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'unowned_arg_copy'
+sil @unowned_arg_copy : $@convention(thin) (Builtin.NativeObject) -> () {
+bb0(%0 : @unowned $Builtin.NativeObject):
+  %1 = copy_value %0 : $Builtin.NativeObject
+  %2 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %2(%1) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %1 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
… stdlib overlays.

We can do this b/c all overlays pass the ownership verifier, so it is safe.
