### PR TITLE
[ParseSIL] Fix `SILParser::parseSILIdentifierSwitch`

### DIFF
--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -264,7 +264,7 @@ namespace {
         return true;
       }
 
-      Result = ValueOwnershipKind(*Iter);
+      Result = T(*Iter);
       return false;
     }
 


### PR DESCRIPTION
Template `SILParser::parseSILIdentifierSwitch` should not use `ValueOwnershipKind` in its implementation.