### PR TITLE
Compute layout when emitting an other-constructor reference.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1630,6 +1630,8 @@ namespace {
 
       auto ref = ConcreteDeclRef(ctor, substitutions);
 
+      tc.requestMemberLayout(ctor);
+
       // The constructor was opened with the allocating type, not the
       // initializer type. Map the former into the latter.
       auto resultTy = solution.simplifyType(openedFullType);

--- a/test/multifile/Inputs/protocol-extension-init-helper.swift
+++ b/test/multifile/Inputs/protocol-extension-init-helper.swift
@@ -1,0 +1,4 @@
+protocol P {
+  init()
+  var x: Int { get set }
+}

--- a/test/multifile/protocol-extension-init.swift
+++ b/test/multifile/protocol-extension-init.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-ir -module-name test %S/Inputs/protocol-extension-init-helper.swift -primary-file %s
+
+// SE-9233: compute layout when emitting an other-constructor reference
+extension P {
+  public init(possibly: Bool) {
+    self.init()
+  }
+}


### PR DESCRIPTION
Fixes [SE-9233](https://bugs.swift.org/browse/SR-9233), a crash due to a failure to validate a storage declaration within a protocol when generating a call to an initiializer.