### PR TITLE
Fix synthesis of 'override' and 'required' on initializers

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2473,11 +2473,12 @@ configureInheritedDesignatedInitAttributes(TypeChecker &tc,
   }
 
   // Wire up the overrides.
-  ctor->getAttrs().add(new (ctx) OverrideAttr(/*IsImplicit=*/true));
   ctor->setOverriddenDecl(superclassCtor);
 
   if (superclassCtor->isRequired())
-    ctor->getAttrs().add(new (ctx) RequiredAttr(/*IsImplicit=*/true));
+    ctor->getAttrs().add(new (ctx) RequiredAttr(/*IsImplicit=*/false));
+  else
+    ctor->getAttrs().add(new (ctx) OverrideAttr(/*IsImplicit=*/false));
 
   // If the superclass constructor is @objc but the subclass constructor is
   // not representable in Objective-C, add @nonobjc implicitly.

--- a/test/ParseableInterface/modifiers.swift
+++ b/test/ParseableInterface/modifiers.swift
@@ -3,7 +3,7 @@
 // RUN: %FileCheck %s < %t/Test.swiftinterface
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-parseable-module-interface-path - -module-name Test -enable-objc-interop | %FileCheck %s
 
-// CHECK: final public class FinalClass {
+// CHECK-LABEL: final public class FinalClass {
 public final class FinalClass {
   // CHECK: @inlinable final public class var a: [[INT:(Swift.)?Int]] {
   // CHECK-NEXT: {{^}} get {
@@ -53,7 +53,35 @@ public final class FinalClass {
   }
 }
 
-// CHECK: public struct MyStruct {
+// CHECK-LABEL: public class Base {
+public class Base {
+  // CHECK-NEXT: @objc public init(){{$}}
+  @objc public init() {}
+  // CHECK-NEXT: @objc required public init(x: [[INT]]){{$}}
+  @objc public required init(x: Int) {}
+  // CHECK-NEXT: @objc deinit{{$}}
+} // CHECK-NEXT: {{^}$}}
+
+
+// CHECK-LABEL: public class SubImplicit : {{(Test[.])?Base}} {
+public class SubImplicit: Base {
+  // CHECK-NEXT: @objc override public init(){{$}}
+  // CHECK-NEXT: @objc required public init(x: [[INT]]){{$}}
+  // CHECK-NEXT: @objc deinit{{$}}
+} // CHECK-NEXT: {{^}$}}
+
+
+// CHECK-LABEL: public class SubExplicit : {{(Test[.])?Base}} {
+public class SubExplicit: Base {
+  // Make sure adding "required" preserves both "required" and "override".
+  // CHECK-NEXT: @objc override required public init(){{$}}
+  public override required init() { super.init() }
+  // CHECK-NEXT: @objc required public init(x: [[INT]]){{$}}
+  public required init(x: Int) { super.init() }
+  // CHECK-NEXT: @objc deinit{{$}}
+} // CHECK-NEXT: {{^}$}}
+
+// CHECK-LABEL: public struct MyStruct {
 public struct MyStruct {
   // CHECK: public var e: [[INT]] {
   // CHECK-NEXT: {{^}} mutating get{{$}}

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -365,12 +365,12 @@ public class PublicInitBase {
 
 // CHECK-LABEL: public{{(\*/)?}} class PublicInitInheritor : PublicInitBase {
 public class PublicInitInheritor : PublicInitBase {
-  // CHECK: {{^}} public init()
-  // CHECK: {{^}} fileprivate init(other: PublicInitBase)
+  // CHECK: {{^}} override public init()
+  // CHECK: {{^}} override fileprivate init(other: PublicInitBase)
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: {{(/\*)?private(\*/)?}} class PublicInitPrivateInheritor : PublicInitBase {
 private class PublicInitPrivateInheritor : PublicInitBase {
-  // CHECK: {{^}} internal init()
-  // CHECK: {{^}} fileprivate init(other: PublicInitBase)
+  // CHECK: {{^}} override internal init()
+  // CHECK: {{^}} override fileprivate init(other: PublicInitBase)
 } // CHECK: {{^[}]}}


### PR DESCRIPTION
This is actually two separate problems:
- `override` wasn't getting added to initializers in deserialization
- `override` was getting added when inheriting a `required` initializer, even though it's normally an error to write that

Needed for parseable interfaces.