### PR TITLE
[Serialization] Only diagnose a bad architecture when there are others

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -117,6 +117,13 @@ static void addDiagnosticInfoForArchitectureMismatch(ASTContext &ctx,
     }
   }
 
+  if (foundArchs.empty()) {
+    // Maybe this swiftmodule directory only contains swiftinterfaces, or
+    // maybe something else is going on. Regardless, we shouldn't emit a
+    // possibly incorrect diagnostic.
+    return;
+  }
+
   ctx.Diags.diagnose(sourceLocation, diag::sema_no_import_arch, moduleName,
                      archName, foundArchs);
 }

--- a/test/Serialization/load-invalid-arch.swift
+++ b/test/Serialization/load-invalid-arch.swift
@@ -5,23 +5,29 @@
 // RUN: touch %t/new_module.swiftmodule/ppc65.swiftmodule
 // RUN: touch %t/new_module.swiftmodule/i387.swiftdoc
 // RUN: touch %t/new_module.swiftmodule/ppc65.swiftdoc
-// RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -DTARGET_ARCHITECTURE=$(echo %target-swiftmodule-name | cut -d. -f1)
+// RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=$(echo %target-swiftmodule-name | cut -d. -f1)
 
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/new_module.framework/Modules/new_module.swiftmodule/
 // RUN: touch %t/new_module.framework/Modules/new_module.swiftmodule/i387.swiftmodule
 // RUN: touch %t/new_module.framework/Modules/new_module.swiftmodule/ppc65.swiftmodule
-// RUN: not %target-swift-frontend %s -F %t -typecheck -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -DTARGET_ARCHITECTURE=$(echo %target-swiftmodule-name | cut -d. -f1)
+// RUN: not %target-swift-frontend %s -F %t -typecheck -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=$(echo %target-swiftmodule-name | cut -d. -f1)
 
-//CHECK: {{.*}} error: could not find module 'new_module' for architecture '[[TARGET_ARCHITECTURE]]'; found: {{ppc65, i387|i387, ppc65}}
-//CHECK-NEXT: import new_module
-//CHECK-NEXT: 		^
-//CHECK: error: no such module 'new_module'
-//CHECK-NEXT: import new_module
-//CHECK-NEXT: 		^
-//CHECK: error: use of unresolved identifier 'new_module'
-//CHECK-NEXT: new_module.foo()
-//CHECK-NEXT: ^~~~~~~~~~
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t/new_module.swiftmodule
+// RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK-EMPTY -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=$(echo %target-swiftmodule-name | cut -d. -f1)
+
+// CHECK-ALL-NOT: error:
+// CHECK: {{.*}} error: could not find module 'new_module' for architecture '[[TARGET_ARCHITECTURE]]'; found: {{ppc65, i387|i387, ppc65}}
+// CHECK-NEXT: import new_module
+// CHECK-NEXT: 		^
+// CHECK-ALL: error: no such module 'new_module'
+// CHECK-ALL-NEXT: import new_module
+// CHECK-ALL-NEXT: 		^
+// CHECK-ALL: error: use of unresolved identifier 'new_module'
+// CHECK-ALL-NEXT: new_module.foo()
+// CHECK-ALL-NEXT: ^~~~~~~~~~
+// CHECK-ALL-NOT: error:
 
 import new_module
 


### PR DESCRIPTION
This diagnostic needs to be adapted for swiftinterfaces too, but meanwhile let's not have it get in the way when dealing with a multi-architecture module that has parseable interfaces.

    MyKit.framework/
      Modules/
        MyKit.swiftmodule/
          x86_64.swiftinterface
          x86_64.swiftdoc
          # no x86_64.swiftmodule