### PR TITLE
[xctest] Check for an error message prefix only

### DIFF
--- a/validation-test/stdlib/XCTest.swift
+++ b/validation-test/stdlib/XCTest.swift
@@ -8,8 +8,6 @@
 // REQUIRES: OS=macosx
 // UNSUPPORTED: remote_run
 
-// REQUIRES: rdar46030955
-
 import StdlibUnittest
 
 
@@ -115,7 +113,7 @@ XCTestTestSuite.test("XCTAssertEqual/T") {
   let failingTestRun = failingTestCase.testRun!
   expectEqual(1, failingTestRun.failureCount)
   expectEqual(0, failingTestRun.unexpectedExceptionCount)
-  expectEqual(observer.failureDescription, "XCTAssertEqual failed: (\"1\") is not equal to (\"2\") - ")
+  expectTrue(observer.failureDescription!.starts(with:  "XCTAssertEqual failed: (\"1\") is not equal to (\"2\")"))
 }
 
 XCTestTestSuite.test("XCTAssertEqual/Optional<T>") {
@@ -149,7 +147,7 @@ XCTestTestSuite.test("XCTAssertEqual/Optional<T>") {
   expectEqual(0, failingTestRun.unexpectedExceptionCount)
   expectEqual(1, failingTestRun.totalFailureCount)
   expectFalse(failingTestRun.hasSucceeded)
-  expectEqual(observer.failureDescription, "XCTAssertEqual failed: (\"Optional(1)\") is not equal to (\"Optional(2)\") - ")
+  expectTrue(observer.failureDescription!.starts(with:  "XCTAssertEqual failed: (\"Optional(1)\") is not equal to (\"Optional(2)\")"))
 }
 
 XCTestTestSuite.test("XCTAssertEqual/Array<T>") {


### PR DESCRIPTION
Checking the whole message is fragile and might break should the
formatting change ever so slightly.

Fixes: <rdar://problem/46030955>