### PR TITLE
Added an experimental flag to delete all graph ops at the end of the deabstraction pass.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -59,8 +59,8 @@ static llvm::cl::opt<bool> TFDeleteGraphOps(
     "tf-delete-graph-ops", llvm::cl::init(false),
     llvm::cl::desc(
         "If enabled, delete all graph_ops at the end of the deabstraction "
-        "pass. This is an internal flag used to assess compiler overtime in "
-        "processing graph_op's in the optimizer passes."));
+        "pass. This is an internal flag used to measure the compiler overhead in"
+        "processing graph_op's in the optimization passes."));
 
 template<typename...T, typename...U>
 static InFlightDiagnostic


### PR DESCRIPTION
Context: Graph mode compilation currently takes ~2 minutes on a resnet 50
model (forward pass only). One conjecture is that running the compiler
performance pipeline over the graph code might have take non-trivial time, and
that could be minimized if we move up the partition pass to be right after
deabstraction, so that we can slice out the accelerator function at the end of
the mandatory pipeline, and do not feed that function through the performance
pipeline (instead, we can optimize the accelerator function at the graph level, say
via TF grappler).

One way to simulate the compiler performance of the above change is to delete
all graph_ops after deabstraction, so that the performance pipeline only pays
the cost of optimizing host code.

**Unfortunately, the performance gain is not significant on a simplified version of the resnet50 model.**

The time cost of compiling a resnet model (source code to be released) under `-DuseToyModel` is
17.6s (with 27900 SIL instructions in the deabstraction result). After deleting
the graph ops via the new flag `-Xllvm -tf-delete-graph-ops`, the time cost
reduced to 14.6s (with 27016 SIL instructions).

This suggests that we should look into other venues for compiler performance
optimization first, such as modular (non-inline-based) compilation.

This patch is to submit the new code path for deleting graph_ops under a flag,
so that this experiment can be performed on other future models in case needed.
