### PR TITLE
Added a new flag `-Xllvm -tf-reduce-optimizing-passes` to turn off selective optimization passes, currently ARCSequenceOpts and ReleaseHosting.

### DIFF
--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -96,6 +96,12 @@ STATISTIC(NumReleasesHoisted, "Number of releases hoisted");
 
 llvm::cl::opt<bool> DisableARCCodeMotion("disable-arc-cm", llvm::cl::init(false));
 
+// SWIFT_ENABLE_TENSORFLOW
+extern llvm::cl::opt<bool> TFReduceOptimizingPasses;
+namespace llvm {
+extern cl::opt<bool> TFDynamicCompilation;
+}
+
 //===----------------------------------------------------------------------===//
 //                             Block State 
 //===----------------------------------------------------------------------===//
@@ -1141,6 +1147,15 @@ public:
 
   /// The entry point to the transformation.
   void run() override {
+    // This pass (in particular ReleaseHoisting) could consume up to 30% of
+    // total compilation time in graph mode (after disabling the ARCSequenceOpts
+    // pass first), and does not yield clear benefit. So add a code path to turn
+    // it off.
+#ifdef SWIFT_ENABLE_TENSORFLOW
+    if (TFReduceOptimizingPasses && !llvm::TFDynamicCompilation)
+      return;
+#endif
+
     // Code motion disabled.
     if (DisableARCCodeMotion)
       return;


### PR DESCRIPTION
On a resnet50 (forward pass only) model, these passes together consume >70% of
compiler time (measured via the performance infra at https://github.com/apple/swift/pull/20558).

After disabling these passes, the compilation time reduced from 2 minutes to 18
seconds.

Unfortunately, this caused test `f()` in `test/TensorFlow/diagnostics.swift` to
regress, where function `ClassTest.init()` is no longer inlined. This could cause
extra sends/recvs in graph mode.

Also, given turning off optimizing passes may not be the right/desirable
approach, we protect the code changes here under a flag, so that we can continue to experiment with this approach.
