### PR TITLE
Give multi-payload enums extra inhabitants.

### DIFF
--- a/include/swift/ABI/Enum.h
+++ b/include/swift/ABI/Enum.h
@@ -1,0 +1,53 @@
+//===--- Enum.h - Enum implementation runtime declarations ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Enum implementation details declarations relevant to the ABI.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_ENUM_H
+#define SWIFT_ABI_ENUM_H
+
+#include <stdlib.h>
+
+namespace swift {
+
+struct EnumTagCounts {
+  unsigned numTags, numTagBytes;
+};
+
+inline EnumTagCounts
+getEnumTagCounts(size_t size, unsigned emptyCases, unsigned payloadCases) {
+  // We can use the payload area with a tag bit set somewhere outside of the
+  // payload area to represent cases. See how many bytes we need to cover
+  // all the empty cases.
+  unsigned numTags = payloadCases;
+  if (emptyCases > 0) {
+    if (size >= 4)
+      // Assume that one tag bit is enough if the precise calculation overflows
+      // an int32.
+      numTags += 1;
+    else {
+      unsigned bits = size * 8U;
+      unsigned casesPerTagBitValue = 1U << bits;
+      numTags += ((emptyCases + (casesPerTagBitValue-1U)) >> bits);
+    }
+  }
+  unsigned numTagBytes = (numTags <=    1 ? 0 :
+                          numTags <   256 ? 1 :
+                          numTags < 65536 ? 2 : 4);
+  return {numTags, numTagBytes};
+}
+
+} // namespace swift
+
+#endif // SWIFT_ABI_ENUM_H

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1181,7 +1181,7 @@ namespace {
     // discriminate enum cases.
     unsigned ExtraTagBitCount = ~0u;
     // The number of possible values for the extra tag bits that are used.
-    // Log2(NumExtraTagValues - 1) + 1 == ExtraTagBitCount
+    // Log2(NumExtraTagValues - 1) + 1 <= ExtraTagBitCount
     unsigned NumExtraTagValues = ~0u;
     
     APInt getExtraTagBitConstant(uint64_t value) const {
@@ -4820,15 +4820,74 @@ namespace {
 
     /// \group Extra inhabitants
 
-    // TODO
+    // If we didn't use all of the available tag bit representations, offer
+    // the remaining ones as extra inhabitants.
 
-    bool mayHaveExtraInhabitants(IRGenModule &) const override { return false; }
+    bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
+      if (TIK >= Fixed)
+        return getFixedExtraInhabitantCount(IGM) > 0;
+      return true;
+    }
+    
+    /// Rounds the extra tag bit count up to the next byte size.
+    unsigned getExtraTagBitCountForExtraInhabitants() const {
+      if (!ExtraTagTy)
+        return 0;
+      return (ExtraTagTy->getBitWidth() + 7) & ~7;
+    }
+    
+    Address projectExtraTagBitsForExtraInhabitants(IRGenFunction &IGF,
+                                                   Address base) const {
+      auto addr = projectExtraTagBits(IGF, base);
+      if (ExtraTagTy->getBitWidth() != getExtraTagBitCountForExtraInhabitants()) {
+        addr = IGF.Builder.CreateBitCast(addr,
+             llvm::IntegerType::get(IGF.IGM.getLLVMContext(),
+                                     getExtraTagBitCountForExtraInhabitants())
+               ->getPointerTo());
+      }
+      return addr;
+    }
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                          Address src,
                                          SILType T,
                                          bool isOutlined) const override {
-      llvm_unreachable("extra inhabitants for multi-payload enums not implemented");
+      // For dynamic layouts, the runtime provides a value witness to do this.
+      if (TIK < Fixed) {
+        return emitGetExtraInhabitantIndexCall(IGF, T, src);
+      }
+      
+      llvm::Value *tag;
+      if (CommonSpareBits.count()) {
+        auto payload = EnumPayload::load(IGF, projectPayload(IGF, src),
+                                         PayloadSchema);
+        tag = payload.emitGatherSpareBits(IGF, CommonSpareBits, 0, 32);
+        if (getExtraTagBitCountForExtraInhabitants()) {
+          auto extraTagAddr = projectExtraTagBitsForExtraInhabitants(IGF, src);
+          auto extraTag = IGF.Builder.CreateLoad(extraTagAddr);
+          auto extraTagBits =
+            IGF.Builder.CreateZExtOrTrunc(extraTag, IGF.IGM.Int32Ty);
+          extraTagBits =
+            IGF.Builder.CreateShl(extraTagBits, CommonSpareBits.count());
+          tag = IGF.Builder.CreateOr(tag, extraTagBits);
+        }
+      } else {
+        auto extraTagAddr = projectExtraTagBitsForExtraInhabitants(IGF, src);
+        auto extraTag = IGF.Builder.CreateLoad(extraTagAddr);
+        tag = IGF.Builder.CreateZExtOrTrunc(extraTag, IGF.IGM.Int32Ty);
+      }
+      
+      // Check whether it really is an extra inhabitant.
+      auto tagBits = CommonSpareBits.count() + getExtraTagBitCountForExtraInhabitants();
+      auto maxTag = tagBits >= 32 ? ~0u : (1 << tagBits) - 1;
+      auto index = IGF.Builder.CreateSub(
+                               llvm::ConstantInt::get(IGF.IGM.Int32Ty, maxTag),
+                               tag);
+      auto isExtraInhabitant = IGF.Builder.CreateICmpULT(index,
+                 llvm::ConstantInt::get(IGF.IGM.Int32Ty,
+                                        getFixedExtraInhabitantCount(IGF.IGM)));
+      return IGF.Builder.CreateSelect(isExtraInhabitant,
+                            index, llvm::ConstantInt::get(IGF.IGM.Int32Ty, -1));
     }
 
     void storeExtraInhabitant(IRGenFunction &IGF,
@@ -4836,25 +4895,86 @@ namespace {
                               Address dest,
                               SILType T,
                               bool isOutlined) const override {
-      llvm_unreachable("extra inhabitants for multi-payload enums not implemented");
+      // For dynamic layouts, the runtime provides a value witness to do this.
+      if (TIK < Fixed) {
+        emitStoreExtraInhabitantCall(IGF, T, index, dest);
+        return;
+      }
+
+      auto indexValue = IGF.Builder.CreateNot(index);
+      if (CommonSpareBits.count()) {
+        // Factor the index value into parts to scatter into the payload and
+        // to store in the extra tag bits, if any.
+        EnumPayload payload =
+          interleaveSpareBits(IGF, PayloadSchema, CommonSpareBits, indexValue);
+        payload.store(IGF, projectPayload(IGF, dest));
+        if (getExtraTagBitCountForExtraInhabitants() > 0) {
+          auto tagBits = IGF.Builder.CreateLShr(indexValue,
+              llvm::ConstantInt::get(IGF.IGM.Int32Ty, CommonSpareBits.count()));
+          auto tagAddr = projectExtraTagBitsForExtraInhabitants(IGF, dest);
+          tagBits = IGF.Builder.CreateZExtOrTrunc(tagBits,
+                      tagAddr.getAddress()->getType()->getPointerElementType());
+          IGF.Builder.CreateStore(tagBits, tagAddr);
+        }
+      } else {
+        // Only need to store the tag value.
+        auto tagAddr = projectExtraTagBitsForExtraInhabitants(IGF, dest);
+        indexValue = IGF.Builder.CreateZExtOrTrunc(indexValue,
+                      tagAddr.getAddress()->getType()->getPointerElementType());
+        IGF.Builder.CreateStore(indexValue, tagAddr);
+      }
     }
     
     APInt
     getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
-      // TODO may not always be all-ones
-      return APInt::getAllOnesValue(
-                      cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits());
+      // The extra inhabitant goes into the tag bits.
+      auto tagBits = CommonSpareBits.asAPInt();
+      auto fixedTI = cast<FixedTypeInfo>(TI);
+      if (getExtraTagBitCountForExtraInhabitants() > 0) {
+        auto bitSize = fixedTI->getFixedSize().getValueInBits();
+        tagBits = tagBits.zext(bitSize);
+        auto extraTagMask = APInt::getAllOnesValue(bitSize)
+          .shl(CommonSpareBits.size());
+        tagBits |= extraTagMask;
+      }
+      return tagBits;
     }
     
     unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {
-      return 0;
+      unsigned totalTagBits = CommonSpareBits.count() + getExtraTagBitCountForExtraInhabitants();
+      if (totalTagBits >= 32)
+        return INT_MAX;
+      unsigned totalTags = 1u << totalTagBits;
+      return totalTags - ElementsWithPayload.size() - NumEmptyElementTags;
     }
 
     APInt
     getFixedExtraInhabitantValue(IRGenModule &IGM,
                                  unsigned bits,
                                  unsigned index) const override {
-      llvm_unreachable("extra inhabitants for multi-payload enums not implemented");
+      // Count down from all-ones since a small negative number constant is
+      // likely to be easier to reify.
+      auto mask = ~index;
+      auto extraTagMask = getExtraTagBitCountForExtraInhabitants() >= 32
+        ? ~0u : (1 << getExtraTagBitCountForExtraInhabitants()) - 1;
+
+      if (auto payloadBitCount = CommonSpareBits.count()) {
+        auto payloadTagMask = payloadBitCount >= 32
+          ? ~0u : (1 << payloadBitCount) - 1;
+        auto payloadPart = mask & payloadTagMask;
+        auto payloadBits = interleaveSpareBits(IGM, CommonSpareBits,
+                                               bits, payloadPart, 0);
+        if (getExtraTagBitCountForExtraInhabitants() > 0) {
+          auto extraBits = APInt(bits,
+                                 (mask >> payloadBitCount) & extraTagMask)
+            .shl(CommonSpareBits.size());
+          payloadBits |= extraBits;
+        }
+        return payloadBits;
+      } else {
+        auto value = APInt(bits, mask & extraTagMask);
+        return value.shl(CommonSpareBits.size());
+      }
     }
 
     ClusteredBitVector

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -81,9 +81,9 @@ swift::swift_initEnumMetadataSinglePayload(EnumMetadata *self,
     size = payloadSize;
     unusedExtraInhabitants = payloadNumExtraInhabitants - emptyCases;
   } else {
-    size = payloadSize + getNumTagBytes(payloadSize,
+    size = payloadSize + getEnumTagCounts(payloadSize,
                                       emptyCases - payloadNumExtraInhabitants,
-                                      1 /*payload case*/);
+                                        1 /*payload case*/).numTagBytes; ;
   }
 
   auto vwtable = getMutableVWTableForInit(self, layoutFlags);
@@ -169,6 +169,12 @@ void swift::swift_storeEnumTagSinglePayload(OpaqueValue *value,
                                 numExtraInhabitants, storeExtraInhabitant);
 }
 
+static int32_t getMultiPayloadExtraInhabitantIndex(const OpaqueValue *value,
+                                                   const Metadata *enumType);
+static void storeMultiPayloadExtraInhabitant(OpaqueValue *value,
+                                             int32_t index,
+                                             const Metadata *enumType);
+
 void
 swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
                                      EnumLayoutFlags layoutFlags,
@@ -190,29 +196,41 @@ swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
   assignUnlessEqual(enumType->getPayloadSize(), payloadSize);
   
   // The total size includes space for the tag.
-  unsigned totalSize = payloadSize + getNumTagBytes(payloadSize,
+  auto tagCounts = getEnumTagCounts(payloadSize,
                                 enumType->getDescription()->getNumEmptyCases(),
                                 numPayloads);
+  unsigned totalSize = payloadSize + tagCounts.numTagBytes;
+  
+  // See whether there are extra inhabitants in the tag.
+  unsigned numExtraInhabitants = tagCounts.numTagBytes == 4
+    ? INT_MAX
+    : (1 << (tagCounts.numTagBytes * 8)) - tagCounts.numTags;
 
   auto vwtable = getMutableVWTableForInit(enumType, layoutFlags);
 
   // Set up the layout info in the vwtable.
-  TypeLayout layout;
-  layout.size = totalSize;
-  layout.flags = ValueWitnessFlags()
+  auto rawStride = (totalSize + alignMask) & ~alignMask;
+  TypeLayout layout{totalSize,
+                    ValueWitnessFlags()
                      .withAlignmentMask(alignMask)
                      .withPOD(isPOD)
                      .withBitwiseTakable(isBT)
-                     // TODO: Extra inhabitants
-                     .withExtraInhabitants(false)
+                     .withExtraInhabitants(numExtraInhabitants > 0)
                      .withEnumWitnesses(true)
                      .withInlineStorage(ValueWitnessTable::isValueInline(
-                         isBT, totalSize, alignMask + 1));
-  auto rawStride = (totalSize + alignMask) & ~alignMask;
-  layout.stride = rawStride == 0 ? 1 : rawStride;
-  
-  installCommonValueWitnesses(layout, vwtable);
+                         isBT, totalSize, alignMask + 1)),
+                    rawStride == 0 ? 1 : rawStride,
+                    numExtraInhabitants > 0
+                      ? ExtraInhabitantFlags()
+                          .withNumExtraInhabitants(numExtraInhabitants)
+                      : ExtraInhabitantFlags()};
 
+  installCommonValueWitnesses(layout, vwtable);
+  if (numExtraInhabitants > 0) {
+    vwtable->extraInhabitantFlags = layout.getExtraInhabitantFlags();
+    vwtable->storeExtraInhabitant = storeMultiPayloadExtraInhabitant;
+    vwtable->getExtraInhabitantIndex = getMultiPayloadExtraInhabitantIndex;
+  }
   vwtable->publishLayout(layout);
 }
 
@@ -271,10 +289,11 @@ static void storeMultiPayloadValue(OpaqueValue *value,
 }
 
 static unsigned loadMultiPayloadTag(const OpaqueValue *value,
-                                    MultiPayloadLayout layout) {
+                                    MultiPayloadLayout layout,
+                                    unsigned baseValue = 0) {
   auto tagBytes = reinterpret_cast<const char *>(value) + layout.payloadSize;
 
-  unsigned tag = 0;
+  unsigned tag = baseValue;
 #if defined(__BIG_ENDIAN__)
   small_memcpy(reinterpret_cast<char *>(&tag) + 4 - layout.numTagBytes,
                tagBytes, layout.numTagBytes);
@@ -300,6 +319,23 @@ static unsigned loadMultiPayloadValue(const OpaqueValue *value,
 #endif
   return payloadValue;
 }
+
+static int32_t getMultiPayloadExtraInhabitantIndex(const OpaqueValue *value,
+                                                   const Metadata *enumType) {
+  auto layout = getMultiPayloadLayout(cast<EnumMetadata>(enumType));
+  unsigned index = ~loadMultiPayloadTag(value, layout, ~0u);
+  
+  if (index >= enumType->getValueWitnesses()->getNumExtraInhabitants())
+    return -1;
+  return index;
+}
+static void storeMultiPayloadExtraInhabitant(OpaqueValue *value,
+                                             int32_t index,
+                                             const Metadata *enumType) {
+  auto layout = getMultiPayloadLayout(cast<EnumMetadata>(enumType));
+  storeMultiPayloadTag(value, layout, ~index);
+}
+
 
 void
 swift::swift_storeEnumTagMultiPayload(OpaqueValue *value,

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -181,9 +181,9 @@ import Swift
 // CHECK-32-SAME:   i8* inttoptr ([[WORD]] 5 to i8*),
 // CHECK-64-SAME:   i8* inttoptr ([[WORD]] 9 to i8*),
 // -- flags                 0x250003 - alignment 4
-// CHECK-32-SAME:   i8* inttoptr ([[WORD]] {{2424835|2097155}} to i8*)
-// -- flags                 0x200007 - alignment 8
-// CHECK-64-SAME:   i8* inttoptr ([[WORD]] 2097159 to i8*)
+// CHECK-32-SAME:   i8* inttoptr ([[WORD]] {{2686979|2359299}} to i8*)
+// -- flags                 0x240007 - alignment 8, extra inhabitants
+// CHECK-64-SAME:   i8* inttoptr ([[WORD]] 2359303 to i8*)
 // CHECK-SAME: ]
 
 enum Empty {}

--- a/test/IRGen/indirect_enum.sil
+++ b/test/IRGen/indirect_enum.sil
@@ -2,8 +2,8 @@
 
 import Swift
 
-// CHECK-64: @"$s13indirect_enum5TreeAOWV" = internal constant {{.*}} i8* inttoptr ([[WORD:i64]] 8 to i8*), i8* inttoptr (i64 2162695 to i8*), i8* inttoptr (i64 8 to i8*)
-// CHECK-32: @"$s13indirect_enum5TreeAOWV" = internal constant {{.*}} i8* inttoptr ([[WORD:i32]] 4 to i8*), i8* inttoptr (i32 2162691 to i8*), i8* inttoptr (i32 4 to i8*)
+// CHECK-64: @"$s13indirect_enum5TreeAOWV" = internal constant {{.*}} i8* inttoptr ([[WORD:i64]] 8 to i8*), i8* inttoptr (i64 2424839 to i8*), i8* inttoptr (i64 8 to i8*)
+// CHECK-32: @"$s13indirect_enum5TreeAOWV" = internal constant {{.*}} i8* inttoptr ([[WORD:i32]] 4 to i8*), i8* inttoptr (i32 2424835 to i8*), i8* inttoptr (i32 4 to i8*)
 
 // CHECK-NOT: define{{( protected)?}} private %swift.type** @get_field_types_TreeA
 indirect enum TreeA<T> {

--- a/test/IRGen/type_layout.swift
+++ b/test/IRGen/type_layout.swift
@@ -60,7 +60,7 @@ struct TypeLayoutTest<T> {
   // CHECK:       store i8** getelementptr inbounds (i8*, i8** @"$sBi64_WV", i32 8)
   var g: ESing
   // -- Multi-case enum, open-coded layout
-  // CHECK:    store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @type_layout_9_8_0_pod, i32 0, i32 0)
+  // CHECK:    store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_9_8_fe_pod, i32 0, i32 0)
   var h: EMult
   // -- Single-element generic struct, shares layout of its field (T)
   // CHECK:       [[T_LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[T_VALUE_WITNESSES]], i32 8

--- a/test/IRGen/type_layout_dumper_all.swift
+++ b/test/IRGen/type_layout_dumper_all.swift
@@ -23,7 +23,7 @@ import type_layout_dumper_other
 // CHECK-NEXT:   - Name:            24type_layout_dumper_other21ConcreteResilientEnumO
 // CHECK-NEXT:     Size:            9
 // CHECK-NEXT:     Alignment:       8
-// CHECK-NEXT:     ExtraInhabitants: 0
+// CHECK-NEXT:     ExtraInhabitants: 254
 // CHECK-NEXT:   - Name:            24type_layout_dumper_other22DependentResilientEnumO09NestedNonefG0O
 // CHECK-NEXT:     Size:            8
 // CHECK-NEXT:     Alignment:       8

--- a/test/IRGen/type_layout_dumper_resilient.swift
+++ b/test/IRGen/type_layout_dumper_resilient.swift
@@ -19,7 +19,7 @@ import type_layout_dumper_other
 // CHECK-NEXT:   - Name:            24type_layout_dumper_other21ConcreteResilientEnumO
 // CHECK-NEXT:     Size:            9
 // CHECK-NEXT:     Alignment:       8
-// CHECK-NEXT:     ExtraInhabitants: 0
+// CHECK-NEXT:     ExtraInhabitants: 254
 // CHECK-NEXT:   - Name:            24type_layout_dumper_other22DependentResilientEnumO09NestedNonefG0O
 // CHECK-NEXT:     Size:            8
 // CHECK-NEXT:     Alignment:       8

--- a/test/IRGen/type_layout_objc.swift
+++ b/test/IRGen/type_layout_objc.swift
@@ -58,7 +58,7 @@ struct TypeLayoutTest<T> {
   // CHECK:       store i8** getelementptr inbounds (i8*, i8** @"$sBi64_WV", i32 8)
   var g: ESing
   // -- Multi-case enum, open-coded layout
-  // CHECK:    store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @type_layout_9_8_0_pod, i32 0, i32 0)
+  // CHECK:    store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_9_8_fe_pod, i32 0, i32 0)
   var h: EMult
   // -- Single-element generic struct, shares layout of its field (T)
   // CHECK:       [[T_LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[T_VALUE_WITNESSES]], i32 8

--- a/test/Interpreter/multi_payload_extra_inhabitant.swift
+++ b/test/Interpreter/multi_payload_extra_inhabitant.swift
@@ -1,0 +1,198 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -parse-stdlib -Xfrontend -verify-type-layout -Xfrontend SpareBitExtraInhabitants -Xfrontend -verify-type-layout -Xfrontend SpareBitSingleExtraInhabitant -Xfrontend -verify-type-layout -Xfrontend SpareBitNoExtraInhabitant -Xfrontend -verify-type-layout -Xfrontend SpareBitNoExtraInhabitant2 -Xfrontend -verify-type-layout -Xfrontend TwoTagExtraInhabitants -Xfrontend -verify-type-layout -Xfrontend ThreeTagExtraInhabitants -Xfrontend -verify-type-layout -Xfrontend NoTagExtraInhabitants -Xfrontend -verify-type-layout -Xfrontend DynamicExtraInhabitantsOneByte -Xfrontend -verify-type-layout -Xfrontend DynamicExtraInhabitantsTwoBytes -O -o %t/a.out %s
+// RUN: %target-run %t/a.out 2>&1
+
+// Type layout verifier is only compiled into the runtime in asserts builds.
+// REQUIRES: swift_stdlib_asserts
+
+// REQUIRES: executable_test
+
+// CHECK-NOT: Type verification
+
+
+import Swift
+import StdlibUnittest
+
+enum SpareBitExtraInhabitants {
+  case a(Builtin.Int30)
+  case b(Builtin.Int30)
+}
+
+enum SpareBitSingleExtraInhabitant {
+  case a(Builtin.Int30)
+  case b(Builtin.Int30)
+  case c(Builtin.Int30)
+}
+
+enum SpareBitNoExtraInhabitant {
+  case a(Builtin.Int30)
+  case b(Builtin.Int30)
+  case c(Builtin.Int30)
+  case d(Builtin.Int30)
+}
+
+enum SpareBitNoExtraInhabitant2 {
+  case a(Builtin.Int30)
+  case b(Builtin.Int30)
+  case c(Builtin.Int30)
+  case d
+}
+
+enum TwoTagExtraInhabitants {
+  case a(Builtin.Int32)
+  case b(Builtin.Int32)
+}
+
+enum ThreeTagExtraInhabitants {
+  case a(Builtin.Int32)
+  case b(Builtin.Int32)
+  case c(Builtin.Int32)
+}
+
+enum NoTagExtraInhabitants {
+  case aaa(Builtin.Int32), aab(Builtin.Int32), aac(Builtin.Int32), aad(Builtin.Int32), aae(Builtin.Int32), aaf(Builtin.Int32), aag(Builtin.Int32), aah(Builtin.Int32)
+  case aba(Builtin.Int32), abb(Builtin.Int32), abc(Builtin.Int32), abd(Builtin.Int32), abe(Builtin.Int32), abf(Builtin.Int32), abg(Builtin.Int32), abh(Builtin.Int32)
+  case aca(Builtin.Int32), acb(Builtin.Int32), acc(Builtin.Int32), acd(Builtin.Int32), ace(Builtin.Int32), acf(Builtin.Int32), acg(Builtin.Int32), ach(Builtin.Int32)
+  case ada(Builtin.Int32), adb(Builtin.Int32), adc(Builtin.Int32), add(Builtin.Int32), ade(Builtin.Int32), adf(Builtin.Int32), adg(Builtin.Int32), adh(Builtin.Int32)
+  case aea(Builtin.Int32), aeb(Builtin.Int32), aec(Builtin.Int32), aed(Builtin.Int32), aee(Builtin.Int32), aef(Builtin.Int32), aeg(Builtin.Int32), aeh(Builtin.Int32)
+  case afa(Builtin.Int32), afb(Builtin.Int32), afc(Builtin.Int32), afd(Builtin.Int32), afe(Builtin.Int32), aff(Builtin.Int32), afg(Builtin.Int32), afh(Builtin.Int32)
+  case aga(Builtin.Int32), agb(Builtin.Int32), agc(Builtin.Int32), agd(Builtin.Int32), age(Builtin.Int32), agf(Builtin.Int32), agg(Builtin.Int32), agh(Builtin.Int32)
+  case aha(Builtin.Int32), ahb(Builtin.Int32), ahc(Builtin.Int32), ahd(Builtin.Int32), ahe(Builtin.Int32), ahf(Builtin.Int32), ahg(Builtin.Int32), ahh(Builtin.Int32)
+
+  case baa(Builtin.Int32), bab(Builtin.Int32), bac(Builtin.Int32), bad(Builtin.Int32), bae(Builtin.Int32), baf(Builtin.Int32), bag(Builtin.Int32), bah(Builtin.Int32)
+  case bba(Builtin.Int32), bbb(Builtin.Int32), bbc(Builtin.Int32), bbd(Builtin.Int32), bbe(Builtin.Int32), bbf(Builtin.Int32), bbg(Builtin.Int32), bbh(Builtin.Int32)
+  case bca(Builtin.Int32), bcb(Builtin.Int32), bcc(Builtin.Int32), bcd(Builtin.Int32), bce(Builtin.Int32), bcf(Builtin.Int32), bcg(Builtin.Int32), bch(Builtin.Int32)
+  case bda(Builtin.Int32), bdb(Builtin.Int32), bdc(Builtin.Int32), bdd(Builtin.Int32), bde(Builtin.Int32), bdf(Builtin.Int32), bdg(Builtin.Int32), bdh(Builtin.Int32)
+  case bea(Builtin.Int32), beb(Builtin.Int32), bec(Builtin.Int32), bed(Builtin.Int32), bee(Builtin.Int32), bef(Builtin.Int32), beg(Builtin.Int32), beh(Builtin.Int32)
+  case bfa(Builtin.Int32), bfb(Builtin.Int32), bfc(Builtin.Int32), bfd(Builtin.Int32), bfe(Builtin.Int32), bff(Builtin.Int32), bfg(Builtin.Int32), bfh(Builtin.Int32)
+  case bga(Builtin.Int32), bgb(Builtin.Int32), bgc(Builtin.Int32), bgd(Builtin.Int32), bge(Builtin.Int32), bgf(Builtin.Int32), bgg(Builtin.Int32), bgh(Builtin.Int32)
+  case bha(Builtin.Int32), bhb(Builtin.Int32), bhc(Builtin.Int32), bhd(Builtin.Int32), bhe(Builtin.Int32), bhf(Builtin.Int32), bhg(Builtin.Int32), bhh(Builtin.Int32)
+
+  case caa(Builtin.Int32), cab(Builtin.Int32), cac(Builtin.Int32), cad(Builtin.Int32), cae(Builtin.Int32), caf(Builtin.Int32), cag(Builtin.Int32), cah(Builtin.Int32)
+  case cba(Builtin.Int32), cbb(Builtin.Int32), cbc(Builtin.Int32), cbd(Builtin.Int32), cbe(Builtin.Int32), cbf(Builtin.Int32), cbg(Builtin.Int32), cbh(Builtin.Int32)
+  case cca(Builtin.Int32), ccb(Builtin.Int32), ccc(Builtin.Int32), ccd(Builtin.Int32), cce(Builtin.Int32), ccf(Builtin.Int32), ccg(Builtin.Int32), cch(Builtin.Int32)
+  case cda(Builtin.Int32), cdb(Builtin.Int32), cdc(Builtin.Int32), cdd(Builtin.Int32), cde(Builtin.Int32), cdf(Builtin.Int32), cdg(Builtin.Int32), cdh(Builtin.Int32)
+  case cea(Builtin.Int32), ceb(Builtin.Int32), cec(Builtin.Int32), ced(Builtin.Int32), cee(Builtin.Int32), cef(Builtin.Int32), ceg(Builtin.Int32), ceh(Builtin.Int32)
+  case cfa(Builtin.Int32), cfb(Builtin.Int32), cfc(Builtin.Int32), cfd(Builtin.Int32), cfe(Builtin.Int32), cff(Builtin.Int32), cfg(Builtin.Int32), cfh(Builtin.Int32)
+  case cga(Builtin.Int32), cgb(Builtin.Int32), cgc(Builtin.Int32), cgd(Builtin.Int32), cge(Builtin.Int32), cgf(Builtin.Int32), cgg(Builtin.Int32), cgh(Builtin.Int32)
+  case cha(Builtin.Int32), chb(Builtin.Int32), chc(Builtin.Int32), chd(Builtin.Int32), che(Builtin.Int32), chf(Builtin.Int32), chg(Builtin.Int32), chh(Builtin.Int32)
+
+  case daa(Builtin.Int32), dab(Builtin.Int32), dac(Builtin.Int32), dad(Builtin.Int32), dae(Builtin.Int32), daf(Builtin.Int32), dag(Builtin.Int32), dah(Builtin.Int32)
+  case dba(Builtin.Int32), dbb(Builtin.Int32), dbc(Builtin.Int32), dbd(Builtin.Int32), dbe(Builtin.Int32), dbf(Builtin.Int32), dbg(Builtin.Int32), dbh(Builtin.Int32)
+  case dca(Builtin.Int32), dcb(Builtin.Int32), dcc(Builtin.Int32), dcd(Builtin.Int32), dce(Builtin.Int32), dcf(Builtin.Int32), dcg(Builtin.Int32), dch(Builtin.Int32)
+  case dda(Builtin.Int32), ddb(Builtin.Int32), ddc(Builtin.Int32), ddd(Builtin.Int32), dde(Builtin.Int32), ddf(Builtin.Int32), ddg(Builtin.Int32), ddh(Builtin.Int32)
+  case dea(Builtin.Int32), deb(Builtin.Int32), dec(Builtin.Int32), ded(Builtin.Int32), dee(Builtin.Int32), def(Builtin.Int32), deg(Builtin.Int32), deh(Builtin.Int32)
+  case dfa(Builtin.Int32), dfb(Builtin.Int32), dfc(Builtin.Int32), dfd(Builtin.Int32), dfe(Builtin.Int32), dff(Builtin.Int32), dfg(Builtin.Int32), dfh(Builtin.Int32)
+  case dga(Builtin.Int32), dgb(Builtin.Int32), dgc(Builtin.Int32), dgd(Builtin.Int32), dge(Builtin.Int32), dgf(Builtin.Int32), dgg(Builtin.Int32), dgh(Builtin.Int32)
+  case dha(Builtin.Int32), dhb(Builtin.Int32), dhc(Builtin.Int32), dhd(Builtin.Int32), dhe(Builtin.Int32), dhf(Builtin.Int32), dhg(Builtin.Int32), dhh(Builtin.Int32)
+}
+
+enum DynamicExtraInhabitants<T> {
+  case payloadA(T)
+  case payloadB(T)
+
+  case tagAAA, tagAAB, tagAAC, tagAAD, tagAAE, tagAAF, tagAAG, tagAAH
+  case tagABA, tagABB, tagABC, tagABD, tagABE, tagABF, tagABG, tagABH
+  case tagACA, tagACB, tagACC, tagACD, tagACE, tagACF, tagACG, tagACH
+  case tagADA, tagADB, tagADC, tagADD, tagADE, tagADF, tagADG, tagADH
+  case tagAEA, tagAEB, tagAEC, tagAED, tagAEE, tagAEF, tagAEG, tagAEH
+  case tagAFA, tagAFB, tagAFC, tagAFD, tagAFE, tagAFF, tagAFG, tagAFH
+  case tagAGA, tagAGB, tagAGC, tagAGD, tagAGE, tagAGF, tagAGG, tagAGH
+  case tagAHA, tagAHB, tagAHC, tagAHD, tagAHE, tagAHF, tagAHG, tagAHH
+  case tagAIA, tagAIB, tagAIC, tagAID, tagAIE, tagAIF, tagAIG, tagAIH
+
+  case tagBAA, tagBAB, tagBAC, tagBAD, tagBAE, tagBAF, tagBAG, tagBAH
+  case tagBBA, tagBBB, tagBBC, tagBBD, tagBBE, tagBBF, tagBBG, tagBBH
+  case tagBCA, tagBCB, tagBCC, tagBCD, tagBCE, tagBCF, tagBCG, tagBCH
+  case tagBDA, tagBDB, tagBDC, tagBDD, tagBDE, tagBDF, tagBDG, tagBDH
+  case tagBEA, tagBEB, tagBEC, tagBED, tagBEE, tagBEF, tagBEG, tagBEH
+  case tagBFA, tagBFB, tagBFC, tagBFD, tagBFE, tagBFF, tagBFG, tagBFH
+  case tagBGA, tagBGB, tagBGC, tagBGD, tagBGE, tagBGF, tagBGG, tagBGH
+  case tagBHA, tagBHB, tagBHC, tagBHD, tagBHE, tagBHF, tagBHG, tagBHH
+  case tagBIA, tagBIB, tagBIC, tagBID, tagBIE, tagBIF, tagBIG, tagBIH
+
+  case tagCAA, tagCAB, tagCAC, tagCAD, tagCAE, tagCAF, tagCAG, tagCAH
+  case tagCBA, tagCBB, tagCBC, tagCBD, tagCBE, tagCBF, tagCBG, tagCBH
+  case tagCCA, tagCCB, tagCCC, tagCCD, tagCCE, tagCCF, tagCCG, tagCCH
+  case tagCDA, tagCDB, tagCDC, tagCDD, tagCDE, tagCDF, tagCDG, tagCDH
+  case tagCEA, tagCEB, tagCEC, tagCED, tagCEE, tagCEF, tagCEG, tagCEH
+  case tagCFA, tagCFB, tagCFC, tagCFD, tagCFE, tagCFF, tagCFG, tagCFH
+  case tagCGA, tagCGB, tagCGC, tagCGD, tagCGE, tagCGF, tagCGG, tagCGH
+  case tagCHA, tagCHB, tagCHC, tagCHD, tagCHE, tagCHF, tagCHG, tagCHH
+  case tagCIA, tagCIB, tagCIC, tagCID, tagCIE, tagCIF, tagCIG, tagCIH
+
+  case tagDAA, tagDAB, tagDAC, tagDAD, tagDAE, tagDAF, tagDAG, tagDAH
+  case tagDBA, tagDBB, tagDBC, tagDBD, tagDBE, tagDBF, tagDBG, tagDBH
+  case tagDCA, tagDCB, tagDCC, tagDCD, tagDCE, tagDCF, tagDCG, tagDCH
+  case tagDDA, tagDDB, tagDDC, tagDDD, tagDDE, tagDDF, tagDDG, tagDDH
+  case tagDEA, tagDEB, tagDEC, tagDED, tagDEE, tagDEF, tagDEG, tagDEH
+  case tagDFA, tagDFB, tagDFC, tagDFD, tagDFE, tagDFF, tagDFG, tagDFH
+  case tagDGA, tagDGB, tagDGC, tagDGD, tagDGE, tagDGF, tagDGG, tagDGH
+  case tagDHA, tagDHB, tagDHC, tagDHD, tagDHE, tagDHF, tagDHG, tagDHH
+  case tagDIA, tagDIB, tagDIC, tagDID, tagDIE, tagDIF, tagDIG, tagDIH
+}
+
+typealias DynamicExtraInhabitantsOneByte = DynamicExtraInhabitants<UInt8>
+typealias DynamicExtraInhabitantsTwoBytes = DynamicExtraInhabitants<UInt16>
+
+var tests = TestSuite("extra inhabitants of structs")
+
+@inline(never)
+func expectHasAtLeastTwoExtraInhabitants<T>(_: T.Type,
+                                            nil theNil: T??,
+                                            someNil: T??,
+                                 file: String = #file, line: UInt = #line) {
+  expectEqual(MemoryLayout<T>.size, MemoryLayout<T??>.size,
+              "\(T.self) has at least two extra inhabitants",
+              file: file, line: line)
+
+  expectNil(theNil,
+            "\(T.self) extra inhabitant should agree in generic and concrete " +
+            "context")
+
+  expectNil(someNil!,
+            "\(T.self) extra inhabitant should agree in generic and concrete " +
+            "context")
+}
+
+@inline(never)
+func expectHasExtraInhabitant<T>(_: T.Type, nil theNil: T?,
+                                 file: String = #file, line: UInt = #line) {
+  expectEqual(MemoryLayout<T>.size, MemoryLayout<T?>.size,
+              "\(T.self) has extra inhabitant",
+              file: file, line: line)
+
+  expectNil(theNil,
+            "\(T.self) extra inhabitant should agree in generic and concrete " +
+            "context")
+}
+
+func expectHasNoExtraInhabitant<T>(_: T.Type,
+                                   file: String = #file, line: UInt = #line) {
+  expectNotEqual(MemoryLayout<T>.size, MemoryLayout<T?>.size,
+                 "\(T.self) does not have extra inhabitant",
+                 file: file, line: line)
+}
+
+tests.test("types that have no extra inhabitant") {
+  expectHasNoExtraInhabitant(SpareBitNoExtraInhabitant.self)
+  expectHasNoExtraInhabitant(SpareBitNoExtraInhabitant2.self)
+  expectHasNoExtraInhabitant(NoTagExtraInhabitants.self)
+}
+tests.test("types that have at least one extra inhabitant") {
+  expectHasExtraInhabitant(SpareBitExtraInhabitants.self, nil: nil)
+  expectHasExtraInhabitant(SpareBitSingleExtraInhabitant.self, nil: nil)
+  expectHasExtraInhabitant(TwoTagExtraInhabitants.self, nil: nil)
+  expectHasExtraInhabitant(ThreeTagExtraInhabitants.self, nil: nil)
+  expectHasExtraInhabitant(DynamicExtraInhabitantsOneByte.self, nil: nil)
+  expectHasExtraInhabitant(DynamicExtraInhabitantsTwoBytes.self, nil: nil)
+}
+tests.test("types that have at least two extra inhabitants") {
+  expectHasExtraInhabitant(SpareBitExtraInhabitants.self, nil: nil)
+  expectHasExtraInhabitant(TwoTagExtraInhabitants.self, nil: nil)
+  expectHasExtraInhabitant(ThreeTagExtraInhabitants.self, nil: nil)
+  expectHasExtraInhabitant(DynamicExtraInhabitantsOneByte.self, nil: nil)
+  expectHasExtraInhabitant(DynamicExtraInhabitantsTwoBytes.self, nil: nil)
+}
+runAllTests()

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1044,19 +1044,19 @@
 // CHECK-64-NEXT:       (field name=Indirect offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=multiPayloadConcrete offset=24
-// CHECK-64-NEXT:     (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:     (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2045 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=Left offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:       (field name=Right offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=multiPayloadGenericFixed offset=32
-// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=Left offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:       (field name=Right offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=multiPayloadGenericDynamic offset=48
-// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=Left offset=0
 // CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
@@ -1082,9 +1082,9 @@
 
 12TypeLowering23EnumStructWithOwnershipV
 // CHECK-64:      (struct TypeLowering.EnumStructWithOwnership)
-// CHECK-64-NEXT: (struct size=25 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=0
+// CHECK-64-NEXT: (struct size=25 alignment=8 stride=32 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-64-NEXT:   (field name=multiPayloadConcrete offset=0
-// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=0
+// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-64-NEXT:       (field name=Left offset=0
 // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-64-NEXT:           (field name=weakRef offset=0
@@ -1094,7 +1094,7 @@
 // CHECK-64-NEXT:           (field name=weakRef offset=0
 // CHECK-64-NEXT:             (reference kind=weak refcounting=native))))))
 // CHECK-64-NEXT:   (field name=multiPayloadGeneric offset=16
-// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=0
+// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-64-NEXT:       (field name=Left offset=0
 // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-64-NEXT:           (field name=weakRef offset=0
@@ -1105,9 +1105,9 @@
 // CHECK-64-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
 // CHECK-32:      (struct TypeLowering.EnumStructWithOwnership)
-// CHECK-32-NEXT: (struct size=13 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=0
+// CHECK-32-NEXT: (struct size=13 alignment=4 stride=16 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-32-NEXT:   (field name=multiPayloadConcrete offset=0
-// CHECK-32-NEXT:     (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=0
+// CHECK-32-NEXT:     (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-32-NEXT:       (field name=Left offset=0
 // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-32-NEXT:           (field name=weakRef offset=0
@@ -1117,7 +1117,7 @@
 // CHECK-32-NEXT:           (field name=weakRef offset=0
 // CHECK-32-NEXT:             (reference kind=weak refcounting=native))))))
 // CHECK-32-NEXT:   (field name=multiPayloadGeneric offset=8
-// CHECK-32-NEXT:     (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=0
+// CHECK-32-NEXT:     (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-32-NEXT:       (field name=Left offset=0
 // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-32-NEXT:           (field name=weakRef offset=0

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -50,9 +50,9 @@ reflect(object: obj)
 // CHECK-32: Type info:
 // CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=t offset=8
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128 bitwise_takable=1
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_str offset=0
-// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128 bitwise_takable=1
+// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -39,14 +39,14 @@ reflect(object: obj)
 // CHECK-32: Type info:
 // CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=t offset=8
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128 bitwise_takable=1
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_guts offset=0
-// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128 bitwise_takable=1
+// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_object offset=0
-// CHECK-32-NEXT:             (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128 bitwise_takable=1
+// CHECK-32-NEXT:             (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:               (field name=_variant offset=4
-// CHECK-32-NEXT:                 (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:                 (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=253 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:               (field name=_discriminator offset=9
 // CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=128 bitwise_takable=1

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -225,7 +225,7 @@ reflect(object: obj)
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t02 offset=16
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128 bitwise_takable=1
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_str offset=0
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t03 offset=28
@@ -271,7 +271,7 @@ reflect(object: obj)
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t16 offset=88
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128 bitwise_takable=1
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t17 offset=100
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1


### PR DESCRIPTION
Previously, they would forward their unused spare bits to be used by other multi-payload enums, but
did not implement anything for single-payload extra inhabitants.
