### PR TITLE
Evolution: Compare symbols before and after

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -671,6 +671,7 @@ public:
   }
 
   static LinkEntity forPropertyDescriptor(AbstractStorageDecl *decl) {
+    assert(decl->exportsPropertyDescriptor());
     LinkEntity entity;
     entity.setForDecl(Kind::PropertyDescriptor, decl);
     return entity;

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -118,6 +118,10 @@ enum class SubclassScope : uint8_t {
   /// This class can only be subclassed in this module.
   Internal,
 
+  /// This class is resilient so even public methods cannot be directly
+  /// referenced from outside the module.
+  Resilient,
+
   /// There is no class to subclass, or it is final.
   NotApplicable,
 };
@@ -249,6 +253,11 @@ inline SILLinkage effectiveLinkageForClassMember(SILLinkage linkage,
     if (linkage == SILLinkage::Private)
       return SILLinkage::Hidden;
     break;
+
+  case SubclassScope::Resilient:
+    if (isAvailableExternally(linkage))
+      return SILLinkage::HiddenExternal;
+    return SILLinkage::Hidden;
 
   case SubclassScope::NotApplicable:
     break;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5335,6 +5335,9 @@ bool AbstractFunctionDecl::isObjCInstanceMethod() const {
 }
 
 static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
+  if (!isa<ClassDecl>(decl->getDeclContext()))
+    return true;
+
   assert(isa<FuncDecl>(decl) || isa<ConstructorDecl>(decl));
 
   // Final members are always be called directly.

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -37,10 +37,11 @@ using namespace irgen;
 /// Emit a global variable.
 void IRGenModule::emitSILGlobalVariable(SILGlobalVariable *var) {
   auto &ti = getTypeInfo(var->getLoweredType());
-  
-  // If the variable is empty in all resilience domains, don't actually emit it;
-  // just return undef.
-  if (ti.isKnownEmpty(ResilienceExpansion::Minimal)) {
+  auto expansion = getResilienceExpansionForLayout(var);
+
+  // If the variable is empty in all resilience domains that can access this
+  // variable directly, don't actually emit it; just return undef.
+  if (ti.isKnownEmpty(expansion)) {
     if (DebugInfo && var->getDecl()) {
       auto DbgTy = DebugTypeInfo::getGlobal(var, Int8Ty, Size(0), Alignment(1));
       DebugInfo->emitGlobalVariableDeclaration(

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -334,7 +334,7 @@ extension ResilientGenericOutsideParent {
 
 // ResilientChild.field getter
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$s16class_resilience14ResilientChildC5fields5Int32Vvg"(%T16class_resilience14ResilientChildC* swiftself)
+// CHECK-LABEL: define hidden swiftcc i32 @"$s16class_resilience14ResilientChildC5fields5Int32Vvg"(%T16class_resilience14ResilientChildC* swiftself)
 // CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @"$s16class_resilience14ResilientChildC5fields5Int32VvpWvd"
 // CHECK-NEXT: [[PTR:%.*]] = bitcast %T16class_resilience14ResilientChildC* %0 to i8*
 // CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
@@ -347,7 +347,7 @@ extension ResilientGenericOutsideParent {
 
 // ResilientGenericChild.field getter
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$s16class_resilience21ResilientGenericChildC5fields5Int32Vvg"(%T16class_resilience21ResilientGenericChildC* swiftself)
+// CHECK-LABEL: define hidden swiftcc i32 @"$s16class_resilience21ResilientGenericChildC5fields5Int32Vvg"(%T16class_resilience21ResilientGenericChildC* swiftself)
 
 // FIXME: we could eliminate the unnecessary isa load by lazily emitting
 // metadata sources in EmitPolymorphicParameters

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -7,35 +7,35 @@
 sil_stage canonical
 import Swift
 
-struct S: Hashable {
-  var x: Int
-  let y: String
-  var z: C
-  var reabstracted: () -> ()
+public struct S: Hashable {
+  public var x: Int
+  public let y: String
+  public var z: C
+  public var reabstracted: () -> ()
 
-  var hashValue: Int { get }
-  static func ==(_: S, _: S) -> Bool
+  public var hashValue: Int { get }
+  public static func ==(_: S, _: S) -> Bool
 }
-class C: Hashable {
-  final var x: Int
-  final let y: String
-  final var z: S
-  var w: Int { get set }
+public class C: Hashable {
+  public final var x: Int
+  public final let y: String
+  public final var z: S
+  public var w: Int { get set }
 
-  init()
+  public init()
 
-  var hashValue: Int { get }
-  static func ==(_: C, _: C) -> Bool
-}
-
-struct G<T> {
-  var x: T { get set }
-  subscript<U: Hashable>(x: U) -> T { get set }
+  public var hashValue: Int { get }
+  public static func ==(_: C, _: C) -> Bool
 }
 
-class C1: C { }
-class C2: C1 {
-  var reabstracted: () -> ()
+public struct G<T> {
+  public var x: T { get set }
+  public subscript<U: Hashable>(x: U) -> T { get set }
+}
+
+public class C1: C { }
+public class C2: C1 {
+  public var reabstracted: () -> ()
 }
 
 sil_vtable C {}

--- a/test/IRGen/method_linkage.swift
+++ b/test/IRGen/method_linkage.swift
@@ -19,26 +19,22 @@
 class Base {
   // CHECK: define hidden swiftcc void @"$s14method_linkage4Base{{.*}}3foo0
   // RESILIENT: define hidden swiftcc void @"$s14method_linkage4Base{{.*}}3foo0
-  @inline(never)
   fileprivate func foo() {
   }
 
   // CHECK: define internal swiftcc void @"$s14method_linkage4Base{{.*}}3bar0
   // RESILIENT: define internal swiftcc void @"$s14method_linkage4Base{{.*}}3bar0
-  @inline(never)
   fileprivate final func bar() {
   }
 
   // CHECK: define hidden swiftcc void @"$s14method_linkage4Base{{.*}}5other0
   // RESILIENT: define hidden swiftcc void @"$s14method_linkage4Base{{.*}}5other0
-  @inline(never)
   fileprivate func other() {
   }
 }
 class Derived : Base {
   // CHECK: define internal swiftcc void @"$s14method_linkage7Derived{{.*}}3foo0
   // RESILIENT: define internal swiftcc void @"$s14method_linkage7Derived{{.*}}3foo0
-  @inline(never)
   fileprivate final override func foo() {
   }
 }
@@ -46,7 +42,6 @@ class Derived : Base {
 extension Base {
   // CHECK: define internal swiftcc void @"$s14method_linkage4Base{{.*}}7extfunc0
   // RESILIENT: define internal swiftcc void @"$s14method_linkage4Base{{.*}}7extfunc0
-  @inline(never)
   fileprivate func extfunc() {
   }
 }
@@ -56,14 +51,22 @@ public class PublicClass {
 
   // CHECK: define hidden swiftcc void @"$s14method_linkage11PublicClass{{.*}}4pfoo0
   // RESILIENT: define hidden swiftcc void @"$s14method_linkage11PublicClass{{.*}}4pfoo0
-  @inline(never)
   fileprivate func pfoo() {
   }
 
   // CHECK: define hidden swiftcc void @"$s14method_linkage11PublicClassC4pbaryyF
   // RESILIENT: define hidden swiftcc void @"$s14method_linkage11PublicClassC4pbaryyF
-  @inline(never)
   internal func pbar() {
+  }
+
+  // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage11PublicClassC4pbazyyF"
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage11PublicClassC4pbazyyF"
+  public func pbaz() {
+  }
+
+  // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage11PublicClassC5pquuxyyF"
+  // RESILIENT: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage11PublicClassC5pquuxyyF"
+  public final func pquux() {
   }
 }
 
@@ -72,24 +75,29 @@ open class OpenClass {
 
   // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage9OpenClassC4pfoo0
   // RESILIENT: define hidden swiftcc void @"$s14method_linkage9OpenClassC4pfoo0
-  @inline(never)
   fileprivate func pfoo() {
   }
 
   // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage9OpenClassC4pbaryyF
   // RESILIENT: define hidden swiftcc void @"$s14method_linkage9OpenClassC4pbaryyF
-  @inline(never)
   internal func pbar() {
+  }
+
+  // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage9OpenClassC4pbazyyF"
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage9OpenClassC4pbazyyF"
+  public func pbaz() {
+  }
+
+  // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage9OpenClassC5pquuxyyF"
+  // RESILIENT: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage9OpenClassC5pquuxyyF"
+  public final func pquux() {
   }
 }
 
 // Just in case anyone wants to delete unused methods...
-func callit(b: Base, p: PublicClass) {
+func callit(b: Base) {
   b.foo()
   b.bar()
   b.other()
   b.extfunc()
-  p.pfoo()
-  p.pbar()
 }
-

--- a/test/SILGen/global_resilience.swift
+++ b/test/SILGen/global_resilience.swift
@@ -7,7 +7,7 @@ import resilient_global
 
 public struct MyEmptyStruct {}
 
-// CHECK-LABEL: sil_global @$s17global_resilience13myEmptyGlobalAA02MyD6StructVvp : $MyEmptyStruct
+// CHECK-LABEL: sil_global private @$s17global_resilience13myEmptyGlobalAA02MyD6StructVvp : $MyEmptyStruct
 
 public var myEmptyGlobal = MyEmptyStruct()
 

--- a/test/SILGen/inline_always.swift
+++ b/test/SILGen/inline_always.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-emit-silgen -parse-as-library -enable-sil-ownership %s | tee /tmp/xxx | %FileCheck %s
+
+// CHECK-LABEL: sil hidden [always_inline] @$s13inline_always0b1_A7_calleeyyF : $@convention(thin) () -> ()
+@inline(__always)
+func always_inline_callee() {}
+
+protocol AlwaysInline {
+  func alwaysInlined()
+}
+
+struct AlwaysInlinedMember : AlwaysInline {
+  // CHECK-LABEL: sil hidden [always_inline] @$s13inline_always19AlwaysInlinedMemberV0bD0yyF : $@convention(method) (AlwaysInlinedMember) -> () {
+  @inline(__always)
+  func alwaysInlined() {}
+
+  @inline(__always)
+  var alwaysInlinedVar: Int {
+    // CHECK-LABEL: sil hidden [always_inline] @$s13inline_always19AlwaysInlinedMemberV0bD3VarSivg : $@convention(method) (AlwaysInlinedMember) -> Int
+    get { return 0 }
+
+    // CHECK-LABEL: sil hidden [always_inline] @$s13inline_always19AlwaysInlinedMemberV0bD3VarSivs : $@convention(method) (Int, @inout AlwaysInlinedMember) -> ()
+    set { }
+  }
+
+  // CHECK-LABEL: sil hidden [always_inline] @$s13inline_always19AlwaysInlinedMemberV0bD6GetterSivg : $@convention(method) (AlwaysInlinedMember) -> Int
+  var alwaysInlinedGetter: Int {
+    @inline(__always)
+    get { return 0 }
+  }
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] [always_inline] @$s13inline_always19AlwaysInlinedMemberVAA0C6InlineA2aDP0bD0yyFTW : $@convention(witness_method: AlwaysInline) (@in_guaranteed AlwaysInlinedMember) -> () {

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1160,9 +1160,11 @@ config.target_resilience_test = (
      % (config.rth, config.target_build_swift, config.target_run, 'lib',
         config.target_dylib_extension, config.target_codesign))
 
-config.target_resilience_test_wmo = (
-     ('%s --additional-compile-flags-library "-whole-module-optimization -parse-as-library"')
-     % (config.target_resilience_test))
+# FIXME: Get symbol diffing working with binutils nm as well. The flags are slightly
+# different.
+if platform.system() != 'Darwin':
+    config.target_resilience_test = ('%s --no-symbol-diff' %
+                                     config.target_resilience_test)
 
 #
 # When changing substitutions, update docs/Testing.rst.
@@ -1268,7 +1270,6 @@ config.substitutions.append(('%target-swiftdoc-name', config.target_swiftdoc_nam
 config.substitutions.append(('%target-object-format', config.target_object_format))
 config.substitutions.append(('%target-dylib-extension', config.target_dylib_extension))
 
-config.substitutions.append(('%target-resilience-test-wmo', config.target_resilience_test_wmo))
 config.substitutions.append(('%target-resilience-test', config.target_resilience_test))
 
 config.substitutions.append(('%llvm-profdata', config.llvm_profdata))

--- a/utils/rth
+++ b/utils/rth
@@ -32,12 +32,13 @@ def verbose_print_command(command):
 class ResilienceTest(object):
 
     def __init__(self, target_build_swift, target_run, target_codesign,
-                 tmp_dir, test_dir, test_src, lib_prefix, lib_suffix,
-                 additional_compile_flags_library,
-                 no_backward_deployment):
+                 target_nm, tmp_dir, test_dir, test_src, lib_prefix,
+                 lib_suffix, additional_compile_flags_library,
+                 no_backward_deployment, no_symbol_diff):
         self.target_build_swift = shlex.split(target_build_swift)
         self.target_run = shlex.split(target_run)
         self.target_codesign = shlex.split(target_codesign)
+        self.target_nm = shlex.split(target_nm)
         self.tmp_dir = tmp_dir
         self.test_dir = test_dir
         self.test_src = test_src
@@ -56,10 +57,12 @@ class ResilienceTest(object):
         self.lib_src = os.path.join(self.test_dir, 'Inputs', self.lib_src_name)
 
         self.no_backward_deployment = no_backward_deployment
+        self.no_symbol_diff = no_symbol_diff
 
     def run(self):
         self.set_up()
         self.compile_library()
+        self.compare_symbols()
         self.compile_main()
         self.link()
         self.execute()
@@ -101,6 +104,37 @@ class ResilienceTest(object):
             verbose_print_command(codesign_cmd)
             returncode = subprocess.call(codesign_cmd)
             assert returncode == 0, str(codesign_cmd)
+
+            if not self.no_symbol_diff:
+                # Global symbols only, don't display address or type, don't
+                # display undefined symbols
+                nm_cmd = self.target_nm + ["-gjU", output_dylib]
+                verbose_print_command(nm_cmd)
+
+                symbol_file = os.path.join(self.config_dir_map[config],
+                                           self.lib_name + ".symbols")
+
+                with open(symbol_file, "w") as handle:
+                    returncode = subprocess.call(nm_cmd, stdout=handle)
+                assert returncode == 0, str(nm_cmd)
+
+    def compare_symbols(self):
+        if self.no_symbol_diff:
+            return
+
+        before_symbol_file = os.path.join(self.config_dir_map["BEFORE"],
+                                          self.lib_name + ".symbols")
+        after_symbol_file = os.path.join(self.config_dir_map["AFTER"],
+                                         self.lib_name + ".symbols")
+
+        diff_cmd = ["diff",
+                    "--changed-group-format=%<",
+                    "--unchanged-group-format=",
+                    before_symbol_file, after_symbol_file]
+        try:
+            subprocess.check_output(diff_cmd)
+        except subprocess.CalledProcessError as e:
+            assert len(e.output) == 0, "Removed symbols:\n" + e.output
 
     def compile_main(self):
         for config in self.config_dir_map:
@@ -178,6 +212,7 @@ def main():
     parser.add_argument('--target-build-swift', required=True)
     parser.add_argument('--target-run', required=True)
     parser.add_argument('--target-codesign', default='echo')
+    parser.add_argument('--target-nm', default='nm')
     parser.add_argument('--t', required=True)
     parser.add_argument('--S', required=True)
     parser.add_argument('--s', required=True)
@@ -186,15 +221,18 @@ def main():
     parser.add_argument('--additional-compile-flags-library', default='')
     parser.add_argument('--no-backward-deployment', default=False,
                         action='store_true')
+    parser.add_argument('--no-symbol-diff', default=False,
+                        action='store_true')
 
     args = parser.parse_args()
 
     resilience_test = ResilienceTest(args.target_build_swift, args.target_run,
-                                     args.target_codesign,
+                                     args.target_codesign, args.target_nm,
                                      args.t, args.S, args.s, args.lib_prefix,
                                      args.lib_suffix,
                                      args.additional_compile_flags_library,
-                                     args.no_backward_deployment)
+                                     args.no_backward_deployment,
+                                     args.no_symbol_diff)
 
     return resilience_test.run()
 

--- a/validation-test/Evolution/Inputs/bitwise_takable.swift
+++ b/validation-test/Evolution/Inputs/bitwise_takable.swift
@@ -14,9 +14,9 @@ public var s5 = Subject(5)
 
 public struct Container : Reporter {
 #if BEFORE
-  public var v : Subject
+  var v : Subject
 #else
-  weak public var v : Subject?
+  weak var v : Subject?
 #endif
   public init(_ s: Subject) {
     v = s

--- a/validation-test/Evolution/Inputs/class_remove_property.swift
+++ b/validation-test/Evolution/Inputs/class_remove_property.swift
@@ -8,9 +8,9 @@ public final class RemoveStoredProperty {
     self.last = last
   }
 
-  public var first: String
-  public var middle: String
-  public var last: String
+  var first: String
+  var middle: String
+  var last: String
 
   public var name: String {
     return "\(first) \(middle) \(last)"

--- a/validation-test/Evolution/Inputs/enum_add_cases.swift
+++ b/validation-test/Evolution/Inputs/enum_add_cases.swift
@@ -8,7 +8,7 @@ public func getVersion() -> Int {
 
 public var starfishCount: Int = 0
 
-public class Starfish {
+public class Starfish : Hashable {
   public init() {
     starfishCount += 1
   }
@@ -16,6 +16,12 @@ public class Starfish {
   deinit {
     starfishCount -= 1
   }
+
+  public static func ==(lhs: Starfish, rhs: Starfish) -> Bool {
+    return true
+  }
+
+  public func hash(into: inout Hasher) {}
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -38,7 +44,7 @@ public func addNoPayloadToSingletonCases() -> [AddNoPayloadToSingleton] {
 
 ///////////////////////////////////////////////////////////////////////
 
-public enum AddPayloadToSingleton {
+public enum AddPayloadToSingleton : Hashable {
   case Cats
 #if AFTER
   case Horses(Starfish)
@@ -56,7 +62,7 @@ public func addPayloadToSingletonCases(_ s: Starfish)
 
 ///////////////////////////////////////////////////////////////////////
 
-public enum AddPayloadsToSingleton {
+public enum AddPayloadsToSingleton : Hashable {
   case Cats
 #if AFTER
   case Horses(Starfish)

--- a/validation-test/Evolution/Inputs/enum_add_cases_trap.swift
+++ b/validation-test/Evolution/Inputs/enum_add_cases_trap.swift
@@ -8,7 +8,7 @@ public func getVersion() -> Int {
 
 public var starfishCount: Int = 0
 
-public class Starfish {
+public class Starfish : Hashable {
   public init() {
     starfishCount += 1
   }
@@ -16,6 +16,12 @@ public class Starfish {
   deinit {
     starfishCount -= 1
   }
+
+  public static func ==(lhs: Starfish, rhs: Starfish) -> Bool {
+    return true
+  }
+
+  public func hash(into: inout Hasher) {}
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -38,7 +44,7 @@ public func addNoPayloadToSingletonCases() -> [AddNoPayloadToSingleton] {
 
 ///////////////////////////////////////////////////////////////////////
 
-public enum AddPayloadToSingleton {
+public enum AddPayloadToSingleton : Hashable {
   case Cats
 #if AFTER
   case Horses(Starfish)
@@ -56,7 +62,7 @@ public func addPayloadToSingletonCases(_ s: Starfish)
 
 ///////////////////////////////////////////////////////////////////////
 
-public enum AddPayloadsToSingleton {
+public enum AddPayloadsToSingleton : Hashable {
   case Cats
 #if AFTER
   case Horses(Starfish)

--- a/validation-test/Evolution/Inputs/struct_remove_property.swift
+++ b/validation-test/Evolution/Inputs/struct_remove_property.swift
@@ -8,9 +8,9 @@ public struct RemoveStoredProperty {
     self.last = last
   }
 
-  public var first: String
-  public var middle: String
-  public var last: String
+  var first: String
+  var middle: String
+  var last: String
 
   public var name: String {
     return "\(first) \(middle) \(last)"

--- a/validation-test/Evolution/test_global_change_size.swift
+++ b/validation-test/Evolution/test_global_change_size.swift
@@ -1,4 +1,4 @@
-// RUN: %target-resilience-test-wmo
+// RUN: %target-resilience-test
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/Evolution/test_keypaths.swift.gyb
+++ b/validation-test/Evolution/test_keypaths.swift.gyb
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t/rth)
 // RUN: env PYTHONPATH=%S/Inputs %gyb < %s > %t/test_keypaths.swift
 // RUN: env PYTHONPATH=%S/Inputs %gyb < %S/Inputs/keypaths.swift.gyb > %t/Inputs/keypaths.swift
-// RUN: %rth --target-build-swift "%target-build-swift" --target-run "%target-run" --t "%t/rth" --S "%t" --s "%t/test_keypaths.swift" --lib-prefix "lib" --lib-suffix ".%target-dylib-extension" --target-codesign "%target-codesign"
+// RUN: %rth --target-build-swift "%target-build-swift" --target-run "%target-run" --t "%t/rth" --S "%t" --s "%t/test_keypaths.swift" --lib-prefix "lib" --lib-suffix ".%target-dylib-extension" --target-codesign "%target-codesign" --no-symbol-diff
 
 // REQUIRES: executable_test
 

--- a/validation-test/Evolution/test_superclass_properties.swift
+++ b/validation-test/Evolution/test_superclass_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-resilience-test
+// RUN: %target-resilience-test --no-symbol-diff
 // REQUIRES: executable_test
 
 import StdlibUnittest


### PR DESCRIPTION
A resilient change should not *remove* previously-public symbols.

Part of <rdar://problem/40432647>.