### PR TITLE
[Driver] Don't suggest using the "major version" for -swift-version

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -103,8 +103,6 @@ ERROR(error_no_source_location_scope_map,none,
       "-dump-scope-maps argument must be 'expanded' or a list of "
       "source locations", ())
 
-NOTE(note_swift_version_major, none,
-     "use major version, as in '-swift-version %0'", (unsigned))
 NOTE(note_valid_swift_versions, none,
      "valid arguments to '-swift-version' are %0", (StringRef))
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -100,18 +100,10 @@ static void diagnoseSwiftVersion(Optional<version::Version> &vers, Arg *verArg,
   diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                  verArg->getAsString(Args), verArg->getValue());
 
-  // Check for an unneeded minor version, otherwise just list valid versions
-  if (vers.hasValue() && !vers.getValue().empty() &&
-      vers.getValue().asMajorVersion().getEffectiveLanguageVersion()) {
-    diags.diagnose(SourceLoc(), diag::note_swift_version_major,
-                   vers.getValue()[0]);
-  } else {
-    // Note valid versions instead
-    auto validVers = version::Version::getValidEffectiveVersions();
-    auto versStr =
-        "'" + llvm::join(validVers.begin(), validVers.end(), "', '") + "'";
-    diags.diagnose(SourceLoc(), diag::note_valid_swift_versions, versStr);
-  }
+  // Note valid versions.
+  auto validVers = version::Version::getValidEffectiveVersions();
+  auto versStr = "'" + llvm::join(validVers, "', '") + "'";
+  diags.diagnose(SourceLoc(), diag::note_valid_swift_versions, versStr);
 }
 
 /// \brief Create a new Regex instance out of the string value in \p RpassArg.

--- a/test/Driver/swift-version.swift
+++ b/test/Driver/swift-version.swift
@@ -6,18 +6,14 @@
 // RUN: not %target-swiftc_driver -swift-version 7.2 %s 2>&1 | %FileCheck --check-prefix BAD %s
 // RUN: not %target-swiftc_driver -swift-version 3.0 %s 2>&1 | %FileCheck --check-prefix BAD %s
 // RUN: not %target-swiftc_driver -swift-version 3.3 %s 2>&1 | %FileCheck --check-prefix BAD %s
-// RUN: not %target-swiftc_driver -swift-version 4.3 %s 2>&1 | %FileCheck --check-prefix FIXIT_4 %s
-// RUN: not %target-swiftc_driver -swift-version 5.1 %s 2>&1 | %FileCheck --check-prefix FIXIT_5 %s
+// RUN: not %target-swiftc_driver -swift-version 4.3 %s 2>&1 | %FileCheck --check-prefix BAD %s
+// RUN: not %target-swiftc_driver -swift-version 5.1 %s 2>&1 | %FileCheck --check-prefix BAD %s
 
 // RUN: not %target-swiftc_driver -swift-version 4 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_4 %s
 // RUN: not %target-swiftc_driver -swift-version 5 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_5 %s
 
 // BAD: invalid value
 // BAD: note: valid arguments to '-swift-version' are '4', '4.2', '5'
-
-// FIXIT_4: use major version, as in '-swift-version 4'
-// FIXIT_5: use major version, as in '-swift-version 5'
-
 
 #if swift(>=3)
 asdf


### PR DESCRIPTION
This was a nice feature when people said "-swift-version 3.1"...up until we got "-swift-version 4.2" as an actual valid version. Just drop the special case.

[SR-8850](https://bugs.swift.org/browse/SR-8850) / rdar://problem/44797691