### PR TITLE
[Runtime] Adjust "conforming type" based on a given conformance descriptor

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4124,7 +4124,7 @@ swift::swift_getAssociatedTypeWitness(MetadataRequest request,
     // For a class, chase the superclass chain up until we hit the
     // type that specified the conformance.
     auto originalConformingType = findConformingSuperclass(conformingType,
-                                                           protocol);
+                                                           conformance);
     SubstGenericParametersFromMetadata substitutions(originalConformingType);
     assocTypeMetadata = _getTypeByMangledName(mangledName, substitutions);
   }

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -452,11 +452,11 @@ public:
                            ProtocolDescriptorRef protocol,
                            const WitnessTable **conformance);
 
-  /// Given a type that we know conforms to the given protocol, find the
-  /// superclass that introduced the conformance.
-  const Metadata *findConformingSuperclass(const Metadata *type,
-                                           const ProtocolDescriptor *protocol);
-
+  /// Given a type that we know can be used with the given conformance, find
+  /// the superclass that introduced the conformance.
+  const Metadata *findConformingSuperclass(
+                             const Metadata *type,
+                             const ProtocolConformanceDescriptor *conformance);
 } // end namespace swift
 
 #endif /* SWIFT_RUNTIME_PRIVATE_H */


### PR DESCRIPTION
When we are looking for the specific type for a protocol conformance (e.g.,
because we may have a subclass of the type that declared conformances), don't
go back through `swift_conformsToProtocol()` multiple times, which
requires more lookups in the global conformance table. Instead, use
the (known) protocol conformance descriptor.
