### PR TITLE
fix documentaion for the Unicode.ParseResult

### DIFF
--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -22,8 +22,7 @@ extension Unicode {
   /// An encoding error was detected.
   ///
   /// `length` is the number of underlying code units consumed by this
-  /// error (the length of the longest prefix of a valid encoding
-  /// sequence that could be recognized).
+  /// error, guaranteed to be greater than 0.
   case error(length: Int)
 
     @inlinable // FIXME(sil-serialize-all)


### PR DESCRIPTION
The previous documentation was not accurate. It said that the length of
the error returned would be the length of the valid prefix. In case of
no valid prefix however the code will still return 1, contrary to the
documentation.
I fixed the documentation by adding the guarantee that the error length
will always be positive and removing the information about the valid
prefix as we might want to change the precise algorithm in the future.
