### PR TITLE
[NFC] Remove extraneous comment.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3569,7 +3569,6 @@ retry_after_fail:
       constraintKind == ConstraintKind::ValueMember &&
       memberName.isSimpleName() && !memberName.isSpecial()) {
     auto name = memberName.getBaseIdentifier();
-    // TC.extract
     if (hasDynamicMemberLookupAttribute(instanceTy, DynamicMemberLookupCache)) {
       auto &ctx = getASTContext();
 


### PR DESCRIPTION
I accidentally added a rogue comment in my last PR.
I planned on removing it in my next real PR, but I won't have time to work on it before the Swift 5 cutoff.
<sub>Sorry comment buddy, you aren't making it into `swift-5.0-branch`.</sub>