### PR TITLE
[IRGen] Record the Swift major/minor version in the top two bytes of the objc_image_info flags field.

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1089,19 +1089,23 @@ void IRGenModule::cleanupClangCodeGenMetadata() {
   // arbitrary keys to put in the image info.
 
   const char *ObjectiveCGarbageCollection = "Objective-C Garbage Collection";
+  uint8_t Major, Minor;
+  std::tie(Major, Minor) = version::getSwiftNumericVersion();
+  uint32_t Value = (Major << 24) | (Minor << 16) | (swiftVersion << 8);
+
   if (Module.getModuleFlag(ObjectiveCGarbageCollection)) {
     bool FoundOldEntry = replaceModuleFlagsEntry(
         Module.getContext(), Module, ObjectiveCGarbageCollection,
         llvm::Module::Override,
         llvm::ConstantAsMetadata::get(
-            llvm::ConstantInt::get(Int32Ty, (uint32_t)(swiftVersion << 8))));
+            llvm::ConstantInt::get(Int32Ty, Value)));
 
     (void)FoundOldEntry;
     assert(FoundOldEntry && "Could not replace old module flag entry?");
   } else
     Module.addModuleFlag(llvm::Module::Override,
                          ObjectiveCGarbageCollection,
-                         (uint32_t)(swiftVersion << 8));
+                         Value);
 }
 
 bool IRGenModule::finalize() {

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -147,6 +147,7 @@ class WeakObjC {
 // CHECK:  i32 1, !"Objective-C Version", i32 2}
 // CHECK:  i32 1, !"Objective-C Image Info Version", i32 0}
 // CHECK:  i32 1, !"Objective-C Image Info Section", !"__DATA,__objc_imageinfo,regular,no_dead_strip"}
-//   1536 == (6 << 8).  6 is the Swift ABI version.
-// CHECK:  i32 4, !"Objective-C Garbage Collection", i32 1536}
+//   67241472 == (4 << 24) | (2 << 16) | (6 << 8). 
+//     4 and 2 is the current major.minor version. 6 is the Swift ABI version.
+// CHECK:  i32 4, !"Objective-C Garbage Collection", i32 67241472}
 // CHECK:  i32 1, !"Swift Version", i32 6}


### PR DESCRIPTION
rdar://problem/44204568