### PR TITLE
[5.0] [ClangImporter] NS_ERROR_ENUMs can be redefined in separate modules

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredErrorEnum/Redeclared.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredErrorEnum/Redeclared.h
@@ -1,7 +1,16 @@
 @import Foundation;
+#ifndef NO_IMPORT_BASE_FROM_REDECLARED
 @import Base;
+#endif
 
 extern NSString * const SomeErrorDomain;
 // typedef NS_ERROR_ENUM(SomeErrorDomain, SomeErrorCode);
 typedef enum SomeErrorCode : long SomeErrorCode;
-enum __attribute__((ns_error_domain(SomeErrorDomain))) SomeErrorCode : long;
+enum __attribute__((ns_error_domain(SomeErrorDomain))) SomeErrorCode : long
+#ifdef NO_IMPORT_BASE_FROM_REDECLARED
+{
+  SomeErrorX,
+  SomeErrorY
+}
+#endif
+;

--- a/test/ClangImporter/enum-error-redeclared.swift
+++ b/test/ClangImporter/enum-error-redeclared.swift
@@ -1,4 +1,10 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -enable-objc-interop -I %S/Inputs/custom-modules/RedeclaredErrorEnum
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -enable-objc-interop -I %S/Inputs/custom-modules/RedeclaredErrorEnum -DIMPORT_BASE
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -enable-objc-interop -I %S/Inputs/custom-modules/RedeclaredErrorEnum -DIMPORT_BASE -Xcc -DNO_IMPORT_BASE_FROM_REDECLARED
+
+#if IMPORT_BASE
+import Base
+#endif
 
 import Redeclared
 


### PR DESCRIPTION
Cherry-pick of #20527 to the swift-5.0-branch. Reviewed by @harlanhaskins.

rdar://problem/45646620
rdar://problem/46066125