### PR TITLE
[ModuleInterface] <rdar://46073729> Temporarily disable module-cache-diagnostics test.

### DIFF
--- a/test/ParseableInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-diagnostics.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar46073729
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/modulecache)
 //


### PR DESCRIPTION
Nondeterministic failure, but disabling while investigating.

rdar://46073729