### PR TITLE
Fixed a bug in `TensorFunctionClassifier::shouldBePartitioned()`

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -350,7 +350,7 @@ bool tf::isAcceleratorOnly(const SILFunction &hostFn) {
 // public or marked @inline(never).
 //
 // For the remaining functions, we use the following heuristics to decide
-// whether to pratition them: If they take or return tensorflow values, inlining
+// whether to partition them: If they take or return tensorflow values, inlining
 // them is believed to be profittable for GPE, so we do not partition
 // them. Otherwise we partition them.
 bool TensorFunctionClassifier::shouldBePartitioned(SILFunction *fn,
@@ -385,9 +385,9 @@ bool TensorFunctionClassifier::shouldBePartitioned(SILFunction *fn,
     }
   }
 
-  // If this is a function that was inlined from some other module but only
-  // exists so we can see into it, don't transform it.  It won't be a canonical
-  // declaration for anything anyway.
+  // If this is a function defined in some other module, don't transform it.
+  // We might still try inlining it into some call-sites defined in this module,
+  // but we never partition externally defined functions.
   if (isAvailableExternally(fn->getLinkage()))
     return false;
 

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -424,10 +424,10 @@ bool TensorFunctionClassifier::shouldBePartitioned(SILFunction *fn,
 
   // Part 3: Use function signature to decide whether to partition.
 
-  // Otherwise, the function is either (public and inlininable) or it is
-  // internal to the current module.  In both cases, we check to see if the
-  // function takes tensorflow values as arguments or results.  If so, it will
-  // be inlined away by deabstraction, and we don't need to touch it.
+  // Otherwise, the function is either (public and inlinable) or it is internal
+  // to the current module.  In both cases, we check to see if the function
+  // takes tensorflow values as arguments or results.  If so, it will be inlined
+  // away by deabstraction, and we don't need to touch it.
   if (containsTensorFlowValue(fn->getLoweredFunctionType())) {
     if (forceTFFunctions) {
       // Return true if it is referenced somewhere.


### PR DESCRIPTION
, which returned true for `_hostOp<A>(_:)` defined in the tensorflow stdlib, when we are
compiling a user module.

The bug was because we were evaluating `if (fn->getInlineStrategy() == NoInline)` (it is true for `_hostOp<A>(_:)`) before evaluating `if (isAvailableExternally(fn->getLinkage()))` (also true for
`_hostOp<A>(_:)`). But for any externally defined functions, they should not be
partitioned when compiling the user module.

Rearranged the code and added comments to improve its readability. Now we first
handle cases where we return false, and then the cases where we return true.
