### PR TITLE
Fix abi_v7k.swift test

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1625,8 +1625,9 @@ extension ${Self} {
 
   // We "shouldn't" need this, but the typechecker barfs on an expression
   // in the test suite without it.
-  @inlinable // FIXME(inline-always)
-  @inline(__always)
+  // If replaced with @inline(__always) the init no longer gets
+  // inlined in -Onone and this breaks the abi_v7k test in a subtle way.
+  @_transparent
   public init(_ v: Int) {
     _value = Builtin.sitofp_Int${word_bits}_FPIEEE${bits}(v._value)
   }

--- a/test/IRGen/abi_v7k.swift
+++ b/test/IRGen/abi_v7k.swift
@@ -3,7 +3,6 @@
 
 // REQUIRES: CPU=armv7k
 // REQUIRES: OS=watchos
-// REQUIRES: rdar45306568
 
 // CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k9addFloats{{.*}}"(float, float)
 // CHECK: fadd float %0, %1
@@ -179,7 +178,7 @@ func testSingleP(x: SinglePayload) -> Double {
 // V7K-LABEL: _$s8test_v7k0A6MultiP
 // V7K:        vldr     d16, [sp{{.*}}]
 // V7K:        vmov.f64 d0, d16
-// V7K:        pop     {{{.*}}}
+// V7K:        bx lr
 // Backend will assign r0, r1 and r2 for input parameters and d0 for return values.
 class Bignum {}
 enum MultiPayload {


### PR DESCRIPTION
The test seems to rely on the fact that Double.init(_: Int) gets inlined
in -Onone.

Fixes: <rdar://problem/45306568>