### PR TITLE
Taught deabstraction and function inline infra to dump under debug log CSV-formatted events for code size measurement.

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -412,6 +412,10 @@ public:
 
   void eraseInstructions();
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Get estimated code size, for debugging only.
+  unsigned codeSize() const { return InstList.size(); }
+
 private:
   friend class SILArgument;
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -997,6 +997,9 @@ public:
   /// Like ViewCFG, but the graph does not show the contents of basic blocks.
   void viewCFGOnly() const;
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Get estimated code size, for debugging only.
+  unsigned codeSize() const;
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -535,6 +535,13 @@ bool SILFunction::shouldVerifyOwnership() const {
   return !hasSemanticsAttr("verify.ownership.sil.never");
 }
 
+unsigned SILFunction::codeSize() const {
+  unsigned size = 0;
+  for (auto &BB : *this)
+    size += BB.codeSize();
+  return size;
+}
+
 // See swift/Basic/Statistic.h for declaration: this enables tracing
 // SILFunctions, is defined here to avoid too much layering violation / circular
 // linkage dependency.


### PR DESCRIPTION
The initial code size metric of a function is defined by the number of SIL
instructions in the function.

Under a newly added compiler flag `-Xllvm -tf-log-deabstraction-stats`, we dump
CSV-formatted events for 2 tables.

# Table schemas

## Table 1: Function size.

The table schema is: "S4TF FuncSize", FuncName, Size, StageName

Here StageName can be one of {"BeforeInline", "AfterInline", "AfterDA"}

This gives us the code size impact of doing inlining and running the
deabstraction pass over SIL functions.

## Table 2: Call graph information used by function inliner

Table schema is: "S4TF CallEdge", ParentName, ParentSizeBefore, ParentSizeAfter, ChildName, ChildSize

Each time when a function `child()` gets inlined into another function
`parent()`, we write such a record, where we log the parent size before and
after the inlining, and the child size.

# Analysis workflow

Based on the above tables, we can do SQL based analysis, similar to
https://github.com/apple/swift/pull/20558.

For example, to analyze table `#2` above, first dump the CSV log via a command like:

```
$ time ../build/$rdir/swift-linux-x86_64/bin/swiftc -frontend -emit-sil -O -Xllvm -tf-dump-intermediates -Xllvm -tf-log-deabstraction-stats ResNet/main_perf.swift >/tmp/raw_log3 2>&1 && grep 'S4TF CallEdge' /tmp/raw_log3 > /tmp/call.log3
```

Next, run `sqlite3 profile.db`. In the `sqlite>` prompt, do the following:

```sql
drop table c;

CREATE TABLE c(
  "S4TF" TEXT,
  "ParentName" TEXT,
  "ParentSizeBefore" INTEGER,
  "ParentSizeAfter" INTEGER,
  "ChildName" TEXT,
  "ChildSize" INTEGER,
  "CallDepth" INTEGER
);

.separator ","
-- call.log stores all CSV events labelled "S4TF CallEdge"
.import /tmp/call.log c

select count(*) from c;
```

Some example SQL queries for analysis:
```sql
-- Which child functions increase code size most after being inlined.
-- Here we filter out functions that are online inlined once, since such
-- inlining would not increase code size, as long as the child function gets
-- deleted after inlining.
SELECT ChildName, COUNT(*) cnt, SUM(ChildSize)
FROM c
GROUP BY 1
HAVING cnt > 1
ORDER BY 3 DESC
LIMIT 10;

-- Find the top K largest children that get inlined into a particular parent
SELECT MIN(ParentSizeBefore), MAX(ParentSizeAfter), ChildName, COUNT(*), SUM(ChildSize)
FROM c
WHERE ParentName = '$s9main_perf3run33_01E2ABC548C103A0BD150EB87B3A1DADLLyyF'
GROUP BY 3
ORDER BY 5 DESC;
```

# Use case study 

Based on the above analysis, we are able to figure out which functions in a
resnet50 model contributed most to code size bloat (and compile time increase)
because of them getting inlined. After marking them with `@inline(never)`, the
compilation cost dropped from 2 minutes to 3 seconds.
