### PR TITLE
tools: remove unnecessary LLVM_COMPONENT linkage

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -7,8 +7,6 @@ add_swift_host_tool(swift
   LINK_LIBRARIES
     swiftDriver
     swiftFrontendTool
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT compiler
 )
 

--- a/tools/lldb-moduleimport-test/CMakeLists.txt
+++ b/tools/lldb-moduleimport-test/CMakeLists.txt
@@ -2,8 +2,6 @@ add_swift_host_tool(lldb-moduleimport-test
   lldb-moduleimport-test.cpp
   LINK_LIBRARIES
     swiftASTSectionImporter swiftFrontend swiftClangImporter
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
 

--- a/tools/sil-func-extractor/CMakeLists.txt
+++ b/tools/sil-func-extractor/CMakeLists.txt
@@ -6,7 +6,5 @@ add_swift_host_tool(sil-func-extractor
     swiftSILOptimizer
     swiftSerialization
     swiftClangImporter
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )

--- a/tools/sil-llvm-gen/CMakeLists.txt
+++ b/tools/sil-llvm-gen/CMakeLists.txt
@@ -8,7 +8,5 @@ add_swift_host_tool(sil-llvm-gen
     # Clang libraries included to appease the linker on linux.
     clangBasic
     clangCodeGen
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )

--- a/tools/sil-nm/CMakeLists.txt
+++ b/tools/sil-nm/CMakeLists.txt
@@ -6,7 +6,5 @@ add_swift_host_tool(sil-nm
     swiftSILOptimizer
     swiftSerialization
     swiftClangImporter
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -8,7 +8,5 @@ add_swift_host_tool(sil-opt
     # Clang libraries included to appease the linker on linux.
     clangBasic
     clangCodeGen
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )

--- a/tools/sil-passpipeline-dumper/CMakeLists.txt
+++ b/tools/sil-passpipeline-dumper/CMakeLists.txt
@@ -9,7 +9,5 @@ add_swift_host_tool(sil-passpipeline-dumper
     # FIXME: Circular dependencies require re-listing these libraries.
     swiftSema
     swiftAST
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -6,8 +6,6 @@ add_swift_host_tool(swift-ide-test
     swiftDriver
     swiftFrontend
     swiftIDE
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
   SWIFT_COMPONENT tools
 )
 

--- a/tools/swift-llvm-opt/CMakeLists.txt
+++ b/tools/swift-llvm-opt/CMakeLists.txt
@@ -11,8 +11,5 @@ add_swift_host_tool(swift-llvm-opt
   clangBasic
   clangCodeGen
 
-  LLVM_COMPONENT_DEPENDS
-    DebugInfoCodeView
-
   SWIFT_COMPONENT tools
 )


### PR DESCRIPTION
Remove the unncessary link against the DebugInfoCodeView component.  THe tools
seem to build without the dependency.  The dependency issue in the linkage
seems to have been resolved.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
