### PR TITLE
Completed graph_op support for different forms of dynamism in graph mode

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -150,7 +150,7 @@ namespace {
   private:
     void logCurrentState(const char *name, bool isDetailed);
     void inlineCalls();
-    bool simplifyTensorOperands();
+    void simplifyTensorOperands();
 
     void promoteToSSA(ArrayRef<AllocStackInst *> allocs);
     void prepareStackAllocForPromotion(AllocStackInst *alloc);
@@ -344,18 +344,22 @@ static SILValue lookThroughSingleElementStructInsts(SILValue value) {
   return value;
 }
 
-/// Scan the argument list of the graph_op.  If any argument is passed indirectly
-/// (i.e., an address of a stack location is passed instead of the value itself)
-/// then rewrite the graph_op to use a loaded version of that value.
+/// Scan the argument list of the graph_op.  If any argument is passed
+/// indirectly (i.e., an address of a stack location is passed instead of the
+/// value itself) then rewrite the graph_op to use a loaded version of that
+/// value.
 ///
-/// Similarly, if an argument is an indirect output, then rewrite the graph_op to
-/// return the value directly, and emit an instruction that stores the direct
+/// Similarly, if an argument is an indirect output, then rewrite the graph_op
+/// to return the value directly, and emit an instruction that stores the direct
 /// value to the indirect output address.
 ///
 /// Also, if a primitive integer or floating point value is passed as a struct
 /// value, extract out the underlying integer or float value.
 ///
-/// Returns nullptr on error.
+/// Returns nullptr when we fail to simplify `origInst` (e.g. when the result of
+/// that graph_op is not loadable, such that this op cannot be included in the
+/// extracted graph). In that case, we can still run this graph_op via eager op
+/// dispatch.
 ///
 static GraphOperationInst *simplifyOperands(GraphOperationInst *origInst,
                                             TFDeabstraction &TFDA) {
@@ -459,14 +463,8 @@ static GraphOperationInst *simplifyOperands(GraphOperationInst *origInst,
       auto argumentType = argumentValue->getType();
       assert(argumentType.isAddress());
       if (!argumentType.isLoadable(origInst->getModule())) {
-        auto astType = argumentType.getASTType();
-        if (astType->hasArchetype()) {
-          diagnose(ctx, getUserSourceLocation(origInst).getSourceLoc(),
-                   diag::tf_op_result_generic, astType);
-        } else {
-          diagnose(ctx, getUserSourceLocation(origInst).getSourceLoc(),
-                   diag::tf_op_result_not_value_or_aggregate, astType);
-        }
+        // In graph mode, we will run this graph_op out-of-graph, via eager op
+        // dispatch.
         return nullptr;
       }
       assert(origInst->getNumResults() == 0 &&
@@ -633,12 +631,9 @@ static bool explodeAggregateInst(SILInstruction *inst,
 /// Since we're scanning the function, keep track of all of the tensor
 /// operations to avoid additional linear scans over the function.
 ///
-/// Returns true on error.
-///
-bool TFDeabstraction::simplifyTensorOperands() {
+void TFDeabstraction::simplifyTensorOperands() {
   llvm::PrettyStackTraceFormat X("TFDeabstraction::simplifyTensorOperands");
   bool containsGraphOp = false;
-  bool hasError = false;
 
   bool alreadyPrinted = false;
   auto logIfFirstChange = [&]() {
@@ -660,7 +655,7 @@ bool TFDeabstraction::simplifyTensorOperands() {
         auto newInst = simplifyOperands(graphOpInst, *this);
 
         if (!newInst) {
-          hasError = true;
+          graphOpInst->setNoClustering(true);
           continue;
         }
 
@@ -726,8 +721,6 @@ bool TFDeabstraction::simplifyTensorOperands() {
   // working on the host-side tensor operation.
   if (!containsGraphOp)
     tensorOps.clear();
-
-  return hasError;
 }
 
 namespace {
@@ -2284,6 +2277,9 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
   };
 
   GraphOperationBuilder opBuilder(opInfo.getOperationName());
+  // When any deabstraction step fails below (e.g. cannot const-evaluate a tfop
+  // attribute), `noClustering` is set to true so that we run the graph_op
+  // out-of-graph via eager op dispatch.
   bool noClustering = false;
 
   // Find the device attribute specified for the instruction if present.
@@ -2355,14 +2351,14 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
           if (unpackTensorAggregates(context, origInst->getLoc(), B, element,
                                      loweredTupleElts, loweredStructFields,
                                      unwrapCache, inputList)) {
-            diagnoseInvalid(argumentLoc,
-                            "argument of type '" + elementType->getString() +
-                            "' is not a TensorFlow value or an aggregate of "
-                            "TensorFlow values");
-            return;
+            noClustering = true;
+            break;
           }
         }
-        opBuilder.addListArgument(inputList);
+        if (noClustering)
+          opBuilder.addArgument(argumentValue);
+        else
+          opBuilder.addListArgument(inputList);
         continue;
       }
 
@@ -2370,19 +2366,14 @@ void TFDeabstraction::evaluateAttributesAndDoPacking(
       if (unpackTensorAggregates(context, origInst->getLoc(), B, argumentValue,
                                  loweredTupleElts, loweredStructFields,
                                  unwrapCache, inputList)) {
-        // FIXME: Since TFDeabstraction happens after mandatory inlining,
-        // numeric arguments will appear as having a builtin type such as
-        // `Builtin.FPIEEE32`. This is undesirable for user-facing diagnostics.
-        auto astTypeString = argumentTy.getASTType().getString();
-        diagnoseInvalid(argumentLoc,
-                        "argument of type '" + astTypeString +
-                        "' is not a TensorFlow value or an aggregate of "
-                        "TensorFlow values");
-        return;
+        noClustering = true;
+        opBuilder.addArgument(argumentValue);
+        continue;
       }
       if (inputList.size() == 1) {
         opBuilder.addArgument(inputList[0]);
       } else {
+        assert(inputList.size() > 1);
         opBuilder.addListArgument(inputList);
       }
       continue;
@@ -2539,8 +2530,7 @@ void TFDeabstraction::doIt() {
 
   // Scan for any Tensor operations, removing indirect operands and structs that
   // interfere with SSA construction.
-  if (simplifyTensorOperands())
-    return;
+  simplifyTensorOperands();
 
   // If we didn't find any ops, early exit processing of this function to save
   // compile time.

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -4680,19 +4680,6 @@ bool TFPartition::partitionFunction(
   LLVM_DEBUG(llvm::dbgs() << "  " << hostFn->getName()
                           << " contains tensor op(s).\n");
 
-  // Check to see if we cannot transform the function but should.  In this
-  // case we emit a compiler error.  This is a limitation of the compiler that
-  // will need to be resolved in the future (possibly through a model change),
-  // it's not clear if we should allow partitioning to work on unspecialized
-  // generics.
-  if (hostFn->getLoweredFunctionType()->isPolymorphic()) {
-    auto &ctx = hostFn->getASTContext();
-    diagnose(ctx, hostFn->getLocation().getSourceLoc(), diag::tf_internal_error,
-             "TensorFlow graph program extraction does not work on generic "
-             "functions yet");
-    return true;
-  }
-
   // Because we're in active development, it is common to do something wrong
   // in the TensorFlow module.  Detect and reject things here.
   if (hostFn->getModule().getSwiftModule() == tfModule) {

--- a/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
@@ -1,3 +1,4 @@
+// RUN: %target-run-simple-swift
 // RUN: %target-run-dynamic-compilation-swift
 // REQUIRES: executable_test
 


### PR DESCRIPTION
Examples include generic types and array-typed inputs without unknown size at compile time.

This is a follow-up to https://github.com/apple/swift/pull/20507, which added dynamic attribute support.
