### PR TITLE
[Runtime] Allow overrides or swift_getAssociated(Type|Conformance)Witness

### DIFF
--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -44,6 +44,7 @@
 #  define OVERRIDE_FOREIGN OVERRIDE
 #  define OVERRIDE_PROTOCOLCONFORMANCE OVERRIDE
 #  define OVERRIDE_KEYPATH OVERRIDE
+#  define OVERRIDE_WITNESSTABLE OVERRIDE
 #else
 #  ifndef OVERRIDE_METADATALOOKUP
 #    define OVERRIDE_METADATALOOKUP(...)
@@ -62,6 +63,9 @@
 #  endif
 #  ifndef OVERRIDE_KEYPATH
 #    define OVERRIDE_KEYPATH(...)
+#  endif
+#  ifndef OVERRIDE_WITNESSTABLE
+#    define OVERRIDE_WITNESSTABLE(...)
 #  endif
 #endif
 
@@ -140,6 +144,22 @@ OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , swift::,
                  (const void *pattern, const void *arguments),
                  (pattern, arguments))
 
+OVERRIDE_WITNESSTABLE(getAssociatedTypeWitnessSlow, MetadataResponse,
+                      SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL, swift::,
+                      (MetadataRequest request, WitnessTable *wtable,
+                       const Metadata *conformingType,
+                       const ProtocolRequirement *reqBase,
+                       const ProtocolRequirement *assocType),
+                      (request, wtable, conformingType, reqBase, assocType))
+
+OVERRIDE_WITNESSTABLE(getAssociatedConformanceWitnessSlow, const WitnessTable *,
+                      SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL, swift::,
+                      (WitnessTable *wtable, const Metadata *conformingType,
+                       const Metadata *assocType,
+                       const ProtocolRequirement *reqBase,
+                       const ProtocolRequirement *assocConformance),
+                      (wtable, conformingType, assocType, reqBase,
+                               assocConformance))
 #if SWIFT_OBJC_INTEROP
 
 OVERRIDE_OBJC(dynamicCastObjCClass, const void *, , swift::,
@@ -183,3 +203,4 @@ OVERRIDE_FOREIGN(dynamicCastForeignClassUnconditional, const void *, , swift::,
 #undef OVERRIDE_FOREIGN
 #undef OVERRIDE_PROTOCOLCONFORMANCE
 #undef OVERRIDE_KEYPATH
+#undef OVERRIDE_WITNESSTABLE

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -457,6 +457,40 @@ public:
   const Metadata *findConformingSuperclass(
                              const Metadata *type,
                              const ProtocolConformanceDescriptor *conformance);
+
+  /// Retrieve an associated type witness from the given witness table.
+  ///
+  /// \param wtable The witness table.
+  /// \param conformingType Metadata for the conforming type.
+  /// \param reqBase "Base" requirement used to compute the witness index
+  /// \param assocType Associated type descriptor.
+  ///
+  /// \returns metadata for the associated type witness.
+  SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+  MetadataResponse swift_getAssociatedTypeWitnessSlow(
+                                        MetadataRequest request,
+                                        WitnessTable *wtable,
+                                        const Metadata *conformingType,
+                                        const ProtocolRequirement *reqBase,
+                                        const ProtocolRequirement *assocType);
+
+  /// Retrieve an associated conformance witness table from the given witness
+  /// table.
+  ///
+  /// \param wtable The witness table.
+  /// \param conformingType Metadata for the conforming type.
+  /// \param assocType Metadata for the associated type.
+  /// \param reqBase "Base" requirement used to compute the witness index
+  /// \param assocConformance Associated conformance descriptor.
+  ///
+  /// \returns corresponding witness table.
+  SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+  const WitnessTable *swift_getAssociatedConformanceWitnessSlow(
+                                  WitnessTable *wtable,
+                                  const Metadata *conformingType,
+                                  const Metadata *assocType,
+                                  const ProtocolRequirement *reqBase,
+                                  const ProtocolRequirement *assocConformance);
 } // end namespace swift
 
 #endif /* SWIFT_RUNTIME_PRIVATE_H */

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -24,6 +24,17 @@ using namespace swift;
 bool EnableOverride;
 bool Ran;
 
+namespace  {
+  template<typename T>
+  T getEmptyValue() {
+    return (T)0;
+  }
+
+  template<>
+  MetadataResponse getEmptyValue<MetadataResponse>() {
+    return MetadataResponse{nullptr, MetadataState::Complete};
+  }
+}
 
 #define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
   static ret name ## Override(COMPATIBILITY_UNPAREN typedArgs,      \
@@ -31,7 +42,7 @@ bool Ran;
     if (!EnableOverride)                                            \
       return originalImpl namedArgs;                                \
     Ran = true;                                                     \
-    return (ret)0;                                                  \
+    return getEmptyValue<ret>();                                    \
   }
 #include "../../stdlib/public/runtime/CompatibilityOverride.def"
 
@@ -162,6 +173,22 @@ TEST_F(CompatibilityOverrideTest,
 TEST_F(CompatibilityOverrideTest, test_swift_conformsToProtocol) {
   auto Result = swift_conformsToProtocol(nullptr, nullptr);
   ASSERT_EQ(Result, nullptr);  
+}
+
+TEST_F(CompatibilityOverrideTest, test_swift_getAssociatedTypeWitnessSlow) {
+  auto Result = swift_getAssociatedTypeWitnessSlow(MetadataState::Complete,
+                                                   nullptr, nullptr,
+                                                   nullptr, nullptr);
+  ASSERT_EQ(Result.Value, nullptr);
+  ASSERT_EQ(Result.State, MetadataState::Complete);
+}
+
+TEST_F(CompatibilityOverrideTest,
+       test_swift_getAssociatedConformanceWitnessSlow) {
+  auto Result = swift_getAssociatedConformanceWitnessSlow(
+                                                   nullptr, nullptr, nullptr,
+                                                   nullptr, nullptr);
+  ASSERT_EQ(Result, nullptr);
 }
 
 #endif


### PR DESCRIPTION
Split these two functions into a fast path (for the cached case) and a slow
path. Make the slow path overridable, so we can patch it in the future if
needed.
