### PR TITLE
[TF] Fix macOS builds by switching to `llvm::sys::toTimeT`

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -354,7 +354,7 @@ void SILPassManager::dumpPassInfo(const char *Title, unsigned TransIdx,
 static void logS4TFPassEvent(long long Delta, llvm::sys::TimePoint<> StartTime,
                              StringRef passName, bool isFunctionPass,
                              StringRef funcName) {
-  auto tt = std::chrono::system_clock::to_time_t(StartTime);
+  auto tt = llvm::sys::toTimeT(StartTime);
   auto strTime = ctime(&tt);
   strTime[strlen(strTime) - 1] = '\0';
   llvm::dbgs() << "S4TF," << Delta << "," << strTime << "," << passName << ","


### PR DESCRIPTION
PR #20558 used `std::chrono::system_clock::to_time_t` which is not compatible with input argument of type `llvm::sys::TimePoint<>` on macOS due to template argument mismatch. It broke macOS builds. This patch fixes the build by switching from STL to `llvm::sys::toTimeT`.