### PR TITLE
Ast dump ignore wmo

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -42,27 +42,26 @@
 DIAG(REMARK,ID,Options,Text,Signature)
 #endif
 
-WARNING(warning_parallel_execution_not_supported, none,
+WARNING(warning_parallel_execution_not_supported,none,
         "parallel execution not supported; falling back to serial execution",
         ())
 
-ERROR(error_unable_to_execute_command, none,
+ERROR(error_unable_to_execute_command,none,
       "unable to execute command: %0", (StringRef))
-ERROR(error_command_signalled_without_signal_number, none,
+ERROR(error_command_signalled_without_signal_number,none,
       "%0 command failed due to signal (use -v to see invocation)", (StringRef))
-ERROR(error_command_signalled, none,
-      "%0 command failed due to signal %1 (use -v to see invocation)",
-      (StringRef, int))
-ERROR(error_command_failed, none,
+ERROR(error_command_signalled,none,
+      "%0 command failed due to signal %1 (use -v to see invocation)", (StringRef, int))
+ERROR(error_command_failed,none,
       "%0 command failed with exit code %1 (use -v to see invocation)",
       (StringRef, int))
 
-ERROR(error_expected_one_frontend_job, none,
+ERROR(error_expected_one_frontend_job,none,
       "unable to handle compilation, expected exactly one frontend job", ())
-ERROR(error_expected_frontend_command, none,
+ERROR(error_expected_frontend_command,none,
       "expected a swift frontend command", ())
 
-ERROR(error_cannot_specify__o_for_multiple_outputs, none,
+ERROR(error_cannot_specify__o_for_multiple_outputs,none,
       "cannot specify -o when generating multiple output files", ())
 
 ERROR(error_static_emit_executable_disallowed,none,
@@ -71,40 +70,40 @@ ERROR(error_static_emit_executable_disallowed,none,
 ERROR(error_unable_to_load_output_file_map, none,
       "unable to load output file map '%1': %0", (StringRef, StringRef))
 
-ERROR(error_no_output_file_map_specified, none,
+ERROR(error_no_output_file_map_specified,none,
       "no output file map specified", ())
 
-ERROR(error_unable_to_make_temporary_file, none,
+ERROR(error_unable_to_make_temporary_file,none,
       "unable to make temporary file: %0", (StringRef))
 
-ERROR(error_no_input_files, none,
+ERROR(error_no_input_files,none,
       "no input files", ())
 
-ERROR(error_unexpected_input_file, none,
+ERROR(error_unexpected_input_file,none,
       "unexpected input file: %0", (StringRef))
 
-ERROR(error_unknown_target, none,
+ERROR(error_unknown_target,none,
       "unknown target '%0'", (StringRef))
 
-ERROR(error_framework_bridging_header, none,
+ERROR(error_framework_bridging_header,none,
       "using bridging headers with framework targets is unsupported", ())
 ERROR(error_bridging_header_module_interface,none,
       "using bridging headers with module interfaces is unsupported",
       ())
 
-ERROR(error_i_mode, none,
+ERROR(error_i_mode,none,
       "the flag '-i' is no longer required and has been removed; "
       "use '%0 input-filename'", (StringRef))
-WARNING(warning_unnecessary_repl_mode, none,
+WARNING(warning_unnecessary_repl_mode,none,
         "unnecessary option '%0'; this is the default for '%1' "
         "with no input files", (StringRef, StringRef))
-ERROR(error_unsupported_option, none,
+ERROR(error_unsupported_option,none,
       "option '%0' is not supported by '%1'; did you mean to use '%2'?",
       (StringRef, StringRef, StringRef))
 
-WARNING(incremental_requires_output_file_map, none,
+WARNING(incremental_requires_output_file_map,none,
         "ignoring -incremental (currently requires an output file map)", ())
-WARNING(incremental_requires_build_record_entry, none,
+WARNING(incremental_requires_build_record_entry,none,
         "ignoring -incremental; output file map has no master dependencies "
         "entry (\"%0\" under \"\")", (StringRef))
 
@@ -113,9 +112,9 @@ WARNING(unable_to_open_incremental_comparison_log,none,
 
 ERROR(error_os_minimum_deployment,none,
       "Swift requires a minimum deployment target of %0", (StringRef))
-ERROR(error_sdk_too_old, none,
+ERROR(error_sdk_too_old,none,
       "Swift does not support the SDK '%0'", (StringRef))
-ERROR(error_ios_maximum_deployment_32, none,
+ERROR(error_ios_maximum_deployment_32,none,
       "iOS %0 does not support 32-bit programs", (unsigned))
 
 WARNING(warn_arclite_not_found_when_link_objc_runtime,none,
@@ -125,11 +124,11 @@ WARNING(warn_arclite_not_found_when_link_objc_runtime,none,
 ERROR(error_two_files_same_name,none,
       "filename \"%0\" used twice: '%1' and '%2'",
       (StringRef, StringRef, StringRef))
-NOTE(note_explain_two_files_same_name, none,
+NOTE(note_explain_two_files_same_name,none,
      "filenames are used to distinguish private declarations with the same "
      "name", ())
 
-WARNING(warn_cannot_stat_input, none,
+WARNING(warn_cannot_stat_input,none,
         "unable to determine when '%0' was last modified: %1",
         (StringRef, StringRef))
 
@@ -137,7 +136,7 @@ WARNING(warn_unable_to_load_dependencies, none,
         "unable to load dependencies file \"%0\", disabling incremental mode",
         (StringRef))
 
-ERROR(error_input_changed_during_build, none,
+ERROR(error_input_changed_during_build,none,
       "input file '%0' was modified during the build",
       (StringRef))
 
@@ -151,13 +150,12 @@ ERROR(error_option_not_supported, none,
 WARNING(warn_ignore_embed_bitcode, none,
         "ignoring -embed-bitcode since no object file is being generated", ())
 WARNING(warn_ignore_embed_bitcode_marker, none,
-        "ignoring -embed-bitcode-marker since no object file is being "
-        "generated", ())
+        "ignoring -embed-bitcode-marker since no object file is being generated", ())
 
-WARNING(verify_debug_info_requires_debug_option, none,
+WARNING(verify_debug_info_requires_debug_option,none,
         "ignoring '-verify-debug-info'; no debug info is being generated", ())
 
-ERROR(error_profile_missing, none,
+ERROR(error_profile_missing,none,
       "no profdata file exists at '%0'", (StringRef))
 
 WARNING(warn_opt_remark_disabled, none,
@@ -165,9 +163,8 @@ WARNING(warn_opt_remark_disabled, none,
         "requires a single compiler invocation: consider enabling the "
         "-whole-module-optimization flag", ())
 
-WARNING(warn_ignoring_batch_mode, none,
-        "ignoring '-enable-batch-mode' because '%0' was also specified",
-        (StringRef))
+WARNING(warn_ignoring_batch_mode,none,
+"ignoring '-enable-batch-mode' because '%0' was also specified", (StringRef))
 
 WARNING(warn_ignoring_single_compile, none,
         "ignoring '%0' because '-dump-ast' was also specified", (StringRef))

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -169,8 +169,8 @@ WARNING(warn_ignoring_batch_mode, none,
         "ignoring '-enable-batch-mode' because '%0' was also specified",
         (StringRef))
 
-WARNING(warn_ignoring_wmo, none,
-        "ignoring '-wmo' because '-dump-ast' was also specified", ())
+WARNING(warn_ignoring_single_compile, none,
+        "ignoring '%0' because '-dump-ast' was also specified", (StringRef))
 
 WARNING(warn_ignoring_source_range_dependencies,none,
 "ignoring '-enable-source-range-dependencies' because '%0' was also specified", (StringRef))

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -166,8 +166,8 @@ WARNING(warn_opt_remark_disabled, none,
 WARNING(warn_ignoring_batch_mode,none,
 "ignoring '-enable-batch-mode' because '%0' was also specified", (StringRef))
 
-WARNING(warn_ignoring_single_compile, none,
-        "ignoring '%0' because '-dump-ast' was also specified", (StringRef))
+WARNING(warn_ignoring_wmo, none,
+        "ignoring '-wmo' because '-dump-ast' was also specified", ())
 
 WARNING(warn_ignoring_source_range_dependencies,none,
 "ignoring '-enable-source-range-dependencies' because '%0' was also specified", (StringRef))

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -42,26 +42,27 @@
 DIAG(REMARK,ID,Options,Text,Signature)
 #endif
 
-WARNING(warning_parallel_execution_not_supported,none,
+WARNING(warning_parallel_execution_not_supported, none,
         "parallel execution not supported; falling back to serial execution",
         ())
 
-ERROR(error_unable_to_execute_command,none,
+ERROR(error_unable_to_execute_command, none,
       "unable to execute command: %0", (StringRef))
-ERROR(error_command_signalled_without_signal_number,none,
+ERROR(error_command_signalled_without_signal_number, none,
       "%0 command failed due to signal (use -v to see invocation)", (StringRef))
-ERROR(error_command_signalled,none,
-      "%0 command failed due to signal %1 (use -v to see invocation)", (StringRef, int))
-ERROR(error_command_failed,none,
+ERROR(error_command_signalled, none,
+      "%0 command failed due to signal %1 (use -v to see invocation)",
+      (StringRef, int))
+ERROR(error_command_failed, none,
       "%0 command failed with exit code %1 (use -v to see invocation)",
       (StringRef, int))
 
-ERROR(error_expected_one_frontend_job,none,
+ERROR(error_expected_one_frontend_job, none,
       "unable to handle compilation, expected exactly one frontend job", ())
-ERROR(error_expected_frontend_command,none,
+ERROR(error_expected_frontend_command, none,
       "expected a swift frontend command", ())
 
-ERROR(error_cannot_specify__o_for_multiple_outputs,none,
+ERROR(error_cannot_specify__o_for_multiple_outputs, none,
       "cannot specify -o when generating multiple output files", ())
 
 ERROR(error_static_emit_executable_disallowed,none,
@@ -70,40 +71,40 @@ ERROR(error_static_emit_executable_disallowed,none,
 ERROR(error_unable_to_load_output_file_map, none,
       "unable to load output file map '%1': %0", (StringRef, StringRef))
 
-ERROR(error_no_output_file_map_specified,none,
+ERROR(error_no_output_file_map_specified, none,
       "no output file map specified", ())
 
-ERROR(error_unable_to_make_temporary_file,none,
+ERROR(error_unable_to_make_temporary_file, none,
       "unable to make temporary file: %0", (StringRef))
 
-ERROR(error_no_input_files,none,
+ERROR(error_no_input_files, none,
       "no input files", ())
 
-ERROR(error_unexpected_input_file,none,
+ERROR(error_unexpected_input_file, none,
       "unexpected input file: %0", (StringRef))
 
-ERROR(error_unknown_target,none,
+ERROR(error_unknown_target, none,
       "unknown target '%0'", (StringRef))
 
-ERROR(error_framework_bridging_header,none,
+ERROR(error_framework_bridging_header, none,
       "using bridging headers with framework targets is unsupported", ())
 ERROR(error_bridging_header_module_interface,none,
       "using bridging headers with module interfaces is unsupported",
       ())
 
-ERROR(error_i_mode,none,
+ERROR(error_i_mode, none,
       "the flag '-i' is no longer required and has been removed; "
       "use '%0 input-filename'", (StringRef))
-WARNING(warning_unnecessary_repl_mode,none,
+WARNING(warning_unnecessary_repl_mode, none,
         "unnecessary option '%0'; this is the default for '%1' "
         "with no input files", (StringRef, StringRef))
-ERROR(error_unsupported_option,none,
+ERROR(error_unsupported_option, none,
       "option '%0' is not supported by '%1'; did you mean to use '%2'?",
       (StringRef, StringRef, StringRef))
 
-WARNING(incremental_requires_output_file_map,none,
+WARNING(incremental_requires_output_file_map, none,
         "ignoring -incremental (currently requires an output file map)", ())
-WARNING(incremental_requires_build_record_entry,none,
+WARNING(incremental_requires_build_record_entry, none,
         "ignoring -incremental; output file map has no master dependencies "
         "entry (\"%0\" under \"\")", (StringRef))
 
@@ -112,9 +113,9 @@ WARNING(unable_to_open_incremental_comparison_log,none,
 
 ERROR(error_os_minimum_deployment,none,
       "Swift requires a minimum deployment target of %0", (StringRef))
-ERROR(error_sdk_too_old,none,
+ERROR(error_sdk_too_old, none,
       "Swift does not support the SDK '%0'", (StringRef))
-ERROR(error_ios_maximum_deployment_32,none,
+ERROR(error_ios_maximum_deployment_32, none,
       "iOS %0 does not support 32-bit programs", (unsigned))
 
 WARNING(warn_arclite_not_found_when_link_objc_runtime,none,
@@ -124,11 +125,11 @@ WARNING(warn_arclite_not_found_when_link_objc_runtime,none,
 ERROR(error_two_files_same_name,none,
       "filename \"%0\" used twice: '%1' and '%2'",
       (StringRef, StringRef, StringRef))
-NOTE(note_explain_two_files_same_name,none,
+NOTE(note_explain_two_files_same_name, none,
      "filenames are used to distinguish private declarations with the same "
      "name", ())
 
-WARNING(warn_cannot_stat_input,none,
+WARNING(warn_cannot_stat_input, none,
         "unable to determine when '%0' was last modified: %1",
         (StringRef, StringRef))
 
@@ -136,7 +137,7 @@ WARNING(warn_unable_to_load_dependencies, none,
         "unable to load dependencies file \"%0\", disabling incremental mode",
         (StringRef))
 
-ERROR(error_input_changed_during_build,none,
+ERROR(error_input_changed_during_build, none,
       "input file '%0' was modified during the build",
       (StringRef))
 
@@ -150,12 +151,13 @@ ERROR(error_option_not_supported, none,
 WARNING(warn_ignore_embed_bitcode, none,
         "ignoring -embed-bitcode since no object file is being generated", ())
 WARNING(warn_ignore_embed_bitcode_marker, none,
-        "ignoring -embed-bitcode-marker since no object file is being generated", ())
+        "ignoring -embed-bitcode-marker since no object file is being "
+        "generated", ())
 
-WARNING(verify_debug_info_requires_debug_option,none,
+WARNING(verify_debug_info_requires_debug_option, none,
         "ignoring '-verify-debug-info'; no debug info is being generated", ())
 
-ERROR(error_profile_missing,none,
+ERROR(error_profile_missing, none,
       "no profdata file exists at '%0'", (StringRef))
 
 WARNING(warn_opt_remark_disabled, none,
@@ -163,8 +165,10 @@ WARNING(warn_opt_remark_disabled, none,
         "requires a single compiler invocation: consider enabling the "
         "-whole-module-optimization flag", ())
 
-WARNING(warn_ignoring_batch_mode,none,
-"ignoring '-enable-batch-mode' because '%0' was also specified", (StringRef))
+WARNING(warn_ignoring_batch_mode, none,
+        "ignoring '-enable-batch-mode' because '%0' was also specified",
+        (StringRef))
+
 WARNING(warn_ignoring_wmo, none,
         "ignoring '-wmo' because '-dump-ast' was also specified", ())
 

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -165,6 +165,8 @@ WARNING(warn_opt_remark_disabled, none,
 
 WARNING(warn_ignoring_batch_mode,none,
 "ignoring '-enable-batch-mode' because '%0' was also specified", (StringRef))
+WARNING(warn_ignoring_wmo, none,
+        "ignoring '-wmo' because '-dump-ast' was also specified", ())
 
 WARNING(warn_ignoring_source_range_dependencies,none,
 "ignoring '-enable-source-range-dependencies' because '%0' was also specified", (StringRef))

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1758,6 +1758,15 @@ Driver::computeCompilerMode(const DerivedArgList &Args,
   const Arg *ArgRequiringSinglePrimaryCompile =
       Args.getLastArg(options::OPT_enable_source_range_dependencies);
 
+  // AST dump doesn't work in WMO. Since it's not common want to dump the AST,
+  // we assume that's the priority and ignore `-wmo`, but we warn the user about
+  // this decision.
+  if (Args.hasArg(options::OPT_whole_module_optimization) &&
+      Args.hasArg(options::OPT_dump_ast)) {
+    Diags.diagnose(SourceLoc(), diag::warn_ignoring_wmo);
+    return OutputInfo::Mode::StandardCompile;
+  }
+
   // Override batch mode if given -wmo or -index-file.
   if (ArgRequiringSingleCompile) {
     if (BatchModeOut) {

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1758,13 +1758,14 @@ Driver::computeCompilerMode(const DerivedArgList &Args,
   const Arg *ArgRequiringSinglePrimaryCompile =
       Args.getLastArg(options::OPT_enable_source_range_dependencies);
 
-  // AST dump doesn't work with `-wmo` or `-index-file`. Since it's not common
-  // to want to dump the AST, we assume that's the priority and ignore the
-  // conflicting option, but we warn the user about this decision.
-  if (ArgRequiringSingleCompile &&
+  // AST dump doesn't work with `-wmo`. Since it's not common to want to dump
+  // the AST, we assume that's the priority and ignore `-wmo`, but we warn the
+  // user about this decision.
+  // FIXME: AST dump also doesn't work with `-index-file`, but that fix is a bit
+  // more complicated than this.
+  if (Args.hasArg(options::OPT_whole_module_optimization) &&
       Args.hasArg(options::OPT_dump_ast)) {
-    Diags.diagnose(SourceLoc(), diag::warn_ignoring_single_compile,
-                   ArgRequiringSingleCompile->getOption().getPrefixedName());
+    Diags.diagnose(SourceLoc(), diag::warn_ignoring_wmo);
     return OutputInfo::Mode::StandardCompile;
   }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1758,12 +1758,13 @@ Driver::computeCompilerMode(const DerivedArgList &Args,
   const Arg *ArgRequiringSinglePrimaryCompile =
       Args.getLastArg(options::OPT_enable_source_range_dependencies);
 
-  // AST dump doesn't work in WMO. Since it's not common want to dump the AST,
-  // we assume that's the priority and ignore `-wmo`, but we warn the user about
-  // this decision.
-  if (Args.hasArg(options::OPT_whole_module_optimization) &&
+  // AST dump doesn't work with `-wmo` or `-index-file`. Since it's not common
+  // to want to dump the AST, we assume that's the priority and ignore the
+  // conflicting option, but we warn the user about this decision.
+  if (ArgRequiringSingleCompile &&
       Args.hasArg(options::OPT_dump_ast)) {
-    Diags.diagnose(SourceLoc(), diag::warn_ignoring_wmo);
+    Diags.diagnose(SourceLoc(), diag::warn_ignoring_single_compile,
+                   ArgRequiringSingleCompile->getOption().getPrefixedName());
     return OutputInfo::Mode::StandardCompile;
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -893,10 +893,6 @@ static SourceFile *getPrimaryOrMainSourceFile(CompilerInvocation &Invocation,
 /// files were specified, use them; otherwise, dump the AST to stdout.
 static void dumpAST(CompilerInvocation &Invocation,
                     CompilerInstance &Instance) {
-  // FIXME: WMO doesn't use the notion of primary files, so this doesn't do the
-  // right thing. Perhaps it'd be best to ignore WMO when dumping the AST, just
-  // like WMO ignores `-incremental`.
-
   auto primaryFiles = Instance.getPrimarySourceFiles();
   if (!primaryFiles.empty()) {
     for (SourceFile *sourceFile: primaryFiles) {

--- a/test/Driver/ast_dump_with_WMO.swift
+++ b/test/Driver/ast_dump_with_WMO.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+
+
+// Check that -wmo is ignored when -dump-ast is present and that the AST gets
+// dumped to stdout, no matter the order of the options
+
+// RUN: %swiftc_driver -whole-module-optimization -dump-ast -module-name=main %S/../Inputs/empty.swift -### 2>%t/stderr_WMO_dump | %FileCheck -check-prefix CHECK-STDOUT %s
+// RUN: %swiftc_driver -dump-ast -whole-module-optimization -module-name=main %S/../Inputs/empty.swift -### 2>%t/stderr_dump_WMO | %FileCheck -check-prefix CHECK-STDOUT %s
+// RUN: %FileCheck -check-prefix CHECK-WMO %s <%t/stderr_WMO_dump
+// RUN: %FileCheck -check-prefix CHECK-WMO %s <%t/stderr_dump_WMO
+
+
+// Check that ignoring -wmo doesn't affect the output file paths for the AST
+// dumps
+
+// RUN: cd %t
+// RUN: echo ' ' > a.swift
+// RUN: echo ' ' > main.swift
+// RUN: echo '{ "a.swift": { "ast-dump": "a.ast" }, "main.swift": { "ast-dump": "main.ast" }}' > outputFileMap.json
+
+// RUN: %swiftc_driver -whole-module-optimization -dump-ast -module-name=main -output-file-map=outputFileMap.json main.swift a.swift -### 2>%t/stderr_WMO_OFM | %FileCheck -check-prefix CHECK-OFM %s
+// RUN: %FileCheck -check-prefix CHECK-WMO %s <%t/stderr_WMO_OFM
+
+
+
+// CHECK-WMO: warning: ignoring '-wmo' because '-dump-ast' was also specified
+
+// CHECK-STDOUT-NOT: -whole-module-optimization
+// CHECK-STDOUT-NOT: -wmo
+// CHECK-STDOUT: -dump-ast
+// CHECK-STDOUT: -o -
+
+// CHECK-OFM-NOT: -whole-module-optimization
+// CHECK-OFM-NOT: -wmo
+// CHECK-OFM: -dump-ast
+// CHECK-OFM-SAME: -o main.ast
+// CHECK-OFM-NEXT: -dump-ast
+// CHECK-OFM-SAME: -o a.ast


### PR DESCRIPTION
The current Dump AST methods dump the AST for primary files or, if there are no primary files, the main file. This behavior is weird on WMO builds, which don't have the concept of primary files. In that case, the compiler currently dumps the main file and ignores all other files.

Since it's uncommon to have the `-dump-ast` argument in an invocation, it is assumed to be a priority over `-wmo`. Therefore, the decision is to ignore `-wmo` when `-dump-ast` is also present, printing a warning for the user and dumping all files normally.

This was briefly discussed on [PR-20392](https://github.com/apple/swift/pull/20392), where it was decided that a `FIXME` would be added to `lib/FrontendTool/FrontendTool.cpp` and the change would be delayed to a separate pull request.

This pull request executes the necessary changes on `Driver.cpp` and `DiagnosticsDriver.def` and removes the FIXME from `FrontendTool.cpp`. It also fixes a bit of the code style in `DiagnosticsDriver.def`.