### PR TITLE
[Character] Permit tagged emoji Character literals

### DIFF
--- a/include/swift/Basic/Unicode.h
+++ b/include/swift/Basic/Unicode.h
@@ -54,17 +54,6 @@ extern const uint16_t ExtendedGraphemeClusterNoBoundaryRulesMatrix[];
 /// point.
 GraphemeClusterBreakProperty getGraphemeClusterBreakProperty(uint32_t C);
 
-/// Returns true if there is always an extended grapheme cluster boundary
-/// after a code point with a given property value.  Use only for optimization,
-/// to skip calculating Grapheme_Cluster_Break property for the second code
-/// point.
-static inline bool
-isExtendedGraphemeClusterBoundaryAfter(GraphemeClusterBreakProperty GCB1) {
-  auto RuleRow =
-      ExtendedGraphemeClusterNoBoundaryRulesMatrix[static_cast<unsigned>(GCB1)];
-  return RuleRow == 0;
-}
-
 /// Determine if there is an extended grapheme cluster boundary between code
 /// points with given Grapheme_Cluster_Break property values.
 static inline bool

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -197,6 +197,7 @@ enum RawTypeWithCharacterValues_Correct : Character {
   case First = "😅" // ok
   case Second = "👩‍👩‍👧‍👦" // ok
   case Third = "👋🏽" // ok
+  case Fourth = "\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}" // ok
 }
 
 enum RawTypeWithCharacterValues_Error1 : Character { // expected-error {{'RawTypeWithCharacterValues_Error1' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}}


### PR DESCRIPTION
Loosen up the compiler's grapheme analysis to allow the emoji tagged
sequences as graphemes.

https://bugs.swift.org/browse/SR-9246