### PR TITLE
Don't implicitly add dynamic to stored properties

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2464,6 +2464,10 @@ void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
     return;
 
   if (auto *VD = dyn_cast<VarDecl>(D)) {
+    // Don't turn stored into computed properties. This could conflict with
+    // exclusivity checking.
+    if (VD->hasStorage())
+      return;
     // Don't add dynamic to local variables.
     if (VD->getDeclContext()->isLocalContext())
       return;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2451,6 +2451,9 @@ TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D) {
 }
 
 void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
+  if (!decl->getModuleContext()->isImplicitDynamicEnabled())
+    return;
+
   // Add the attribute if the decl kind allows it and it is not an accessor
   // decl. Accessor decls should always infer the var/subscript's attribute.
   if (!DeclAttribute::canAttributeAppearOnDecl(DAK_Dynamic, D) ||

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2451,7 +2451,7 @@ TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D) {
 }
 
 void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
-  if (!decl->getModuleContext()->isImplicitDynamicEnabled())
+  if (!D->getModuleContext()->isImplicitDynamicEnabled())
     return;
 
   // Add the attribute if the decl kind allows it and it is not an accessor

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1215,9 +1215,7 @@ IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
     return false;
 
   // Add dynamic if -enable-implicit-dynamic was requested.
-  if (decl->getModuleContext()->isImplicitDynamicEnabled()) {
-    TypeChecker::addImplicitDynamicAttribute(decl);
-  }
+  TypeChecker::addImplicitDynamicAttribute(decl);
 
   // If 'dynamic' was explicitly specified, check it.
   if (decl->getAttrs().hasAttribute<DynamicAttr>()) {

--- a/test/Interpreter/Inputs/dynamic_replacement_module.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_module.swift
@@ -101,7 +101,7 @@ public struct PublicStruct {
   public func genericFunction<T>(_ t: T.Type) -> String {
     return "public_struct_generic_func"
   }
-  public var public_stored_property : String = "public_stored_property"
+  dynamic public var public_stored_property : String = "public_stored_property"
 
   public subscript(_ x: Int) -> String {
     get {

--- a/test/Interpreter/Inputs/dynamic_replacement_module.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_module.swift
@@ -66,7 +66,7 @@ public enum PublicEnumeration<Q> {
   }
 }
 #elseif MODULENODYNAMIC
-public var public_global_var = "public_global_var"
+public dynamic var public_global_var = "public_global_var"
 
 public func public_global_func() -> String {
   return "public_global_func"


### PR DESCRIPTION
This can introduce an exclusivity check failure.