### PR TITLE
[Runtime] Accept Nil in the patched bundleForClass:.

### DIFF
--- a/stdlib/public/runtime/ObjCRuntimeGetImageNameFromClass.mm
+++ b/stdlib/public/runtime/ObjCRuntimeGetImageNameFromClass.mm
@@ -56,8 +56,11 @@ static objc_hook_getImageName defaultGetImageNameFromClass = nullptr;
 /// Get the image name corresponding to a Swift class, accounting for
 /// dynamically-initialized class metadata. Returns NO for ObjC classes.
 static BOOL
-getImageNameFromSwiftClass(Class _Nonnull objcClass,
+getImageNameFromSwiftClass(Class _Nullable objcClass,
                            const char * _Nullable * _Nonnull outImageName) {
+  if (objcClass == Nil)
+    return NO;
+  
   auto *classAsMetadata = reinterpret_cast<const ClassMetadata *>(objcClass);
 
   // Is this a Swift class?

--- a/test/stdlib/Bundle.swift
+++ b/test/stdlib/Bundle.swift
@@ -1,0 +1,25 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+
+var BundleTests = TestSuite("BundleTests")
+
+BundleTests.test("Bundle.bundleForNilClass") {
+  // Ensure that bundleForClass: tolerates a nil parameter. The
+  // Foundation implementation does. The patched version from
+  // ObjCRuntimeGetImageNameFromClass did not.
+  //
+  // SR-9188
+  typealias BundleForClassFunc =
+    @convention(c) (AnyObject, Selector, AnyObject?) -> Bundle
+  
+  let sel = #selector(Bundle.init(for:))
+  let imp = unsafeBitCast(Bundle.method(for: sel), to: BundleForClassFunc.self)
+  let bundleForNil = imp(Bundle.self, sel, nil);
+  expectEqual(Bundle.main, bundleForNil)
+}
+
+runAllTests()


### PR DESCRIPTION
The patched `+[NSBundle bundleForClass:]` crashes on `Nil`, while the original Foundation implementation returns the main bundle. Avoid the crash and pass `Nil` through to Foundation. This also ensures that `Nil` is passed through to `class_getImageName` rather than crashing.

Fixes [SR-9188](https://bugs.swift.org/browse/SR-9188) rdar://problem/45849924