### PR TITLE
[ABI] Ensure that symbolic references to accessor functions are 2-byte aligned

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -691,6 +691,7 @@ emitGeneratorForKeyPath(IRGenModule &IGM,
         // Form the mangled name with its relative reference.
         auto S = B.beginStruct();
         S.setPacked(true);
+        S.add(llvm::ConstantInt::get(IGM.Int8Ty, 255));
         S.add(llvm::ConstantInt::get(IGM.Int8Ty, 9));
         S.addRelativeAddress(accessorThunk);
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -217,6 +217,7 @@ llvm::Constant *IRGenModule::getMangledAssociatedConformance(
   ConstantInitBuilder B(*this);
   auto S = B.beginStruct();
   S.setPacked(true);
+  S.add(llvm::ConstantInt::get(Int8Ty, 255));
   S.add(llvm::ConstantInt::get(Int8Ty, kind));
   S.addRelativeAddress(accessor);
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2410,15 +2410,16 @@ internal func _resolveKeyPathGenericArgReference(_ reference: UnsafeRawPointer,
 
   // If we have a symbolic reference to an accessor, call it.
   let first = referenceStart.load(as: UInt8.self)
-  if first == 9 {
+  if first == 255 && reference.load(as: UInt8.self) == 9 {
     typealias MetadataAccessor =
       @convention(c) (UnsafeRawPointer) -> UnsafeRawPointer
 
     // Unaligned load of the offset.
+    let pointerReference = reference + 1
     var offset: Int32 = 0
-    _memcpy(dest: &offset, src: reference, size: 4)
+    _memcpy(dest: &offset, src: pointerReference, size: 4)
 
-    let accessorPtr = _resolveRelativeAddress(reference, offset)
+    let accessorPtr = _resolveRelativeAddress(pointerReference, offset)
     let accessor = unsafeBitCast(accessorPtr, to: MetadataAccessor.self)
     return accessor(arguments)
   }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4212,6 +4212,9 @@ static const WitnessTable *swift_getAssociatedConformanceWitnessSlowImpl(
 
 
   // Extract the mangled name itself.
+  if (*mangledNameBase == '\xFF')
+    ++mangledNameBase;
+
   StringRef mangledName =
     Demangle::makeSymbolicMangledNameStringRef(mangledNameBase);
 


### PR DESCRIPTION
When we emit "false" symbolic references to accesors for conformances or
type metadata, ensure that we end up with two-byte-aligned symbolic
references. This addresses a problem with ARM+Thumb compilation where the
low bit wasn't getting set for Thumb code.

Fixes rdar://problem/46067353.
