### PR TITLE
 [Runtime] Make swift_getTypeByMangled(Name|Node) overridable.

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2427,10 +2427,7 @@ internal func _resolveKeyPathGenericArgReference(_ reference: UnsafeRawPointer,
   let namePtr = referenceStart.bindMemory(to: UInt8.self,
                                           capacity: nameLength + 1)
   // FIXME: Could extract this information from the mangled name.
-  let parametersPerLevel: [UInt] = []
-  let substitutions: [Any.Type] = []
-  guard let result = _getTypeByMangledName(namePtr, UInt(nameLength), 0,
-                                           parametersPerLevel, substitutions)
+  guard let result = _getTypeByMangledName(namePtr, UInt(nameLength))
     else {
       let nameStr = String._fromUTF8Repairing(
         UnsafeBufferPointer(start: namePtr, count: nameLength)

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -83,22 +83,14 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
 public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)
-  let parametersPerLevel = [UInt]()
-  let flatSubstitutions = [Any.Type]()
   return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
     return  _getTypeByMangledName(nameUTF8.baseAddress!,
-                                  UInt(nameUTF8.endIndex),
-                                  0,
-                                  parametersPerLevel,
-                                  flatSubstitutions)
+                                  UInt(nameUTF8.endIndex))
   }
 }
 
-@_silgen_name("swift_getTypeByMangledName")
+@_silgen_name("swift_stdlib_getTypeByMangledName")
 internal func _getTypeByMangledName(
   _ name: UnsafePointer<UInt8>,
-  _ nameLength: UInt,
-  _ numberOfLevels: UInt,
-  _ parametersPerLevel: UnsafePointer<UInt>,
-  _ substitutions: UnsafePointer<Any.Type>)
+  _ nameLength: UInt)
   -> Any.Type?

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -83,8 +83,8 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
 public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)
-  var parametersPerLevel = [UInt]()
-  var flatSubstitutions = [Any.Type]()
+  let parametersPerLevel = [UInt]()
+  let flatSubstitutions = [Any.Type]()
   return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
     return  _getTypeByMangledName(nameUTF8.baseAddress!,
                                   UInt(nameUTF8.endIndex),

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -82,7 +82,16 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
 /// names is stabilized, this is limited to top-level class names (Foo.bar).
 public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
-  return _typeByMangledName(name);
+  let nameUTF8 = Array(name.utf8)
+  var parametersPerLevel = [UInt]()
+  var flatSubstitutions = [Any.Type]()
+  return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
+    return  _getTypeByMangledName(nameUTF8.baseAddress!,
+                                  UInt(nameUTF8.endIndex),
+                                  0,
+                                  parametersPerLevel,
+                                  flatSubstitutions)
+  }
 }
 
 @_silgen_name("swift_getTypeByMangledName")
@@ -93,28 +102,3 @@ internal func _getTypeByMangledName(
   _ parametersPerLevel: UnsafePointer<UInt>,
   _ substitutions: UnsafePointer<Any.Type>)
   -> Any.Type?
-
-/// Lookup a class given a mangled name. This is a placeholder while we bring
-/// up this functionality.
-public  // TEMPORARY
-func _typeByMangledName(_ name: String,
-                        substitutions: [[Any.Type]] = []) -> Any.Type? {
-  // Map the substitutions to a flat representation that's easier to thread
-  // through to the runtime.
-  let numberOfLevels = UInt(substitutions.count)
-  var parametersPerLevel = [UInt]()
-  var flatSubstitutions = [Any.Type]()
-  for level in substitutions {
-    parametersPerLevel.append(UInt(level.count))
-    flatSubstitutions.append(contentsOf: level)
-  }
-
-  let nameUTF8 = Array(name.utf8)
-  return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
-    return  _getTypeByMangledName(nameUTF8.baseAddress!,
-                                  UInt(nameUTF8.endIndex),
-                                  numberOfLevels,
-                                  parametersPerLevel,
-                                  flatSubstitutions)
-  }
-}

--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -134,6 +134,18 @@ OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , swift::,
                  (const void *pattern, const void *arguments),
                  (pattern, arguments))
 
+OVERRIDE_METADATALOOKUP(getTypeByMangledNode, TypeInfo, , swift::,
+                        (Demangler &demangler,
+                         Demangle::NodePointer node,
+                         SubstGenericParameterFn substGenericParam,
+                         SubstDependentWitnessTableFn substWitnessTable),
+                        (demangler, node, substGenericParam, substWitnessTable))
+OVERRIDE_METADATALOOKUP(getTypeByMangledName, TypeInfo, , swift::,
+                        (StringRef typeName,
+                         SubstGenericParameterFn substGenericParam,
+                         SubstDependentWitnessTableFn substWitnessTable),
+                        (typeName, substGenericParam, substWitnessTable))
+
 OVERRIDE_WITNESSTABLE(getAssociatedTypeWitnessSlow, MetadataResponse,
                       SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL, swift::,
                       (MetadataRequest request, WitnessTable *wtable,

--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -69,16 +69,6 @@
 #  endif
 #endif
 
-OVERRIDE_METADATALOOKUP(getTypeByMangledName, const Metadata *,
-                        SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL, ,
-                        (const char *typeNameStart, size_t typeNameLength,
-                         size_t numberOfLevels,
-                         size_t *parametersPerLevel,
-                         const Metadata * const *flatSubstitutions),
-                        (typeNameStart, typeNameLength, numberOfLevels,
-                         parametersPerLevel, flatSubstitutions))
-
-
 OVERRIDE_CASTING(dynamicCast, bool, , swift::,
                  (OpaqueValue *dest, OpaqueValue *src,
                   const Metadata *srcType,

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2552,7 +2552,7 @@ swift::swift_initClassMetadata(ClassMetadata *self,
       Demangle::makeSymbolicMangledNameStringRef(superclassNameBase);
     SubstGenericParametersFromMetadata substitutions(self);
     const Metadata *superclass =
-      _getTypeByMangledName(superclassName, substitutions, substitutions);
+      swift_getTypeByMangledName(superclassName, substitutions, substitutions);
     if (!superclass) {
       fatalError(0,
                  "failed to demangle superclass of %s from mangled name '%s'\n",
@@ -2642,7 +2642,7 @@ swift::swift_updateClassMetadata(ClassMetadata *self,
       Demangle::makeSymbolicMangledNameStringRef(superclassNameBase);
     SubstGenericParametersFromMetadata substitutions(self);
     const Metadata *superclass =
-      _getTypeByMangledName(superclassName, substitutions, substitutions);
+      swift_getTypeByMangledName(superclassName, substitutions, substitutions);
     if (!superclass) {
       fatalError(0,
                  "failed to demangle superclass of %s from mangled name '%s'\n",
@@ -4110,7 +4110,7 @@ swift_getAssociatedTypeWitnessSlowImpl(
     // The protocol's Self is the only generic parameter that can occur in the
     // type.
     assocTypeMetadata =
-      _getTypeByMangledName(mangledName,
+      swift_getTypeByMangledName(mangledName,
         [conformingType](unsigned depth, unsigned index) -> const Metadata * {
           if (depth == 0 && index == 0)
             return conformingType;
@@ -4137,8 +4137,8 @@ swift_getAssociatedTypeWitnessSlowImpl(
     auto originalConformingType = findConformingSuperclass(conformingType,
                                                            conformance);
     SubstGenericParametersFromMetadata substitutions(originalConformingType);
-    assocTypeMetadata = _getTypeByMangledName(mangledName, substitutions,
-                                              substitutions);
+    assocTypeMetadata = swift_getTypeByMangledName(mangledName, substitutions,
+                                                   substitutions);
   }
 
   if (!assocTypeMetadata) {
@@ -4875,7 +4875,8 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
   
   auto mangledName = Demangle::mangleNode(node);
   auto result =
-    _getTypeByMangledName(mangledName,
+    swift_getTypeByMangledName(
+                          mangledName,
                           [](unsigned, unsigned){ return nullptr; },
                           [](const Metadata *, unsigned) { return nullptr; });
   if (metadata != result)

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2552,7 +2552,7 @@ swift::swift_initClassMetadata(ClassMetadata *self,
       Demangle::makeSymbolicMangledNameStringRef(superclassNameBase);
     SubstGenericParametersFromMetadata substitutions(self);
     const Metadata *superclass =
-      _getTypeByMangledName(superclassName, substitutions);
+      _getTypeByMangledName(superclassName, substitutions, substitutions);
     if (!superclass) {
       fatalError(0,
                  "failed to demangle superclass of %s from mangled name '%s'\n",
@@ -2642,7 +2642,7 @@ swift::swift_updateClassMetadata(ClassMetadata *self,
       Demangle::makeSymbolicMangledNameStringRef(superclassNameBase);
     SubstGenericParametersFromMetadata substitutions(self);
     const Metadata *superclass =
-      _getTypeByMangledName(superclassName, substitutions);
+      _getTypeByMangledName(superclassName, substitutions, substitutions);
     if (!superclass) {
       fatalError(0,
                  "failed to demangle superclass of %s from mangled name '%s'\n",
@@ -4111,12 +4111,23 @@ swift_getAssociatedTypeWitnessSlowImpl(
     // type.
     assocTypeMetadata =
       _getTypeByMangledName(mangledName,
-         [conformingType](unsigned depth, unsigned index) -> const Metadata * {
-        if (depth == 0 && index == 0)
-          return conformingType;
+        [conformingType](unsigned depth, unsigned index) -> const Metadata * {
+          if (depth == 0 && index == 0)
+            return conformingType;
 
-        return nullptr;
-      });
+          return nullptr;
+        },
+        [&](const Metadata *type, unsigned index) -> const WitnessTable * {
+          auto requirements = protocol->getRequirements();
+          auto dependentDescriptor = requirements.data() + index;
+          if (dependentDescriptor < requirements.begin() ||
+              dependentDescriptor >= requirements.end())
+            return nullptr;
+
+          return swift_getAssociatedConformanceWitness(wtable, conformingType,
+                                                       type, reqBase,
+                                                       dependentDescriptor);
+        });
   } else {
     // The generic parameters in the associated type name are those of the
     // conforming type.
@@ -4126,7 +4137,8 @@ swift_getAssociatedTypeWitnessSlowImpl(
     auto originalConformingType = findConformingSuperclass(conformingType,
                                                            conformance);
     SubstGenericParametersFromMetadata substitutions(originalConformingType);
-    assocTypeMetadata = _getTypeByMangledName(mangledName, substitutions);
+    assocTypeMetadata = _getTypeByMangledName(mangledName, substitutions,
+                                              substitutions);
   }
 
   if (!assocTypeMetadata) {
@@ -4191,8 +4203,11 @@ static const WitnessTable *swift_getAssociatedConformanceWitnessSlowImpl(
     assert(assocConformance >= requirements.begin() &&
            assocConformance < requirements.end());
     assert(reqBase == requirements.data() - WitnessTableFirstRequirementOffset);
-    assert(assocConformance->Flags.getKind() ==
-           ProtocolRequirementFlags::Kind::AssociatedConformanceAccessFunction);
+    assert(
+      assocConformance->Flags.getKind() ==
+        ProtocolRequirementFlags::Kind::AssociatedConformanceAccessFunction ||
+      assocConformance->Flags.getKind() ==
+        ProtocolRequirementFlags::Kind::BaseProtocol);
   }
 #endif
 
@@ -4859,8 +4874,10 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
     return;
   
   auto mangledName = Demangle::mangleNode(node);
-  auto result = _getTypeByMangledName(mangledName,
-                                      [](unsigned, unsigned){ return nullptr; });
+  auto result =
+    _getTypeByMangledName(mangledName,
+                          [](unsigned, unsigned){ return nullptr; },
+                          [](const Metadata *, unsigned) { return nullptr; });
   if (metadata != result)
     swift::warning(RuntimeErrorFlagNone,
                    "Metadata mangled name failed to roundtrip: %p -> %s -> %p\n",

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1260,27 +1260,16 @@ swift::_getTypeByMangledName(StringRef typeName,
                                substWitnessTable);
 }
 
-static const Metadata * _Nullable
-swift_getTypeByMangledNameImpl(const char *typeNameStart, size_t typeNameLength,
-                           size_t numberOfLevels,
-                           size_t *parametersPerLevel,
-                           const Metadata * const *flatSubstitutions) {
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+const Metadata * _Nullable
+swift_stdlib_getTypeByMangledName(const char *typeNameStart,
+                                  size_t typeNameLength) {
   llvm::StringRef typeName(typeNameStart, typeNameLength);
-  auto metadata = _getTypeByMangledName(typeName,
-    [&](unsigned depth, unsigned index) -> const Metadata * {
-      if (depth >= numberOfLevels)
-        return nullptr;
-
-      if (index >= parametersPerLevel[depth])
-        return nullptr;
-
-      unsigned flatIndex = index;
-      for (unsigned i = 0; i < depth; ++i)
-        flatIndex += parametersPerLevel[i];
-
-      return flatSubstitutions[flatIndex];
-    },
-    [](const Metadata *type, unsigned index) { return nullptr; });
+  auto metadata =
+    _getTypeByMangledName(
+      typeName,
+      [](unsigned depth, unsigned index) { return nullptr; },
+      [](const Metadata *type, unsigned index) { return nullptr; });
 
   if (!metadata) return nullptr;
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1197,21 +1197,21 @@ public:
 
 }
 
-TypeInfo
-swift::_getTypeByMangledNode(Demangler &demangler,
-                             Demangle::NodePointer node,
-                             SubstGenericParameterFn substGenericParam,
-                             SubstDependentWitnessTableFn substWitnessTable) {
+static TypeInfo swift_getTypeByMangledNodeImpl(
+                              Demangler &demangler,
+                              Demangle::NodePointer node,
+                              SubstGenericParameterFn substGenericParam,
+                              SubstDependentWitnessTableFn substWitnessTable) {
   DecodedMetadataBuilder builder(demangler, substGenericParam,
                                  substWitnessTable);
   auto type = Demangle::decodeMangledType(builder, node);
   return {type, builder.getReferenceOwnership()};
 }
 
-TypeInfo
-swift::_getTypeByMangledName(StringRef typeName,
-                             SubstGenericParameterFn substGenericParam,
-                             SubstDependentWitnessTableFn substWitnessTable) {
+TypeInfo swift_getTypeByMangledNameImpl(
+                              StringRef typeName,
+                              SubstGenericParameterFn substGenericParam,
+                              SubstDependentWitnessTableFn substWitnessTable) {
   auto demangler = getDemanglerForRuntimeTypeResolution();
   NodePointer node;
 
@@ -1256,8 +1256,8 @@ swift::_getTypeByMangledName(StringRef typeName,
       return TypeInfo();
   }
 
-  return _getTypeByMangledNode(demangler, node, substGenericParam,
-                               substWitnessTable);
+  return swift_getTypeByMangledNode(demangler, node, substGenericParam,
+                                    substWitnessTable);
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
@@ -1266,7 +1266,7 @@ swift_stdlib_getTypeByMangledName(const char *typeNameStart,
                                   size_t typeNameLength) {
   llvm::StringRef typeName(typeNameStart, typeNameLength);
   auto metadata =
-    _getTypeByMangledName(
+    swift_getTypeByMangledName(
       typeName,
       [](unsigned depth, unsigned index) { return nullptr; },
       [](const Metadata *type, unsigned index) { return nullptr; });
@@ -1487,8 +1487,8 @@ void swift::gatherWrittenGenericArgs(
       SubstGenericParametersFromWrittenArgs substitutions(allGenericArgs,
                                                           genericParamCounts);
       allGenericArgs[*lhsFlatIndex] =
-          _getTypeByMangledName(req.getMangledTypeName(), substitutions,
-                                substitutions);
+          swift_getTypeByMangledName(req.getMangledTypeName(), substitutions,
+                                     substitutions);
       continue;
     }
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1066,8 +1066,7 @@ public:
                                                           genericParamCounts);
       bool failed =
         _checkGenericRequirements(genericContext->getGenericRequirements(),
-                                  allGenericArgsVec, substitutions,
-                                  substitutions);
+                                  allGenericArgsVec, substitutions);
       if (failed)
         return BuiltType();
 
@@ -1331,29 +1330,6 @@ void SubstGenericParametersFromMetadata::setup() const {
     return;
 
   buildDescriptorPath(base->getTypeContextDescriptor());
-}
-
-const Metadata *
-SubstGenericParametersFromMetadata::operator()(unsigned flatIndex) const {
-  // On first access, compute the descriptor path.
-  setup();
-
-  // Find the depth at which this parameter occurs.
-  unsigned depth = descriptorPath.size();
-  unsigned index = flatIndex;
-  for (const auto &pathElement : descriptorPath) {
-    // If the flat index is beyond the element at this position, we're done.
-    if (flatIndex >= pathElement.context->getNumGenericParams()) {
-      // Subtract off the number of parameters.
-      index -= pathElement.context->getNumGenericParams();
-      break;
-    }
-
-    --depth;
-  }
-
-  // Perform the access based on depth/index.
-  return (*this)(depth, index);
 }
 
 const Metadata *

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1375,14 +1375,6 @@ SubstGenericParametersFromMetadata::operator()(
 }
 
 const Metadata *SubstGenericParametersFromWrittenArgs::operator()(
-                                                    unsigned flatIndex) const {
-  if (flatIndex < allGenericArgs.size())
-    return allGenericArgs[flatIndex];
-
-  return nullptr;
-}
-
-const Metadata *SubstGenericParametersFromWrittenArgs::operator()(
                                                         unsigned depth,
                                                         unsigned index) const {
   if (auto flatIndex =

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -310,7 +310,6 @@ public:
       : allGenericArgs(allGenericArgs), genericParamCounts(genericParamCounts) {
     }
 
-    const Metadata *operator()(unsigned flatIndex) const;
     const Metadata *operator()(unsigned depth, unsigned index) const;
   };
 

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -289,7 +289,7 @@ public:
   /// given a particular generic parameter specified by depth/index.
   /// \p substWitnessTable Function that provides witness tables given a
   /// particular dependent conformance index.
-  TypeInfo _getTypeByMangledNode(
+  TypeInfo swift_getTypeByMangledNode(
                                Demangler &demangler,
                                Demangle::NodePointer node,
                                SubstGenericParameterFn substGenericParam,
@@ -301,7 +301,7 @@ public:
   /// given a particular generic parameter specified by depth/index.
   /// \p substWitnessTable Function that provides witness tables given a
   /// particular dependent conformance index.
-  TypeInfo _getTypeByMangledName(
+  TypeInfo swift_getTypeByMangledName(
                                StringRef typeName,
                                SubstGenericParameterFn substGenericParam,
                                SubstDependentWitnessTableFn substWitnessTable);

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -224,12 +224,6 @@ public:
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type,
                                                       Demangle::Demangler &Dem);
 
-  /// Callback used to provide the substitution for a generic parameter
-  /// referenced by a "flat" index (where all depths have been collapsed)
-  /// to its metadata.
-  using SubstFlatGenericParameterFn =
-    llvm::function_ref<const Metadata *(unsigned flatIndex)>;
-
   /// Callback used to provide the substitution of a generic parameter
   /// (described by depth/index) to its metadata.
   using SubstGenericParameterFn =
@@ -277,7 +271,6 @@ public:
     explicit SubstGenericParametersFromMetadata(const Metadata *base)
       : base(base) { }
 
-    const Metadata *operator()(unsigned flatIndex) const;
     const Metadata *operator()(unsigned depth, unsigned index) const;
   };
 
@@ -346,7 +339,6 @@ public:
   bool _checkGenericRequirements(
                     llvm::ArrayRef<GenericRequirementDescriptor> requirements,
                     std::vector<const void *> &extraArguments,
-                    SubstFlatGenericParameterFn substFlatGenericParam,
                     SubstGenericParameterFn substGenericParam);
 
   /// A helper function which avoids performing a store if the destination

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -238,7 +238,7 @@ public:
   /// that occur within a mangled name, using the generic arguments from
   /// the given metadata.
   ///
-  /// Use with \c swift_getTypeByMangledName to decode potentially-generic
+  /// Use with \c _getTypeByMangledName to decode potentially-generic
   /// types.
   class SWIFT_RUNTIME_LIBRARY_VISIBILITY SubstGenericParametersFromMetadata {
     const Metadata *base;

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -239,7 +239,8 @@ public:
   /// that occur within a mangled name, using the generic arguments from
   /// the given metadata.
   ///
-  /// Use with \c _getTypeByMangledName to decode potentially-generic types.
+  /// Use with \c swift__getTypeByMangledName to decode potentially-generic
+  /// types.
   class SWIFT_RUNTIME_LIBRARY_VISIBILITY SubstGenericParametersFromMetadata {
     const Metadata *base;
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -163,7 +163,7 @@ ProtocolConformanceDescriptor::getWitnessTable(const Metadata *type) const {
     SubstGenericParametersFromMetadata substitutions(type);
     bool failed =
       _checkGenericRequirements(getConditionalRequirements(), conditionalArgs,
-                                substitutions, substitutions);
+                                substitutions);
     if (failed) return nullptr;
   }
 
@@ -619,7 +619,6 @@ swift::_searchConformancesByMangledTypeName(Demangle::NodePointer node) {
 bool swift::_checkGenericRequirements(
                       llvm::ArrayRef<GenericRequirementDescriptor> requirements,
                       std::vector<const void *> &extraArguments,
-                      SubstFlatGenericParameterFn substFlatGenericParam,
                       SubstGenericParameterFn substGenericParam) {
   for (const auto &req : requirements) {
     // Make sure we understand the requirement we're dealing with.

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -627,8 +627,8 @@ bool swift::_checkGenericRequirements(
 
     // Resolve the subject generic parameter.
     const Metadata *subjectType =
-      _getTypeByMangledName(req.getParam(), substGenericParam,
-                            substWitnessTable);
+      swift_getTypeByMangledName(req.getParam(), substGenericParam,
+                                 substWitnessTable);
     if (!subjectType)
       return true;
 
@@ -652,8 +652,8 @@ bool swift::_checkGenericRequirements(
     case GenericRequirementKind::SameType: {
       // Demangle the second type under the given substitutions.
       auto otherType =
-        _getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
-                              substWitnessTable);
+        swift_getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
+                                   substWitnessTable);
       if (!otherType) return true;
 
       assert(!req.getFlags().hasExtraArgument());
@@ -679,8 +679,8 @@ bool swift::_checkGenericRequirements(
     case GenericRequirementKind::BaseClass: {
       // Demangle the base type under the given substitutions.
       auto baseType =
-        _getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
-                              substWitnessTable);
+        swift_getTypeByMangledName(req.getMangledTypeName(), substGenericParam,
+                                   substWitnessTable);
       if (!baseType) return true;
 
       // Check whether it's dynamically castable, which works as a superclass

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -336,7 +336,8 @@ getFieldAt(const Metadata *base, unsigned index) {
   auto typeName = field.getMangledTypeName(0);
 
   SubstGenericParametersFromMetadata substitutions(base);
-  auto typeInfo = _getTypeByMangledName(typeName, substitutions);
+  auto typeInfo = _getTypeByMangledName(typeName, substitutions,
+                                        substitutions);
 
   // Complete the type metadata before returning it to the caller.
   if (typeInfo) {

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -336,8 +336,8 @@ getFieldAt(const Metadata *base, unsigned index) {
   auto typeName = field.getMangledTypeName(0);
 
   SubstGenericParametersFromMetadata substitutions(base);
-  auto typeInfo = _getTypeByMangledName(typeName, substitutions,
-                                        substitutions);
+  auto typeInfo = swift_getTypeByMangledName(typeName, substitutions,
+                                             substitutions);
 
   // Complete the type metadata before returning it to the caller.
   if (typeInfo) {

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -11,18 +11,18 @@ let DemangleToMetadataTests = TestSuite("DemangleToMetadata")
 
 
 DemangleToMetadataTests.test("malformed mangled names") {
-  expectNil(_typeByMangledName("blah"))
+  expectNil(_typeByName("blah"))
 }
 
 DemangleToMetadataTests.test("tuple types") {
-  expectEqual(type(of: ()), _typeByMangledName("yt")!)
-  expectEqual(type(of: ((), ())), _typeByMangledName("yt_ytt")!)
-  expectEqual(type(of: ((), b: ())), _typeByMangledName("yt_yt1bt")!)
-  expectEqual(type(of: (a: (), ())), _typeByMangledName("yt1a_ytt")!)
-  expectEqual(type(of: (a: (), b: ())), _typeByMangledName("yt1a_yt1bt")!)
+  expectEqual(type(of: ()), _typeByName("yt")!)
+  expectEqual(type(of: ((), ())), _typeByName("yt_ytt")!)
+  expectEqual(type(of: ((), b: ())), _typeByName("yt_yt1bt")!)
+  expectEqual(type(of: (a: (), ())), _typeByName("yt1a_ytt")!)
+  expectEqual(type(of: (a: (), b: ())), _typeByName("yt1a_yt1bt")!)
 
   // Initial creation of metadata via demangling a type name.
-  expectNotNil(_typeByMangledName("yt1a_yt3bcdt"))
+  expectNotNil(_typeByName("yt1a_yt3bcdt"))
 }
 
 func f0() { }
@@ -51,48 +51,48 @@ func f1_escaping_autoclosure(_: @autoclosure @escaping () -> Float) { }
 
 DemangleToMetadataTests.test("function types") {
   // Conventions
-  expectEqual(type(of: f0), _typeByMangledName("yyc")!)
-  expectEqual(type(of: f0_thin), _typeByMangledName("yyXf")!)
-  expectEqual(type(of: f0_c), _typeByMangledName("yyXC")!)
+  expectEqual(type(of: f0), _typeByName("yyc")!)
+  expectEqual(type(of: f0_thin), _typeByName("yyXf")!)
+  expectEqual(type(of: f0_c), _typeByName("yyXC")!)
 #if _runtime(_ObjC)
-  expectEqual(type(of: f0_block), _typeByMangledName("yyXB")!)
+  expectEqual(type(of: f0_block), _typeByName("yyXB")!)
 #endif
 
   // Throwing functions
-  expectEqual(type(of: f0_throws), _typeByMangledName("yyKc")!)
+  expectEqual(type(of: f0_throws), _typeByName("yyKc")!)
 
   // More parameters.
-  expectEqual(type(of: f1), _typeByMangledName("yyyt_tc")!)
-  expectEqual(type(of: f2), _typeByMangledName("yyyt_yttc")!)
+  expectEqual(type(of: f1), _typeByName("yyyt_tc")!)
+  expectEqual(type(of: f2), _typeByName("yyyt_yttc")!)
 
   // Variadic parameters.
-  expectEqual(type(of: f1_variadic), _typeByMangledName("yyytd_tc")!)
+  expectEqual(type(of: f1_variadic), _typeByName("yyytd_tc")!)
 
   // Inout parameters.
-  expectEqual(type(of: f1_inout), _typeByMangledName("yyytzc")!)
+  expectEqual(type(of: f1_inout), _typeByName("yyytzc")!)
 
   // Ownership parameters.
-  expectEqual(type(of: f1_shared), _typeByMangledName("yyyXlhc")!)
-  expectEqual(type(of: f1_owned), _typeByMangledName("yyyXlnc")!)
+  expectEqual(type(of: f1_shared), _typeByName("yyyXlhc")!)
+  expectEqual(type(of: f1_owned), _typeByName("yyyXlnc")!)
 
   // Mix-and-match.
-  expectEqual(type(of: f2_variadic_inout), _typeByMangledName("yyytd_ytztc")!)
+  expectEqual(type(of: f2_variadic_inout), _typeByName("yyytd_ytztc")!)
 
   // A function type that hasn't been built before.
   expectEqual("(Int, Float, Double, String, Character, UInt, Bool) -> ()",
-    String(describing: _typeByMangledName("yySi_SfSdSSs9CharacterVSuSbtc")!))
+    String(describing: _typeByName("yySi_SfSdSSs9CharacterVSuSbtc")!))
 
   // Escaping
-  expectEqual(type(of: f1_escaping), _typeByMangledName("ySfSicc")!)
+  expectEqual(type(of: f1_escaping), _typeByName("ySfSicc")!)
 
   // Autoclosure
-  expectEqual(type(of: f1_autoclosure), _typeByMangledName("ySfyXKc")!)
-  expectEqual(type(of: f1_escaping_autoclosure), _typeByMangledName("ySfyXAc")!)
+  expectEqual(type(of: f1_autoclosure), _typeByName("ySfyXKc")!)
+  expectEqual(type(of: f1_escaping_autoclosure), _typeByName("ySfyXAc")!)
 }
 
 DemangleToMetadataTests.test("metatype types") {
-  expectEqual(type(of: type(of: ())), _typeByMangledName("ytm")!)
-  expectEqual(type(of: type(of: f0)), _typeByMangledName("yycm")!)
+  expectEqual(type(of: type(of: ())), _typeByName("ytm")!)
+  expectEqual(type(of: type(of: f0)), _typeByName("yycm")!)
 }
 
 func f2_any_anyobject(_: Any, _: AnyObject) { }
@@ -109,33 +109,33 @@ func f1_composition_superclass(_: C & P1 & P2) { }
 
 DemangleToMetadataTests.test("existential types") {
   // Any, AnyObject
-  expectEqual(type(of: f2_any_anyobject), _typeByMangledName("yyyp_yXltc")!)
+  expectEqual(type(of: f2_any_anyobject), _typeByName("yyyp_yXltc")!)
 
   // References to protocols.
-  expectEqual(type(of: f1_composition), _typeByMangledName("yy4main2P1_4main2P2pc")!)
+  expectEqual(type(of: f1_composition), _typeByName("yy4main2P1_4main2P2pc")!)
 
   // Reference to protocol with AnyObject.
-  expectEqual(type(of: f1_composition_anyobject), _typeByMangledName("yy4main2P1_Xlc")!)
+  expectEqual(type(of: f1_composition_anyobject), _typeByName("yy4main2P1_Xlc")!)
 
   // References to superclass.
-  expectEqual(type(of: f1_composition_superclass), _typeByMangledName("yy4main2P1_4main2P2AA1CCXcc")!)
+  expectEqual(type(of: f1_composition_superclass), _typeByName("yy4main2P1_4main2P2AA1CCXcc")!)
 
   // Demangle an existential type that hasn't been seen before.
-  expectEqual("P1 & P2 & P3", String(describing: _typeByMangledName("4main2P1_4main2P24main2P3p")!))
+  expectEqual("P1 & P2 & P3", String(describing: _typeByName("4main2P1_4main2P24main2P3p")!))
 }
 
 DemangleToMetadataTests.test("existential metatype types") {
   // Any
-  expectEqual(type(of: Any.self), _typeByMangledName("ypm")!)
+  expectEqual(type(of: Any.self), _typeByName("ypm")!)
 
   // AnyObject
-  expectEqual(type(of: AnyObject.self), _typeByMangledName("yXlm")!)
+  expectEqual(type(of: AnyObject.self), _typeByName("yXlm")!)
 
   // References to metatype of protocols.
-  expectEqual(type(of: (P1 & P2).self), _typeByMangledName("4main2P1_4main2P2pm")!)
+  expectEqual(type(of: (P1 & P2).self), _typeByName("4main2P1_4main2P2pm")!)
 
   // References to metatype involving protocols and superclass.
-  expectEqual(type(of: (C & P1 & P2).self), _typeByMangledName("4main2P1_4main2P2AA1CCXcm")!)
+  expectEqual(type(of: (C & P1 & P2).self), _typeByName("4main2P1_4main2P2AA1CCXcm")!)
 }
 
 struct S {
@@ -146,23 +146,23 @@ enum E { case e }
 
 DemangleToMetadataTests.test("nominal types") {
   // Simple Struct
-  expectEqual(type(of: S()), _typeByMangledName("4main1SV")!)
+  expectEqual(type(of: S()), _typeByName("4main1SV")!)
 
   // Simple Enum
-  expectEqual(type(of: E.e), _typeByMangledName("4main1EO")!)
+  expectEqual(type(of: E.e), _typeByName("4main1EO")!)
 
   // Simple Class
-  expectEqual(type(of: C()), _typeByMangledName("4main1CC")!)
+  expectEqual(type(of: C()), _typeByName("4main1CC")!)
 
   // Swift standard library types
-  expectEqual(type(of: Int()), _typeByMangledName("Si")!)
-  expectEqual(type(of: Int16()), _typeByMangledName("s5Int16V")!)
+  expectEqual(type(of: Int()), _typeByName("Si")!)
+  expectEqual(type(of: Int16()), _typeByName("s5Int16V")!)
 
   // Nested struct
-  expectEqual(type(of: S.Nested()), _typeByMangledName("4main1SV6NestedV")!)
+  expectEqual(type(of: S.Nested()), _typeByName("4main1SV6NestedV")!)
 
   // Class referenced by "ModuleName.ClassName" syntax.
-  expectEqual(type(of: C()), _typeByMangledName("main.C")!)
+  expectEqual(type(of: C()), _typeByName("main.C")!)
 }
 
 protocol P4 {
@@ -175,26 +175,15 @@ extension S: P4 {
   typealias Assoc2 = String
 }
 
-DemangleToMetadataTests.test("substitutions") {
-  // Type parameter substitutions.
-  expectEqual(type(of: (1, 3.14159, "Hello")),
-    _typeByMangledName("yyx_q_qd__t",
-      substitutions: [[Int.self, Double.self], [String.self]])!)
-
-  // Associated type substitutions
-  expectEqual(type(of: (S(), 1, "Hello")),
-    _typeByMangledName("x_6Assoc14main2P4PQz6Assoc24main2P4PQzt", substitutions: [[S.self]])!)
-}
-
 enum EG<T, U> { case a }
 
 class CG3<T, U, V> { }
 
 
 DemangleToMetadataTests.test("simple generic specializations") {
-  expectEqual([Int].self, _typeByMangledName("SaySiG")!)
-  expectEqual(EG<Int, String>.self, _typeByMangledName("4main2EGOySiSSG")!)
-  expectEqual(CG3<Int, Double, String>.self, _typeByMangledName("4main3CG3CySiSdSSG")!)
+  expectEqual([Int].self, _typeByName("SaySiG")!)
+  expectEqual(EG<Int, String>.self, _typeByName("4main2EGOySiSSG")!)
+  expectEqual(CG3<Int, Double, String>.self, _typeByName("4main3CG3CySiSdSSG")!)
 }
 
 extension EG {
@@ -219,33 +208,33 @@ class CG2<T, U> {
 
 DemangleToMetadataTests.test("nested generic specializations") {
   expectEqual(EG<Int, String>.NestedSG<Double>.self,
-    _typeByMangledName("4main2EGO8NestedSGVySiSS_SdG")!)
+    _typeByName("4main2EGO8NestedSGVySiSS_SdG")!)
   expectEqual(C.Nested<Int, String>.Innermore.Innermost<Double>.self,
-    _typeByMangledName("4main1CC6NestedO9InnermoreV9InnermostVy_SiSS__SdG")!)
+    _typeByName("4main1CC6NestedO9InnermoreV9InnermostVy_SiSS__SdG")!)
   expectEqual(CG2<Int, String>.Inner<Double>.self,
-    _typeByMangledName("4main3CG2C5InnerCySiSS_SdG")!)
+    _typeByName("4main3CG2C5InnerCySiSS_SdG")!)
   expectEqual(
     CG2<Int, String>.Inner<Double>.Innermost<Int8, Int16, Int32, Int64>.self,
-    _typeByMangledName("4main3CG2C5InnerC9InnermostVySiSS_Sd_s4Int8Vs5Int16Vs5Int32Vs5Int64VG")!)
+    _typeByName("4main3CG2C5InnerC9InnermostVySiSS_Sd_s4Int8Vs5Int16Vs5Int32Vs5Int64VG")!)
 }
 
 DemangleToMetadataTests.test("demangle built-in types") {
-  expectEqual(Builtin.Int8.self,     _typeByMangledName("Bi8_")!)
-  expectEqual(Builtin.Int16.self,    _typeByMangledName("Bi16_")!)
-  expectEqual(Builtin.Int32.self,    _typeByMangledName("Bi32_")!)
-  expectEqual(Builtin.Int64.self,    _typeByMangledName("Bi64_")!)
-  expectEqual(Builtin.Int128.self,   _typeByMangledName("Bi128_")!)
-  expectEqual(Builtin.Int256.self,   _typeByMangledName("Bi256_")!)
-  expectEqual(Builtin.Int512.self,   _typeByMangledName("Bi512_")!)
+  expectEqual(Builtin.Int8.self,     _typeByName("Bi8_")!)
+  expectEqual(Builtin.Int16.self,    _typeByName("Bi16_")!)
+  expectEqual(Builtin.Int32.self,    _typeByName("Bi32_")!)
+  expectEqual(Builtin.Int64.self,    _typeByName("Bi64_")!)
+  expectEqual(Builtin.Int128.self,   _typeByName("Bi128_")!)
+  expectEqual(Builtin.Int256.self,   _typeByName("Bi256_")!)
+  expectEqual(Builtin.Int512.self,   _typeByName("Bi512_")!)
 
-  expectEqual(Builtin.NativeObject.self, _typeByMangledName("Bo")!)
-  expectEqual(Builtin.BridgeObject.self, _typeByMangledName("Bb")!)
-  expectEqual(Builtin.UnsafeValueBuffer.self, _typeByMangledName("BB")!)
+  expectEqual(Builtin.NativeObject.self, _typeByName("Bo")!)
+  expectEqual(Builtin.BridgeObject.self, _typeByName("Bb")!)
+  expectEqual(Builtin.UnsafeValueBuffer.self, _typeByName("BB")!)
 
-  expectEqual(Builtin.FPIEEE32.self, _typeByMangledName("Bf32_")!)
-  expectEqual(Builtin.FPIEEE64.self, _typeByMangledName("Bf64_")!)
+  expectEqual(Builtin.FPIEEE32.self, _typeByName("Bf32_")!)
+  expectEqual(Builtin.FPIEEE64.self, _typeByName("Bf64_")!)
 
-  expectEqual(Builtin.Vec4xFPIEEE32.self, _typeByMangledName("Bf32_Bv4_")!)
+  expectEqual(Builtin.Vec4xFPIEEE32.self, _typeByName("Bf32_Bv4_")!)
 }
 
 class CG4<T: P1, U: P2> {
@@ -258,14 +247,14 @@ struct ConformsToP3: P3 { }
 
 DemangleToMetadataTests.test("protocol conformance requirements") {
   expectEqual(CG4<ConformsToP1, ConformsToP2>.self,
-    _typeByMangledName("4main3CG4CyAA12ConformsToP1VAA12ConformsToP2VG")!)
+    _typeByName("4main3CG4CyAA12ConformsToP1VAA12ConformsToP2VG")!)
   expectEqual(CG4<ConformsToP1, ConformsToP2>.InnerGeneric<ConformsToP3>.self,
-    _typeByMangledName("4main3CG4C12InnerGenericVyAA12ConformsToP1VAA12ConformsToP2V_AA12ConformsToP3VG")!)
+    _typeByName("4main3CG4C12InnerGenericVyAA12ConformsToP1VAA12ConformsToP2V_AA12ConformsToP3VG")!)
 
   // Failure cases: failed conformance requirements.
-  expectNil(_typeByMangledName("4main3CG4CyAA12ConformsToP1VAA12ConformsToP1VG"))
-  expectNil(_typeByMangledName("4main3CG4CyAA12ConformsToP2VAA12ConformsToP2VG"))
-  expectNil(_typeByMangledName("4main3CG4C12InnerGenericVyAA12ConformsToP1VAA12ConformsToP2V_AA12ConformsToP2VG"))
+  expectNil(_typeByName("4main3CG4CyAA12ConformsToP1VAA12ConformsToP1VG"))
+  expectNil(_typeByName("4main3CG4CyAA12ConformsToP2VAA12ConformsToP2VG"))
+  expectNil(_typeByName("4main3CG4C12InnerGenericVyAA12ConformsToP1VAA12ConformsToP2V_AA12ConformsToP2VG"))
 }
 
 struct SG5<T: P4> where T.Assoc1: P1, T.Assoc2: P2 { }
@@ -287,12 +276,12 @@ struct ConformsToP4c : P4 {
 
 DemangleToMetadataTests.test("associated type conformance requirements") {
   expectEqual(SG5<ConformsToP4a>.self,
-    _typeByMangledName("4main3SG5VyAA13ConformsToP4aVG")!)
+    _typeByName("4main3SG5VyAA13ConformsToP4aVG")!)
 
   // Failure cases: failed conformance requirements.
-  expectNil(_typeByMangledName("4main3SG5VyAA13ConformsToP4bVG"))
-  expectNil(_typeByMangledName("4main3SG5VyAA13ConformsToP4cVG"))
-  expectNil(_typeByMangledName("4main3SG5VyAA12ConformsToP1cVG"))
+  expectNil(_typeByName("4main3SG5VyAA13ConformsToP4bVG"))
+  expectNil(_typeByName("4main3SG5VyAA13ConformsToP4cVG"))
+  expectNil(_typeByName("4main3SG5VyAA12ConformsToP1cVG"))
 }
 
 struct SG6<T: P4> where T.Assoc1 == T.Assoc2 { }
@@ -307,32 +296,32 @@ struct ConformsToP4d : P4 {
 DemangleToMetadataTests.test("same-type requirements") {
   // Concrete type.
   expectEqual(SG7<S>.self,
-    _typeByMangledName("4main3SG7VyAA1SVG")!)
+    _typeByName("4main3SG7VyAA1SVG")!)
 
   // Other associated type.
   expectEqual(SG6<ConformsToP4b>.self,
-    _typeByMangledName("4main3SG6VyAA13ConformsToP4bVG")!)
+    _typeByName("4main3SG6VyAA13ConformsToP4bVG")!)
   expectEqual(SG6<ConformsToP4c>.self,
-    _typeByMangledName("4main3SG6VyAA13ConformsToP4cVG")!)
+    _typeByName("4main3SG6VyAA13ConformsToP4cVG")!)
 
   // Structural type.
   expectEqual(SG8<ConformsToP4d>.self,
-    _typeByMangledName("4main3SG8VyAA13ConformsToP4dVG")!)
+    _typeByName("4main3SG8VyAA13ConformsToP4dVG")!)
 
   // Failure cases: types don't match.
-  expectNil(_typeByMangledName("4main3SG7VyAA13ConformsToP4aVG"))
-  expectNil(_typeByMangledName("4main3SG6VyAA13ConformsToP4aVG"))
-  expectNil(_typeByMangledName("4main3SG8VyAA13ConformsToP4cVG"))
+  expectNil(_typeByName("4main3SG7VyAA13ConformsToP4aVG"))
+  expectNil(_typeByName("4main3SG6VyAA13ConformsToP4aVG"))
+  expectNil(_typeByName("4main3SG8VyAA13ConformsToP4cVG"))
 }
 
 struct SG9<T: AnyObject> { }
 
 DemangleToMetadataTests.test("AnyObject requirements") {
   expectEqual(SG9<C>.self,
-    _typeByMangledName("4main3SG9VyAA1CCG")!)
+    _typeByName("4main3SG9VyAA1CCG")!)
 
   // Failure cases: failed AnyObject constraint.
-  expectNil(_typeByMangledName("4main3SG9VyAA1SVG"))
+  expectNil(_typeByName("4main3SG9VyAA1SVG"))
 }
 
 struct SG10<T: C> { }
@@ -342,12 +331,12 @@ class C3 { }
 
 DemangleToMetadataTests.test("superclass requirements") {
   expectEqual(SG10<C>.self,
-    _typeByMangledName("4main4SG10VyAA1CCG")!)
+    _typeByName("4main4SG10VyAA1CCG")!)
   expectEqual(SG10<C2>.self,
-    _typeByMangledName("4main4SG10VyAA2C2CG")!)
+    _typeByName("4main4SG10VyAA2C2CG")!)
 
   // Failure cases: not a subclass.
-  expectNil(_typeByMangledName("4main4SG10VyAA2C3CG"))
+  expectNil(_typeByName("4main4SG10VyAA2C3CG"))
 }
 
 //
@@ -373,24 +362,24 @@ struct ConformsToP2AndP3: P2, P3 { }
 DemangleToMetadataTests.test("Nested types in extensions") {
   expectEqual(
     Dictionary<String, Int>.Inner<ConformsToP1>.self,
-    _typeByMangledName("s10DictionaryV4mainE5InnerVySSSi_AC12ConformsToP1VG")!)
+    _typeByName("s10DictionaryV4mainE5InnerVySSSi_AC12ConformsToP1VG")!)
   expectEqual(
     SG11<ConformsToP1>.InnerTConformsToP1<ConformsToP2>.self,
-    _typeByMangledName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VyAA08ConformsfC0V_AA0gF2P2VG")!)
+    _typeByName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VyAA08ConformsfC0V_AA0gF2P2VG")!)
   expectEqual(
     SG11<ConformsToP1>.InnerTConformsToP1<ConformsToP2AndP3>
                       .InnermostUConformsToP3<ConformsToP4a>.self,
-    _typeByMangledName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VA2A2P3Rd__rlE018InnermostUConformsfG0VyAA08ConformsfC0V_AA0jf5P2AndG0V_AA0jF3P4aVG")!)
+    _typeByName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VA2A2P3Rd__rlE018InnermostUConformsfG0VyAA08ConformsfC0V_AA0jf5P2AndG0V_AA0jF3P4aVG")!)
 
   // Failure case: Dictionary's outer `Key: Hashable` constraint not sastified
-  expectNil(_typeByMangledName("s10DictionaryV4mainE5InnerVyAC12ConformsToP1VSi_AC12ConformsToP1VG"))
+  expectNil(_typeByName("s10DictionaryV4mainE5InnerVyAC12ConformsToP1VSi_AC12ConformsToP1VG"))
   // Failure case: Dictionary's inner `V: P1` constraint not satisfied
-  expectNil(_typeByMangledName("s10DictionaryV4mainE5InnerVySSSi_AC12ConformsToP2VG"))
+  expectNil(_typeByName("s10DictionaryV4mainE5InnerVySSSi_AC12ConformsToP2VG"))
 
   // Failure case: SG11's outer `T: P1` constraint not satisfied
-  expectNil(_typeByMangledName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VyAA08ConformsF2P2V_AHGMa"))
+  expectNil(_typeByName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VyAA08ConformsF2P2V_AHGMa"))
   // Failure case: SG11's inner `U: P2` constraint not satisfied
-  expectNil(_typeByMangledName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VyAA08ConformsfC0V_AHGMa"))
+  expectNil(_typeByName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VyAA08ConformsfC0V_AHGMa"))
 
   // TODO: Failure case: InnermostUConformsToP3's 'U: P3' constraint not satisfied
   
@@ -419,13 +408,13 @@ extension SG12 where U == ConformsToP2 {
 DemangleToMetadataTests.test("Nested types in same-type-constrained extensions") {
   expectEqual(
     SG12<ConformsToP1AndP2, ConformsToP1AndP2>.InnerTEqualsU<ConformsToP3>.self,
-    _typeByMangledName("4main4SG12VA2A2P2Rzq_RszrlE13InnerTEqualsUVyAA015ConformsToP1AndC0VAH_AA0fG2P3VG")!)
+    _typeByName("4main4SG12VA2A2P2Rzq_RszrlE13InnerTEqualsUVyAA015ConformsToP1AndC0VAH_AA0fG2P3VG")!)
   expectEqual(
     SG12<ConformsToP1, ConformsToP2>.InnerTEqualsConformsToP1<ConformsToP3>.self,
-    _typeByMangledName("4main4SG12VA2A12ConformsToP1VRszrlE012InnerTEqualscdE0VyAeA0cD2P2V_AA0cD2P3VG")!)
+    _typeByName("4main4SG12VA2A12ConformsToP1VRszrlE012InnerTEqualscdE0VyAeA0cD2P2V_AA0cD2P3VG")!)
   expectEqual(
     SG12<ConformsToP1, ConformsToP2>.InnerUEqualsConformsToP2<ConformsToP3>.self,
-    _typeByMangledName("4main4SG12VA2A12ConformsToP2VRs_rlE012InnerUEqualscdE0VyAA0cD2P1VAE_AA0cD2P3VG")!)
+    _typeByName("4main4SG12VA2A12ConformsToP2VRs_rlE012InnerUEqualscdE0VyAA0cD2P1VAE_AA0cD2P3VG")!)
 
   // TODO: Cases where mangled name doesn't match constraints
   // T != U in InnerTEqualsU

--- a/test/Runtime/demangleToMetadataObjC.swift
+++ b/test/Runtime/demangleToMetadataObjC.swift
@@ -18,11 +18,11 @@ protocol P2 { }
 @objc protocol mainP4 { }
 
 DemangleToMetadataTests.test("@objc classes") {
-  expectEqual(type(of: C()), _typeByMangledName("4main1CC")!)
+  expectEqual(type(of: C()), _typeByName("4main1CC")!)
 }
 
 DemangleToMetadataTests.test("@objc enums") {
-  expectEqual(type(of: E.a), _typeByMangledName("4main1EO")!)
+  expectEqual(type(of: E.a), _typeByName("4main1EO")!)
 }
 
 func f1_composition_objc_protocol(_: P1) { }
@@ -30,43 +30,43 @@ func f1_composition_objc_protocol_P4(_: mainP4) { }
 
 DemangleToMetadataTests.test("@objc protocols") {
   expectEqual(type(of: f1_composition_objc_protocol),
-              _typeByMangledName("yy4main2P1_pc")!)
+              _typeByName("yy4main2P1_pc")!)
   expectEqual(type(of: f1_composition_objc_protocol_P4),
-              _typeByMangledName("yy4main0A2P4_pc")!)
+              _typeByName("yy4main0A2P4_pc")!)
 }
 
 DemangleToMetadataTests.test("Objective-C classes") {
-  expectEqual(type(of: NSObject()), _typeByMangledName("So8NSObjectC")!)
+  expectEqual(type(of: NSObject()), _typeByName("So8NSObjectC")!)
 }
 
 func f1_composition_NSCoding(_: NSCoding) { }
 
 DemangleToMetadataTests.test("Objective-C protocols") {
-  expectEqual(type(of: f1_composition_NSCoding), _typeByMangledName("yySo8NSCoding_pc")!)
+  expectEqual(type(of: f1_composition_NSCoding), _typeByName("yySo8NSCoding_pc")!)
 }
 
 DemangleToMetadataTests.test("Classes that don't exist") {
-  expectNil(_typeByMangledName("4main4BoomC"))
+  expectNil(_typeByName("4main4BoomC"))
 }
 
 DemangleToMetadataTests.test("CoreFoundation classes") {
-  expectEqual(CFArray.self, _typeByMangledName("So10CFArrayRefa")!)
+  expectEqual(CFArray.self, _typeByName("So10CFArrayRefa")!)
 }
 
 DemangleToMetadataTests.test("Imported error types") {
-  expectEqual(URLError.self, _typeByMangledName("10Foundation8URLErrorV")!)
+  expectEqual(URLError.self, _typeByName("10Foundation8URLErrorV")!)
   expectEqual(URLError.Code.self,
-    _typeByMangledName("10Foundation8URLErrorV4CodeV")!)
+    _typeByName("10Foundation8URLErrorV4CodeV")!)
 }
 
 DemangleToMetadataTests.test("Imported swift_wrapper types") {
   expectEqual(URLFileResourceType.self,
-    _typeByMangledName("So21NSURLFileResourceTypea")!)
+    _typeByName("So21NSURLFileResourceTypea")!)
 }
 
 DemangleToMetadataTests.test("Imported enum types") {
   expectEqual(URLSessionTask.State.self,
-    _typeByMangledName("So21NSURLSessionTaskStateV")!)
+    _typeByName("So21NSURLSessionTaskStateV")!)
 }
 
 class CG4<T: P1, U: P2> { }
@@ -77,14 +77,14 @@ class D: P2 { }
 
 DemangleToMetadataTests.test("@objc protocol conformances") {
   expectEqual(CG4<C, C>.self,
-    _typeByMangledName("4main3CG4CyAA1CCAA1CCG")!)
-  expectNil(_typeByMangledName("4main3CG4CyAA1DCAA1DCG"))
+    _typeByName("4main3CG4CyAA1CCAA1CCG")!)
+  expectNil(_typeByName("4main3CG4CyAA1DCAA1DCG"))
 }
 
 DemangleToMetadataTests.test("synthesized declarations") {
-  expectEqual(CLError.self, _typeByMangledName("SC7CLErrorLeV")!)
-  expectNil(_typeByMangledName("SC7CLErrorV"))
-  expectEqual(CLError.Code.self, _typeByMangledName("So7CLErrorV")!)
+  expectEqual(CLError.self, _typeByName("SC7CLErrorLeV")!)
+  expectNil(_typeByName("SC7CLErrorV"))
+  expectEqual(CLError.Code.self, _typeByName("So7CLErrorV")!)
 
   let error = NSError(domain: NSCocoaErrorDomain, code: 0)
   let reflectionString = String(reflecting: CLError(_nsError: error))
@@ -93,18 +93,18 @@ DemangleToMetadataTests.test("synthesized declarations") {
 
 DemangleToMetadataTests.test("members of runtime-only Objective-C classes") {
   expectEqual(DispatchQueue.Attributes.self,
-    _typeByMangledName("So17OS_dispatch_queueC8DispatchE10AttributesV")!)
+    _typeByName("So17OS_dispatch_queueC8DispatchE10AttributesV")!)
 }
 
 DemangleToMetadataTests.test("runtime conformance lookup via foreign superclasses") {
   expectEqual(Set<CFMutableString>.self,
-    _typeByMangledName("ShySo18CFMutableStringRefaG")!)
+    _typeByName("ShySo18CFMutableStringRefaG")!)
 }
 
 class F<T: P1> { }
 
 DemangleToMetadataTests.test("runtime conformance check for @objc protocol inheritance") {
-  expectEqual(F<P3>.self, _typeByMangledName("4main1FCyAA2P3PG")!)
+  expectEqual(F<P3>.self, _typeByName("4main1FCyAA2P3PG")!)
 }
 
 runAllTests()

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -14,6 +14,7 @@ Struct _Buffer72 has been removed
 Func _int64ToString(_:radix:uppercase:) has been removed
 Func _int64ToStringImpl(_:_:_:_:_:) has been removed
 Func _uint64ToStringImpl(_:_:_:_:_:) has been removed
+Func _typeByMangledName(_:substitutions:) has been removed
 Func _withUninitializedString(_:) has been removed
 
 Class _stdlib_AtomicInt has been removed

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -34,6 +34,11 @@ namespace  {
   MetadataResponse getEmptyValue<MetadataResponse>() {
     return MetadataResponse{nullptr, MetadataState::Complete};
   }
+
+  template<>
+  TypeInfo getEmptyValue<TypeInfo>() {
+    return TypeInfo();
+  }
 }
 
 #define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs) \
@@ -161,6 +166,18 @@ TEST_F(CompatibilityOverrideTest,
 TEST_F(CompatibilityOverrideTest, test_swift_conformsToProtocol) {
   auto Result = swift_conformsToProtocol(nullptr, nullptr);
   ASSERT_EQ(Result, nullptr);  
+}
+
+TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledNode) {
+  Demangler demangler;
+  auto Result = swift_getTypeByMangledNode(demangler, nullptr, nullptr,
+                                           nullptr);
+  ASSERT_EQ((const Metadata *)Result, nullptr);
+}
+
+TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledName) {
+  auto Result = swift_getTypeByMangledName("", nullptr, nullptr);
+  ASSERT_EQ((const Metadata *)Result, nullptr);
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_getAssociatedTypeWitnessSlow) {

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -62,13 +62,6 @@ OverrideSection Overrides __attribute__((section("__DATA,__swift_hooks"))) = {
 #include "../../stdlib/public/runtime/CompatibilityOverride.def"
 };
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
-const Metadata * _Nullable
-swift_getTypeByMangledName(const char *typeNameStart, size_t typeNameLength,
-                           size_t numberOfLevels,
-                           size_t *parametersPerLevel,
-                           const Metadata * const *flatSubstitutions);
-
 class CompatibilityOverrideTest : public ::testing::Test {
 protected:
   virtual void SetUp() {
@@ -87,11 +80,6 @@ protected:
     ASSERT_TRUE(Ran);
   }
 };
-
-TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledName) {
-  auto Result = swift_getTypeByMangledName("", 0, 0, nullptr, nullptr);
-  ASSERT_EQ(Result, nullptr);
-}
 
 TEST_F(CompatibilityOverrideTest, test_swift_dynamicCast) {
   auto Result = swift_dynamicCast(nullptr, nullptr, nullptr, nullptr,


### PR DESCRIPTION
Centralize the demangle-to-metadata operations in the runtime into two new functions, `swift_getTypeByMangledName` and `swift_getTypeByMangledNode`, clean up their interfaces to support future improvements in demangling generic types, and make them overridable. This will let
us back-deploy mangling improvements and bug fixes.