### PR TITLE
[DNM] [SILVerifier] Verify that graph_op inputs conform to TensorArrayProtocol

### DIFF
--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -119,8 +119,8 @@ public:
     };
 
   public:
-   StructuredArgument(StructuredArgumentKind Kind, StringRef Name,
-                      SILValue SingleArgument)
+    StructuredArgument(StructuredArgumentKind Kind, StringRef Name,
+                       SILValue SingleArgument)
         : Kind(Kind), Name(Name), SingleArgument(SingleArgument) {}
     StructuredArgument(StructuredArgumentKind Kind, StringRef Name,
                       ArrayRef<Operand> ArgumentList)

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1538,17 +1538,26 @@ public:
               tf::GraphOperationInfo::ArgumentLowering::Input)
         continue;
       switch (sa.getKind()) {
-      case tf::GraphOperationInfo::SAK_Single:
-        require(conformsToProtocol(sa.getSingleArgument()->getType(),
-                                   KnownProtocolKind::TensorArrayProtocol),
-                "graph_op operands must conform to TensorArrayProtocol");
+      case tf::GraphOperationInfo::SAK_Single: {
+        auto argTy = sa.getSingleArgument()->getType();
+        if (tf::isTensorFlowValue(argTy) || argTy.is<BuiltinType>())
+          continue;
+        require(
+            conformsToProtocol(argTy, KnownProtocolKind::TensorArrayProtocol),
+            "graph_op operands must conform to TensorArrayProtocol");
         break;
-      case tf::GraphOperationInfo::SAK_List:
-        for (auto arg : sa.getArgumentList())
-          require(conformsToProtocol(arg->getType(),
-                                     KnownProtocolKind::TensorArrayProtocol),
-                  "graph_op operands must conform to TensorArrayProtocol");
+      }
+      case tf::GraphOperationInfo::SAK_List: {
+        for (auto arg : sa.getArgumentList()) {
+          auto argTy = arg->getType();
+          if (tf::isTensorFlowValue(argTy) || argTy.is<BuiltinType>())
+            continue;
+          require(
+              conformsToProtocol(argTy, KnownProtocolKind::TensorArrayProtocol),
+              "graph_op operands must conform to TensorArrayProtocol");
+        }
         break;
+      }
       }
     }
   }

--- a/test/TensorFlow/canonicalize_cfg_xla.sil
+++ b/test/TensorFlow/canonicalize_cfg_xla.sil
@@ -2,7 +2,7 @@
 
 import Builtin
 import Swift
-struct TensorCore<Element> {}
+import TensorFlow
 
 /* This corresponds to this input code:
   var a = <<opaque>>
@@ -24,38 +24,38 @@ struct TensorCore<Element> {}
 // CHECK-NEXT:   block bb1]
 // CHECK-NEXT: --- XLA CFG Canonicalize end
 
-sil private @testLoop : $@callee_owned (TensorCore<Float>) -> (TensorCore<Float>, TensorCore<Float>) {
+sil private @testLoop : $@callee_owned (TensorHandle<Float>) -> (TensorHandle<Float>, TensorHandle<Float>) {
 // %0                                             // users: %1, %1
-bb0(%0 : $TensorCore<Float>):
-  %1 = graph_op "Sub"(%0 : $TensorCore<Float>, %0 : $TensorCore<Float>) : $TensorCore<Float> // users: %6, %6
+bb0(%0 : $TensorHandle<Float>):
+  %1 = graph_op "Sub"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) : $TensorHandle<Float> // users: %6, %6
   %2 = integer_literal $Builtin.Int64, 0          // user: %3
-  %3 = graph_op "Const"(value$tensor %2 : $Builtin.Int64) : $TensorCore<Builtin.Int64> // user: %10
+  %3 = graph_op "Const"(value$tensor %2 : $Builtin.Int64) : $TensorHandle<Builtin.Int64> // user: %10
   %4 = integer_literal $Builtin.Int64, 100        // user: %5
-  %5 = graph_op "Const"(value$tensor %4 : $Builtin.Int64) : $TensorCore<Builtin.Int64> // user: %17
-  %6 = graph_op "Add"(%1 : $TensorCore<Float>, %1 : $TensorCore<Float>) : $TensorCore<Float> // users: %7, %7
-  %7 = graph_op "Add"(%6 : $TensorCore<Float>, %6 : $TensorCore<Float>) : $TensorCore<Float> // user: %10
+  %5 = graph_op "Const"(value$tensor %4 : $Builtin.Int64) : $TensorHandle<Builtin.Int64> // user: %17
+  %6 = graph_op "Add"(%1 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) : $TensorHandle<Float> // users: %7, %7
+  %7 = graph_op "Add"(%6 : $TensorHandle<Float>, %6 : $TensorHandle<Float>) : $TensorHandle<Float> // user: %10
   %8 = integer_literal $Builtin.Int64, 1          // user: %9
-  %9 = graph_op "Const"(value$tensor %8 : $Builtin.Int64) : $TensorCore<Builtin.Int64> // user: %16
-  br bb2(%3 : $TensorCore<Builtin.Int64>, %7 : $TensorCore<Float>) // id: %10
+  %9 = graph_op "Const"(value$tensor %8 : $Builtin.Int64) : $TensorHandle<Builtin.Int64> // user: %16
+  br bb2(%3 : $TensorHandle<Builtin.Int64>, %7 : $TensorHandle<Float>) // id: %10
 
 bb1:                                              // Preds: bb2
-  %11 = graph_op "Sub"(%20 : $TensorCore<Float>, %20 : $TensorCore<Float>) : $TensorCore<Float> // user: %12
-  %12 = tuple (%20 : $TensorCore<Float>, %11 : $TensorCore<Float>) // user: %13
-  return %12 : $(TensorCore<Float>, TensorCore<Float>) // id: %13
+  %11 = graph_op "Sub"(%20 : $TensorHandle<Float>, %20 : $TensorHandle<Float>) : $TensorHandle<Float> // user: %12
+  %12 = tuple (%20 : $TensorHandle<Float>, %11 : $TensorHandle<Float>) // user: %13
+  return %12 : $(TensorHandle<Float>, TensorHandle<Float>) // id: %13
 
 // %14                                            // user: %16
 // %15                                            // users: %18, %18
-bb2(%14 : $TensorCore<Builtin.Int64>, %15 : $TensorCore<Float>): // Preds: bb3 bb0
-  %16 = graph_op "Add"(%14 : $TensorCore<Builtin.Int64>, %9 : $TensorCore<Builtin.Int64>) : $TensorCore<Builtin.Int64> // users: %23, %17
-  %17 = graph_op "Equal"(%16 : $TensorCore<Builtin.Int64>, %5 : $TensorCore<Builtin.Int64>) : $TensorCore<Builtin.Int1> // user: %21
-  %18 = graph_op "Add"(%15 : $TensorCore<Float>, %15 : $TensorCore<Float>) : $TensorCore<Float> // user: %19
-  %19 = graph_op "tensorflowSend"(%18 : $TensorCore<Float>) : $()
-  %20 = graph_op "tensorflowReceive"() : $TensorCore<Float> // users: %12, %23, %11, %11
-  %21 = graph_op "tf_tensor_to_i1"(%17 : $TensorCore<Builtin.Int1>) : $Builtin.Int1 // user: %22
+bb2(%14 : $TensorHandle<Builtin.Int64>, %15 : $TensorHandle<Float>): // Preds: bb3 bb0
+  %16 = graph_op "Add"(%14 : $TensorHandle<Builtin.Int64>, %9 : $TensorHandle<Builtin.Int64>) : $TensorHandle<Builtin.Int64> // users: %23, %17
+  %17 = graph_op "Equal"(%16 : $TensorHandle<Builtin.Int64>, %5 : $TensorHandle<Builtin.Int64>) : $TensorHandle<Builtin.Int1> // user: %21
+  %18 = graph_op "Add"(%15 : $TensorHandle<Float>, %15 : $TensorHandle<Float>) : $TensorHandle<Float> // user: %19
+  %19 = graph_op "tensorflowSend"(%18 : $TensorHandle<Float>) : $()
+  %20 = graph_op "tensorflowReceive"() : $TensorHandle<Float> // users: %12, %23, %11, %11
+  %21 = graph_op "tf_tensor_to_i1"(%17 : $TensorHandle<Builtin.Int1>) : $Builtin.Int1 // user: %22
   cond_br %21, bb1, bb3                           // id: %22
 
 bb3:                                              // Preds: bb2
-  br bb2(%16 : $TensorCore<Builtin.Int64>, %20 : $TensorCore<Float>) // id: %23
+  br bb2(%16 : $TensorHandle<Builtin.Int64>, %20 : $TensorHandle<Float>) // id: %23
 }
 
 /* This is a simple if diamond, corresponding to this Swift code:
@@ -79,25 +79,25 @@ bb3:                                              // Preds: bb2
 // CHECK-NEXT:     block bb2}
 // CHECK-NEXT:   block bb3]
 // CHECK-NEXT: --- XLA CFG Canonicalize end
-sil private @testIf : $@callee_owned (TensorCore<Float>, Builtin.Int1) -> TensorCore<Float> {
+sil private @testIf : $@callee_owned (TensorHandle<Float>, Builtin.Int1) -> TensorHandle<Float> {
 // %0                                             // users: %2, %2
 // %1                                             // user: %4
-bb0(%0 : $TensorCore<Float>, %1 : $Builtin.Int1):
-  %2 = graph_op "Sub"(%0 : $TensorCore<Float>, %0 : $TensorCore<Float>) : $TensorCore<Float> // users: %3, %5, %5
+bb0(%0 : $TensorHandle<Float>, %1 : $Builtin.Int1):
+  %2 = graph_op "Sub"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) : $TensorHandle<Float> // users: %3, %5, %5
   cond_br %1, bb1, bb2                            // id: %4
 
 bb1:                                              // Preds: bb0
-  %5 = graph_op "Sub"(%2 : $TensorCore<Float>, %2 : $TensorCore<Float>) : $TensorCore<Float> // user: %6
-  br bb3(%5 : $TensorCore<Float>)                 // id: %6
+  %5 = graph_op "Sub"(%2 : $TensorHandle<Float>, %2 : $TensorHandle<Float>) : $TensorHandle<Float> // user: %6
+  br bb3(%5 : $TensorHandle<Float>)                 // id: %6
 
 bb2:                                              // Preds: bb0
-  %7 = graph_op "Add"(%2 : $TensorCore<Float>, %2 : $TensorCore<Float>) : $TensorCore<Float>
-  br bb3(%7 : $TensorCore<Float>)                 // id: %8
+  %7 = graph_op "Add"(%2 : $TensorHandle<Float>, %2 : $TensorHandle<Float>) : $TensorHandle<Float>
+  br bb3(%7 : $TensorHandle<Float>)                 // id: %8
 
 // %9                                             // users: %10, %11, %11
-bb3(%9 : $TensorCore<Float>):                     // Preds: bb2 bb1
-  %11 = graph_op "Sub"(%9 : $TensorCore<Float>, %9 : $TensorCore<Float>) : $TensorCore<Float> // user: %12
-  return %11 : $TensorCore<Float>                 // id: %12
+bb3(%9 : $TensorHandle<Float>):                     // Preds: bb2 bb1
+  %11 = graph_op "Sub"(%9 : $TensorHandle<Float>, %9 : $TensorHandle<Float>) : $TensorHandle<Float> // user: %12
+  return %11 : $TensorHandle<Float>                 // id: %12
 }
 
 /* This CFG generates a merge block with three predecessors.  It corresponds
@@ -129,31 +129,31 @@ bb3(%9 : $TensorCore<Float>):                     // Preds: bb2 bb1
 // CHECK-NEXT:   block bb5]
 // CHECK-NEXT: --- XLA CFG Canonicalize end
 //
-sil private @testIfIf : $@callee_owned (TensorCore<Float>, TensorCore<Builtin.Int1>, TensorCore<Builtin.Int1>) -> TensorCore<Float> {
+sil private @testIfIf : $@callee_owned (TensorHandle<Float>, TensorHandle<Builtin.Int1>, TensorHandle<Builtin.Int1>) -> TensorHandle<Float> {
 // %0                                             // users: %1, %1
-bb0(%0 : $TensorCore<Float>, %3: $TensorCore<Builtin.Int1>, %7: $TensorCore<Builtin.Int1>):
-  %1 = graph_op "Sub"(%0 : $TensorCore<Float>, %0 : $TensorCore<Float>) : $TensorCore<Float>
-  %4 = graph_op "tf_tensor_to_i1"(%3 : $TensorCore<Builtin.Int1>) : $Builtin.Int1
+bb0(%0 : $TensorHandle<Float>, %3: $TensorHandle<Builtin.Int1>, %7: $TensorHandle<Builtin.Int1>):
+  %1 = graph_op "Sub"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) : $TensorHandle<Float>
+  %4 = graph_op "tf_tensor_to_i1"(%3 : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
   cond_br %4, bb1, bb4                            // id: %5
 
 bb1:                                              // Preds: bb0
-  %6 = graph_op "Add"(%1 : $TensorCore<Float>, %1 : $TensorCore<Float>) : $TensorCore<Float>
-  %8 = graph_op "tf_tensor_to_i1"(%7 : $TensorCore<Builtin.Int1>) : $Builtin.Int1 // user: %9
+  %6 = graph_op "Add"(%1 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) : $TensorHandle<Float>
+  %8 = graph_op "tf_tensor_to_i1"(%7 : $TensorHandle<Builtin.Int1>) : $Builtin.Int1 // user: %9
   cond_br %8, bb3, bb2                            // id: %9
 
 bb2:                                              // Preds: bb1
-  br bb5(%6 : $TensorCore<Float>)                 // id: %10
+  br bb5(%6 : $TensorHandle<Float>)                 // id: %10
 
 bb3:                                              // Preds: bb1
-  %11 = graph_op "Add"(%6 : $TensorCore<Float>, %6 : $TensorCore<Float>) : $TensorCore<Float> // user: %12
-  br bb5(%11 : $TensorCore<Float>)                // id: %12
+  %11 = graph_op "Add"(%6 : $TensorHandle<Float>, %6 : $TensorHandle<Float>) : $TensorHandle<Float> // user: %12
+  br bb5(%11 : $TensorHandle<Float>)                // id: %12
 
 bb4:                                              // Preds: bb0
-  %13 = graph_op "Add"(%1 : $TensorCore<Float>, %1 : $TensorCore<Float>) : $TensorCore<Float>
-  br bb5(%13 : $TensorCore<Float>)                // id: %14
+  %13 = graph_op "Add"(%1 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) : $TensorHandle<Float>
+  br bb5(%13 : $TensorHandle<Float>)                // id: %14
 
 // %15                                            // users: %16, %17, %17
-bb5(%15 : $TensorCore<Float>):                    // Preds: bb4 bb2 bb3
-  %17 = graph_op "Sub"(%15 : $TensorCore<Float>, %15 : $TensorCore<Float>) : $TensorCore<Float> // user: %18
-  return %17 : $TensorCore<Float>                 // id: %18
+bb5(%15 : $TensorHandle<Float>):                    // Preds: bb4 bb2 bb3
+  %17 = graph_op "Sub"(%15 : $TensorHandle<Float>, %15 : $TensorHandle<Float>) : $TensorHandle<Float> // user: %18
+  return %17 : $TensorHandle<Float>                 // id: %18
 }

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -4,76 +4,74 @@ sil_stage raw
 
 import Builtin
 import Swift
+import TensorFlow
 
-// Dummy struct mimicking the real `Tensor` type.
-struct Tensor<Scalar> {}
-
-sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
+sil @attribute_test : $@convention(thin) () -> TensorHandle<Float> {
 bb0:
-  %0 = graph_op [no_clustering] "tf.Dummy"() {int1: i32 -3, int2: i8 4, int3: i64 42} : $Tensor<Float>
-  %1 = graph_op "tf.Dummy"() {hex1: f64 0x40091EB851EB851F, hex2: f32 0x4048F5C3} : $Tensor<Float>
-  %2 = graph_op "tf.Dummy"() {float1: f64 3.14, float2: f32 -3.14} : $Tensor<Float>
-  %3 = graph_op "tf.Dummy"() {string1: "hello", string2: "world"} : $Tensor<Float>
-  %4 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $Tensor<Float>} : $Tensor<Float>
-  %5 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> (N)} : $Tensor<Float>
-  %6 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> (W)} : $Tensor<Float>
-  %7 = graph_op "tf.Dummy"() {aggregate: ((i8 1, i32 -2), (f32 -1.0, $Float))} : $Tensor<Float>
-  %8 = graph_op "tf.Smarty"() {array: [$Int: i32 -2, i32 97]} : $Tensor<Float>
-  return %0 : $Tensor<Float>
+  %0 = graph_op [no_clustering] "tf.Dummy"() {int1: i32 -3, int2: i8 4, int3: i64 42} : $TensorHandle<Float>
+  %1 = graph_op "tf.Dummy"() {hex1: f64 0x40091EB851EB851F, hex2: f32 0x4048F5C3} : $TensorHandle<Float>
+  %2 = graph_op "tf.Dummy"() {float1: f64 3.14, float2: f32 -3.14} : $TensorHandle<Float>
+  %3 = graph_op "tf.Dummy"() {string1: "hello", string2: "world"} : $TensorHandle<Float>
+  %4 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $TensorHandle<Float>} : $TensorHandle<Float>
+  %5 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> (N)} : $TensorHandle<Float>
+  %6 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> (W)} : $TensorHandle<Float>
+  %7 = graph_op "tf.Dummy"() {aggregate: ((i8 1, i32 -2), (f32 -1.0, $Float))} : $TensorHandle<Float>
+  %8 = graph_op "tf.Smarty"() {array: [$Int: i32 -2, i32 97]} : $TensorHandle<Float>
+  return %0 : $TensorHandle<Float>
 }
 
-// CHECK-LABEL: sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
+// CHECK-LABEL: sil @attribute_test : $@convention(thin) () -> TensorHandle<Float> {
 // CHECK: bb0:
-// CHECK-NEXT:   %0 = graph_op [no_clustering] "tf.Dummy"() {int1: i32 -3, int2: i8 4, int3: i64 42} : $Tensor<Float>
-// CHECK-NEXT:   %1 = graph_op "tf.Dummy"() {hex1: f64 0x40091EB851EB851F /* 3.1400000000000001 */, hex2: f32 0x4048F5C3 /* 3.1400001 */} : $Tensor<Float>
-// CHECK-NEXT:   %2 = graph_op "tf.Dummy"() {float1: f64 0x40091EB851EB851F /* 3.1400000000000001 */, float2: f32 0xC048F5C3 /* -3.1400001 */} : $Tensor<Float>
-// CHECK-NEXT:   %3 = graph_op "tf.Dummy"() {string1: "hello", string2: "world"} : $Tensor<Float>
-// CHECK-NEXT:   %4 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $Tensor<Float>} : $Tensor<Float>
-// CHECK-NEXT:   %5 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> (N)} : $Tensor<Float>
-// CHECK-NEXT:   %6 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> (W)} : $Tensor<Float>
-// CHECK-NEXT:   %7 = graph_op "tf.Dummy"() {aggregate: ((i8 1, i32 -2), (f32 0xBF800000 /* -1 */, $Float))} : $Tensor<Float>
-// CHECK-NEXT:   %8 = graph_op "tf.Smarty"() {array: [$Int: i32 -2, i32 97]} : $Tensor<Float>
-// CHECK-NEXT:   return %0 : $Tensor<Float>
+// CHECK-NEXT:   %0 = graph_op [no_clustering] "tf.Dummy"() {int1: i32 -3, int2: i8 4, int3: i64 42} : $TensorHandle<Float>
+// CHECK-NEXT:   %1 = graph_op "tf.Dummy"() {hex1: f64 0x40091EB851EB851F /* 3.1400000000000001 */, hex2: f32 0x4048F5C3 /* 3.1400001 */} : $TensorHandle<Float>
+// CHECK-NEXT:   %2 = graph_op "tf.Dummy"() {float1: f64 0x40091EB851EB851F /* 3.1400000000000001 */, float2: f32 0xC048F5C3 /* -3.1400001 */} : $TensorHandle<Float>
+// CHECK-NEXT:   %3 = graph_op "tf.Dummy"() {string1: "hello", string2: "world"} : $TensorHandle<Float>
+// CHECK-NEXT:   %4 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $TensorHandle<Float>} : $TensorHandle<Float>
+// CHECK-NEXT:   %5 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> (N)} : $TensorHandle<Float>
+// CHECK-NEXT:   %6 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> (W)} : $TensorHandle<Float>
+// CHECK-NEXT:   %7 = graph_op "tf.Dummy"() {aggregate: ((i8 1, i32 -2), (f32 0xBF800000 /* -1 */, $Float))} : $TensorHandle<Float>
+// CHECK-NEXT:   %8 = graph_op "tf.Smarty"() {array: [$Int: i32 -2, i32 97]} : $TensorHandle<Float>
+// CHECK-NEXT:   return %0 : $TensorHandle<Float>
 // CHECK-NEXT: }
 
-sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
-bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
-  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
-  %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
-  return %3 : $Tensor<Float>
+sil @chained_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
+bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
+  %2 = graph_op "tf.Add"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float} : $TensorHandle<Float>
+  %3 = graph_op "tf.Mul"(%2 : $TensorHandle<Float>, %2 : $TensorHandle<Float>) {T: $Float} : $TensorHandle<Float>
+  return %3 : $TensorHandle<Float>
 }
 
-// CHECK-LABEL: sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
-// CHECK: bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
-// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
-// CHECK-NEXT:   %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
-// CHECK-NEXT:   return %3 : $Tensor<Float>
+// CHECK-LABEL: sil @chained_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
+// CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
+// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float} : $TensorHandle<Float>
+// CHECK-NEXT:   %3 = graph_op "tf.Mul"(%2 : $TensorHandle<Float>, %2 : $TensorHandle<Float>) {T: $Float} : $TensorHandle<Float>
+// CHECK-NEXT:   return %3 : $TensorHandle<Float>
 // CHECK-NEXT: }
 
-sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
-bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
-  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
-  return %2 : $Tensor<Float>
+sil @single_result_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
+bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
+  %2 = graph_op "tf.Add"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float} : $TensorHandle<Float>
+  return %2 : $TensorHandle<Float>
 }
 
-// CHECK-LABEL: sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
-// CHECK: bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
-// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
-// CHECK-NEXT:   return %2 : $Tensor<Float>
+// CHECK-LABEL: sil @single_result_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
+// CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
+// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float} : $TensorHandle<Float>
+// CHECK-NEXT:   return %2 : $TensorHandle<Float>
 // CHECK-NEXT: }
 
-sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
-bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
-  (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>, $Tensor<Float>
-  %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
-  return %4 : $(Tensor<Float>, Tensor<Float>)
+sil @multiple_result_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> (TensorHandle<Float>, TensorHandle<Float>) {
+bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
+  (%2, %3) = graph_op "tf.Dummy"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float} : $TensorHandle<Float>, $TensorHandle<Float>
+  %4 = tuple (%2 : $TensorHandle<Float>, %3 : $TensorHandle<Float>)
+  return %4 : $(TensorHandle<Float>, TensorHandle<Float>)
 }
 
-// CHECK-LABEL: sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
-// CHECK: bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
-// CHECK-NEXT:   (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>, $Tensor<Float>
-// CHECK-NEXT:   %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
-// CHECK-NEXT:   return %4 : $(Tensor<Float>, Tensor<Float>)
+// CHECK-LABEL: sil @multiple_result_op_test : $@convention(thin) (TensorHandle<Float>, TensorHandle<Float>) -> (TensorHandle<Float>, TensorHandle<Float>) {
+// CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
+// CHECK-NEXT:   (%2, %3) = graph_op "tf.Dummy"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float} : $TensorHandle<Float>, $TensorHandle<Float>
+// CHECK-NEXT:   %4 = tuple (%2 : $TensorHandle<Float>, %3 : $TensorHandle<Float>)
+// CHECK-NEXT:   return %4 : $(TensorHandle<Float>, TensorHandle<Float>)
 // CHECK-NEXT: }
 
 sil @operand_test : $@convention(thin) () -> () {
@@ -83,29 +81,29 @@ bb0:
   %1 = integer_literal $Builtin.Int64, 1
   %2 = integer_literal $Builtin.Int64, 2
 
-  %3 = graph_op "Dummy1"(%0 : $Builtin.Int64) : $Tensor<Float>
-  // CHECK: %3 = graph_op "Dummy1"(%0 : $Builtin.Int64) : $Tensor<Float>
+  %3 = graph_op "Dummy1"(%0 : $Builtin.Int64) : $TensorHandle<Float>
+  // CHECK: %3 = graph_op "Dummy1"(%0 : $Builtin.Int64) : $TensorHandle<Float>
 
-  %4 = graph_op "Dummy2"(named$something %0 : $Builtin.Int64) : $Tensor<Float>
-  // CHECK-NEXT: %4 = graph_op "Dummy2"(named$something %0 : $Builtin.Int64) : $Tensor<Float>
+  %4 = graph_op "Dummy2"(named$tensor %0 : $Builtin.Int64) : $TensorHandle<Float>
+  // CHECK-NEXT: %4 = graph_op "Dummy2"(named$tensor %0 : $Builtin.Int64) : $TensorHandle<Float>
 
-  %5 = graph_op "Dummy3"([%0 : $Builtin.Int64, %1 : $Builtin.Int64]) : $Tensor<Float>
-  // CHECK-NEXT: %5 = graph_op "Dummy3"([%0 : $Builtin.Int64, %1 : $Builtin.Int64]) : $Tensor<Float>
+  %5 = graph_op "Dummy3"([%0 : $Builtin.Int64, %1 : $Builtin.Int64]) : $TensorHandle<Float>
+  // CHECK-NEXT: %5 = graph_op "Dummy3"([%0 : $Builtin.Int64, %1 : $Builtin.Int64]) : $TensorHandle<Float>
 
-  %6 = graph_op "Dummy4"(named$something [%0 : $Builtin.Int64, %1 : $Builtin.Int64]) : $Tensor<Float>
-  // CHECK-NEXT: %6 = graph_op "Dummy4"(named$something [%0 : $Builtin.Int64, %1 : $Builtin.Int64]) : $Tensor<Float>
+  %6 = graph_op "Dummy4"(named$tensor [%0 : $Builtin.Int64, %1 : $Builtin.Int64]) : $TensorHandle<Float>
+  // CHECK-NEXT: %6 = graph_op "Dummy4"(named$tensor [%0 : $Builtin.Int64, %1 : $Builtin.Int64]) : $TensorHandle<Float>
 
-  %7 = graph_op "Dummy5"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Tensor<Float>
-  // CHECK-NEXT: %7 = graph_op "Dummy5"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Tensor<Float>
+  %7 = graph_op "Dummy5"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $TensorHandle<Float>
+  // CHECK-NEXT: %7 = graph_op "Dummy5"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $TensorHandle<Float>
 
-  %8 = graph_op "Dummy6"(%0 : $Builtin.Int64, [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $Tensor<Float>
-  // CHECK-NEXT: %8 = graph_op "Dummy6"(%0 : $Builtin.Int64, [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $Tensor<Float>
+  %8 = graph_op "Dummy6"(%0 : $Builtin.Int64, [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $TensorHandle<Float>
+  // CHECK-NEXT: %8 = graph_op "Dummy6"(%0 : $Builtin.Int64, [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $TensorHandle<Float>
 
-  %9 = graph_op "Dummy7"(named$something %0 : $Builtin.Int64, [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $Tensor<Float>
-  // CHECK-NEXT: 9 = graph_op "Dummy7"(named$something %0 : $Builtin.Int64, [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $Tensor<Float>
+  %9 = graph_op "Dummy7"(named$tensor %0 : $Builtin.Int64, [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $TensorHandle<Float>
+  // CHECK-NEXT: 9 = graph_op "Dummy7"(named$tensor %0 : $Builtin.Int64, [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $TensorHandle<Float>
 
-  %10 = graph_op "Dummy8"(named$something %0 : $Builtin.Int64, named$somethingelse [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $Tensor<Float>
-  // CHECK-NEXT: %10 = graph_op "Dummy8"(named$something %0 : $Builtin.Int64, named$somethingelse [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $Tensor<Float>
+  %10 = graph_op "Dummy8"(named$tensor %0 : $Builtin.Int64, named$tensor [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $TensorHandle<Float>
+  // CHECK-NEXT: %10 = graph_op "Dummy8"(named$tensor %0 : $Builtin.Int64, named$tensor [%1 : $Builtin.Int64, %2 : $Builtin.Int64]) : $TensorHandle<Float>
 
   return undef : $()
 }

--- a/test/TensorFlow/graph_op_inst_serialization.sil
+++ b/test/TensorFlow/graph_op_inst_serialization.sil
@@ -5,19 +5,17 @@
 // RUN: %target-sil-opt %t/tmp.2.sib -module-name graph_op | %FileCheck %s
 
 import Swift
-
-// Dummy struct mimicking the real `Tensor` type.
-struct Tensor<Scalar> {}
+import TensorFlow
 
 sil [serialized] @test_func : $@convention(thin) () -> () {
 // CHECK-LABEL: sil [serialized] @test_func
 bb0:
 // CHECK-NEXT: bb0
-  %0 = graph_op "Dummy1"() : $Tensor<Float>
-  // CHECK-NEXT: %0 = graph_op "Dummy1"() : $Tensor<Float>
-  %1 = graph_op "Dummy2"(%0 : $Tensor<Float>) : $Tensor<Float>
-  // CHECK-NEXT: %1 = graph_op "Dummy2"(%0 : $Tensor<Float>) : $Tensor<Float>
-  (%2, %3) = graph_op "Dummy3"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) : $Tensor<Float>, $Tensor<Float>
-  // CHECK-NEXT: (%2, %3) = graph_op "Dummy3"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) : $Tensor<Float>, $Tensor<Float>
+  %0 = graph_op "Dummy1"() : $TensorHandle<Float>
+  // CHECK-NEXT: %0 = graph_op "Dummy1"() : $TensorHandle<Float>
+  %1 = graph_op "Dummy2"(%0 : $TensorHandle<Float>) : $TensorHandle<Float>
+  // CHECK-NEXT: %1 = graph_op "Dummy2"(%0 : $TensorHandle<Float>) : $TensorHandle<Float>
+  (%2, %3) = graph_op "Dummy3"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) : $TensorHandle<Float>, $TensorHandle<Float>
+  // CHECK-NEXT: (%2, %3) = graph_op "Dummy3"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) : $TensorHandle<Float>, $TensorHandle<Float>
   return undef : $()
 }


### PR DESCRIPTION
There are assertions from IRGen that `graph_op` inputs must conform to `TensorArrayProtocol`.
```console
Assertion failed: (conformance && "input type does not conform to TensorArrayProtocol"), function operator()
```

Although Sema checks `#tfop` arguments, `graph_op` needs its own verification to guarantee the correct semantics instead of getting asserted in a later compilation phase. This patch verification logic that checks `graph_op` input operands.

```console
SIL verification failed: graph_op operands must conform to TensorArrayProtocol: !conformances.empty()
Verifying instruction:
   %0 = argument of bb0 : $Tensor<IndexType>      // user: %9
   %1 = argument of bb0 : $Tensor<T>              // user: %9
     %5 = apply %4<T>(%3) : $@convention(witness_method: _TensorFlowDataTypeCompatible) <τ_0_0 where τ_0_0 : _TensorFlowDataTypeCompatible> (@thick τ_0_0.Type) -> TensorDataType // user: %9
     %8 = apply %7<IndexType>(%6) : $@convention(witness_method: _TensorFlowDataTypeCompatible) <τ_0_0 where τ_0_0 : _TensorFlowDataTypeCompatible> (@thick τ_0_0.Type) -> TensorDataType // user: %9
->   %9 = graph_op "Fill"(%0 : $Tensor<IndexType>, %1 : $Tensor<T>, T$dtype %5 : $TensorDataType, index_type$dtype %8 : $TensorDataType) : $TensorHandle<T> // users: %14, %13, %11
```