### PR TITLE
[stdlib] Replace "sanityCheck" with "internalInvariant"

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1029,7 +1029,7 @@ extension Array: RangeReplaceableCollection {
       _buffer = _Buffer(
         _buffer: newBuffer, shiftedToStartIndex: _buffer.startIndex)
     }
-    _sanityCheck(capacity >= minimumCapacity)
+    _internalInvariant(capacity >= minimumCapacity)
   }
 
   /// Copy the contents of the current buffer to a new unique mutable buffer.
@@ -1056,9 +1056,9 @@ extension Array: RangeReplaceableCollection {
   @_semantics("array.mutate_unknown")
   internal mutating func _reserveCapacityAssumingUniqueBuffer(oldCount: Int) {
     // This is a performance optimization. This code used to be in an ||
-    // statement in the _sanityCheck below.
+    // statement in the _internalInvariant below.
     //
-    //   _sanityCheck(_buffer.capacity == 0 ||
+    //   _internalInvariant(_buffer.capacity == 0 ||
     //                _buffer.isMutableAndUniquelyReferenced())
     //
     // SR-6437
@@ -1073,7 +1073,7 @@ extension Array: RangeReplaceableCollection {
     // This specific case is okay because we will make the buffer unique in this
     // function because we request a capacity > 0 and therefore _copyToNewBuffer
     // will be called creating a new buffer.
-    _sanityCheck(capacity ||
+    _internalInvariant(capacity ||
                  _buffer.isMutableAndUniquelyReferenced())
 
     if _slowPath(oldCount + 1 > _buffer.capacity) {
@@ -1087,8 +1087,8 @@ extension Array: RangeReplaceableCollection {
     _ oldCount: Int,
     newElement: __owned Element
   ) {
-    _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
-    _sanityCheck(_buffer.capacity >= _buffer.count + 1)
+    _internalInvariant(_buffer.isMutableAndUniquelyReferenced())
+    _internalInvariant(_buffer.capacity >= _buffer.count + 1)
 
     _buffer.count = oldCount + 1
     (_buffer.firstElementAddress + oldCount).initialize(to: newElement)
@@ -1610,8 +1610,8 @@ extension Array: Equatable where Element: Equatable {
     }
 
 
-    _sanityCheck(lhs.startIndex == 0 && rhs.startIndex == 0)
-    _sanityCheck(lhs.endIndex == lhsCount && rhs.endIndex == lhsCount)
+    _internalInvariant(lhs.startIndex == 0 && rhs.startIndex == 0)
+    _internalInvariant(lhs.endIndex == lhsCount && rhs.endIndex == lhsCount)
 
     // We know that lhs.count == rhs.count, compare element wise.
     for idx in 0..<lhsCount {

--- a/stdlib/public/core/ArrayBody.swift
+++ b/stdlib/public/core/ArrayBody.swift
@@ -27,8 +27,8 @@ internal struct _ArrayBody {
   internal init(
     count: Int, capacity: Int, elementTypeIsBridgedVerbatim: Bool = false
   ) {
-    _sanityCheck(count >= 0)
-    _sanityCheck(capacity >= 0)
+    _internalInvariant(count >= 0)
+    _internalInvariant(capacity >= 0)
     
     _storage = _SwiftArrayBodyStorage(
       count: count,

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -34,7 +34,7 @@ internal struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
 
   @inlinable
   internal init(nsArray: AnyObject) {
-    _sanityCheck(_isClassOrObjCExistential(Element.self))
+    _internalInvariant(_isClassOrObjCExistential(Element.self))
     _storage = _ArrayBridgeStorage(objC: nsArray)
   }
 
@@ -44,8 +44,8 @@ internal struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
   ///   is a class or `@objc` existential.
   @inlinable
   __consuming internal func cast<U>(toBufferOf _: U.Type) -> _ArrayBuffer<U> {
-    _sanityCheck(_isClassOrObjCExistential(Element.self))
-    _sanityCheck(_isClassOrObjCExistential(U.self))
+    _internalInvariant(_isClassOrObjCExistential(Element.self))
+    _internalInvariant(_isClassOrObjCExistential(U.self))
     return _ArrayBuffer<U>(storage: _storage)
   }
 
@@ -58,12 +58,12 @@ internal struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
   __consuming internal func downcast<U>(
     toBufferWithDeferredTypeCheckOf _: U.Type
   ) -> _ArrayBuffer<U> {
-    _sanityCheck(_isClassOrObjCExistential(Element.self))
-    _sanityCheck(_isClassOrObjCExistential(U.self))
+    _internalInvariant(_isClassOrObjCExistential(Element.self))
+    _internalInvariant(_isClassOrObjCExistential(U.self))
     
     // FIXME: can't check that U is derived from Element pending
     // <rdar://problem/20028320> generic metatype casting doesn't work
-    // _sanityCheck(U.self is Element.Type)
+    // _internalInvariant(U.self is Element.Type)
 
     return _ArrayBuffer<U>(
       storage: _ArrayBridgeStorage(native: _native._storage, isFlagged: true))
@@ -89,7 +89,7 @@ extension _ArrayBuffer {
   /// Adopt the storage of `source`.
   @inlinable
   internal init(_buffer source: NativeBuffer, shiftedToStartIndex: Int) {
-    _sanityCheck(shiftedToStartIndex == 0, "shiftedToStartIndex must be 0")
+    _internalInvariant(shiftedToStartIndex == 0, "shiftedToStartIndex must be 0")
     _storage = _ArrayBridgeStorage(native: source._storage)
   }
 
@@ -244,7 +244,7 @@ extension _ArrayBuffer {
   /// - Precondition: The elements are known to be stored contiguously.
   @inlinable
   internal var firstElementAddress: UnsafeMutablePointer<Element> {
-    _sanityCheck(_isNative, "must be a native buffer")
+    _internalInvariant(_isNative, "must be a native buffer")
     return _native.firstElementAddress
   }
 
@@ -261,7 +261,7 @@ extension _ArrayBuffer {
       return _fastPath(_isNative) ? _native.count : _nonNative.count
     }
     set {
-      _sanityCheck(_isNative, "attempting to update count of Cocoa array")
+      _internalInvariant(_isNative, "attempting to update count of Cocoa array")
       _native.count = newValue
     }
   }
@@ -322,7 +322,7 @@ extension _ArrayBuffer {
   @inline(never)
   @inlinable // @specializable
   internal func _getElementSlowPath(_ i: Int) -> AnyObject {
-    _sanityCheck(
+    _internalInvariant(
       _isClassOrObjCExistential(Element.self),
       "Only single reference elements can be indexed here.")
     let element: AnyObject
@@ -398,7 +398,7 @@ extension _ArrayBuffer {
   internal mutating func withUnsafeMutableBufferPointer<R>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
-    _sanityCheck(
+    _internalInvariant(
       _isNative || count == 0,
       "Array is bridging an opaque NSArray; can't get a pointer to the elements"
     )
@@ -418,7 +418,7 @@ extension _ArrayBuffer {
   /// - Precondition: This buffer is backed by a `_ContiguousArrayBuffer`.
   @inlinable
   internal var nativeOwner: AnyObject {
-    _sanityCheck(_isNative, "Expect a native array")
+    _internalInvariant(_isNative, "Expect a native array")
     return _native._storage
   }
 
@@ -504,7 +504,7 @@ extension _ArrayBuffer {
   internal var _nonNative: _CocoaArrayWrapper {
     @inline(__always)
     get {
-      _sanityCheck(_isClassOrObjCExistential(Element.self))
+      _internalInvariant(_isClassOrObjCExistential(Element.self))
       return _CocoaArrayWrapper(_storage.objCInstance)
     }
   }

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -144,7 +144,7 @@ extension _ArrayBufferProtocol where Indices == Range<Int>{
     with newCount: Int,
     elementsOf newValues: __owned C
   ) where C : Collection, C.Element == Element {
-    _sanityCheck(startIndex == 0, "_SliceBuffer should override this function.")
+    _internalInvariant(startIndex == 0, "_SliceBuffer should override this function.")
     let oldCount = self.count
     let eraseCount = subrange.count
 

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -178,9 +178,9 @@ extension _ArrayBufferProtocol {
     countForBuffer: Int, minNewCapacity: Int,
     requiredCapacity: Int
   ) -> _ContiguousArrayBuffer<Element> {
-    _sanityCheck(countForBuffer >= 0)
-    _sanityCheck(requiredCapacity >= countForBuffer)
-    _sanityCheck(minNewCapacity >= countForBuffer)
+    _internalInvariant(countForBuffer >= 0)
+    _internalInvariant(requiredCapacity >= countForBuffer)
+    _internalInvariant(minNewCapacity >= countForBuffer)
 
     let minimumCapacity = Swift.max(requiredCapacity,
       minNewCapacity > capacity
@@ -207,17 +207,17 @@ extension _ArrayBufferProtocol {
     _ newCount: Int,  // Number of new elements to insert
     _ initializeNewElements: 
         ((UnsafeMutablePointer<Element>, _ count: Int) -> ()) = { ptr, count in
-      _sanityCheck(count == 0)
+      _internalInvariant(count == 0)
     }
   ) {
 
-    _sanityCheck(headCount >= 0)
-    _sanityCheck(newCount >= 0)
+    _internalInvariant(headCount >= 0)
+    _internalInvariant(newCount >= 0)
 
     // Count of trailing source elements to copy/move
     let sourceCount = self.count
     let tailCount = dest.count - headCount - newCount
-    _sanityCheck(headCount + tailCount <= sourceCount)
+    _internalInvariant(headCount + tailCount <= sourceCount)
 
     let oldCount = sourceCount - headCount - tailCount
     let destStart = dest.firstElementAddress
@@ -293,7 +293,7 @@ extension _ArrayBufferProtocol {
     
     // this function is only ever called from append(contentsOf:)
     // which should always have exhausted its capacity before calling
-    _sanityCheck(count == capacity)
+    _internalInvariant(count == capacity)
     var newCount = self.count
 
     // there might not be any elements to append remaining,

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -822,7 +822,7 @@ extension ArraySlice: RangeReplaceableCollection {
       _buffer = _Buffer(
         _buffer: newBuffer, shiftedToStartIndex: _buffer.startIndex)
     }
-    _sanityCheck(capacity >= minimumCapacity)
+    _internalInvariant(capacity >= minimumCapacity)
   }
 
   /// Copy the contents of the current buffer to a new unique mutable buffer.
@@ -850,9 +850,9 @@ extension ArraySlice: RangeReplaceableCollection {
   @_semantics("array.mutate_unknown")
   internal mutating func _reserveCapacityAssumingUniqueBuffer(oldCount: Int) {
     // This is a performance optimization. This code used to be in an ||
-    // statement in the _sanityCheck below.
+    // statement in the _internalInvariant below.
     //
-    //   _sanityCheck(_buffer.capacity == 0 ||
+    //   _internalInvariant(_buffer.capacity == 0 ||
     //                _buffer.isMutableAndUniquelyReferenced())
     //
     // SR-6437
@@ -867,7 +867,7 @@ extension ArraySlice: RangeReplaceableCollection {
     // This specific case is okay because we will make the buffer unique in this
     // function because we request a capacity > 0 and therefore _copyToNewBuffer
     // will be called creating a new buffer.
-    _sanityCheck(capacity ||
+    _internalInvariant(capacity ||
                  _buffer.isMutableAndUniquelyReferenced())
 
     if _slowPath(oldCount + 1 > _buffer.capacity) {
@@ -881,8 +881,8 @@ extension ArraySlice: RangeReplaceableCollection {
     _ oldCount: Int,
     newElement: __owned Element
   ) {
-    _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
-    _sanityCheck(_buffer.capacity >= _buffer.count + 1)
+    _internalInvariant(_buffer.isMutableAndUniquelyReferenced())
+    _internalInvariant(_buffer.capacity >= _buffer.count + 1)
 
     _buffer.count = oldCount + 1
     (_buffer.firstElementAddress + oldCount).initialize(to: newElement)

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -285,7 +285,7 @@ internal func _debugPreconditionFailure(
 /// with the build configuration INTERNAL_CHECKS_ENABLED enabled. Otherwise, the
 /// call to this function is a noop.
 @usableFromInline @_transparent
-internal func _sanityCheck(
+internal func _internalInvariant(
   _ condition: @autoclosure () -> Bool, _ message: StaticString = StaticString(),
   file: StaticString = #file, line: UInt = #line
 ) {
@@ -298,10 +298,10 @@ internal func _sanityCheck(
 }
 
 @usableFromInline @_transparent
-internal func _sanityCheckFailure(
+internal func _internalInvariantFailure(
   _ message: StaticString = StaticString(),
   file: StaticString = #file, line: UInt = #line
 ) -> Never {
-  _sanityCheck(false, message, file: file, line: line)
+  _internalInvariant(false, message, file: file, line: line)
   _conditionallyUnreachable()
 }

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -37,7 +37,7 @@ extension _UnsafeBitset {
   @inlinable
   @inline(__always)
   internal static func word(for element: Int) -> Int {
-    _sanityCheck(element >= 0)
+    _internalInvariant(element >= 0)
     // Note: We perform on UInts to get faster unsigned math (shifts).
     let element = UInt(bitPattern: element)
     let capacity = UInt(bitPattern: Word.capacity)
@@ -47,7 +47,7 @@ extension _UnsafeBitset {
   @inlinable
   @inline(__always)
   internal static func bit(for element: Int) -> Int {
-    _sanityCheck(element >= 0)
+    _internalInvariant(element >= 0)
     // Note: We perform on UInts to get faster unsigned math (masking).
     let element = UInt(bitPattern: element)
     let capacity = UInt(bitPattern: Word.capacity)
@@ -63,7 +63,7 @@ extension _UnsafeBitset {
   @inlinable
   @inline(__always)
   internal static func join(word: Int, bit: Int) -> Int {
-    _sanityCheck(bit >= 0 && bit < Word.capacity)
+    _internalInvariant(bit >= 0 && bit < Word.capacity)
     return word &* Word.capacity &+ bit
   }
 }
@@ -92,7 +92,7 @@ extension _UnsafeBitset {
   @inlinable
   @inline(__always)
   internal func uncheckedContains(_ element: Int) -> Bool {
-    _sanityCheck(isValid(element))
+    _internalInvariant(isValid(element))
     let (word, bit) = _UnsafeBitset.split(element)
     return words[word].uncheckedContains(bit)
   }
@@ -101,7 +101,7 @@ extension _UnsafeBitset {
   @inline(__always)
   @discardableResult
   internal func uncheckedInsert(_ element: Int) -> Bool {
-    _sanityCheck(isValid(element))
+    _internalInvariant(isValid(element))
     let (word, bit) = _UnsafeBitset.split(element)
     return words[word].uncheckedInsert(bit)
   }
@@ -110,7 +110,7 @@ extension _UnsafeBitset {
   @inline(__always)
   @discardableResult
   internal func uncheckedRemove(_ element: Int) -> Bool {
-    _sanityCheck(isValid(element))
+    _internalInvariant(isValid(element))
     let (word, bit) = _UnsafeBitset.split(element)
     return words[word].uncheckedRemove(bit)
   }
@@ -207,7 +207,7 @@ extension _UnsafeBitset.Word {
   @inlinable
   @inline(__always)
   internal func uncheckedContains(_ bit: Int) -> Bool {
-    _sanityCheck(bit >= 0 && bit < UInt.bitWidth)
+    _internalInvariant(bit >= 0 && bit < UInt.bitWidth)
     return value & (1 &<< bit) != 0
   }
 
@@ -215,7 +215,7 @@ extension _UnsafeBitset.Word {
   @inline(__always)
   @discardableResult
   internal mutating func uncheckedInsert(_ bit: Int) -> Bool {
-    _sanityCheck(bit >= 0 && bit < UInt.bitWidth)
+    _internalInvariant(bit >= 0 && bit < UInt.bitWidth)
     let mask: UInt = 1 &<< bit
     let inserted = value & mask == 0
     value |= mask
@@ -226,7 +226,7 @@ extension _UnsafeBitset.Word {
   @inline(__always)
   @discardableResult
   internal mutating func uncheckedRemove(_ bit: Int) -> Bool {
-    _sanityCheck(bit >= 0 && bit < UInt.bitWidth)
+    _internalInvariant(bit >= 0 && bit < UInt.bitWidth)
     let mask: UInt = 1 &<< bit
     let removed = value & mask != 0
     value &= ~mask
@@ -264,7 +264,7 @@ extension _UnsafeBitset.Word {
   @inlinable
   @inline(__always)
   internal func subtracting(elementsBelow bit: Int) -> _UnsafeBitset.Word {
-    _sanityCheck(bit >= 0 && bit < _UnsafeBitset.Word.capacity)
+    _internalInvariant(bit >= 0 && bit < _UnsafeBitset.Word.capacity)
     let mask = UInt.max &<< bit
     return _UnsafeBitset.Word(value & mask)
   }
@@ -272,7 +272,7 @@ extension _UnsafeBitset.Word {
   @inlinable
   @inline(__always)
   internal func intersecting(elementsBelow bit: Int) -> _UnsafeBitset.Word {
-    _sanityCheck(bit >= 0 && bit < _UnsafeBitset.Word.capacity)
+    _internalInvariant(bit >= 0 && bit < _UnsafeBitset.Word.capacity)
     let mask: UInt = (1 as UInt &<< bit) &- 1
     return _UnsafeBitset.Word(value & mask)
   }
@@ -280,7 +280,7 @@ extension _UnsafeBitset.Word {
   @inlinable
   @inline(__always)
   internal func intersecting(elementsAbove bit: Int) -> _UnsafeBitset.Word {
-    _sanityCheck(bit >= 0 && bit < _UnsafeBitset.Word.capacity)
+    _internalInvariant(bit >= 0 && bit < _UnsafeBitset.Word.capacity)
     let mask = (UInt.max &<< bit) &<< 1
     return _UnsafeBitset.Word(value & mask)
   }

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -534,7 +534,7 @@ internal struct _CocoaFastEnumerationStackBuf {
     _item14 = _item0
     _item15 = _item0
 
-    _sanityCheck(MemoryLayout.size(ofValue: self) >=
+    _internalInvariant(MemoryLayout.size(ofValue: self) >=
                    MemoryLayout<Optional<UnsafeRawPointer>>.size * count)
   }
 }

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -40,7 +40,7 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
     // Note: Some platforms provide more than one spare bit, but the minimum is
     // a single bit.
 
-    _sanityCheck(_usesNativeSwiftReferenceCounting(NativeClass.self))
+    _internalInvariant(_usesNativeSwiftReferenceCounting(NativeClass.self))
 
     rawValue = _makeNativeBridgeObject(
       native,
@@ -50,14 +50,14 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
   @inlinable
   @inline(__always)
   internal init(objC: ObjC) {
-    _sanityCheck(_usesNativeSwiftReferenceCounting(NativeClass.self))
+    _internalInvariant(_usesNativeSwiftReferenceCounting(NativeClass.self))
     rawValue = _makeObjCBridgeObject(objC)
   }
 
   @inlinable
   @inline(__always)
   internal init(native: Native) {
-    _sanityCheck(_usesNativeSwiftReferenceCounting(NativeClass.self))
+    _internalInvariant(_usesNativeSwiftReferenceCounting(NativeClass.self))
     rawValue = Builtin.reinterpretCast(native)
   }
 
@@ -110,7 +110,7 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
   @inlinable
   internal var nativeInstance: Native {
     @inline(__always) get {
-      _sanityCheck(isNative)
+      _internalInvariant(isNative)
       return Builtin.castReferenceFromBridgeObject(rawValue)
     }
   }
@@ -118,8 +118,8 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
   @inlinable
   internal var unflaggedNativeInstance: Native {
     @inline(__always) get {
-      _sanityCheck(isNative)
-      _sanityCheck(_nonPointerBits(rawValue) == 0)
+      _internalInvariant(isNative)
+      _internalInvariant(_nonPointerBits(rawValue) == 0)
       return Builtin.reinterpretCast(rawValue)
     }
   }
@@ -127,14 +127,14 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
   @inlinable
   @inline(__always)
   internal mutating func isUniquelyReferencedUnflaggedNative() -> Bool {
-    _sanityCheck(isNative)
+    _internalInvariant(isNative)
     return _isUnique_native(&rawValue)
   }
 
   @inlinable
   internal var objCInstance: ObjC {
     @inline(__always) get {
-      _sanityCheck(isObjC)
+      _internalInvariant(isObjC)
       return Builtin.castReferenceFromBridgeObject(rawValue)
     }
   }

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -21,8 +21,8 @@ import SwiftShims
 @inlinable
 @inline(__always)
 internal func _roundUpImpl(_ offset: UInt, toAlignment alignment: Int) -> UInt {
-  _sanityCheck(alignment > 0)
-  _sanityCheck(_isPowerOf2(alignment))
+  _internalInvariant(alignment > 0)
+  _internalInvariant(_isPowerOf2(alignment))
   // Note, given that offset is >= 0, and alignment > 0, we don't
   // need to underflow check the -1, as it can never underflow.
   let x = offset + UInt(bitPattern: alignment) &- 1
@@ -38,7 +38,7 @@ internal func _roundUp(_ offset: UInt, toAlignment alignment: Int) -> UInt {
 
 @inlinable
 internal func _roundUp(_ offset: Int, toAlignment alignment: Int) -> Int {
-  _sanityCheck(offset >= 0)
+  _internalInvariant(offset >= 0)
   return Int(_roundUpImpl(UInt(bitPattern: offset), toAlignment: alignment))
 }
 
@@ -238,7 +238,7 @@ public func unsafeDowncast<T : AnyObject>(_ x: AnyObject, to type: T.Type) -> T 
 
 @_transparent
 public func _unsafeUncheckedDowncast<T : AnyObject>(_ x: AnyObject, to type: T.Type) -> T {
-  _sanityCheck(x is T, "invalid unsafeDowncast")
+  _internalInvariant(x is T, "invalid unsafeDowncast")
   return Builtin.castReference(x)
 }
 
@@ -363,7 +363,7 @@ internal var _objectPointerSpareBits: UInt {
 @inlinable
 internal var _objectPointerLowSpareBitShift: UInt {
     @inline(__always) get {
-      _sanityCheck(_swift_abi_ObjCReservedLowBits < 2,
+      _internalInvariant(_swift_abi_ObjCReservedLowBits < 2,
         "num bits now differs from num-shift-amount, new platform?")
       return UInt(_swift_abi_ObjCReservedLowBits)
     }
@@ -428,7 +428,7 @@ func _isNonTaggedObjCPointer(_ x: Builtin.BridgeObject) -> Bool {
 @inline(__always)
 func _getNonTagBits(_ x: Builtin.BridgeObject) -> UInt {
   // Zero out the tag bits, and leave them all at the top.
-  _sanityCheck(_isTaggedObject(x), "not tagged!")
+  _internalInvariant(_isTaggedObject(x), "not tagged!")
   return (_bitPattern(x) & ~_bridgeObjectTaggedPointerBits)
     >> _objectPointerLowSpareBitShift
 }
@@ -437,9 +437,9 @@ func _getNonTagBits(_ x: Builtin.BridgeObject) -> UInt {
 @inline(__always)
 @inlinable
 public func _bridgeObject(fromNative x: AnyObject) -> Builtin.BridgeObject {
-  _sanityCheck(!_isObjCTaggedPointer(x))
+  _internalInvariant(!_isObjCTaggedPointer(x))
   let object = Builtin.castToBridgeObject(x, 0._builtinWordValue)
-  _sanityCheck(_isNativePointer(object))
+  _internalInvariant(_isNativePointer(object))
   return object
 }
 
@@ -448,18 +448,18 @@ public func _bridgeObject(fromNative x: AnyObject) -> Builtin.BridgeObject {
 public func _bridgeObject(
   fromNonTaggedObjC x: AnyObject
 ) -> Builtin.BridgeObject {
-  _sanityCheck(!_isObjCTaggedPointer(x))
+  _internalInvariant(!_isObjCTaggedPointer(x))
   let object = _makeObjCBridgeObject(x)
-  _sanityCheck(_isNonTaggedObjCPointer(object))
+  _internalInvariant(_isNonTaggedObjCPointer(object))
   return object
 }
 
 @inline(__always)
 @inlinable
 public func _bridgeObject(fromTagged x: UInt) -> Builtin.BridgeObject {
-  _sanityCheck(x & _bridgeObjectTaggedPointerBits != 0)
+  _internalInvariant(x & _bridgeObjectTaggedPointerBits != 0)
   let object: Builtin.BridgeObject = Builtin.valueToBridgeObject(x._value)
-  _sanityCheck(_isTaggedObject(object))
+  _internalInvariant(_isTaggedObject(object))
   return object
 }
 
@@ -467,9 +467,9 @@ public func _bridgeObject(fromTagged x: UInt) -> Builtin.BridgeObject {
 @inlinable
 public func _bridgeObject(taggingPayload x: UInt) -> Builtin.BridgeObject {
   let shifted = x &<< _objectPointerLowSpareBitShift
-  _sanityCheck(x == (shifted &>> _objectPointerLowSpareBitShift),
+  _internalInvariant(x == (shifted &>> _objectPointerLowSpareBitShift),
     "out-of-range: limited bit range requires some zero top bits")
-  _sanityCheck(shifted & _bridgeObjectTaggedPointerBits == 0,
+  _internalInvariant(shifted & _bridgeObjectTaggedPointerBits == 0,
     "out-of-range: post-shift use of tag bits")
   return _bridgeObject(fromTagged: shifted | _bridgeObjectTaggedPointerBits)
 }
@@ -478,7 +478,7 @@ public func _bridgeObject(taggingPayload x: UInt) -> Builtin.BridgeObject {
 @inline(__always)
 @inlinable
 public func _bridgeObject(toNative x: Builtin.BridgeObject) -> AnyObject {
-  _sanityCheck(_isNativePointer(x))
+  _internalInvariant(_isNativePointer(x))
   return Builtin.castReferenceFromBridgeObject(x)
 }
 
@@ -487,16 +487,16 @@ public func _bridgeObject(toNative x: Builtin.BridgeObject) -> AnyObject {
 public func _bridgeObject(
   toNonTaggedObjC x: Builtin.BridgeObject
 ) -> AnyObject {
-  _sanityCheck(_isNonTaggedObjCPointer(x))
+  _internalInvariant(_isNonTaggedObjCPointer(x))
   return Builtin.castReferenceFromBridgeObject(x)
 }
 
 @inline(__always)
 @inlinable
 public func _bridgeObject(toTagged x: Builtin.BridgeObject) -> UInt {
-  _sanityCheck(_isTaggedObject(x))
+  _internalInvariant(_isTaggedObject(x))
   let bits = _bitPattern(x)
-  _sanityCheck(bits & _bridgeObjectTaggedPointerBits != 0)
+  _internalInvariant(bits & _bridgeObjectTaggedPointerBits != 0)
   return bits
 }
 @inline(__always)
@@ -520,9 +520,9 @@ public func _bridgeObject(
 @inlinable
 @inline(__always)
 public func _nativeObject(fromNative x: AnyObject) -> Builtin.NativeObject {
-  _sanityCheck(!_isObjCTaggedPointer(x))
+  _internalInvariant(!_isObjCTaggedPointer(x))
   let native = Builtin.unsafeCastToNativeObject(x)
-  // _sanityCheck(native == Builtin.castToNativeObject(x))
+  // _internalInvariant(native == Builtin.castToNativeObject(x))
   return native
 }
 
@@ -563,7 +563,7 @@ extension ManagedBufferPointer {
 internal func _makeNativeBridgeObject(
   _ nativeObject: AnyObject, _ bits: UInt
 ) -> Builtin.BridgeObject {
-  _sanityCheck(
+  _internalInvariant(
     (bits & _objectPointerIsObjCBit) == 0,
     "BridgeObject is treated as non-native when ObjC bit is set"
   )
@@ -596,17 +596,17 @@ func _makeObjCBridgeObject(
 internal func _makeBridgeObject(
   _ object: AnyObject, _ bits: UInt
 ) -> Builtin.BridgeObject {
-  _sanityCheck(!_isObjCTaggedPointer(object) || bits == 0,
+  _internalInvariant(!_isObjCTaggedPointer(object) || bits == 0,
     "Tagged pointers cannot be combined with bits")
 
-  _sanityCheck(
+  _internalInvariant(
     _isObjCTaggedPointer(object)
     || _usesNativeSwiftReferenceCounting(type(of: object))
     || bits == _objectPointerIsObjCBit,
     "All spare bits must be set in non-native, non-tagged bridge objects"
   )
 
-  _sanityCheck(
+  _internalInvariant(
     bits & _objectPointerSpareBits == bits,
     "Can't store non-spare bits into Builtin.BridgeObject")
 
@@ -669,10 +669,10 @@ func _isUnique_native<T>(_ object: inout T) -> Bool {
   // This could be a bridge object, single payload enum, or plain old
   // reference. Any case it's non pointer bits must be zero, so
   // force cast it to BridgeObject and check the spare bits.
-  _sanityCheck(
+  _internalInvariant(
     (_bitPattern(Builtin.reinterpretCast(object)) & _objectPointerSpareBits)
     == 0)
-  _sanityCheck(_usesNativeSwiftReferenceCounting(
+  _internalInvariant(_usesNativeSwiftReferenceCounting(
       type(of: Builtin.reinterpretCast(object) as AnyObject)))
   return Bool(Builtin.isUnique_native(&object))
 }
@@ -703,7 +703,7 @@ func _isOptional<T>(_ type: T.Type) -> Bool {
 /// Extract an object reference from an Any known to contain an object.
 @inlinable
 internal func _unsafeDowncastToAnyObject(fromAny any: Any) -> AnyObject {
-  _sanityCheck(type(of: any) is AnyObject.Type
+  _internalInvariant(type(of: any) is AnyObject.Type
                || type(of: any) is AnyObject.Protocol,
                "Any expected to contain object reference")
   // Ideally we would do something like this:

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -79,8 +79,8 @@ extension Character {
   #else
   @usableFromInline @inline(never) @_effects(releasenone)
   internal func _invariantCheck() {
-    _sanityCheck(_str.count == 1)
-    _sanityCheck(_str._guts.isFastUTF8)
+    _internalInvariant(_str.count == 1)
+    _internalInvariant(_str._guts.isFastUTF8)
   }
   #endif // INTERNAL_CHECKS_ENABLED
 }

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -107,7 +107,7 @@ internal struct _CocoaArrayWrapper : RandomAccessCollection {
     _ subRange: Range<Int>
   ) -> UnsafeMutablePointer<AnyObject>?
   {
-    _sanityCheck(!subRange.isEmpty)
+    _internalInvariant(!subRange.isEmpty)
     var enumerationState = _makeSwiftNSFastEnumerationState()
 
     // This function currently returns nil unless the first

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -670,7 +670,7 @@ extension ContiguousArray: RangeReplaceableCollection {
       _buffer = _Buffer(
         _buffer: newBuffer, shiftedToStartIndex: _buffer.startIndex)
     }
-    _sanityCheck(capacity >= minimumCapacity)
+    _internalInvariant(capacity >= minimumCapacity)
   }
 
   /// Copy the contents of the current buffer to a new unique mutable buffer.
@@ -698,9 +698,9 @@ extension ContiguousArray: RangeReplaceableCollection {
   @_semantics("array.mutate_unknown")
   internal mutating func _reserveCapacityAssumingUniqueBuffer(oldCount: Int) {
     // This is a performance optimization. This code used to be in an ||
-    // statement in the _sanityCheck below.
+    // statement in the _internalInvariant below.
     //
-    //   _sanityCheck(_buffer.capacity == 0 ||
+    //   _internalInvariant(_buffer.capacity == 0 ||
     //                _buffer.isMutableAndUniquelyReferenced())
     //
     // SR-6437
@@ -715,7 +715,7 @@ extension ContiguousArray: RangeReplaceableCollection {
     // This specific case is okay because we will make the buffer unique in this
     // function because we request a capacity > 0 and therefore _copyToNewBuffer
     // will be called creating a new buffer.
-    _sanityCheck(capacity ||
+    _internalInvariant(capacity ||
                  _buffer.isMutableAndUniquelyReferenced())
 
     if _slowPath(oldCount + 1 > _buffer.capacity) {
@@ -729,8 +729,8 @@ extension ContiguousArray: RangeReplaceableCollection {
     _ oldCount: Int,
     newElement: __owned Element
   ) {
-    _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
-    _sanityCheck(_buffer.capacity >= _buffer.count + 1)
+    _internalInvariant(_buffer.isMutableAndUniquelyReferenced())
+    _internalInvariant(_buffer.capacity >= _buffer.count + 1)
 
     _buffer.count = oldCount + 1
     (_buffer.firstElementAddress + oldCount).initialize(to: newElement)
@@ -1203,8 +1203,8 @@ extension ContiguousArray: Equatable where Element: Equatable {
     }
 
 
-    _sanityCheck(lhs.startIndex == 0 && rhs.startIndex == 0)
-    _sanityCheck(lhs.endIndex == lhsCount && rhs.endIndex == lhsCount)
+    _internalInvariant(lhs.startIndex == 0 && rhs.startIndex == 0)
+    _internalInvariant(lhs.endIndex == lhsCount && rhs.endIndex == lhsCount)
 
     // We know that lhs.count == rhs.count, compare element wise.
     for idx in 0..<lhsCount {

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -30,7 +30,7 @@ internal final class __EmptyArrayStorage
   @inlinable
   @nonobjc
   internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("creating instance of __EmptyArrayStorage")
+    _internalInvariantFailure("creating instance of __EmptyArrayStorage")
   }
   
 #if _runtime(_ObjC)
@@ -116,7 +116,7 @@ internal final class _ContiguousArrayStorage<
   /// - Precondition: `Element` is bridged non-verbatim.
   @nonobjc
   override internal func _getNonVerbatimBridgedCount() -> Int {
-    _sanityCheck(
+    _internalInvariant(
       !_isBridgedVerbatimToObjectiveC(Element.self),
       "Verbatim bridging should be handled separately")
     return countAndCapacity.count
@@ -126,7 +126,7 @@ internal final class _ContiguousArrayStorage<
   ///
   /// - Precondition: `Element` is bridged non-verbatim.
   override internal func _getNonVerbatimBridgingBuffer() -> _BridgingBuffer {
-    _sanityCheck(
+    _internalInvariant(
       !_isBridgedVerbatimToObjectiveC(Element.self),
       "Verbatim bridging should be handled separately")
     let count = countAndCapacity.count
@@ -289,7 +289,7 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
 
   @inlinable
   internal init(_buffer buffer: _ContiguousArrayBuffer, shiftedToStartIndex: Int) {
-    _sanityCheck(shiftedToStartIndex == 0, "shiftedToStartIndex must be 0")
+    _internalInvariant(shiftedToStartIndex == 0, "shiftedToStartIndex must be 0")
     self = buffer
   }
 
@@ -319,7 +319,7 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   @inlinable
   @inline(__always)
   internal func getElement(_ i: Int) -> Element {
-    _sanityCheck(i >= 0 && i < count, "Array index out of range")
+    _internalInvariant(i >= 0 && i < count, "Array index out of range")
     return firstElementAddress[i]
   }
 
@@ -332,7 +332,7 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
     }
     @inline(__always)
     nonmutating set {
-      _sanityCheck(i >= 0 && i < count, "Array index out of range")
+      _internalInvariant(i >= 0 && i < count, "Array index out of range")
 
       // FIXME: Manually swap because it makes the ARC optimizer happy.  See
       // <rdar://problem/16831852> check retain/release order
@@ -351,9 +351,9 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
       return _storage.countAndCapacity.count
     }
     nonmutating set {
-      _sanityCheck(newValue >= 0)
+      _internalInvariant(newValue >= 0)
 
-      _sanityCheck(
+      _internalInvariant(
         newValue <= capacity,
         "Can't grow an array buffer past its capacity")
 
@@ -387,9 +387,9 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
     subRange bounds: Range<Int>,
     initializing target: UnsafeMutablePointer<Element>
   ) -> UnsafeMutablePointer<Element> {
-    _sanityCheck(bounds.lowerBound >= 0)
-    _sanityCheck(bounds.upperBound >= bounds.lowerBound)
-    _sanityCheck(bounds.upperBound <= count)
+    _internalInvariant(bounds.lowerBound >= 0)
+    _internalInvariant(bounds.upperBound >= bounds.lowerBound)
+    _internalInvariant(bounds.upperBound <= count)
 
     let initializedCount = bounds.upperBound - bounds.lowerBound
     target.initialize(
@@ -479,7 +479,7 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   internal func storesOnlyElementsOfType<U>(
     _: U.Type
   ) -> Bool {
-    _sanityCheck(_isClassOrObjCExistential(U.self))
+    _internalInvariant(_isClassOrObjCExistential(U.self))
 
     if _fastPath(_storage.staticElementType is U.Type) {
       // Done in O(1)
@@ -697,7 +697,7 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
   @inlinable
   @inline(__always) // For performance reasons.
   internal mutating func addWithExistingCapacity(_ element: Element) {
-    _sanityCheck(remainingCapacity > 0,
+    _internalInvariant(remainingCapacity > 0,
       "_UnsafePartiallyInitializedContiguousArrayBuffer has no more capacity")
     remainingCapacity -= 1
 
@@ -728,7 +728,7 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
   @inlinable
   @inline(__always) // For performance reasons.
   internal mutating func finishWithOriginalCount() -> ContiguousArray<Element> {
-    _sanityCheck(remainingCapacity == result.capacity - result.count,
+    _internalInvariant(remainingCapacity == result.capacity - result.count,
       "_UnsafePartiallyInitializedContiguousArrayBuffer has incorrect count")
     var finalResult = _ContiguousArrayBuffer<Element>()
     (finalResult, result) = (result, finalResult)

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -415,7 +415,7 @@ public struct Dictionary<Key: Hashable, Value> {
   @inlinable
   public // SPI(Foundation)
   init(_immutableCocoaDictionary: __owned AnyObject) {
-    _sanityCheck(
+    _internalInvariant(
       _isBridgedVerbatimToObjectiveC(Key.self) &&
       _isBridgedVerbatimToObjectiveC(Value.self),
       """
@@ -2028,7 +2028,7 @@ extension Dictionary.Iterator {
         return nativeIterator
 #if _runtime(_ObjC)
       case .cocoa:
-        _sanityCheckFailure("internal error: does not contain a native index")
+        _internalInvariantFailure("internal error: does not contain a native index")
 #endif
       }
     }
@@ -2043,7 +2043,7 @@ extension Dictionary.Iterator {
     get {
       switch _variant {
       case .native:
-        _sanityCheckFailure("internal error: does not contain a Cocoa index")
+        _internalInvariantFailure("internal error: does not contain a Cocoa index")
       case .cocoa(let cocoa):
         return cocoa
       }
@@ -2132,7 +2132,7 @@ extension Dictionary {
   public // FIXME(reserveCapacity): Should be inlinable
   mutating func reserveCapacity(_ minimumCapacity: Int) {
     _variant.reserveCapacity(minimumCapacity)
-    _sanityCheck(self.capacity >= minimumCapacity)
+    _internalInvariant(self.capacity >= minimumCapacity)
   }
 }
 

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -62,11 +62,11 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
 
   @objc
   internal override required init() {
-    _sanityCheckFailure("don't call this designated initializer")
+    _internalInvariantFailure("don't call this designated initializer")
   }
 
   internal init(_ base: __owned _NativeDictionary<Key, Value>) {
-    _sanityCheck(_isBridgedVerbatimToObjectiveC(Key.self))
+    _internalInvariant(_isBridgedVerbatimToObjectiveC(Key.self))
     self.base = base
     self.bridgedKeys = nil
     self.nextBucket = base.hashTable.startBucket
@@ -75,7 +75,7 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
 
   @nonobjc
   internal init(_ deferred: __owned _SwiftDeferredNSDictionary<Key, Value>) {
-    _sanityCheck(!_isBridgedVerbatimToObjectiveC(Key.self))
+    _internalInvariant(!_isBridgedVerbatimToObjectiveC(Key.self))
     self.base = deferred.native
     self.bridgedKeys = deferred.bridgeKeys()
     self.nextBucket = base.hashTable.startBucket
@@ -83,7 +83,7 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
   }
 
   private func bridgedKey(at bucket: _HashTable.Bucket) -> AnyObject {
-    _sanityCheck(base.hashTable.isOccupied(bucket))
+    _internalInvariant(base.hashTable.isOccupied(bucket))
     if let bridgedKeys = self.bridgedKeys {
       return bridgedKeys[bucket]
     }
@@ -157,8 +157,8 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   internal var native: _NativeDictionary<Key, Value>
 
   internal init(_ native: __owned _NativeDictionary<Key, Value>) {
-    _sanityCheck(native.count > 0)
-    _sanityCheck(!_isBridgedVerbatimToObjectiveC(Key.self) ||
+    _internalInvariant(native.count > 0)
+    _internalInvariant(!_isBridgedVerbatimToObjectiveC(Key.self) ||
       !_isBridgedVerbatimToObjectiveC(Value.self))
     self.native = native
     super.init()
@@ -170,7 +170,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     forKeys: UnsafeRawPointer,
     count: Int
   ) {
-    _sanityCheckFailure("don't call this designated initializer")
+    _internalInvariantFailure("don't call this designated initializer")
   }
 
   @nonobjc
@@ -498,7 +498,7 @@ extension _CocoaDictionary: _DictionaryBuffer {
         return Index(Index.Storage(self, allKeys), offset: i)
       }
     }
-    _sanityCheckFailure(
+    _internalInvariantFailure(
       "An NSDictionary key wassn't listed amongst its enumerated contents")
   }
 

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -78,7 +78,7 @@ internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
   // But we still need to have an init to satisfy the compiler.
   @nonobjc
   internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("This class cannot be directly initialized")
+    _internalInvariantFailure("This class cannot be directly initialized")
   }
 
   @inlinable
@@ -114,7 +114,7 @@ internal class _RawDictionaryStorage: __SwiftNativeNSDictionary {
 internal class _EmptyDictionarySingleton: _RawDictionaryStorage {
   @nonobjc
   internal override init(_doNotCallMe: ()) {
-    _sanityCheckFailure("This class cannot be directly initialized")
+    _internalInvariantFailure("This class cannot be directly initialized")
   }
 
 #if _runtime(_ObjC)
@@ -124,7 +124,7 @@ internal class _EmptyDictionarySingleton: _RawDictionaryStorage {
     forKeys: UnsafeRawPointer,
     count: Int
   ) {
-    _sanityCheckFailure("This class cannot be directly initialized")
+    _internalInvariantFailure("This class cannot be directly initialized")
   }
 #endif
 }
@@ -199,7 +199,7 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
   // But we still need to have an init to satisfy the compiler.
   @nonobjc
   override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("This class cannot be directly initialized")
+    _internalInvariantFailure("This class cannot be directly initialized")
   }
 
   deinit {
@@ -247,7 +247,7 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
     forKeys: UnsafeRawPointer,
     count: Int
   ) {
-    _sanityCheckFailure("This class cannot be directly initialized")
+    _internalInvariantFailure("This class cannot be directly initialized")
   }
 
   @objc(copyWithZone:)
@@ -405,7 +405,7 @@ extension _DictionaryStorage {
   ) -> _DictionaryStorage {
     // The entry count must be representable by an Int value; hence the scale's
     // peculiar upper bound.
-    _sanityCheck(scale >= 0 && scale < Int.bitWidth - 1)
+    _internalInvariant(scale >= 0 && scale < Int.bitWidth - 1)
 
     let bucketCount = (1 as Int) &<< scale
     let wordCount = _UnsafeBitset.wordCount(forCapacity: bucketCount)

--- a/stdlib/public/core/FixedArray.swift.gyb
+++ b/stdlib/public/core/FixedArray.swift.gyb
@@ -66,11 +66,11 @@ extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
     @inline(__always)
     get {
       let count = self.count // for exclusive access
-      _sanityCheck(i >= 0 && i < count)
+      _internalInvariant(i >= 0 && i < count)
       let res: T = withUnsafeBytes(of: storage) {
         (rawPtr : UnsafeRawBufferPointer) -> T in
         let stride = MemoryLayout<T>.stride
-        _sanityCheck(rawPtr.count == ${N}*stride, "layout mismatch?")
+        _internalInvariant(rawPtr.count == ${N}*stride, "layout mismatch?")
         let bufPtr = UnsafeBufferPointer(
           start: rawPtr.baseAddress!.assumingMemoryBound(to: T.self),
           count: count)
@@ -80,7 +80,7 @@ extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
     }
     @inline(__always)
     set {
-      _sanityCheck(i >= 0 && i < count)
+      _internalInvariant(i >= 0 && i < count)
       self.withUnsafeMutableBufferPointer { buffer in
         buffer[i] = newValue
       }
@@ -100,7 +100,7 @@ extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
 
 extension _FixedArray${N} {
   internal mutating func append(_ newElement: T) {
-    _sanityCheck(count < capacity)
+    _internalInvariant(count < capacity)
     _count += 1
     self[count-1] = newElement
   }
@@ -109,7 +109,7 @@ extension _FixedArray${N} {
 extension _FixedArray${N} where T : ExpressibleByIntegerLiteral {
   @inline(__always)
   internal init(count: Int) {
-    _sanityCheck(count >= 0 && count <= _FixedArray${N}.capacity)
+    _internalInvariant(count >= 0 && count <= _FixedArray${N}.capacity)
     self.storage = (
 % for i in range(0, N-1):
     0,
@@ -136,7 +136,7 @@ extension _FixedArray${N} {
   ) rethrows -> R {
     let count = self.count // for exclusive access
     return try withUnsafeMutableBytes(of: &storage) { rawBuffer in
-      _sanityCheck(rawBuffer.count == ${N}*MemoryLayout<T>.stride,
+      _internalInvariant(rawBuffer.count == ${N}*MemoryLayout<T>.stride,
         "layout mismatch?")
       let buffer = UnsafeMutableBufferPointer<Element>(
         start: rawBuffer.baseAddress._unsafelyUnwrappedUnchecked
@@ -151,7 +151,7 @@ extension _FixedArray${N} {
   ) rethrows -> R {
     let count = self.count // for exclusive access
     return try withUnsafeBytes(of: &storage) { rawBuffer in
-      _sanityCheck(rawBuffer.count == ${N}*MemoryLayout<T>.stride,
+      _internalInvariant(rawBuffer.count == ${N}*MemoryLayout<T>.stride,
         "layout mismatch?")
       let buffer = UnsafeBufferPointer<Element>(
         start: rawBuffer.baseAddress._unsafelyUnwrappedUnchecked

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -319,7 +319,7 @@ extension FlattenCollection: Collection {
   @inline(__always)
   @inlinable // lazy-performance
   internal func _advanceIndex(_ i: inout Index, step: Int) {
-    _sanityCheck(-1...1 ~= step, "step should be within the -1...1 range")
+    _internalInvariant(-1...1 ~= step, "step should be within the -1...1 range")
     i = step < 0 ? _index(before: i) : _index(after: i)
   }
 

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1851,8 +1851,8 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
   }
 
   internal func _isEqual(to box: _AnyHashableBox) -> Bool? {
-    _sanityCheck(Int64(exactly: _value) == nil, "self isn't canonical")
-    _sanityCheck(UInt64(exactly: _value) == nil, "self isn't canonical")
+    _internalInvariant(Int64(exactly: _value) == nil, "self isn't canonical")
+    _internalInvariant(UInt64(exactly: _value) == nil, "self isn't canonical")
     if let box = box as? _${Self}AnyHashableBox {
       return _value == box._value
     }
@@ -1864,8 +1864,8 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
   }
 
   internal func _hash(into hasher: inout Hasher) {
-    _sanityCheck(Int64(exactly: _value) == nil, "self isn't canonical")
-    _sanityCheck(UInt64(exactly: _value) == nil, "self isn't canonical")
+    _internalInvariant(Int64(exactly: _value) == nil, "self isn't canonical")
+    _internalInvariant(UInt64(exactly: _value) == nil, "self isn't canonical")
     hasher.combine(_value)
   }
 

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -31,7 +31,7 @@ internal struct _HashTable {
   @inlinable
   @inline(__always)
   internal init(words: UnsafeMutablePointer<Word>, bucketCount: Int) {
-    _sanityCheck(bucketCount > 0 && bucketCount & (bucketCount - 1) == 0,
+    _internalInvariant(bucketCount > 0 && bucketCount & (bucketCount - 1) == 0,
       "bucketCount must be a power of two")
     self.words = words
     // The bucket count is a power of two, so subtracting 1 will never overflow
@@ -77,10 +77,10 @@ extension _HashTable {
     // two greater than or equal to the minimum entry count. Calculate its
     // exponent.
     let exponent = (Swift.max(minimumEntries, 2) - 1)._binaryLogarithm() + 1
-    _sanityCheck(exponent >= 0 && exponent < Int.bitWidth)
+    _internalInvariant(exponent >= 0 && exponent < Int.bitWidth)
     // The scale is the exponent corresponding to the bucket count.
     let scale = Int8(truncatingIfNeeded: exponent)
-    _sanityCheck(self.capacity(forScale: scale) >= capacity)
+    _internalInvariant(self.capacity(forScale: scale) >= capacity)
     return scale
   }
 
@@ -127,7 +127,7 @@ extension _HashTable {
     @inlinable
     @inline(__always)
     internal init(offset: Int) {
-      _sanityCheck(offset >= 0)
+      _internalInvariant(offset >= 0)
       self.offset = offset
     }
 
@@ -272,7 +272,7 @@ extension _HashTable {
   @inlinable
   @inline(__always)
   internal func _isOccupied(_ bucket: Bucket) -> Bool {
-    _sanityCheck(isValid(bucket))
+    _internalInvariant(isValid(bucket))
     return words[bucket.word].uncheckedContains(bucket.bit)
   }
 
@@ -292,7 +292,7 @@ extension _HashTable {
   @inlinable
   @inline(__always)
   internal func _firstOccupiedBucket(fromWord word: Int) -> Bucket {
-    _sanityCheck(word >= 0 && word <= wordCount)
+    _internalInvariant(word >= 0 && word <= wordCount)
     var word = word
     while word < wordCount {
       if let bit = words[word].minimum {
@@ -305,7 +305,7 @@ extension _HashTable {
 
   @inlinable
   internal func occupiedBucket(after bucket: Bucket) -> Bucket {
-    _sanityCheck(isValid(bucket))
+    _internalInvariant(isValid(bucket))
     let word = bucket.word
     if let bit = words[word].intersecting(elementsAbove: bucket.bit).minimum {
       return Bucket(word: word, bit: bit)
@@ -347,7 +347,7 @@ extension _HashTable {
 extension _HashTable {
   @inlinable
   internal func previousHole(before bucket: Bucket) -> Bucket {
-    _sanityCheck(isValid(bucket))
+    _internalInvariant(isValid(bucket))
     // Note that if we have only a single partial word, its out-of-bounds bits
     // are guaranteed to be all set, so the formula below gives correct results.
     var word = bucket.word
@@ -374,7 +374,7 @@ extension _HashTable {
 
   @inlinable
   internal func nextHole(atOrAfter bucket: Bucket) -> Bucket {
-    _sanityCheck(isValid(bucket))
+    _internalInvariant(isValid(bucket))
     // Note that if we have only a single partial word, its out-of-bounds bits
     // are guaranteed to be all set, so the formula below gives correct results.
     var word = bucket.word
@@ -405,7 +405,7 @@ extension _HashTable {
   @inline(__always)
   @_effects(releasenone)
   internal func copyContents(of other: _HashTable) {
-    _sanityCheck(bucketCount == other.bucketCount)
+    _internalInvariant(bucketCount == other.bucketCount)
     self.words.assign(from: other.words, count: bucketCount)
   }
 
@@ -423,7 +423,7 @@ extension _HashTable {
   @inlinable
   @inline(__always)
   internal func insert(_ bucket: Bucket) {
-    _sanityCheck(!isOccupied(bucket))
+    _internalInvariant(!isOccupied(bucket))
     words[bucket.word].uncheckedInsert(bucket.bit)
   }
 
@@ -446,7 +446,7 @@ extension _HashTable {
     at bucket: Bucket,
     with delegate: D
   ) {
-    _sanityCheck(isOccupied(bucket))
+    _internalInvariant(isOccupied(bucket))
 
     // If we've put a hole in a chain of contiguous elements, some element after
     // the hole may belong where the new hole is.

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -47,7 +47,7 @@ internal func _loadPartialUnalignedUInt64LE(
   case 0:
     return result
   default:
-    _sanityCheckFailure()
+    _internalInvariantFailure()
   }
 }
 
@@ -81,7 +81,7 @@ extension Hasher {
       // behavior in the expression type checker <rdar://problem/42672946>.
       let shiftedByteCount: UInt64 = ((byteCount & 7) << 3)
       let mask: UInt64 = (1 << shiftedByteCount - 1)
-      _sanityCheck(tail & ~mask == 0)
+      _internalInvariant(tail & ~mask == 0)
       self.value = (byteCount &<< 56 | tail)
     }
 
@@ -116,8 +116,8 @@ extension Hasher {
     @inline(__always)
     internal
     mutating func append(_ bytes: UInt64, count: UInt64) -> UInt64? {
-      _sanityCheck(count >= 0 && count < 8)
-      _sanityCheck(bytes & ~((1 &<< (count &<< 3)) &- 1) == 0)
+      _internalInvariant(count >= 0 && count < 8)
+      _internalInvariant(bytes & ~((1 &<< (count &<< 3)) &- 1) == 0)
       let c = byteCount & 7
       let shift = c &<< 3
       if c + count < 8 {
@@ -198,7 +198,7 @@ extension Hasher {
 
     @inline(__always)
     internal mutating func combine(bytes: UInt64, count: Int) {
-      _sanityCheck(count >= 0 && count < 8)
+      _internalInvariant(count >= 0 && count < 8)
       let count = UInt64(truncatingIfNeeded: count)
       if let chunk = _buffer.append(bytes, count: count) {
         _state.compress(chunk)
@@ -223,7 +223,7 @@ extension Hasher {
           remaining -= c
         }
       }
-      _sanityCheck(
+      _internalInvariant(
         remaining == 0 ||
         Int(bitPattern: data) & (MemoryLayout<UInt64>.alignment - 1) == 0)
 
@@ -235,7 +235,7 @@ extension Hasher {
       }
 
       // Load last partial word of data
-      _sanityCheck(remaining >= 0 && remaining < 8)
+      _internalInvariant(remaining >= 0 && remaining < 8)
       if remaining > 0 {
         let chunk = _loadPartialUnalignedUInt64LE(data, byteCount: remaining)
         combine(bytes: chunk, count: remaining)
@@ -424,12 +424,12 @@ public struct Hasher {
   internal static func _hash(seed: Int, _ value: UInt) -> Int {
     var state = _State(seed: seed)
 #if arch(i386) || arch(arm)
-    _sanityCheck(UInt.bitWidth < UInt64.bitWidth)
+    _internalInvariant(UInt.bitWidth < UInt64.bitWidth)
     let tbc = _TailBuffer(
       tail: UInt64(truncatingIfNeeded: value),
       byteCount: UInt.bitWidth &>> 3)
 #else
-    _sanityCheck(UInt.bitWidth == UInt64.bitWidth)
+    _internalInvariant(UInt.bitWidth == UInt64.bitWidth)
     state.compress(UInt64(truncatingIfNeeded: value))
     let tbc = _TailBuffer(tail: 0, byteCount: 8)
 #endif
@@ -442,7 +442,7 @@ public struct Hasher {
     seed: Int,
     bytes value: UInt64,
     count: Int) -> Int {
-    _sanityCheck(count >= 0 && count < 8)
+    _internalInvariant(count >= 0 && count < 8)
     var state = _State(seed: seed)
     let tbc = _TailBuffer(tail: value, byteCount: count)
     return Int(truncatingIfNeeded: state.finalize(tailAndByteCount: tbc.value))

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -138,7 +138,7 @@ internal final class _BridgingHashBuffer
 
   internal subscript(bucket: _HashTable.Bucket) -> AnyObject {
     @inline(__always) get {
-      _sanityCheck(header.hashTable.isOccupied(bucket))
+      _internalInvariant(header.hashTable.isOccupied(bucket))
       defer { _fixLifetime(self) }
       return firstElementAddress[bucket.offset]
     }
@@ -146,7 +146,7 @@ internal final class _BridgingHashBuffer
 
   @inline(__always)
   internal func initialize(at bucket: _HashTable.Bucket, to object: AnyObject) {
-    _sanityCheck(header.hashTable.isOccupied(bucket))
+    _internalInvariant(header.hashTable.isOccupied(bucket))
     (firstElementAddress + bucket.offset).initialize(to: object)
     _fixLifetime(self)
   }

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -32,7 +32,7 @@ public func readLine(strippingNewline: Bool = true) -> String? {
   if readBytes == -1 {
     return nil
   }
-  _sanityCheck(readBytes >= 0,
+  _internalInvariant(readBytes >= 0,
     "unexpected return value from swift_stdlib_readLine_stdin")
   if readBytes == 0 {
     return ""

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -13,7 +13,7 @@
 /// Returns c as a UTF16.CodeUnit.  Meant to be used as _ascii16("x").
 @inlinable
 internal func _ascii16(_ c: Unicode.Scalar) -> UTF16.CodeUnit {
-  _sanityCheck(c.value >= 0 && c.value <= 0x7F, "not ASCII")
+  _internalInvariant(c.value >= 0 && c.value <= 0x7F, "not ASCII")
   return UTF16.CodeUnit(c.value)
 }
 

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1435,7 +1435,7 @@ ${assignmentOperatorComment(x.operator, True)}
         _precondition(position >= 0, "Negative word index")
         _precondition(position < endIndex, "Word index out of range")
         let shift = UInt(position._value) &* ${word_bits}
-        _sanityCheck(shift < UInt(_value.bitWidth._value))
+        _internalInvariant(shift < UInt(_value.bitWidth._value))
         return (_value &>> ${Self}(_truncatingBits: shift))._lowWord
       }
     }
@@ -1784,7 +1784,7 @@ ${assignmentOperatorComment(x.operator, True)}
 /// It has only an effect if the argument is a load or call.
 @_transparent
 public func _assumeNonNegative(_ x: ${Self}) -> ${Self} {
-  _sanityCheck(x >= (0 as ${Self}))
+  _internalInvariant(x >= (0 as ${Self}))
   return ${Self}(Builtin.assumeNonNegative_${BuiltinName}(x._value))
 }
 % end
@@ -1881,19 +1881,19 @@ internal struct _IntegerAnyHashableBox<
   }
 
   internal var _hashValue: Int {
-    _sanityCheck(Base.self == UInt64.self || Base.self == Int64.self,
+    _internalInvariant(Base.self == UInt64.self || Base.self == Int64.self,
       "self isn't canonical")
     return _value.hashValue
   }
 
   internal func _hash(into hasher: inout Hasher) {
-    _sanityCheck(Base.self == UInt64.self || Base.self == Int64.self,
+    _internalInvariant(Base.self == UInt64.self || Base.self == Int64.self,
       "self isn't canonical")
     _value.hash(into: &hasher)
   }
 
   internal func _rawHashValue(_seed: Int) -> Int {
-    _sanityCheck(Base.self == UInt64.self || Base.self == Int64.self,
+    _internalInvariant(Base.self == UInt64.self || Base.self == Int64.self,
       "self isn't canonical")
     return _value._rawHashValue(seed: _seed)
   }

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -125,7 +125,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   // Prevent normal initialization. We use tail allocation via
   // allocWithTailElems().
   internal init() {
-    _sanityCheckFailure("use _create(...)")
+    _internalInvariantFailure("use _create(...)")
   }
 
   @usableFromInline
@@ -137,7 +137,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
     capacityInBytes bytes: Int,
     initializedBy body: (UnsafeMutableRawBufferPointer) -> Void
   ) -> Self {
-    _sanityCheck(bytes > 0 && bytes % 4 == 0,
+    _internalInvariant(bytes > 0 && bytes % 4 == 0,
                  "capacity must be multiple of 4 bytes")
     let result = Builtin.allocWithTailElems_1(self, (bytes/4)._builtinWordValue,
                                               Int32.self)
@@ -245,7 +245,7 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
               to: NewValue.self, endingWith: Value.self) {
             case .continue(let newBase):
               if isLast {
-                _sanityCheck(NewValue.self == Value.self,
+                _internalInvariant(NewValue.self == Value.self,
                              "key path does not terminate in correct type")
                 return unsafeBitCast(newBase, to: Value.self)
               } else {
@@ -290,7 +290,7 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
     return withBuffer {
       var buffer = $0
       
-      _sanityCheck(!buffer.hasReferencePrefix,
+      _internalInvariant(!buffer.hasReferencePrefix,
                    "WritableKeyPath should not have a reference prefix")
       
       if buffer.data.isEmpty {
@@ -356,7 +356,7 @@ public class ReferenceWritableKeyPath<
       var base: Any = origBase
       while buffer.hasReferencePrefix {
         let (rawComponent, optNextType) = buffer.next()
-        _sanityCheck(optNextType != nil,
+        _internalInvariant(optNextType != nil,
                      "reference prefix should not go to end of buffer")
         let nextType = optNextType.unsafelyUnwrapped
         
@@ -801,7 +801,7 @@ internal struct RawKeyPathComponent {
     }
 
     internal var isStoredMutable: Bool {
-      _sanityCheck(kind == .struct || kind == .class)
+      _internalInvariant(kind == .struct || kind == .class)
       return _value & Header.storedMutableFlag != 0
     }
 
@@ -809,7 +809,7 @@ internal struct RawKeyPathComponent {
       return _SwiftKeyPathComponentHeader_ComputedMutatingFlag
     }
     internal var isComputedMutating: Bool {
-      _sanityCheck(kind == .computed)
+      _internalInvariant(kind == .computed)
       return _value & Header.computedMutatingFlag != 0
     }
 
@@ -817,7 +817,7 @@ internal struct RawKeyPathComponent {
       return _SwiftKeyPathComponentHeader_ComputedSettableFlag
     }
     internal var isComputedSettable: Bool {
-      _sanityCheck(kind == .computed)
+      _internalInvariant(kind == .computed)
       return _value & Header.computedSettableFlag != 0
     }
 
@@ -833,7 +833,7 @@ internal struct RawKeyPathComponent {
 
       switch (storedProperty, vtableOffset) {
       case (true, true):
-        _sanityCheckFailure("not allowed")
+        _internalInvariantFailure("not allowed")
       case (true, false):
         return .storedPropertyIndex
       case (false, true):
@@ -847,7 +847,7 @@ internal struct RawKeyPathComponent {
       return _SwiftKeyPathComponentHeader_ComputedHasArgumentsFlag
     }
     internal var hasComputedArguments: Bool {
-      _sanityCheck(kind == .computed)
+      _internalInvariant(kind == .computed)
       return _value & Header.computedHasArgumentsFlag != 0
     }
 
@@ -860,12 +860,12 @@ internal struct RawKeyPathComponent {
     }
     internal var isComputedInstantiatedFromExternalWithArguments: Bool {
       get {
-        _sanityCheck(kind == .computed)
+        _internalInvariant(kind == .computed)
         return
           _value & Header.computedInstantiatedFromExternalWithArgumentsFlag != 0
       }
       set {
-        _sanityCheck(kind == .computed)
+        _internalInvariant(kind == .computed)
         _value =
             _value & ~Header.computedInstantiatedFromExternalWithArgumentsFlag
           | (newValue ? Header.computedInstantiatedFromExternalWithArgumentsFlag
@@ -898,7 +898,7 @@ internal struct RawKeyPathComponent {
       }
       set {
         let shifted = newValue << Header.discriminatorShift
-        _sanityCheck(shifted & Header.discriminatorMask == shifted,
+        _internalInvariant(shifted & Header.discriminatorMask == shifted,
                      "discriminator doesn't fit")
         _value = _value & ~Header.discriminatorMask | shifted
       }
@@ -908,21 +908,21 @@ internal struct RawKeyPathComponent {
         return _value & Header.payloadMask
       }
       set {
-        _sanityCheck(newValue & Header.payloadMask == newValue,
+        _internalInvariant(newValue & Header.payloadMask == newValue,
                      "payload too big")
         _value = _value & ~Header.payloadMask | newValue
       }
     }
     internal var storedOffsetPayload: UInt32 {
       get {
-        _sanityCheck(kind == .struct || kind == .class,
+        _internalInvariant(kind == .struct || kind == .class,
                      "not a stored component")
         return _value & Header.storedOffsetPayloadMask
       }
       set {
-        _sanityCheck(kind == .struct || kind == .class,
+        _internalInvariant(kind == .struct || kind == .class,
                      "not a stored component")
-        _sanityCheck(newValue & Header.storedOffsetPayloadMask == newValue,
+        _internalInvariant(newValue & Header.storedOffsetPayloadMask == newValue,
                      "payload too big")
         _value = _value & ~Header.storedOffsetPayloadMask | newValue
       }
@@ -957,7 +957,7 @@ internal struct RawKeyPathComponent {
       case (Header.optionalTag, Header.optionalForcePayload):
         return .optionalForce
       default:
-        _sanityCheckFailure("invalid header")
+        _internalInvariantFailure("invalid header")
       }
     }
 
@@ -1055,7 +1055,7 @@ internal struct RawKeyPathComponent {
       case .class: discriminator = Header.classTag
       }
 
-      _sanityCheck(inlineOffset <= Header.maximumOffsetPayload)
+      _internalInvariant(inlineOffset <= Header.maximumOffsetPayload)
       let payload = inlineOffset
         | (mutable ? Header.storedMutableFlag : 0)
       self.init(discriminator: discriminator,
@@ -1111,7 +1111,7 @@ internal struct RawKeyPathComponent {
       }
       return 0
     case .external:
-      _sanityCheckFailure("should be instantiated away")
+      _internalInvariantFailure("should be instantiated away")
     case .optionalChain, .optionalForce, .optionalWrap:
       return 0
     case .computed:
@@ -1136,13 +1136,13 @@ internal struct RawKeyPathComponent {
   }
 
   internal var _structOrClassOffset: Int {
-    _sanityCheck(header.kind == .struct || header.kind == .class,
+    _internalInvariant(header.kind == .struct || header.kind == .class,
                  "no offset for this kind")
     // An offset too large to fit inline is represented by a signal and stored
     // in the body.
     if header.storedOffsetPayload == Header.outOfLineOffsetPayload {
       // Offset overflowed into body
-      _sanityCheck(body.count >= MemoryLayout<UInt32>.size,
+      _internalInvariant(body.count >= MemoryLayout<UInt32>.size,
                    "component not big enough")
       return Int(body.load(as: UInt32.self))
     }
@@ -1150,14 +1150,14 @@ internal struct RawKeyPathComponent {
   }
 
   internal var _computedIDValue: Int {
-    _sanityCheck(header.kind == .computed,
+    _internalInvariant(header.kind == .computed,
                  "not a computed property")
     return body.load(fromByteOffset: Header.pointerAlignmentSkew,
                      as: Int.self)
   }
 
   internal var _computedID: ComputedPropertyID {
-    _sanityCheck(header.kind == .computed,
+    _internalInvariant(header.kind == .computed,
                  "not a computed property")
 
     return ComputedPropertyID(
@@ -1166,7 +1166,7 @@ internal struct RawKeyPathComponent {
   }
 
   internal var _computedGetter: UnsafeRawPointer {
-    _sanityCheck(header.kind == .computed,
+    _internalInvariant(header.kind == .computed,
                  "not a computed property")
 
     return body.load(
@@ -1175,7 +1175,7 @@ internal struct RawKeyPathComponent {
   }
 
   internal var _computedSetter: UnsafeRawPointer {
-    _sanityCheck(header.isComputedSettable,
+    _internalInvariant(header.isComputedSettable,
                  "not a settable property")
 
     return body.load(
@@ -1184,7 +1184,7 @@ internal struct RawKeyPathComponent {
   }
 
   internal var _computedArgumentHeaderPointer: UnsafeRawPointer {
-    _sanityCheck(header.hasComputedArguments, "no arguments")
+    _internalInvariant(header.hasComputedArguments, "no arguments")
 
     return body.baseAddress.unsafelyUnwrapped
       + Header.pointerAlignmentSkew
@@ -1269,10 +1269,10 @@ internal struct RawKeyPathComponent {
                                set: _computedSetter,
                                argument: argument)
       case (false, true):
-        _sanityCheckFailure("impossible")
+        _internalInvariantFailure("impossible")
       }
     case .external:
-      _sanityCheckFailure("should have been instantiated away")
+      _internalInvariantFailure("should have been instantiated away")
     }
   }
 
@@ -1293,7 +1293,7 @@ internal struct RawKeyPathComponent {
                  _computedArgumentSize - _computedArgumentWitnessSizeAdjustment)
       }
     case .external:
-      _sanityCheckFailure("should have been instantiated away")
+      _internalInvariantFailure("should have been instantiated away")
     }
   }
 
@@ -1376,7 +1376,7 @@ internal struct RawKeyPathComponent {
       }
 
     case .external:
-      _sanityCheckFailure("should have been instantiated away")
+      _internalInvariantFailure("should have been instantiated away")
     }
     buffer = UnsafeMutableRawBufferPointer(
       start: buffer.baseAddress.unsafelyUnwrapped + componentSize,
@@ -1395,7 +1395,7 @@ internal struct RawKeyPathComponent {
       case .continue(let x):
         return x
       case .break:
-        _sanityCheckFailure("should not have stopped key path projection")
+        _internalInvariantFailure("should not have stopped key path projection")
       }
     }
   }
@@ -1416,7 +1416,7 @@ internal struct RawKeyPathComponent {
       })
 
     case .class(let offset):
-      _sanityCheck(CurValue.self is AnyObject.Type,
+      _internalInvariant(CurValue.self is AnyObject.Type,
                    "base is not a class")
       let baseObj = unsafeBitCast(base, to: AnyObject.self)
       let basePtr = UnsafeRawPointer(Builtin.bridgeToRawPointer(baseObj))
@@ -1444,9 +1444,9 @@ internal struct RawKeyPathComponent {
                            argument?.data.count ?? 0))
 
     case .optionalChain:
-      _sanityCheck(CurValue.self == Optional<NewValue>.self,
+      _internalInvariant(CurValue.self == Optional<NewValue>.self,
                    "should be unwrapping optional value")
-      _sanityCheck(_isOptional(LeafValue.self),
+      _internalInvariant(_isOptional(LeafValue.self),
                    "leaf result should be optional")
       if let baseValue = unsafeBitCast(base, to: Optional<NewValue>.self) {
         return .continue(baseValue)
@@ -1457,12 +1457,12 @@ internal struct RawKeyPathComponent {
       }
 
     case .optionalForce:
-      _sanityCheck(CurValue.self == Optional<NewValue>.self,
+      _internalInvariant(CurValue.self == Optional<NewValue>.self,
                    "should be unwrapping optional value")
       return .continue(unsafeBitCast(base, to: Optional<NewValue>.self)!)
 
     case .optionalWrap:
-      _sanityCheck(NewValue.self == Optional<CurValue>.self,
+      _internalInvariant(NewValue.self == Optional<CurValue>.self,
                    "should be wrapping optional value")
       return .continue(
         unsafeBitCast(base as Optional<CurValue>, to: NewValue.self))
@@ -1482,7 +1482,7 @@ internal struct RawKeyPathComponent {
     case .class(let offset):
       // A class dereference should only occur at the root of a mutation,
       // since otherwise it would be part of the reference prefix.
-      _sanityCheck(isRoot,
+      _internalInvariant(isRoot,
                  "class component should not appear in the middle of mutation")
       // AnyObject memory can alias any class reference memory, so we can
       // assume type here
@@ -1527,7 +1527,7 @@ internal struct RawKeyPathComponent {
                             argument: let argument):
       // A nonmutating property should only occur at the root of a mutation,
       // since otherwise it would be part of the reference prefix.
-      _sanityCheck(isRoot,
+      _internalInvariant(isRoot,
            "nonmutating component should not appear in the middle of mutation")
 
       typealias Getter
@@ -1553,7 +1553,7 @@ internal struct RawKeyPathComponent {
       return UnsafeRawPointer(Builtin.addressof(&writeback.value))
 
     case .optionalForce:
-      _sanityCheck(CurValue.self == Optional<NewValue>.self,
+      _internalInvariant(CurValue.self == Optional<NewValue>.self,
                    "should be unwrapping an optional value")
       // Optional's layout happens to always put the payload at the start
       // address of the Optional value itself, if a value is present at all.
@@ -1564,7 +1564,7 @@ internal struct RawKeyPathComponent {
       return base
     
     case .optionalChain, .optionalWrap, .get:
-      _sanityCheckFailure("not a mutable key path component")
+      _internalInvariantFailure("not a mutable key path component")
     }
   }
 }
@@ -1577,7 +1577,7 @@ internal func _pop<T>(from: inout UnsafeRawBufferPointer,
 internal func _pop<T>(from: inout UnsafeRawBufferPointer,
                       as: T.Type,
                       count: Int) -> UnsafeBufferPointer<T> {
-  _sanityCheck(_isPOD(T.self), "should be POD")
+  _internalInvariant(_isPOD(T.self), "should be POD")
   from = MemoryLayout<T>._roundingUpBaseToAlignment(from)
   let byteCount = MemoryLayout<T>.stride * count
   let result = UnsafeBufferPointer(
@@ -1616,7 +1616,7 @@ internal struct KeyPathBuffer {
     }
 
     internal init(size: Int, trivial: Bool, hasReferencePrefix: Bool) {
-      _sanityCheck(size <= Int(Header.sizeMask), "key path too big")
+      _internalInvariant(size <= Int(Header.sizeMask), "key path too big")
       _value = UInt32(size)
         | (trivial ? Header.trivialFlag : 0)
         | (hasReferencePrefix ? Header.hasReferencePrefixFlag : 0)
@@ -1682,7 +1682,7 @@ internal struct KeyPathBuffer {
     let header = _pop(from: &data, as: RawKeyPathComponent.Header.self)
     // Track if this is the last component of the reference prefix.
     if header.endOfReferencePrefix {
-      _sanityCheck(self.hasReferencePrefix,
+      _internalInvariant(self.hasReferencePrefix,
                    "beginMutation marker in non-reference-writable key path?")
       self.hasReferencePrefix = false
     }
@@ -2210,7 +2210,7 @@ internal func _appendingKeyPaths<
           }
         }
         
-        _sanityCheck(destBuffer.count == 0,
+        _internalInvariant(destBuffer.count == 0,
                      "did not fill entire result buffer")
       }
 
@@ -2634,7 +2634,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
     var bufferSizeBefore = 0
     var expectedPop = 0
 
-    _sanityCheck({
+    _internalInvariant({
       bufferSizeBefore = buffer.count
       expectedPop = header.patternComponentBodySize
       return true
@@ -2695,7 +2695,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
       let localCandidateHeader = _pop(from: &buffer,
                                       as: RawKeyPathComponent.Header.self)
       let localCandidateSize = localCandidateHeader.patternComponentBodySize
-      _sanityCheck({
+      _internalInvariant({
         expectedPop += localCandidateSize + 4
         return true
       }())
@@ -2753,12 +2753,12 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
           arguments: arguments,
           externalArgs: genericParamCount > 0 ? externalArgs : nil)
       case .optionalChain, .optionalWrap, .optionalForce, .external:
-        _sanityCheckFailure("not possible for property descriptor")
+        _internalInvariantFailure("not possible for property descriptor")
       }
     }
 
     // Check that we consumed the expected amount of data from the pattern.
-    _sanityCheck(
+    _internalInvariant(
       {
         // Round the amount of data we read up to alignment.
         let popped = MemoryLayout<Int32>._roundingUpToAlignment(
@@ -2780,11 +2780,11 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
     let componentTypeRef = _resolveRelativeAddress(componentTypeBase,
                                                    componentTypeOffset)
     walker.visitIntermediateComponentType(metadataRef: componentTypeRef)
-    _sanityCheck(!buffer.isEmpty)
+    _internalInvariant(!buffer.isEmpty)
   }
 
   // We should have walked the entire pattern.
-  _sanityCheck(buffer.isEmpty, "did not walk entire pattern buffer")
+  _internalInvariant(buffer.isEmpty, "did not walk entire pattern buffer")
   walker.finish()
 }
 
@@ -2866,7 +2866,7 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
       // Writable if the base is. No effect.
       break
     case (false, true):
-      _sanityCheckFailure("unpossible")
+      _internalInvariantFailure("unpossible")
     }
 
     // Save space for the header...
@@ -2889,7 +2889,7 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
       // the layout function.
       let (addedSize, addedAlignmentMask) = arguments.getLayout(patternArgs)
       // TODO: Handle over-aligned values
-      _sanityCheck(addedAlignmentMask < MemoryLayout<Int>.alignment,
+      _internalInvariant(addedAlignmentMask < MemoryLayout<Int>.alignment,
                    "overaligned computed property element not supported")
       size += addedSize
     
@@ -2901,7 +2901,7 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
       size += argumentHeaderSize
       let (addedSize, addedAlignmentMask) = arguments.getLayout(patternArgs)
       // TODO: Handle over-aligned values
-      _sanityCheck(addedAlignmentMask < MemoryLayout<Int>.alignment,
+      _internalInvariant(addedAlignmentMask < MemoryLayout<Int>.alignment,
                    "overaligned computed property element not supported")
       size += addedSize
       // We also need to store the size of the local arguments so we can
@@ -3013,7 +3013,7 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
   var previousComponentAddr: UnsafeMutableRawPointer? = nil
 
   mutating func pushDest<T>(_ value: T) {
-    _sanityCheck(_isPOD(T.self))
+    _internalInvariant(_isPOD(T.self))
     let size = MemoryLayout<T>.size
     let alignment = MemoryLayout<T>.alignment
     var baseAddress = destData.baseAddress.unsafelyUnwrapped
@@ -3118,7 +3118,7 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
 
     switch idKind {
     case .storedPropertyIndex, .vtableOffset:
-      _sanityCheck(idResolved)
+      _internalInvariant(idResolved)
       // Zero-extend the integer value to get the instantiated id.
       let value = UInt(UInt32(bitPattern: idValue))
       resolvedID = UnsafeRawPointer(bitPattern: value)
@@ -3153,7 +3153,7 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
     if let arguments = arguments {
       // Instantiate the arguments.
       let (baseSize, alignmentMask) = arguments.getLayout(patternArgs)
-      _sanityCheck(alignmentMask < MemoryLayout<Int>.alignment,
+      _internalInvariant(alignmentMask < MemoryLayout<Int>.alignment,
                    "overaligned computed arguments not implemented yet")
 
       // The real buffer stride will be rounded up to alignment.
@@ -3183,7 +3183,7 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
       }
 
       // Initialize the local candidate arguments here.
-      _sanityCheck(Int(bitPattern: destData.baseAddress) & alignmentMask == 0,
+      _internalInvariant(Int(bitPattern: destData.baseAddress) & alignmentMask == 0,
                    "argument destination not aligned")
       arguments.initializer(patternArgs,
                             destData.baseAddress.unsafelyUnwrapped)
@@ -3243,7 +3243,7 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
   mutating func finish() {
     // Should have filled the entire buffer by the time we reach the end of the
     // pattern.
-    _sanityCheck(destData.isEmpty,
+    _internalInvariant(destData.isEmpty,
                  "should have filled entire destination buffer")
   }
 }
@@ -3342,7 +3342,7 @@ internal struct ValidatingInstantiateKeyPathBuffer: KeyPathPatternVisitor {
     let nextDest = instantiateVisitor.destData.baseAddress.unsafelyUnwrapped
     let curSize = nextDest - origDest + MemoryLayout<Int>.size
 
-    _sanityCheck(curSize == sizeVisitor.size,
+    _internalInvariant(curSize == sizeVisitor.size,
                  "size and instantiation visitors out of sync")
   }
 }

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -45,7 +45,7 @@ open class ManagedBuffer<Header, Element> {
   public final var header: Header
 
   internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only initialize these by calling create")
+    _internalInvariantFailure("Only initialize these by calling create")
   }
 }
 
@@ -263,7 +263,7 @@ public struct ManagedBufferPointer<Header, Element> {
   /// it in this specialized constructor.
   @inlinable
   internal init(_uncheckedUnsafeBufferObject buffer: AnyObject) {
-    ManagedBufferPointer._sanityCheckValidBufferClass(type(of: buffer))
+    ManagedBufferPointer._internalInvariantValidBufferClass(type(of: buffer))
     self._nativeBuffer = Builtin.unsafeCastToNativeObject(buffer)
   }
 
@@ -299,8 +299,8 @@ public struct ManagedBufferPointer<Header, Element> {
     _uncheckedBufferClass: AnyClass,
     minimumCapacity: Int
   ) {
-    ManagedBufferPointer._sanityCheckValidBufferClass(_uncheckedBufferClass, creating: true)
-    _sanityCheck(
+    ManagedBufferPointer._internalInvariantValidBufferClass(_uncheckedBufferClass, creating: true)
+    _internalInvariant(
       minimumCapacity >= 0,
       "ManagedBufferPointer must have non-negative capacity")
 
@@ -421,10 +421,10 @@ extension ManagedBufferPointer {
   }
 
   @inlinable
-  internal static func _sanityCheckValidBufferClass(
+  internal static func _internalInvariantValidBufferClass(
     _ bufferClass: AnyClass, creating: Bool = false
   ) {
-    _sanityCheck(
+    _internalInvariant(
       _class_getInstancePositiveExtentSize(bufferClass) == MemoryLayout<_HeapObject>.size
       || (
         (!creating || bufferClass is ManagedBuffer<Header, Element>.Type)
@@ -432,7 +432,7 @@ extension ManagedBufferPointer {
           == _headerOffset + MemoryLayout<Header>.size),
       "ManagedBufferPointer buffer class has illegal stored properties"
     )
-    _sanityCheck(
+    _internalInvariant(
       _usesNativeSwiftReferenceCounting(bufferClass),
       "ManagedBufferPointer buffer class must be non-@objc"
     )

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -48,7 +48,7 @@ internal struct _NativeDictionary<Key: Hashable, Value> {
 
   @inlinable
   internal init(_ cocoa: __owned _CocoaDictionary, capacity: Int) {
-    _sanityCheck(cocoa.count <= capacity)
+    _internalInvariant(cocoa.count <= capacity)
     self._storage =
       _DictionaryStorage<Key, Value>.convert(cocoa, capacity: capacity)
     for (key, value) in cocoa {
@@ -109,7 +109,7 @@ extension _NativeDictionary { // Low-level unchecked operations
   @inline(__always)
   internal func uncheckedKey(at bucket: Bucket) -> Key {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(bucket))
+    _internalInvariant(hashTable.isOccupied(bucket))
     return _keys[bucket.offset]
   }
 
@@ -117,7 +117,7 @@ extension _NativeDictionary { // Low-level unchecked operations
   @inline(__always)
   internal func uncheckedValue(at bucket: Bucket) -> Value {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(bucket))
+    _internalInvariant(hashTable.isOccupied(bucket))
     return _values[bucket.offset]
   }
 
@@ -128,7 +128,7 @@ extension _NativeDictionary { // Low-level unchecked operations
     toKey key: __owned Key,
     value: __owned Value) {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isValid(bucket))
+    _internalInvariant(hashTable.isValid(bucket))
     (_keys + bucket.offset).initialize(to: key)
     (_values + bucket.offset).initialize(to: value)
   }
@@ -137,7 +137,7 @@ extension _NativeDictionary { // Low-level unchecked operations
   @inline(__always)
   internal func uncheckedDestroy(at bucket: Bucket) {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(bucket))
+    _internalInvariant(hashTable.isOccupied(bucket))
     (_keys + bucket.offset).deinitialize(count: 1)
     (_values + bucket.offset).deinitialize(count: 1)
   }
@@ -222,9 +222,9 @@ extension _NativeDictionary { // ensureUnique
   @inlinable
   internal mutating func copy() {
     let newStorage = _DictionaryStorage<Key, Value>.copy(original: _storage)
-    _sanityCheck(newStorage._scale == _storage._scale)
-    _sanityCheck(newStorage._age == _storage._age)
-    _sanityCheck(newStorage._seed == _storage._seed)
+    _internalInvariant(newStorage._scale == _storage._scale)
+    _internalInvariant(newStorage._age == _storage._age)
+    _internalInvariant(newStorage._seed == _storage._seed)
     let result = _NativeDictionary(newStorage)
     if count > 0 {
       result.hashTable.copyContents(of: hashTable)
@@ -409,7 +409,7 @@ extension _NativeDictionary { // Insertions
   /// The `key` must not be already present in the Dictionary.
   @inlinable
   internal func _unsafeInsertNew(key: __owned Key, value: __owned Value) {
-    _sanityCheck(count + 1 <= capacity)
+    _internalInvariant(count + 1 <= capacity)
     let hashValue = self.hashValue(for: key)
     if _isDebugAssertConfiguration() {
       // In debug builds, perform a full lookup and trap if we detect duplicate
@@ -472,7 +472,7 @@ extension _NativeDictionary { // Insertions
     at bucket: Bucket,
     key: __owned Key,
     value: __owned Value) {
-    _sanityCheck(count < capacity)
+    _internalInvariant(count < capacity)
     hashTable.insert(bucket)
     uncheckedInitialize(at: bucket, toKey: key, value: value)
     _storage._count += 1
@@ -518,8 +518,8 @@ extension _NativeDictionary {
     isUnique: Bool
   ) {
     let rehashed = ensureUnique(isUnique: isUnique, capacity: capacity)
-    _sanityCheck(!rehashed)
-    _sanityCheck(hashTable.isOccupied(a) && hashTable.isOccupied(b))
+    _internalInvariant(!rehashed)
+    _internalInvariant(hashTable.isOccupied(a) && hashTable.isOccupied(b))
     let value = (_values + a.offset).move()
     (_values + a.offset).moveInitialize(from: _values + b.offset, count: 1)
     (_values + b.offset).initialize(to: value)
@@ -586,7 +586,7 @@ extension _NativeDictionary { // Deletion
   internal func _delete(at bucket: Bucket) {
     hashTable.delete(at: bucket, with: self)
     _storage._count -= 1
-    _sanityCheck(_storage._count >= 0)
+    _internalInvariant(_storage._count >= 0)
     invalidateIndices()
   }
 
@@ -596,9 +596,9 @@ extension _NativeDictionary { // Deletion
     at bucket: Bucket,
     isUnique: Bool
   ) -> Element {
-    _sanityCheck(hashTable.isOccupied(bucket))
+    _internalInvariant(hashTable.isOccupied(bucket))
     let rehashed = ensureUnique(isUnique: isUnique, capacity: capacity)
-    _sanityCheck(!rehashed)
+    _internalInvariant(!rehashed)
     let oldKey = (_keys + bucket.offset).move()
     let oldValue = (_values + bucket.offset).move()
     _delete(at: bucket)
@@ -631,7 +631,7 @@ extension _NativeDictionary { // High-level operations
     _ transform: (Value) throws -> T
   ) rethrows -> _NativeDictionary<Key, T> {
     let resultStorage = _DictionaryStorage<Key, T>.copy(original: _storage)
-    _sanityCheck(resultStorage._seed == _storage._seed)
+    _internalInvariant(resultStorage._seed == _storage._seed)
     let result = _NativeDictionary<Key, T>(resultStorage)
     // Because the current and new buffer have the same scale and seed, we can
     // initialize to the same locations in the new buffer, skipping hash value

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -47,7 +47,7 @@ internal struct _NativeSet<Element: Hashable> {
 
   @inlinable
   internal init(_ cocoa: __owned _CocoaSet, capacity: Int) {
-    _sanityCheck(cocoa.count <= capacity)
+    _internalInvariant(cocoa.count <= capacity)
     self._storage = _SetStorage<Element>.convert(cocoa, capacity: capacity)
     for element in cocoa {
       let nativeElement = _forceBridgeFromObjectiveC(element, Element.self)
@@ -101,7 +101,7 @@ extension _NativeSet { // Low-level unchecked operations
   @inline(__always)
   internal func uncheckedElement(at bucket: Bucket) -> Element {
     defer { _fixLifetime(self) }
-    _sanityCheck(hashTable.isOccupied(bucket))
+    _internalInvariant(hashTable.isOccupied(bucket))
     return _elements[bucket.offset]
   }
 
@@ -110,7 +110,7 @@ extension _NativeSet { // Low-level unchecked operations
   internal func uncheckedInitialize(
     at bucket: Bucket,
     to element: __owned Element) {
-    _sanityCheck(hashTable.isValid(bucket))
+    _internalInvariant(hashTable.isValid(bucket))
     (_elements + bucket.offset).initialize(to: element)
   }
 }
@@ -189,9 +189,9 @@ extension _NativeSet { // ensureUnique
   @inlinable
   internal mutating func copy() {
     let newStorage = _SetStorage<Element>.copy(original: _storage)
-    _sanityCheck(newStorage._scale == _storage._scale)
-    _sanityCheck(newStorage._age == _storage._age)
-    _sanityCheck(newStorage._seed == _storage._seed)
+    _internalInvariant(newStorage._scale == _storage._scale)
+    _internalInvariant(newStorage._age == _storage._age)
+    _internalInvariant(newStorage._seed == _storage._seed)
     let result = _NativeSet(newStorage)
     if count > 0 {
       result.hashTable.copyContents(of: hashTable)
@@ -343,7 +343,7 @@ extension _NativeSet { // Insertions
   /// The `element` must not be already present in the Set.
   @inlinable
   internal func _unsafeInsertNew(_ element: __owned Element) {
-    _sanityCheck(count + 1 <= capacity)
+    _internalInvariant(count + 1 <= capacity)
     let hashValue = self.hashValue(for: element)
     if _isDebugAssertConfiguration() {
       // In debug builds, perform a full lookup and trap if we detect duplicate
@@ -385,7 +385,7 @@ extension _NativeSet { // Insertions
     at bucket: Bucket,
     isUnique: Bool
   ) {
-    _sanityCheck(!hashTable.isOccupied(bucket))
+    _internalInvariant(!hashTable.isOccupied(bucket))
     var bucket = bucket
     let rehashed = ensureUnique(isUnique: isUnique, capacity: count + 1)
     if rehashed {
@@ -474,7 +474,7 @@ extension _NativeSet { // Deletion
   internal mutating func _delete(at bucket: Bucket) {
     hashTable.delete(at: bucket, with: self)
     _storage._count -= 1
-    _sanityCheck(_storage._count >= 0)
+    _internalInvariant(_storage._count >= 0)
     invalidateIndices()
   }
 
@@ -483,9 +483,9 @@ extension _NativeSet { // Deletion
   internal mutating func uncheckedRemove(
     at bucket: Bucket,
     isUnique: Bool) -> Element {
-    _sanityCheck(hashTable.isOccupied(bucket))
+    _internalInvariant(hashTable.isOccupied(bucket))
     let rehashed = ensureUnique(isUnique: isUnique, capacity: capacity)
-    _sanityCheck(!rehashed)
+    _internalInvariant(!rehashed)
     let old = (_elements + bucket.offset).move()
     _delete(at: bucket)
     return old

--- a/stdlib/public/core/NormalizedCodeUnitIterator.swift
+++ b/stdlib/public/core/NormalizedCodeUnitIterator.swift
@@ -29,7 +29,7 @@ extension Unicode.Scalar {
 
   // Whether this scalar value always has a normalization boundary before it.
   internal var _hasNormalizationBoundaryBefore: Bool {
-    _sanityCheck(Int32(exactly: self.value) != nil, "top bit shouldn't be set")
+    _internalInvariant(Int32(exactly: self.value) != nil, "top bit shouldn't be set")
     let value = Int32(bitPattern: self.value)
     return 0 != __swift_stdlib_unorm2_hasBoundaryBefore(
       _Normalization._nfcNormalizer, value)
@@ -148,7 +148,7 @@ internal struct _NormalizedUTF8CodeUnitIterator: IteratorProtocol {
   var bufferCount = 0
 
   internal init(foreign guts: _StringGuts, range: Range<String.Index>) {
-    _sanityCheck(guts.isForeign)
+    _internalInvariant(guts.isForeign)
     utf16Iterator = _NormalizedUTF16CodeUnitIterator(guts, range)
   }
 
@@ -177,8 +177,8 @@ internal struct _NormalizedUTF8CodeUnitIterator: IteratorProtocol {
       let iterator = array.makeIterator()
       _ = transcode(iterator, from: UTF16.self, to: UTF8.self,
         stoppingOnError: false) { codeUnit in
-          _sanityCheck(bufferCount < 4)
-          _sanityCheck(bufferIndex < 4)
+          _internalInvariant(bufferCount < 4)
+          _internalInvariant(bufferIndex < 4)
 
           utf8Buffer[bufferIndex] = codeUnit
           bufferIndex += 1
@@ -412,7 +412,7 @@ struct _NormalizedUTF16CodeUnitIterator: IteratorProtocol {
     }
 
     //exactly one of the buffers should have code units for us to return
-    _sanityCheck((segmentBufferCount == 0)
+    _internalInvariant((segmentBufferCount == 0)
               != ((overflowBuffer?.count ?? 0) == 0))
 
     if segmentBufferIndex < segmentBufferCount {
@@ -420,7 +420,7 @@ struct _NormalizedUTF16CodeUnitIterator: IteratorProtocol {
       segmentBufferIndex += 1
       return segmentBuffer[index]
     } else if overflowBufferIndex < overflowBufferCount {
-      _sanityCheck(overflowBufferIndex < overflowBuffer!.count)
+      _internalInvariant(overflowBufferIndex < overflowBuffer!.count)
       let index = overflowBufferIndex
       overflowBufferIndex += 1
       return overflowBuffer![index]
@@ -494,13 +494,13 @@ extension _NormalizedUTF8CodeUnitIterator_2 {
       }
       fill()
       if _slowPath(outputBufferEmpty) {
-        //_sanityCheck(inputBufferEmpty)
+        //_internalInvariant(inputBufferEmpty)
         return nil
       }
     }
-    _sanityCheck(!outputBufferEmpty)
+    _internalInvariant(!outputBufferEmpty)
 
-    _sanityCheck(outputPosition < outputBufferCount)
+    _internalInvariant(outputPosition < outputBufferCount)
     let result = outputBuffer[outputPosition]
     outputPosition &+= 1
     return result
@@ -534,7 +534,7 @@ extension _NormalizedUTF8CodeUnitIterator_2 {
 
           // Check scalar-based fast-paths
           let (scalar, len) = _decodeScalar(utf8, startingAt: inputCount)
-          _sanityCheck(inputCount &+ len <= inputEnd)
+          _internalInvariant(inputCount &+ len <= inputEnd)
 
           if _slowPath(
                !utf8.hasNormalizationBoundary(before: inputCount &+ len)
@@ -549,7 +549,7 @@ extension _NormalizedUTF8CodeUnitIterator_2 {
             outputCount &+= 1
           }
 
-          _sanityCheck(inputCount == outputCount,
+          _internalInvariant(inputCount == outputCount,
             "non-normalizing UTF-8 fast path should be 1-to-1 in code units")
         }
       }
@@ -559,7 +559,7 @@ extension _NormalizedUTF8CodeUnitIterator_2 {
           offsetBy: inputCount)
         let (scalar, len) = gutsSlice.foreignErrorCorrectedScalar(
           startingAt: startIdx)
-        _sanityCheck(inputCount &+ len <= inputEnd)
+        _internalInvariant(inputCount &+ len <= inputEnd)
 
         if _slowPath(
              !gutsSlice.foreignHasNormalizationBoundary(
@@ -575,7 +575,7 @@ extension _NormalizedUTF8CodeUnitIterator_2 {
           outputCount &+= 1
         }
 
-        _sanityCheck(inputCount <= outputCount,
+        _internalInvariant(inputCount <= outputCount,
           "non-normalizing UTF-16 fast path shoule be 1-to-many in code units")
       }
     }
@@ -584,7 +584,7 @@ extension _NormalizedUTF8CodeUnitIterator_2 {
 
   @_effects(releasenone)
   private mutating func fill() {
-    _sanityCheck(outputBufferEmpty)
+    _internalInvariant(outputBufferEmpty)
 
     let priorInputCount = gutsSlice._offsetRange.count
 
@@ -594,11 +594,11 @@ extension _NormalizedUTF8CodeUnitIterator_2 {
 
     // Check if we filled in any, and adjust our scanning range appropriately
     if inputCount > 0 {
-      _sanityCheck(outputCount > 0)
+      _internalInvariant(outputCount > 0)
       gutsSlice._offsetRange = Range(uncheckedBounds: (
         gutsSlice._offsetRange.lowerBound + inputCount,
         gutsSlice._offsetRange.upperBound))
-      _sanityCheck(gutsSlice._offsetRange.count >= 0)
+      _internalInvariant(gutsSlice._offsetRange.count >= 0)
       return
     }
 
@@ -612,15 +612,15 @@ extension _NormalizedUTF8CodeUnitIterator_2 {
     }
 
     if !(outputBufferCount == 0 || remaining < priorInputCount) {
-      // TODO: _sanityCheck(outputBufferCount == 0 || remaining < priorInputCount)
+      // TODO: _internalInvariant(outputBufferCount == 0 || remaining < priorInputCount)
     }
 
     gutsSlice._offsetRange = Range(uncheckedBounds: (
       gutsSlice._offsetRange.lowerBound + (priorInputCount - remaining),
       gutsSlice._offsetRange.upperBound))
 
-    _sanityCheck(outputBufferFull || gutsSlice._offsetRange.isEmpty)
-    _sanityCheck(gutsSlice._offsetRange.count >= 0)
+    _internalInvariant(outputBufferFull || gutsSlice._offsetRange.isEmpty)
+    _internalInvariant(gutsSlice._offsetRange.count >= 0)
   }
 
   @_effects(readonly)

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -259,7 +259,7 @@ public enum Optional<Wrapped> : ExpressibleByNilLiteral {
       if let x = self {
         return x
       }
-      _sanityCheckFailure("_unsafelyUnwrappedUnchecked of nil optional")
+      _internalInvariantFailure("_unsafelyUnwrappedUnchecked of nil optional")
     }
   }
 }

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -255,7 +255,7 @@ where Base: BidirectionalCollection {
       // Safe to assume that `_base.startIndex != _base.endIndex`; if they
       // were equal, `_base.startIndex` would be used as the `endIndex` of
       // this collection.
-      _sanityCheck(!_base.isEmpty)
+      _internalInvariant(!_base.isEmpty)
       var result = _base.startIndex
       while true {
         let next = _base.index(after: result)

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -214,7 +214,7 @@ internal func _float${bits}ToStringImpl(
 internal func _float${bits}ToString(
   _ value: Float${bits}, debug: Bool
 ) -> (buffer: _Buffer32, length: Int) {
-  _sanityCheck(MemoryLayout<_Buffer32>.size == 32)
+  _internalInvariant(MemoryLayout<_Buffer32>.size == 32)
   var buffer = _Buffer32()
   let length = buffer.withBytes { (bufferPtr) in
     Int(_float${bits}ToStringImpl(bufferPtr, 32, value, debug))

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -188,7 +188,7 @@ public struct Set<Element: Hashable> {
   @inlinable
   public // SPI(Foundation)
   init(_immutableCocoaSet: __owned AnyObject) {
-    _sanityCheck(_isBridgedVerbatimToObjectiveC(Element.self),
+    _internalInvariant(_isBridgedVerbatimToObjectiveC(Element.self),
       "Set can be backed by NSSet _variant only when the member type can be bridged verbatim to Objective-C")
     self.init(_cocoa: _CocoaSet(_immutableCocoaSet))
   }
@@ -1518,7 +1518,7 @@ extension Set.Iterator {
         return nativeIterator
 #if _runtime(_ObjC)
       case .cocoa:
-        _sanityCheckFailure("internal error: does not contain a native index")
+        _internalInvariantFailure("internal error: does not contain a native index")
 #endif
       }
     }
@@ -1533,7 +1533,7 @@ extension Set.Iterator {
     get {
       switch _variant {
       case .native:
-        _sanityCheckFailure("internal error: does not contain a Cocoa index")
+        _internalInvariantFailure("internal error: does not contain a Cocoa index")
       case .cocoa(let cocoa):
         return cocoa
       }
@@ -1613,7 +1613,7 @@ extension Set {
   public // FIXME(reserveCapacity): Should be inlinable
   mutating func reserveCapacity(_ minimumCapacity: Int) {
     _variant.reserveCapacity(minimumCapacity)
-    _sanityCheck(self.capacity >= minimumCapacity)
+    _internalInvariant(self.capacity >= minimumCapacity)
   }
 }
 

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -65,11 +65,11 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
 
   @objc
   internal override required init() {
-    _sanityCheckFailure("don't call this designated initializer")
+    _internalInvariantFailure("don't call this designated initializer")
   }
 
   internal init(_ base: __owned _NativeSet<Element>) {
-    _sanityCheck(_isBridgedVerbatimToObjectiveC(Element.self))
+    _internalInvariant(_isBridgedVerbatimToObjectiveC(Element.self))
     self.base = base
     self.bridgedElements = nil
     self.nextBucket = base.hashTable.startBucket
@@ -78,7 +78,7 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
 
   @nonobjc
   internal init(_ deferred: __owned _SwiftDeferredNSSet<Element>) {
-    _sanityCheck(!_isBridgedVerbatimToObjectiveC(Element.self))
+    _internalInvariant(!_isBridgedVerbatimToObjectiveC(Element.self))
     self.base = deferred.native
     self.bridgedElements = deferred.bridgeElements()
     self.nextBucket = base.hashTable.startBucket
@@ -86,7 +86,7 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
   }
 
   private func bridgedElement(at bucket: _HashTable.Bucket) -> AnyObject {
-    _sanityCheck(base.hashTable.isOccupied(bucket))
+    _internalInvariant(base.hashTable.isOccupied(bucket))
     if let bridgedElements = self.bridgedElements {
       return bridgedElements[bucket]
     }
@@ -156,8 +156,8 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   internal var native: _NativeSet<Element>
 
   internal init(_ native: __owned _NativeSet<Element>) {
-    _sanityCheck(native.count > 0)
-    _sanityCheck(!_isBridgedVerbatimToObjectiveC(Element.self))
+    _internalInvariant(native.count > 0)
+    _internalInvariant(!_isBridgedVerbatimToObjectiveC(Element.self))
     self.native = native
     super.init()
   }
@@ -208,7 +208,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
 
   @objc
   internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
-    _sanityCheckFailure("don't call this designated initializer")
+    _internalInvariantFailure("don't call this designated initializer")
   }
 
   @objc(copyWithZone:)
@@ -379,7 +379,7 @@ extension _CocoaSet: _SetBuffer {
         return Index(Index.Storage(self, allKeys), offset: i)
       }
     }
-    _sanityCheckFailure(
+    _internalInvariantFailure(
       "An NSSet member wasn't listed amongst its enumerated contents")
   }
 
@@ -399,7 +399,7 @@ extension _CocoaSet: _SetBuffer {
   @_effects(releasenone)
   internal func element(at i: Index) -> AnyObject {
     let element: AnyObject? = i.element
-    _sanityCheck(element != nil, "Item not found in underlying NSSet")
+    _internalInvariant(element != nil, "Item not found in underlying NSSet")
     return element!
   }
 }

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -73,7 +73,7 @@ internal class _RawSetStorage: __SwiftNativeNSSet {
   // But we still need to have an init to satisfy the compiler.
   @nonobjc
   internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("This class cannot be directly initialized")
+    _internalInvariantFailure("This class cannot be directly initialized")
   }
 
   @inlinable
@@ -109,13 +109,13 @@ internal class _RawSetStorage: __SwiftNativeNSSet {
 internal class _EmptySetSingleton: _RawSetStorage {
   @nonobjc
   override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("This class cannot be directly initialized")
+    _internalInvariantFailure("This class cannot be directly initialized")
   }
 
 #if _runtime(_ObjC)
   @objc
   internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
-    _sanityCheckFailure("This class cannot be directly initialized")
+    _internalInvariantFailure("This class cannot be directly initialized")
   }
 #endif
 }
@@ -182,7 +182,7 @@ final internal class _SetStorage<Element: Hashable>
   // But we still need to have an init to satisfy the compiler.
   @nonobjc
   override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("This class cannot be directly initialized")
+    _internalInvariantFailure("This class cannot be directly initialized")
   }
 
   deinit {
@@ -211,7 +211,7 @@ final internal class _SetStorage<Element: Hashable>
 #if _runtime(_ObjC)
   @objc
   internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
-    _sanityCheckFailure("don't call this designated initializer")
+    _internalInvariantFailure("don't call this designated initializer")
   }
 
   @objc(copyWithZone:)
@@ -329,7 +329,7 @@ extension _SetStorage {
   ) -> _SetStorage {
     // The entry count must be representable by an Int value; hence the scale's
     // peculiar upper bound.
-    _sanityCheck(scale >= 0 && scale < Int.bitWidth - 1)
+    _internalInvariant(scale >= 0 && scale < Int.bitWidth - 1)
 
     let bucketCount = (1 as Int) &<< scale
     let wordCount = _UnsafeBitset.wordCount(forCapacity: bucketCount)

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -88,9 +88,9 @@ internal struct _SliceBuffer<Element>
   internal func _invariantCheck() {
     let isNative = _hasNativeBuffer
     let isNativeStorage: Bool = owner is __ContiguousArrayStorageBase
-    _sanityCheck(isNativeStorage == isNative)
+    _internalInvariant(isNativeStorage == isNative)
     if isNative {
-      _sanityCheck(count <= nativeBuffer.count)
+      _internalInvariant(count <= nativeBuffer.count)
     }
   }
 
@@ -101,14 +101,14 @@ internal struct _SliceBuffer<Element>
 
   @inlinable
   internal var nativeBuffer: NativeBuffer {
-    _sanityCheck(_hasNativeBuffer)
+    _internalInvariant(_hasNativeBuffer)
     return NativeBuffer(
       owner as? __ContiguousArrayStorageBase ?? _emptyArrayStorage)
   }
 
   @inlinable
   internal var nativeOwner: AnyObject {
-    _sanityCheck(_hasNativeBuffer, "Expect a native array")
+    _internalInvariant(_hasNativeBuffer, "Expect a native array")
     return owner
   }
 
@@ -126,10 +126,10 @@ internal struct _SliceBuffer<Element>
   ) where C : Collection, C.Element == Element {
 
     _invariantCheck()
-    _sanityCheck(insertCount <= numericCast(newValues.count))
+    _internalInvariant(insertCount <= numericCast(newValues.count))
 
-    _sanityCheck(_hasNativeBuffer)
-    _sanityCheck(isUniquelyReferenced())
+    _internalInvariant(_hasNativeBuffer)
+    _internalInvariant(isUniquelyReferenced())
 
     let eraseCount = subrange.count
     let growth = insertCount - eraseCount
@@ -138,7 +138,7 @@ internal struct _SliceBuffer<Element>
     var native = nativeBuffer
     let hiddenElementCount = firstElementAddress - native.firstElementAddress
 
-    _sanityCheck(native.count + growth <= native.capacity)
+    _internalInvariant(native.count + growth <= native.capacity)
 
     let start = subrange.lowerBound - startIndex + hiddenElementCount
     let end = subrange.upperBound - startIndex + hiddenElementCount
@@ -246,9 +246,9 @@ internal struct _SliceBuffer<Element>
     initializing target: UnsafeMutablePointer<Element>
   ) -> UnsafeMutablePointer<Element> {
     _invariantCheck()
-    _sanityCheck(bounds.lowerBound >= startIndex)
-    _sanityCheck(bounds.upperBound >= bounds.lowerBound)
-    _sanityCheck(bounds.upperBound <= endIndex)
+    _internalInvariant(bounds.lowerBound >= startIndex)
+    _internalInvariant(bounds.upperBound >= bounds.lowerBound)
+    _internalInvariant(bounds.upperBound <= endIndex)
     let c = bounds.count
     target.initialize(from: subscriptBaseAddress + bounds.lowerBound, count: c)
     return target + c
@@ -304,8 +304,8 @@ internal struct _SliceBuffer<Element>
 
   @inlinable
   internal func getElement(_ i: Int) -> Element {
-    _sanityCheck(i >= startIndex, "slice index is out of range (before startIndex)")
-    _sanityCheck(i < endIndex, "slice index is out of range")
+    _internalInvariant(i >= startIndex, "slice index is out of range (before startIndex)")
+    _internalInvariant(i < endIndex, "slice index is out of range")
     return subscriptBaseAddress[i]
   }
 
@@ -319,8 +319,8 @@ internal struct _SliceBuffer<Element>
       return getElement(position)
     }
     nonmutating set {
-      _sanityCheck(position >= startIndex, "slice index is out of range (before startIndex)")
-      _sanityCheck(position < endIndex, "slice index is out of range")
+      _internalInvariant(position >= startIndex, "slice index is out of range (before startIndex)")
+      _internalInvariant(position < endIndex, "slice index is out of range")
       subscriptBaseAddress[position] = newValue
     }
   }
@@ -328,9 +328,9 @@ internal struct _SliceBuffer<Element>
   @inlinable
   internal subscript(bounds: Range<Int>) -> _SliceBuffer {
     get {
-      _sanityCheck(bounds.lowerBound >= startIndex)
-      _sanityCheck(bounds.upperBound >= bounds.lowerBound)
-      _sanityCheck(bounds.upperBound <= endIndex)
+      _internalInvariant(bounds.lowerBound >= startIndex)
+      _internalInvariant(bounds.upperBound >= bounds.lowerBound)
+      _internalInvariant(bounds.upperBound <= endIndex)
       return _SliceBuffer(
         owner: owner,
         subscriptBaseAddress: subscriptBaseAddress,
@@ -387,7 +387,7 @@ internal struct _SliceBuffer<Element>
 
   @inlinable
   internal func unsafeCastElements<T>(to type: T.Type) -> _SliceBuffer<T> {
-    _sanityCheck(_isClassOrObjCExistential(T.self))
+    _internalInvariant(_isClassOrObjCExistential(T.self))
     let baseAddress = UnsafeMutableRawPointer(self.subscriptBaseAddress)
       .assumingMemoryBound(to: T.self)
     return _SliceBuffer<T>(

--- a/stdlib/public/core/SmallBuffer.swift
+++ b/stdlib/public/core/SmallBuffer.swift
@@ -45,7 +45,7 @@ extension _SmallBuffer {
 
   internal subscript(i: Int) -> T {
     get {
-      _sanityCheck(i >= 0 && i < capacity)
+      _internalInvariant(i >= 0 && i < capacity)
       let capacity = self.capacity
       return withUnsafeBytes(of: _inlineStorage) {
         let rawPtr = $0.baseAddress._unsafelyUnwrappedUnchecked
@@ -55,7 +55,7 @@ extension _SmallBuffer {
       }
     }
     set {
-      _sanityCheck(i >= 0 && i < capacity)
+      _internalInvariant(i >= 0 && i < capacity)
       let capacity = self.capacity
       withUnsafeMutableBytes(of: &_inlineStorage) {
         let rawPtr = $0.baseAddress._unsafelyUnwrappedUnchecked
@@ -73,9 +73,9 @@ extension _SmallBuffer {
  #else
  @usableFromInline @inline(never) @_effects(releasenone)
  internal mutating func _invariantCheck() {
-   _sanityCheck(MemoryLayout<_SmallBuffer<Int>>.stride == byteCapacity)
-   _sanityCheck(capacity * stride == byteCapacity)
-   _sanityCheck(_isPOD(T.self))
+   _internalInvariant(MemoryLayout<_SmallBuffer<Int>>.stride == byteCapacity)
+   _internalInvariant(capacity * stride == byteCapacity)
+   _internalInvariant(_isPOD(T.self))
  }
  #endif // INTERNAL_CHECKS_ENABLED
 }

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -49,7 +49,7 @@ internal struct _SmallString {
 
   @inlinable @inline(__always)
   internal init(_ object: _StringObject) {
-    _sanityCheck(object.isSmall)
+    _internalInvariant(object.isSmall)
     self.init(raw: object.rawBits)
   }
 
@@ -139,8 +139,8 @@ extension _SmallString {
   #else
   @usableFromInline @inline(never) @_effects(releasenone)
   internal func _invariantCheck() {
-    _sanityCheck(count <= _SmallString.capacity)
-    _sanityCheck(isASCII == computeIsASCII())
+    _internalInvariant(count <= _SmallString.capacity)
+    _internalInvariant(isASCII == computeIsASCII())
   }
   #endif // INTERNAL_CHECKS_ENABLED
 
@@ -175,7 +175,7 @@ extension _SmallString: RandomAccessCollection, MutableCollection {
   @inlinable
   internal subscript(_ idx: Int) -> UInt8 {
     @inline(__always) get {
-      _sanityCheck(idx >= 0 && idx <= 15)
+      _internalInvariant(idx >= 0 && idx <= 15)
       if idx < 8 {
         return leadingRawBits._uncheckedGetByte(at: idx)
       } else {
@@ -183,7 +183,7 @@ extension _SmallString: RandomAccessCollection, MutableCollection {
       }
     }
     @inline(__always) set {
-      _sanityCheck(idx >= 0 && idx <= 15)
+      _internalInvariant(idx >= 0 && idx <= 15)
       if idx < 8 {
         leadingRawBits._uncheckedSetByte(at: idx, to: newValue)
       } else {
@@ -232,7 +232,7 @@ extension _SmallString {
         start: ptr, count: _SmallString.capacity))
     }
 
-    _sanityCheck(len <= _SmallString.capacity)
+    _internalInvariant(len <= _SmallString.capacity)
     discriminator = .small(withCount: len, isASCII: self.computeIsASCII())
   }
 }
@@ -271,7 +271,7 @@ extension _SmallString {
       result[writeIdx] = other[readIdx]
       writeIdx &+= 1
     }
-    _sanityCheck(writeIdx == totalCount)
+    _internalInvariant(writeIdx == totalCount)
 
     let isASCII = base.isASCII && other.isASCII
     let discriminator = _StringObject.Discriminator.small(
@@ -294,7 +294,7 @@ extension _SmallString {
     self.init()
     self.withMutableCapacity {
       let len = _bridgeTagged(cocoa, intoUTF8: $0)
-      _sanityCheck(len != nil && len! < _SmallString.capacity,
+      _internalInvariant(len != nil && len! < _SmallString.capacity,
         "Internal invariant violated: large tagged NSStrings")
       return len._unsafelyUnwrappedUnchecked
     }
@@ -309,7 +309,7 @@ extension UInt64 {
   // TODO: endianess awareness day
   @inlinable @inline(__always)
   internal func _uncheckedGetByte(at i: Int) -> UInt8 {
-    _sanityCheck(i >= 0 && i < MemoryLayout<UInt64>.stride)
+    _internalInvariant(i >= 0 && i < MemoryLayout<UInt64>.stride)
     let shift = UInt64(truncatingIfNeeded: i) &* 8
     return UInt8(truncatingIfNeeded: (self &>> shift))
   }
@@ -319,7 +319,7 @@ extension UInt64 {
   // TODO: endianess awareness day
   @inlinable @inline(__always)
   internal mutating func _uncheckedSetByte(at i: Int, to value: UInt8) {
-    _sanityCheck(i >= 0 && i < MemoryLayout<UInt64>.stride)
+    _internalInvariant(i >= 0 && i < MemoryLayout<UInt64>.stride)
     let shift = UInt64(truncatingIfNeeded: i) &* 8
     let valueMask: UInt64 = 0xFF &<< shift
     self = (self & ~valueMask) | (UInt64(truncatingIfNeeded: value) &<< shift)

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -478,7 +478,7 @@ internal func _findNextRun<C: RandomAccessCollection>(
   from start: C.Index,
   by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
 ) rethrows -> (end: C.Index, descending: Bool) {
-  _sanityCheck(start < elements.endIndex)
+  _internalInvariant(start < elements.endIndex)
 
   var previous = start
   var current = elements.index(after: start)
@@ -519,7 +519,7 @@ extension UnsafeMutableBufferPointer {
     buffer: UnsafeMutablePointer<Element>,
     by areInIncreasingOrder: (Element, Element) throws -> Bool
   ) rethrows -> Bool {
-    _sanityCheck(runs[i - 1].upperBound == runs[i].lowerBound)
+    _internalInvariant(runs[i - 1].upperBound == runs[i].lowerBound)
     let low = runs[i - 1].lowerBound
     let middle = runs[i].lowerBound
     let high = runs[i].upperBound

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -443,7 +443,7 @@ extension String {
     if targetEncoding == UTF8.self {
       return try self.withCString {
         (cPtr: UnsafePointer<CChar>) -> Result  in
-        _sanityCheck(UInt8.self == TargetEncoding.CodeUnit.self)
+        _internalInvariant(UInt8.self == TargetEncoding.CodeUnit.self)
         let ptr = UnsafeRawPointer(cPtr).assumingMemoryBound(
           to: TargetEncoding.CodeUnit.self)
         return try body(ptr)
@@ -468,7 +468,7 @@ extension String {
         stoppingOnError: false,
         into: { arg.append($0) })
       arg.append(TargetEncoding.CodeUnit(0))
-      _sanityCheck(!repaired)
+      _internalInvariant(!repaired)
       return try body(arg)
     }
   }

--- a/stdlib/public/core/StringBreadcrumbs.swift
+++ b/stdlib/public/core/StringBreadcrumbs.swift
@@ -55,7 +55,7 @@ internal final class _StringBreadcrumbs {
     }
 
     self.utf16Length = i
-    _sanityCheck(self.crumbs.count == 1 + (self.utf16Length / stride))
+    _internalInvariant(self.crumbs.count == 1 + (self.utf16Length / stride))
 
     _invariantCheck(for: str)
   }
@@ -81,8 +81,8 @@ extension _StringBreadcrumbs {
   ) -> (lowerBound: String.Index, offset: Int) {
     var lowerBound = idx.encodedOffset / 3 / stride
     var upperBound = Swift.min(1 + (idx.encodedOffset / stride), crumbs.count)
-    _sanityCheck(crumbs[lowerBound] <= idx)
-    _sanityCheck(upperBound == crumbs.count || crumbs[upperBound] >= idx)
+    _internalInvariant(crumbs[lowerBound] <= idx)
+    _internalInvariant(upperBound == crumbs.count || crumbs[upperBound] >= idx)
 
     while (upperBound &- lowerBound) > 1 {
       let mid = lowerBound + ((upperBound &- lowerBound) / 2)
@@ -90,8 +90,8 @@ extension _StringBreadcrumbs {
     }
 
     let crumb = crumbs[lowerBound]
-    _sanityCheck(crumb <= idx)
-    _sanityCheck(lowerBound == crumbs.count-1 || crumbs[lowerBound+1] > idx)
+    _internalInvariant(crumb <= idx)
+    _internalInvariant(lowerBound == crumbs.count-1 || crumbs[lowerBound+1] > idx)
 
     return (crumb, lowerBound &* stride)
   }
@@ -101,7 +101,7 @@ extension _StringBreadcrumbs {
   #else
   @nonobjc @inline(never) @_effects(releasenone)
   internal func _invariantCheck(for str: String) {
-    _sanityCheck(self.utf16Length == str.utf16._distance(
+    _internalInvariant(self.utf16Length == str.utf16._distance(
       from: str.startIndex, to: str.endIndex),
       "Stale breadcrumbs")
   }
@@ -111,7 +111,7 @@ extension _StringBreadcrumbs {
 extension _StringGuts {
   @_effects(releasenone)
   internal func getBreadcrumbsPtr() -> UnsafePointer<_StringBreadcrumbs> {
-    _sanityCheck(hasBreadcrumbs)
+    _internalInvariant(hasBreadcrumbs)
 
     let mutPtr: UnsafeMutablePointer<_StringBreadcrumbs?>
     if hasNativeStorage {
@@ -125,7 +125,7 @@ extension _StringGuts {
       populateBreadcrumbs(mutPtr)
     }
 
-    _sanityCheck(mutPtr.pointee != nil)
+    _internalInvariant(mutPtr.pointee != nil)
     return UnsafePointer(mutPtr)
   }
 

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -111,10 +111,10 @@ internal func _bridgeTagged(
   _ cocoa: _CocoaString,
   intoUTF8 bufPtr: UnsafeMutableBufferPointer<UInt8>
 ) -> Int? {
-  _sanityCheck(_isObjCTaggedPointer(cocoa))
+  _internalInvariant(_isObjCTaggedPointer(cocoa))
   let ptr = bufPtr.baseAddress._unsafelyUnwrappedUnchecked
   let length = _stdlib_binary_CFStringGetLength(cocoa)
-  _sanityCheck(length <= _SmallString.capacity)
+  _internalInvariant(length <= _SmallString.capacity)
   var count = 0
   let numCharWritten = _swift_stdlib_CFStringGetBytes(
     cocoa, _swift_shims_CFRange(location: 0, length: length),
@@ -228,7 +228,7 @@ extension String {
         countAndFlags: _guts._object._countAndFlags)
     }
 
-    _sanityCheck(_guts._object.hasObjCBridgeableObject,
+    _internalInvariant(_guts._object.hasObjCBridgeableObject,
       "Unknown non-bridgeable object case")
     return _guts._object.objCBridgeableObject
   }
@@ -309,7 +309,7 @@ extension String {
     into buffer: UnsafeMutableBufferPointer<UInt16>,
     range: Range<Int>
   ) {
-    _sanityCheck(buffer.count >= range.count)
+    _internalInvariant(buffer.count >= range.count)
     let indexRange = self._toUTF16Indices(range)
     self._nativeCopyUTF16CodeUnits(into: buffer, range: indexRange)
   }

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -19,7 +19,7 @@ internal func _stringCompare(
   _ lhs: _StringGuts, _ rhs: _StringGuts,
   expecting: _StringComparisonResult
 ) -> Bool {
-  _sanityCheck(expecting == .equal || expecting == .less)
+  _internalInvariant(expecting == .equal || expecting == .less)
   if lhs.rawBits == rhs.rawBits {
     return expecting == .equal
   }
@@ -32,7 +32,7 @@ internal func _stringCompare(
           if expecting == .equal {
             return cmp == 0
           }
-          _sanityCheck(expecting == .less)
+          _internalInvariant(expecting == .less)
           return cmp < 0
         }
 
@@ -51,7 +51,7 @@ internal func _stringCompare(
   _ rhs: _StringGuts, _ rhsRange: Range<Int>,
   expecting: _StringComparisonResult
 ) -> Bool {
-  _sanityCheck(expecting == .equal || expecting == .less)
+  _internalInvariant(expecting == .equal || expecting == .less)
   if lhs.rawBits == rhs.rawBits && lhsRange == rhsRange {
     return expecting == .equal
   }
@@ -64,7 +64,7 @@ internal func _stringCompare(
           if expecting == .equal {
             return cmp == 0
           }
-          _sanityCheck(expecting == .less)
+          _internalInvariant(expecting == .less)
           return cmp < 0
         }
 
@@ -94,7 +94,7 @@ internal func _stringCompare(
   _ right: UnsafeBufferPointer<UInt8>,
   expecting: _StringComparisonResult
 ) -> Bool {
-  _sanityCheck(expecting == .equal || expecting == .less)
+  _internalInvariant(expecting == .equal || expecting == .less)
 
   if _binaryCompare(left, right) == 0 {
     return expecting == .equal
@@ -111,7 +111,7 @@ internal func _stringCompare(
     guard leftPtr[idx] == rightPtr[idx] else { break }
     idx &+= 1
   }
-  _sanityCheck(idx != left.count || idx != right.count,
+  _internalInvariant(idx != left.count || idx != right.count,
     "should of been cought by prior binary compare")
   if idx == end {
     // We finished one of our inputs.
@@ -131,7 +131,7 @@ internal func _stringCompare(
   if !_isContinuation(right[idx]) {
     let (leftScalar, leftLen) = _decodeScalar(left, startingAt: idx)
     let (rightScalar, rightLen) = _decodeScalar(right, startingAt: idx)
-    _sanityCheck(leftScalar != rightScalar)
+    _internalInvariant(leftScalar != rightScalar)
 
     let nfcQC = leftScalar._isNFCQCYes && rightScalar._isNFCQCYes
     let isSegmentEnd = left.hasNormalizationBoundary(before: idx + leftLen)

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -32,7 +32,7 @@ extension String {
   internal static func _fromASCII(
     _ input: UnsafeBufferPointer<UInt8>
   ) -> String {
-    _sanityCheck(_allASCII(input), "not actually ASCII")
+    _internalInvariant(_allASCII(input), "not actually ASCII")
 
     if let smol = _SmallString(input) {
       return String(_StringGuts(smol))
@@ -119,7 +119,7 @@ extension String {
       to: UTF8.self,
       stoppingOnError: false,
       into: { contents.append($0) })
-    _sanityCheck(!repaired, "Error present")
+    _internalInvariant(!repaired, "Error present")
 
     return contents.withUnsafeBufferPointer { String._uncheckedFromUTF8($0) }
   }

--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -88,10 +88,10 @@ private func _measureCharacterStrideICU(
   // ubrk_following returns -1 (UBRK_DONE) when it hits the end of the buffer.
   if _fastPath(offset != -1) {
     // The offset into our buffer is the distance.
-    _sanityCheck(offset > i, "zero-sized grapheme?")
+    _internalInvariant(offset > i, "zero-sized grapheme?")
     return Int(truncatingIfNeeded: offset) &- i
   }
-  _sanityCheck(utf8.count > i)
+  _internalInvariant(utf8.count > i)
   return utf8.count &- i
 }
 
@@ -106,7 +106,7 @@ private func _measureCharacterStrideICU(
   // ubrk_following returns -1 (UBRK_DONE) when it hits the end of the buffer.
   if _fastPath(offset != -1) {
     // The offset into our buffer is the distance.
-    _sanityCheck(offset > i, "zero-sized grapheme?")
+    _internalInvariant(offset > i, "zero-sized grapheme?")
     return Int(truncatingIfNeeded: offset) &- i
   }
   return utf16.count &- i
@@ -123,7 +123,7 @@ private func _measureCharacterStrideICU(
   // ubrk_following returns -1 (UBRK_DONE) when it hits the end of the buffer.
   if _fastPath(offset != -1) {
     // The offset into our buffer is the distance.
-    _sanityCheck(offset < i, "zero-sized grapheme?")
+    _internalInvariant(offset < i, "zero-sized grapheme?")
     return i &- Int(truncatingIfNeeded: offset)
   }
   return i &- utf8.count
@@ -140,7 +140,7 @@ private func _measureCharacterStrideICU(
   // ubrk_following returns -1 (UBRK_DONE) when it hits the end of the buffer.
   if _fastPath(offset != -1) {
     // The offset into our buffer is the distance.
-    _sanityCheck(offset < i, "zero-sized grapheme?")
+    _internalInvariant(offset < i, "zero-sized grapheme?")
     return i &- Int(truncatingIfNeeded: offset)
   }
   return i &- utf16.count
@@ -187,7 +187,7 @@ extension _StringGuts {
   @_effects(releasenone)
   private func _foreignOpaqueCharacterStride(startingAt i: Int) -> Int {
 #if _runtime(_ObjC)
-    _sanityCheck(isForeign)
+    _internalInvariant(isForeign)
 
     // TODO(String performance): Faster to do it from a pointer directly
     let count = _object.largeCount
@@ -253,7 +253,7 @@ extension _StringGuts {
   @_effects(releasenone)
   private func _foreignOpaqueCharacterStride(endingAt i: Int) -> Int {
 #if _runtime(_ObjC)
-    _sanityCheck(isForeign)
+    _internalInvariant(isForeign)
 
     // TODO(String performance): Faster to do it from a pointer directly
     let count = _object.largeCount

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -143,7 +143,7 @@ extension _StringGuts {
   internal func withFastUTF8<R>(
     _ f: (UnsafeBufferPointer<UInt8>) throws -> R
   ) rethrows -> R {
-    _sanityCheck(isFastUTF8)
+    _internalInvariant(isFastUTF8)
 
     if self.isSmall { return try _SmallString(_object).withUTF8(f) }
 
@@ -187,12 +187,12 @@ extension _StringGuts {
   @usableFromInline @inline(never) @_effects(releasenone)
   internal func _invariantCheck() {
     #if arch(i386) || arch(arm)
-    _sanityCheck(MemoryLayout<String>.size == 12, """
+    _internalInvariant(MemoryLayout<String>.size == 12, """
     the runtime is depending on this, update Reflection.mm and \
     this if you change it
     """)
     #else
-    _sanityCheck(MemoryLayout<String>.size == 16, """
+    _internalInvariant(MemoryLayout<String>.size == 16, """
     the runtime is depending on this, update Reflection.mm and \
     this if you change it
     """)
@@ -223,7 +223,7 @@ extension _StringGuts {
   internal func _slowWithCString<Result>(
     _ body: (UnsafePointer<Int8>) throws -> Result
   ) rethrows -> Result {
-    _sanityCheck(!_object.isFastZeroTerminated)
+    _internalInvariant(!_object.isFastZeroTerminated)
     return try String(self).utf8CString.withUnsafeBufferPointer {
       let ptr = $0.baseAddress._unsafelyUnwrappedUnchecked
       return try body(ptr)

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -76,7 +76,7 @@ extension _StringGuts {
   internal mutating func grow(_ n: Int) {
     defer { self._invariantCheck() }
 
-    _sanityCheck(
+    _internalInvariant(
       self.uniqueNativeCapacity == nil || self.uniqueNativeCapacity! < n)
 
     let growthTarget = Swift.max(n, (self.uniqueNativeCapacity ?? 0) * 2)
@@ -112,9 +112,9 @@ extension _StringGuts {
     otherUTF8Count otherCount: Int
   ) {
     defer {
-      _sanityCheck(self.uniqueNativeUnusedCapacity != nil,
+      _internalInvariant(self.uniqueNativeUnusedCapacity != nil,
         "growth should produce uniqueness")
-      _sanityCheck(self.uniqueNativeUnusedCapacity! >= otherCount,
+      _internalInvariant(self.uniqueNativeUnusedCapacity! >= otherCount,
         "growth should produce enough capacity")
     }
 
@@ -195,8 +195,8 @@ extension _StringGuts {
 
   @inline(never) // slow-path
   private mutating func _foreignAppendInPlace(_ other: _StringGutsSlice) {
-    _sanityCheck(!other.isFastUTF8)
-    _sanityCheck(self.uniqueNativeUnusedCapacity != nil)
+    _internalInvariant(!other.isFastUTF8)
+    _internalInvariant(self.uniqueNativeUnusedCapacity != nil)
 
     var iter = Substring(other).utf8.makeIterator()
     self._object.nativeStorage.appendInPlace(&iter, isASCII: other.isASCII)
@@ -220,8 +220,8 @@ extension _StringGuts {
   internal mutating func remove(from lower: Index, to upper: Index) {
     let lowerOffset = lower.encodedOffset
     let upperOffset = upper.encodedOffset
-    _sanityCheck(lower.transcodedOffset == 0 && upper.transcodedOffset == 0)
-    _sanityCheck(lowerOffset <= upperOffset && upperOffset <= self.count)
+    _internalInvariant(lower.transcodedOffset == 0 && upper.transcodedOffset == 0)
+    _internalInvariant(lowerOffset <= upperOffset && upperOffset <= self.count)
 
     if isUniqueNative {
       _object.nativeStorage.remove(from: lowerOffset, to: upperOffset)
@@ -283,8 +283,8 @@ extension _StringGuts {
       + codeUnits.count + (self.count - bounds.upperBound.encodedOffset)
     reserveCapacity(neededCapacity)
 
-    _sanityCheck(bounds.lowerBound.transcodedOffset == 0)
-    _sanityCheck(bounds.upperBound.transcodedOffset == 0)
+    _internalInvariant(bounds.lowerBound.transcodedOffset == 0)
+    _internalInvariant(bounds.upperBound.transcodedOffset == 0)
 
     _object.nativeStorage.replace(
       from: bounds.lowerBound.encodedOffset,
@@ -304,8 +304,8 @@ extension _StringGuts {
       + replCount + (self.count - bounds.upperBound.encodedOffset)
     reserveCapacity(neededCapacity)
 
-    _sanityCheck(bounds.lowerBound.transcodedOffset == 0)
-    _sanityCheck(bounds.upperBound.transcodedOffset == 0)
+    _internalInvariant(bounds.lowerBound.transcodedOffset == 0)
+    _internalInvariant(bounds.upperBound.transcodedOffset == 0)
 
     _object.nativeStorage.replace(
       from: bounds.lowerBound.encodedOffset,

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -85,8 +85,8 @@ extension String.Index {
   internal init(encodedOffset: Int, transcodedOffset: Int) {
     let pos = UInt64(truncatingIfNeeded: encodedOffset)
     let trans = UInt64(truncatingIfNeeded: transcodedOffset)
-    _sanityCheck(pos == pos & 0x0000_FFFF_FFFF_FFFF)
-    _sanityCheck(trans <= 3)
+    _internalInvariant(pos == pos & 0x0000_FFFF_FFFF_FFFF)
+    _internalInvariant(trans <= 3)
 
     self.init((pos &<< 16) | (trans &<< 14))
   }
@@ -106,7 +106,7 @@ extension String.Index {
     self.init(encodedOffset: encodedOffset, transcodedOffset: transcodedOffset)
     if _slowPath(characterStride > 63) { return }
 
-    _sanityCheck(characterStride == characterStride & 0x3F)
+    _internalInvariant(characterStride == characterStride & 0x3F)
     self._rawBits |= UInt64(truncatingIfNeeded: characterStride &<< 8)
     self._invariantCheck()
   }
@@ -121,7 +121,7 @@ extension String.Index {
   #else
   @usableFromInline @inline(never) @_effects(releasenone)
   internal func _invariantCheck() {
-    _sanityCheck(encodedOffset >= 0)
+    _internalInvariant(encodedOffset >= 0)
   }
   #endif // INTERNAL_CHECKS_ENABLED
 }
@@ -139,7 +139,7 @@ extension String.Index {
   @inlinable
   internal var nextEncoded: String.Index {
     @inline(__always) get {
-      _sanityCheck(self.transcodedOffset == 0)
+      _internalInvariant(self.transcodedOffset == 0)
       return String.Index(encodedOffset: self.encodedOffset &+ 1)
     }
   }
@@ -147,7 +147,7 @@ extension String.Index {
   @inlinable
   internal var priorEncoded: String.Index {
     @inline(__always) get {
-      _sanityCheck(self.transcodedOffset == 0)
+      _internalInvariant(self.transcodedOffset == 0)
       return String.Index(encodedOffset: self.encodedOffset &- 1)
     }
   }
@@ -179,7 +179,7 @@ extension String.Index {
 
   @inlinable @inline(__always)
   internal func transcoded(withOffset n: Int) -> String.Index {
-    _sanityCheck(self.transcodedOffset == 0)
+    _internalInvariant(self.transcodedOffset == 0)
     return String.Index(encodedOffset: self.encodedOffset, transcodedOffset: n)
   }
 

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -152,7 +152,7 @@ extension StringProtocol {
     @inline(__always) get {
       let start = startIndex
       let end = endIndex
-      _sanityCheck(start.transcodedOffset == 0 && end.transcodedOffset == 0)
+      _internalInvariant(start.transcodedOffset == 0 && end.transcodedOffset == 0)
       return Range(uncheckedBounds: (start.encodedOffset, end.encodedOffset))
     }
   }

--- a/stdlib/public/core/StringTesting.swift
+++ b/stdlib/public/core/StringTesting.swift
@@ -59,8 +59,8 @@ extension _StringGuts {
     }
 
     // TODO: shared native
-    _sanityCheck(_object.providesFastUTF8)
-    _sanityCheck(_object.largeFastIsNative)
+    _internalInvariant(_object.providesFastUTF8)
+    _internalInvariant(_object.largeFastIsNative)
     if _object.isImmortal {
       result._form = ._immortal(
         address: UInt(bitPattern: _object.nativeUTF8Start))

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -164,7 +164,7 @@ extension String.UTF16View: BidirectionalCollection {
     if _slowPath(_guts.isForeign) { return _foreignIndex(before: i) }
 
     if i.transcodedOffset != 0 {
-      _sanityCheck(i.transcodedOffset == 1)
+      _internalInvariant(i.transcodedOffset == 1)
       return i.strippingTranscoding
     }
 
@@ -176,7 +176,7 @@ extension String.UTF16View: BidirectionalCollection {
     }
 
     // Single UTF-16 code unit
-    _sanityCheck((1...3) ~= len)
+    _internalInvariant((1...3) ~= len)
     return i.encoded(offsetBy: -len)
   }
 
@@ -385,28 +385,28 @@ extension String.UTF16View {
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(after i: Index) -> Index {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return i.nextEncoded
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(before i: Index) -> Index {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return i.priorEncoded
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignSubscript(position i: Index) -> UTF16.CodeUnit {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return _guts.foreignErrorCorrectedUTF16CodeUnit(at: i)
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignDistance(from start: Index, to end: Index) -> Int {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return end.encodedOffset - start.encodedOffset
   }
 
@@ -415,7 +415,7 @@ extension String.UTF16View {
   internal func _foreignIndex(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     let l = limit.encodedOffset - i.encodedOffset
     if n > 0 ? l >= 0 && l < n : l <= 0 && n < l {
       return nil
@@ -426,14 +426,14 @@ extension String.UTF16View {
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(_ i: Index, offsetBy n: Int) -> Index {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return i.encoded(offsetBy: n)
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignCount() -> Int {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return endIndex.encodedOffset - startIndex.encodedOffset
   }
 }
@@ -442,7 +442,7 @@ extension String.Index {
   @usableFromInline @inline(never) // opaque slow-path
   @_effects(releasenone)
   internal func _foreignIsWithin(_ target: String.UTF16View) -> Bool {
-    _sanityCheck(target._guts.isForeign)
+    _internalInvariant(target._guts.isForeign)
 
     // If we're transcoding, we're a UTF-8 view index, not UTF-16.
     return self.transcodedOffset == 0
@@ -497,7 +497,7 @@ extension String.UTF16View {
     return _guts.withFastUTF8 { utf8 in
       var readIdx = crumb.encodedOffset
       let readEnd = utf8.count
-      _sanityCheck(readIdx < readEnd)
+      _internalInvariant(readIdx < readEnd)
 
       var utf16I = 0
       let utf16End: Int = remaining
@@ -517,7 +517,7 @@ extension String.UTF16View {
         if utf16I >= utf16End {
           // Uncommon: final sub-scalar transcoded offset
           if _slowPath(utf16I > utf16End) {
-            _sanityCheck(utf16Len == 2)
+            _internalInvariant(utf16Len == 2)
             return Index(encodedOffset: readIdx, transcodedOffset: 1)
           }
           return Index(encodedOffset: readIdx &+ len)
@@ -535,7 +535,7 @@ extension String {
     into buffer: UnsafeMutableBufferPointer<UInt16>,
     range: Range<String.Index>
   ) {
-    _sanityCheck(_guts.isFastUTF8)
+    _internalInvariant(_guts.isFastUTF8)
 
     return _guts.withFastUTF8 { utf8 in
       var writeIdx = 0
@@ -545,7 +545,7 @@ extension String {
 
       // Handle mid-transcoded-scalar initial index
       if _slowPath(range.lowerBound.transcodedOffset != 0) {
-        _sanityCheck(range.lowerBound.transcodedOffset == 1)
+        _internalInvariant(range.lowerBound.transcodedOffset == 1)
         let (scalar, len) = _decodeScalar(utf8, startingAt: readIdx)
         buffer[writeIdx] = scalar.utf16[1]
         readIdx &+= len
@@ -566,14 +566,14 @@ extension String {
 
       // Handle mid-transcoded-scalar final index
       if _slowPath(range.upperBound.transcodedOffset == 1) {
-        _sanityCheck(writeIdx < writeEnd)
+        _internalInvariant(writeIdx < writeEnd)
         let (scalar, _) = _decodeScalar(utf8, startingAt: readIdx)
-        _sanityCheck(scalar.utf16.count == 2)
+        _internalInvariant(scalar.utf16.count == 2)
 
         buffer[writeIdx] = scalar.utf16[0]
         writeIdx &+= 1
       }
-      _sanityCheck(writeIdx <= writeEnd)
+      _internalInvariant(writeIdx <= writeEnd)
 
     }
   }

--- a/stdlib/public/core/StringUTF8Validation.swift
+++ b/stdlib/public/core/StringUTF8Validation.swift
@@ -94,7 +94,7 @@ internal func validateUTF8(_ buf: UnsafeBufferPointer<UInt8>) -> UTF8ValidationR
       endIndex += 1
     }
     let illegalRange = Range(buf.startIndex...endIndex)
-    _sanityCheck(illegalRange.clamped(to: (buf.startIndex..<buf.endIndex)) == illegalRange,
+    _internalInvariant(illegalRange.clamped(to: (buf.startIndex..<buf.endIndex)) == illegalRange,
                  "illegal range out of full range")
     // FIXME: Remove the call to `_legacyNarrowIllegalRange` and return `illegalRange` directly
     return _legacyNarrowIllegalRange(buf: buf[illegalRange])
@@ -154,8 +154,8 @@ internal func validateUTF8(_ buf: UnsafeBufferPointer<UInt8>) -> UTF8ValidationR
 }
 
 internal func repairUTF8(_ input: UnsafeBufferPointer<UInt8>, firstKnownBrokenRange: Range<Int>) -> String {
-  _sanityCheck(input.count > 0, "empty input doesn't need to be repaired")
-  _sanityCheck(firstKnownBrokenRange.clamped(to: input.indices) == firstKnownBrokenRange)
+  _internalInvariant(input.count > 0, "empty input doesn't need to be repaired")
+  _internalInvariant(firstKnownBrokenRange.clamped(to: input.indices) == firstKnownBrokenRange)
   // During this process, `remainingInput` contains the remaining bytes to process. It's split into three
   // non-overlapping sub-regions:
   //
@@ -176,8 +176,8 @@ internal func repairUTF8(_ input: UnsafeBufferPointer<UInt8>, firstKnownBrokenRa
   var brokenRange: Range<Int> = firstKnownBrokenRange
   var remainingInput = input
   repeat {
-    _sanityCheck(brokenRange.count > 0, "broken range empty")
-    _sanityCheck(remainingInput.count > 0, "empty remaining input doesn't need to be repaired")
+    _internalInvariant(brokenRange.count > 0, "broken range empty")
+    _internalInvariant(remainingInput.count > 0, "empty remaining input doesn't need to be repaired")
     let goodChunk = remainingInput[..<brokenRange.startIndex]
 
     // very likely this capacity reservation does not actually do anything because we reserved space for the entire

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -415,14 +415,14 @@ extension String.UTF8View {
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(after i: Index) -> Index {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
 
     let (scalar, scalarLen) = _guts.foreignErrorCorrectedScalar(
       startingAt: i.strippingTranscoding)
     let utf8Len = _numUTF8CodeUnits(scalar)
 
     if utf8Len == 1 {
-      _sanityCheck(i.transcodedOffset == 0)
+      _internalInvariant(i.transcodedOffset == 0)
       return i.nextEncoded
     }
 
@@ -438,9 +438,9 @@ extension String.UTF8View {
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(before i: Index) -> Index {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     if i.transcodedOffset != 0 {
-      _sanityCheck((1...3) ~= i.transcodedOffset)
+      _internalInvariant((1...3) ~= i.transcodedOffset)
       return i.priorTranscoded
     }
 
@@ -453,12 +453,12 @@ extension String.UTF8View {
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignSubscript(position i: Index) -> UTF8.CodeUnit {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
 
     let scalar = _guts.foreignErrorCorrectedScalar(
       startingAt: _guts.scalarAlign(i)).0
     let encoded = Unicode.UTF8.encode(scalar)._unsafelyUnwrappedUnchecked
-    _sanityCheck(i.transcodedOffset < 1+encoded.count)
+    _internalInvariant(i.transcodedOffset < 1+encoded.count)
 
     return encoded[
       encoded.index(encoded.startIndex, offsetBy: i.transcodedOffset)]
@@ -467,7 +467,7 @@ extension String.UTF8View {
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(_ i: Index, offsetBy n: Int) -> Index {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return _index(i, offsetBy: n)
   }
 
@@ -476,21 +476,21 @@ extension String.UTF8View {
   internal func _foreignIndex(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return _index(i, offsetBy: n, limitedBy: limit)
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignDistance(from i: Index, to j: Index) -> Int {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return _distance(from: i, to: j)
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignCount() -> Int {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     return _distance(from: startIndex, to: endIndex)
   }
 }
@@ -499,7 +499,7 @@ extension String.Index {
   @usableFromInline @inline(never) // opaque slow-path
   @_effects(releasenone)
   internal func _foreignIsWithin(_ target: String.UTF8View) -> Bool {
-    _sanityCheck(target._guts.isForeign)
+    _internalInvariant(target._guts.isForeign)
     // Currently, foreign means UTF-16.
 
     // If we're transcoding, we're already a UTF8 view index.

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -110,7 +110,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
   /// - Precondition: The next location exists.
   @inlinable @inline(__always)
   public func index(after i: Index) -> Index {
-    _sanityCheck(i < endIndex)
+    _internalInvariant(i < endIndex)
     // TODO(String performance): isASCII fast-path
 
     if _fastPath(_guts.isFastUTF8) {
@@ -133,7 +133,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
       let len = _guts.withFastUTF8 { utf8 -> Int in
         return _utf8ScalarLength(utf8, endingAt: i.encodedOffset)
       }
-      _sanityCheck(len <= 4, "invalid UTF8")
+      _internalInvariant(len <= 4, "invalid UTF8")
       return i.encoded(offsetBy: -len)
     }
 
@@ -415,7 +415,7 @@ extension String.UnicodeScalarView {
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(after i: Index) -> Index {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: i)
     let len = _isLeadingSurrogate(cu) ? 2 : 1
 
@@ -425,7 +425,7 @@ extension String.UnicodeScalarView {
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(before i: Index) -> Index {
-    _sanityCheck(_guts.isForeign)
+    _internalInvariant(_guts.isForeign)
     let priorIdx = i.priorEncoded
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: priorIdx)
     let len = _isTrailingSurrogate(cu) ? 2 : 1

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -130,7 +130,7 @@ extension Substring {
     @inline(__always) get {
       let start = _slice.startIndex
       let end = _slice.endIndex
-      _sanityCheck(start.transcodedOffset == 0 && end.transcodedOffset == 0)
+      _internalInvariant(start.transcodedOffset == 0 && end.transcodedOffset == 0)
 
       return Range(uncheckedBounds: (start.encodedOffset, end.encodedOffset))
     }

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -267,7 +267,7 @@ internal class __ContiguousArrayStorageBase
   @usableFromInline
   final var countAndCapacity: _ArrayBody
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @nonobjc
   internal init(_doNotCallMeBase: ()) {
     _internalInvariantFailure("creating instance of __ContiguousArrayStorageBase")
@@ -306,17 +306,20 @@ internal class __ContiguousArrayStorageBase
   }
 #endif
 
+@inlinable
   internal func canStoreElements(ofDynamicType _: Any.Type) -> Bool {
     _internalInvariantFailure(
       "Concrete subclasses must implement canStoreElements(ofDynamicType:)")
   }
 
   /// A type that every element in the array is.
+  @inlinable
   internal var staticElementType: Any.Type {
     _internalInvariantFailure(
       "Concrete subclasses must implement staticElementType")
   }
 
+  @inlinable
   deinit {
     _internalInvariant(
       self !== _emptyArrayStorage, "Deallocating empty array storage?!")

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -56,7 +56,7 @@ internal class __SwiftNativeNSArrayWithContiguousStorage
   internal func withUnsafeBufferOfObjects<R>(
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> R
   ) rethrows -> R {
-    _sanityCheckFailure(
+    _internalInvariantFailure(
       "Must override withUnsafeBufferOfObjects in derived classes")
   }
 }
@@ -270,7 +270,7 @@ internal class __ContiguousArrayStorageBase
   @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal init(_doNotCallMeBase: ()) {
-    _sanityCheckFailure("creating instance of __ContiguousArrayStorageBase")
+    _internalInvariantFailure("creating instance of __ContiguousArrayStorageBase")
   }
   
 #if _runtime(_ObjC)
@@ -280,7 +280,7 @@ internal class __ContiguousArrayStorageBase
     if let result = try _withVerbatimBridgedUnsafeBuffer(body) {
       return result
     }
-    _sanityCheckFailure(
+    _internalInvariantFailure(
       "Can't use a buffer of non-verbatim-bridged elements as an NSArray")
   }
 
@@ -290,38 +290,35 @@ internal class __ContiguousArrayStorageBase
   internal func _withVerbatimBridgedUnsafeBuffer<R>(
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> R
   ) rethrows -> R? {
-    _sanityCheckFailure(
+    _internalInvariantFailure(
       "Concrete subclasses must implement _withVerbatimBridgedUnsafeBuffer")
   }
 
   @nonobjc
   internal func _getNonVerbatimBridgedCount() -> Int {
-    _sanityCheckFailure(
+    _internalInvariantFailure(
       "Concrete subclasses must implement _getNonVerbatimBridgedCount")
   }
 
   internal func _getNonVerbatimBridgingBuffer() -> _BridgingBuffer {
-    _sanityCheckFailure(
+    _internalInvariantFailure(
       "Concrete subclasses must implement _getNonVerbatimBridgingBuffer")
   }
 #endif
 
-  @inlinable // FIXME(sil-serialize-all)
   internal func canStoreElements(ofDynamicType _: Any.Type) -> Bool {
-    _sanityCheckFailure(
+    _internalInvariantFailure(
       "Concrete subclasses must implement canStoreElements(ofDynamicType:)")
   }
 
   /// A type that every element in the array is.
-  @inlinable // FIXME(sil-serialize-all)
   internal var staticElementType: Any.Type {
-    _sanityCheckFailure(
+    _internalInvariantFailure(
       "Concrete subclasses must implement staticElementType")
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   deinit {
-    _sanityCheck(
+    _internalInvariant(
       self !== _emptyArrayStorage, "Deallocating empty array storage?!")
   }
 }

--- a/stdlib/public/core/ThreadLocalStorage.swift
+++ b/stdlib/public/core/ThreadLocalStorage.swift
@@ -140,7 +140,7 @@ internal struct _ThreadLocalStorage {
 // owned.
 @_silgen_name("_stdlib_destroyTLS")
 internal func _destroyTLS(_ ptr: UnsafeMutableRawPointer?) {
-  _sanityCheck(ptr != nil,
+  _internalInvariant(ptr != nil,
     "_destroyTLS was called, but with nil...")
   let tlsPtr = ptr!.assumingMemoryBound(to: _ThreadLocalStorage.self)
   __swift_stdlib_ubrk_close(tlsPtr[0].uBreakIterator)

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -46,8 +46,8 @@ extension Unicode.UTF16 : Unicode.Encoding {
     _ lead: CodeUnit,
     _ trail: CodeUnit
   ) -> Unicode.Scalar {
-    _sanityCheck(isLeadSurrogate(lead))
-    _sanityCheck(isTrailSurrogate(trail))
+    _internalInvariant(isLeadSurrogate(lead))
+    _internalInvariant(isTrailSurrogate(trail))
     return Unicode.Scalar(
       _unchecked: 0x10000 +
         (UInt32(lead & 0x03ff) &<< 10 | UInt32(trail & 0x03ff)))
@@ -59,7 +59,7 @@ extension Unicode.UTF16 : Unicode.Encoding {
     if _fastPath(source._bitCount == 16) {
       return Unicode.Scalar(_unchecked: bits & 0xffff)
     }
-    _sanityCheck(source._bitCount == 32)
+    _internalInvariant(source._bitCount == 32)
     let lower: UInt32 = bits >> 16 & 0x03ff
     let upper: UInt32 = (bits & 0x03ff) << 10
     let value = 0x10000 + (lower | upper)
@@ -147,7 +147,7 @@ extension UTF16.ReverseParser : Unicode.Parser, _UTFParser {
 
   @inlinable
   public func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8) {
-    _sanityCheck(  // this case handled elsewhere
+    _internalInvariant(  // this case handled elsewhere
       !Encoding._isScalar(UInt16(truncatingIfNeeded: _buffer._storage)))
     if _fastPath(_buffer._storage & 0xFC00_FC00 == 0xD800_DC00) {
       return (true, 2*16)
@@ -170,7 +170,7 @@ extension Unicode.UTF16.ForwardParser : Unicode.Parser, _UTFParser {
   
   @inlinable
   public func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8) {
-    _sanityCheck(  // this case handled elsewhere
+    _internalInvariant(  // this case handled elsewhere
       !Encoding._isScalar(UInt16(truncatingIfNeeded: _buffer._storage)))
     if _fastPath(_buffer._storage & 0xFC00_FC00 == 0xDC00_D800) {
       return (true, 2*16)

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -49,7 +49,7 @@ extension Unicode.UTF8 : _UnicodeEncoding {
       value    |= (bits & 0b0________________________________0000_1111) &<< 12
       return Unicode.Scalar(_unchecked: value)
     default:
-      _sanityCheck(source.count == 4)
+      _internalInvariant(source.count == 4)
       let bits = source._biasedBits &- 0x01010101
       var value = (bits & 0b0_11_1111__0000_0000__0000_0000__0000_0000) &>> 24
       value    |= (bits & 0b0____________11_1111__0000_0000__0000_0000) &>> 10
@@ -144,7 +144,7 @@ extension UTF8.ReverseParser : Unicode.Parser, _UTFParser {
   @inline(__always)
   @inlinable
   public func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8) {
-    _sanityCheck(_buffer._storage & 0x80 != 0) // this case handled elsewhere
+    _internalInvariant(_buffer._storage & 0x80 != 0) // this case handled elsewhere
     if _buffer._storage                & 0b0__1110_0000__1100_0000
                                       == 0b0__1100_0000__1000_0000 {
       // 2-byte sequence.  Top 4 bits of decoded result must be nonzero
@@ -221,7 +221,7 @@ extension Unicode.UTF8.ForwardParser : Unicode.Parser, _UTFParser {
   @inline(__always)
   @inlinable
   public func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8) {
-    _sanityCheck(_buffer._storage & 0x80 != 0) // this case handled elsewhere
+    _internalInvariant(_buffer._storage & 0x80 != 0) // this case handled elsewhere
     
     if _buffer._storage & 0b0__1100_0000__1110_0000
                        == 0b0__1000_0000__1100_0000 {

--- a/stdlib/public/core/UTFEncoding.swift
+++ b/stdlib/public/core/UTFEncoding.swift
@@ -66,9 +66,9 @@ where Encoding.EncodedScalar : RangeReplaceableCollection {
 
     // Find one unicode scalar.
     let (isValid, scalarBitCount) = _parseMultipleCodeUnits()
-    _sanityCheck(scalarBitCount % numericCast(Encoding.CodeUnit.bitWidth) == 0)
-    _sanityCheck(1...4 ~= scalarBitCount / 8)
-    _sanityCheck(scalarBitCount <= _buffer._bitCount)
+    _internalInvariant(scalarBitCount % numericCast(Encoding.CodeUnit.bitWidth) == 0)
+    _internalInvariant(1...4 ~= scalarBitCount / 8)
+    _internalInvariant(scalarBitCount <= _buffer._bitCount)
     
     // Consume the decoded bytes (or maximal subpart of ill-formed sequence).
     let encodedScalar = _bufferedScalar(bitCount: scalarBitCount)

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -615,7 +615,7 @@ extension UTF8.CodeUnit : _StringElement {
   @inlinable
   public // @testable
   static func _toUTF16CodeUnit(_ x: UTF8.CodeUnit) -> UTF16.CodeUnit {
-    _sanityCheck(x <= 0x7f, "should only be doing this with ASCII")
+    _internalInvariant(x <= 0x7f, "should only be doing this with ASCII")
     return UTF16.CodeUnit(truncatingIfNeeded: x)
   }
   @inlinable
@@ -623,7 +623,7 @@ extension UTF8.CodeUnit : _StringElement {
   static func _fromUTF16CodeUnit(
     _ utf16: UTF16.CodeUnit
   ) -> UTF8.CodeUnit {
-    _sanityCheck(utf16 <= 0x7f, "should only be doing this with ASCII")
+    _internalInvariant(utf16 <= 0x7f, "should only be doing this with ASCII")
     return UTF8.CodeUnit(truncatingIfNeeded: utf16)
   }
 }
@@ -871,9 +871,9 @@ extension Unicode.Scalar {
   /// precondition checks for code point validity.
   @inlinable
   internal init(_unchecked value: UInt32) {
-    _sanityCheck(value < 0xD800 || value > 0xDFFF,
+    _internalInvariant(value < 0xD800 || value > 0xDFFF,
       "high- and low-surrogate code points are not valid Unicode scalar values")
-    _sanityCheck(value <= 0x10FFFF, "value is outside of Unicode codespace")
+    _internalInvariant(value <= 0x10FFFF, "value is outside of Unicode codespace")
 
     self._value = value
   }

--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -40,15 +40,15 @@ internal func _isASCII(_ x: UInt8) -> Bool {
 @inlinable
 @inline(__always)
 internal func _decodeUTF8(_ x: UInt8) -> Unicode.Scalar {
-  _sanityCheck(_isASCII(x))
+  _internalInvariant(_isASCII(x))
   return Unicode.Scalar(_unchecked: UInt32(x))
 }
 
 @inlinable
 @inline(__always)
 internal func _decodeUTF8(_ x: UInt8, _ y: UInt8) -> Unicode.Scalar {
-  _sanityCheck(_utf8ScalarLength(x) == 2)
-  _sanityCheck(_isContinuation(y))
+  _internalInvariant(_utf8ScalarLength(x) == 2)
+  _internalInvariant(_isContinuation(y))
   let x = UInt32(x)
   let value = ((x & 0b0001_1111) &<< 6) | _continuationPayload(y)
   return Unicode.Scalar(_unchecked: value)
@@ -59,8 +59,8 @@ internal func _decodeUTF8(_ x: UInt8, _ y: UInt8) -> Unicode.Scalar {
 internal func _decodeUTF8(
   _ x: UInt8, _ y: UInt8, _ z: UInt8
 ) -> Unicode.Scalar {
-  _sanityCheck(_utf8ScalarLength(x) == 3)
-  _sanityCheck(_isContinuation(y) && _isContinuation(z))
+  _internalInvariant(_utf8ScalarLength(x) == 3)
+  _internalInvariant(_isContinuation(y) && _isContinuation(z))
   let x = UInt32(x)
   let value = ((x & 0b0000_1111) &<< 12)
             | (_continuationPayload(y) &<< 6)
@@ -73,8 +73,8 @@ internal func _decodeUTF8(
 internal func _decodeUTF8(
   _ x: UInt8, _ y: UInt8, _ z: UInt8, _ w: UInt8
 ) -> Unicode.Scalar {
-  _sanityCheck(_utf8ScalarLength(x) == 4)
-  _sanityCheck(
+  _internalInvariant(_utf8ScalarLength(x) == 4)
+  _internalInvariant(
     _isContinuation(y) && _isContinuation(z) && _isContinuation(w))
   let x = UInt32(x)
   let value = ((x & 0b0000_1111) &<< 18)
@@ -106,13 +106,13 @@ internal func _decodeScalar(
 ) -> (Unicode.Scalar, scalarLength: Int) {
   let len = _utf8ScalarLength(utf8, endingAt: i)
   let (scalar, scalarLen) = _decodeScalar(utf8, startingAt: i &- len)
-  _sanityCheck(len == scalarLen)
+  _internalInvariant(len == scalarLen)
   return (scalar, len)
 }
 
 @inlinable @inline(__always)
 internal func _utf8ScalarLength(_ x: UInt8) -> Int {
-  _sanityCheck(!_isContinuation(x))
+  _internalInvariant(!_isContinuation(x))
   if _isASCII(x) { return 1 }
   // TODO(String micro-performance): check codegen
   return (~x).leadingZeroBitCount
@@ -126,7 +126,7 @@ internal func _utf8ScalarLength(
   while _isContinuation(utf8[i &- len]) {
     len += 1
   }
-  _sanityCheck(len == _utf8ScalarLength(utf8[i &- len]))
+  _internalInvariant(len == _utf8ScalarLength(utf8[i &- len]))
   return len
 }
 
@@ -145,11 +145,11 @@ internal func _continuationPayload(_ x: UInt8) -> UInt32 {
 internal func _decodeSurrogatePair(
   leading high: UInt16, trailing low: UInt16
 ) -> UInt32 {
-  _sanityCheck(_isLeadingSurrogate(high) && _isTrailingSurrogate(low))
+  _internalInvariant(_isLeadingSurrogate(high) && _isTrailingSurrogate(low))
   let hi10: UInt32 = UInt32(high) &- UInt32(_leadingSurrogateBias)
-  _sanityCheck(hi10 < 1<<10, "I said high 10. Not high, like, 20 or something")
+  _internalInvariant(hi10 < 1<<10, "I said high 10. Not high, like, 20 or something")
   let lo10: UInt32 = UInt32(low) &- UInt32(_trailingSurrogateBias)
-  _sanityCheck(lo10 < 1<<10, "I said low 10. Not low, like, 20 or something")
+  _internalInvariant(lo10 < 1<<10, "I said low 10. Not low, like, 20 or something")
 
   return ((hi10 &<< 10) | lo10) &+ 0x1_00_00
 }
@@ -189,7 +189,7 @@ extension _StringGuts {
       var i = idx.encodedOffset
       while _slowPath(_isContinuation(utf8[i])) {
         i -= 1
-        _sanityCheck(
+        _internalInvariant(
           i >= 0, "Malformed contents: starts with continuation byte")
       }
       // If no alignment is performed, keep grapheme cache
@@ -203,31 +203,31 @@ extension _StringGuts {
 
   @inlinable
   internal func fastUTF8ScalarLength(startingAt i: Int) -> Int {
-    _sanityCheck(isFastUTF8)
+    _internalInvariant(isFastUTF8)
     let len = _utf8ScalarLength(self.withFastUTF8 { $0[i] })
-    _sanityCheck((1...4) ~= len)
+    _internalInvariant((1...4) ~= len)
     return len
   }
 
   @inlinable
   internal func fastUTF8ScalarLength(endingAt i: Int) -> Int {
-    _sanityCheck(isFastUTF8)
+    _internalInvariant(isFastUTF8)
 
     return self.withFastUTF8 { utf8 in
-      _sanityCheck(i == utf8.count || !_isContinuation(utf8[i]))
+      _internalInvariant(i == utf8.count || !_isContinuation(utf8[i]))
       var len = 1
       while _isContinuation(utf8[i - len]) {
-        _sanityCheck(i - len > 0)
+        _internalInvariant(i - len > 0)
         len += 1
       }
-      _sanityCheck(len <= 4)
+      _internalInvariant(len <= 4)
       return len
     }
   }
 
   @inlinable
   internal func fastUTF8Scalar(startingAt i: Int) -> Unicode.Scalar {
-    _sanityCheck(isFastUTF8)
+    _internalInvariant(isFastUTF8)
     return self.withFastUTF8 { _decodeScalar($0, startingAt: i).0 }
   }
 
@@ -268,8 +268,8 @@ extension _StringGuts {
   internal func foreignErrorCorrectedScalar(
     startingAt idx: String.Index
   ) -> (Unicode.Scalar, scalarLength: Int) {
-    _sanityCheck(idx.transcodedOffset == 0)
-    _sanityCheck(idx.encodedOffset < self.count)
+    _internalInvariant(idx.transcodedOffset == 0)
+    _internalInvariant(idx.encodedOffset < self.count)
 
     let start = idx.encodedOffset
     let leading = _getForeignCodeUnit(at: start)
@@ -301,9 +301,9 @@ extension _StringGuts {
   internal func foreignErrorCorrectedScalar(
     endingAt idx: String.Index
   ) -> (Unicode.Scalar, scalarLength: Int) {
-    _sanityCheck(idx.transcodedOffset == 0)
-    _sanityCheck(idx.encodedOffset <= self.count)
-    _sanityCheck(idx.encodedOffset > 0)
+    _internalInvariant(idx.transcodedOffset == 0)
+    _internalInvariant(idx.encodedOffset <= self.count)
+    _internalInvariant(idx.encodedOffset > 0)
 
     let end = idx.encodedOffset
     let trailing = _getForeignCodeUnit(at: end &- 1)
@@ -334,8 +334,8 @@ extension _StringGuts {
   internal func foreignErrorCorrectedUTF16CodeUnit(
     at idx: String.Index
   ) -> UInt16 {
-    _sanityCheck(idx.transcodedOffset == 0)
-    _sanityCheck(idx.encodedOffset < self.count)
+    _internalInvariant(idx.transcodedOffset == 0)
+    _internalInvariant(idx.encodedOffset < self.count)
 
     let start = idx.encodedOffset
     let cu = _getForeignCodeUnit(at: start)
@@ -366,13 +366,13 @@ extension _StringGuts {
   @usableFromInline @inline(never) // slow-path
   @_effects(releasenone)
   internal func foreignScalarAlign(_ idx: Index) -> Index {
-    _sanityCheck(idx.encodedOffset < self.count)
+    _internalInvariant(idx.encodedOffset < self.count)
 
     let ecCU = foreignErrorCorrectedUTF16CodeUnit(at: idx)
     if _fastPath(!_isTrailingSurrogate(ecCU)) {
       return idx
     }
-    _sanityCheck(idx.encodedOffset > 0,
+    _internalInvariant(idx.encodedOffset > 0,
       "Error-correction shouldn't give trailing surrogate at position zero")
     return String.Index(encodedOffset: idx.encodedOffset &- 1)
   }
@@ -383,7 +383,7 @@ extension _StringGuts {
     startingAt start: Int, endingAt end: Int
   ) -> Character {
 #if _runtime(_ObjC)
-    _sanityCheck(self.isForeign)
+    _internalInvariant(self.isForeign)
 
     // Both a fast-path for single-code-unit graphemes and validation:
     //   ICU treats isolated surrogates as isolated graphemes

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -457,7 +457,7 @@ extension Unicode.Scalar {
     var codeUnits: (UInt16, UInt16) = (self.utf16[0], 0)
     let utf16Count = self.utf16.count
     if utf16Count > 1 {
-      _sanityCheck(utf16Count == 2)
+      _internalInvariant(utf16Count == 2)
       codeUnits.1 = self.utf16[1]
     }
     return try Swift.withUnsafePointer(to: &codeUnits) {

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -707,7 +707,7 @@ extension Unicode.Scalar.Properties {
         guard err.isSuccess else {
           fatalError("Unexpected error case-converting Unicode scalar.")
         }
-        // TODO: _sanityCheck(count == correctSize, "inconsistent ICU behavior")
+        // TODO: _internalInvariant(count == correctSize, "inconsistent ICU behavior")
         return Int(correctSize)
       }
     }
@@ -1108,7 +1108,7 @@ extension Unicode.Scalar.Properties {
       guard err.isSuccess else {
         fatalError("Unexpected error case-converting Unicode scalar.")
       }
-      _sanityCheck(count == correctSize, "inconsistent ICU behavior")
+      _internalInvariant(count == correctSize, "inconsistent ICU behavior")
       return String._fromASCII(
         UnsafeBufferPointer(rebasing: bufPtr[..<count]))
     }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -72,7 +72,7 @@ extension UnsafeBufferPointer.Iterator: IteratorProtocol {
     guard let start = _position else {
       return nil
     }
-    _sanityCheck(_end != nil, "inconsistent _position, _end pointers")
+    _internalInvariant(_end != nil, "inconsistent _position, _end pointers")
 
     if start == _end._unsafelyUnwrappedUnchecked { return nil }
 

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -30,7 +30,7 @@ public struct _ValidUTF8Buffer {
 
   @inlinable
   internal init(_containing e: Element) {
-    _sanityCheck(
+    _internalInvariant(
       e != 192 && e != 193 && !(245...255).contains(e), "invalid UTF8 byte")
     _biasedBits = UInt32(truncatingIfNeeded: e &+ 1)
   }
@@ -164,7 +164,7 @@ extension _ValidUTF8Buffer : RangeReplaceableCollection {
   @inline(__always)
   public mutating func append(_ e: Element) {
     _debugPrecondition(count + 1 <= capacity)
-    _sanityCheck(
+    _internalInvariant(
       e != 192 && e != 193 && !(245...255).contains(e), "invalid UTF8 byte")
     _biasedBits |= UInt32(e &+ 1) &<< (count &<< 3)
   }

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -184,7 +184,7 @@ public func _encodeBitsAsWords<T>(_ x: T) -> [Int] {
   let result = [Int](
     repeating: 0,
     count: (MemoryLayout<T>.size + MemoryLayout<Int>.size - 1) / MemoryLayout<Int>.size)
-  _sanityCheck(result.count > 0)
+  _internalInvariant(result.count > 0)
   var tmp = x
   // FIXME: use UnsafeMutablePointer.assign(from:) instead of memcpy.
   _memcpy(dest: UnsafeMutablePointer(result._baseAddressIfContiguous!),

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -482,3 +482,7 @@ Protocol _NSCopying has been removed
 Protocol _NSEnumerator has been removed
 Protocol _NSFastEnumeration has been removed
 Protocol _ShadowProtocol has been removed
+
+Func ManagedBufferPointer._sanityCheckValidBufferClass(_:creating:) has been removed
+Func _sanityCheck(_:_:file:line:) has been removed
+Func _sanityCheckFailure(_:file:line:) has been removed

--- a/validation-test/stdlib/Assert.swift
+++ b/validation-test/stdlib/Assert.swift
@@ -30,7 +30,7 @@ func testTrapsAreNoreturn(i: Int) -> Int {
   case 4:
     _debugPreconditionFailure("cannot happen")
   case 5:
-    _sanityCheckFailure("cannot happen")
+    _internalInvariantFailure("cannot happen")
 
   default:
     return 0
@@ -196,26 +196,26 @@ Assert.test("_debugPreconditionFailure")
   _debugPreconditionFailure("this should fail")
 }
 
-Assert.test("_sanityCheck")
+Assert.test("_internalInvariant")
   .xfail(.custom(
     { !_isStdlibInternalChecksEnabled() },
-    reason: "sanity checks are disabled in this build of stdlib"))
+    reason: "internal invariant checks are disabled in this build of stdlib"))
   .crashOutputMatches("this should fail")
   .code {
   var x = 2
-  _sanityCheck(x * 21 == 42, "should not fail")
+  _internalInvariant(x * 21 == 42, "should not fail")
   expectCrashLater()
-  _sanityCheck(x == 42, "this should fail")
+  _internalInvariant(x == 42, "this should fail")
 }
 
-Assert.test("_sanityCheckFailure")
+Assert.test("_internalInvariantFailure")
   .skip(.custom(
     { !_isStdlibInternalChecksEnabled() },
     reason: "optimizer assumes that the code path is unreachable"))
   .crashOutputMatches("this should fail")
   .code {
   expectCrashLater()
-  _sanityCheckFailure("this should fail")
+  _internalInvariantFailure("this should fail")
 }
 
 runAllTests()


### PR DESCRIPTION
These symbols are in the ABI because they appear in inline code (even though they should always be optimized away as only apply to assert builds).