### PR TITLE
[ConstraintSystem] When we have multiple conversions/fixes, make equa…

### DIFF
--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -15,7 +15,8 @@ struct TakesArray<T> {
 // CHECK: assign_expr
 // CHECK-NOT: collection_upcast_expr
 // CHECK: array_expr type='[(X) -> Void]'
-// CHECK-NEXT: function_conversion_expr implicit type='(X) -> Void'
+// CHECK: semantic_expr
+// CHECK: function_conversion_expr implicit type='(X) -> Void'
 // CHECK-NEXT: {{declref_expr.*x1}}
 // CHECK-NEXT: function_conversion_expr implicit type='(X) -> Void'
 // CHECK-NEXT: {{declref_expr.*x2}}

--- a/validation-test/Sema/type_checker_perf/fast/rdar24543332.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar24543332.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 5 --end 20 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 5 --end 20 --step 1 --select NumLeafScopes %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
…lity favored.

This allows us to skip attempting actual conversions.

This speeds up one of our slow test cases, and perturbs the output of
another test. In the latter case, we stop emitting conversions as part
of the non-semantic piece of the array_expr. The fact that we're not
putting conversions in on that path is something I've seen before in
other instances. I'll open a bug if I cannot find one for it, although
I believe it's entirely cosmetic in this case since we don't rely on
the conversion being there.
