### PR TITLE
Fix SIL verification of findAccessedStorage for address phis.

### DIFF
--- a/lib/SIL/MemAccessUtils.cpp
+++ b/lib/SIL/MemAccessUtils.cpp
@@ -206,10 +206,10 @@ static bool isUnsafePointerExtraction(StructExtractInst *SEI) {
     || decl == C.getUnsafePointerDecl();
 }
 
-// Given an address base is a block argument, verify that it is actually a box
-// projected from a switch_enum. This is a valid pattern at any SIL stage
-// resulting in a block-type phi. In later SIL stages, the optimizer may form
-// address-type phis, causing this assert if called on those cases.
+// Given a block argument address base, check if it is actually a box projected
+// from a switch_enum. This is a valid pattern at any SIL stage resulting in a
+// block-type phi. In later SIL stages, the optimizer may form address-type
+// phis, causing this assert if called on those cases.
 static void checkSwitchEnumBlockArg(SILPhiArgument *arg) {
   assert(!arg->getType().isAddress());
   SILBasicBlock *Pred = arg->getParent()->getSinglePredecessorBlock();
@@ -289,22 +289,21 @@ AccessedStorage swift::findAccessedStorage(SILValue sourceAddr) {
 
     case ValueKind::SILPhiArgument: {
       auto *phiArg = cast<SILPhiArgument>(address);
-      bool allValsMatch = true;
-      SmallVector<SILValue, 8> incomingPhis;
-      phiArg->getIncomingPhiValues(incomingPhis);
-      if (!incomingPhis.empty()) {
-        auto firstVal = incomingPhis.front();
-        for (auto val : incomingPhis) {
-          if (val != firstVal) {
-            allValsMatch = false;
-            break;
-          }
+      if (phiArg->isPhiArgument()) {
+        SmallVector<SILValue, 8> incomingValues;
+        phiArg->getIncomingPhiValues(incomingValues);
+        if (incomingValues.empty())
+          return AccessedStorage();
+
+        auto storage = findAccessedStorage(incomingValues.pop_back_val());
+        for (auto val : incomingValues) {
+          auto otherStorage = findAccessedStorage(val);
+          if (!accessingIdenticalLocations(storage, otherStorage))
+            return AccessedStorage();
         }
-        if (allValsMatch) {
-          return findAccessedStorage(firstVal);
-        }
+        return storage;
       }
-      // A block argument may be a box value projected out of
+      // A non-phi block argument may be a box value projected out of
       // switch_enum. Address-type block arguments are not allowed.
       if (address->getType().isAddress())
         return AccessedStorage();

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -626,3 +626,38 @@ bb2(%7 : ${ var Int }):
 bb3(%result : $Int):
   return %result : $Int
 }
+
+// Make sure findAccessedStorage returns a valid storage object for an address-phi
+// that feeds ref_element_addr instructions. The ref_element_addr's need to have the
+// same base object and same field id.
+// <rdar://problem/46114512> SIL verification failed: Unknown formal access pattern: storage
+class BaseClass {
+  var f: Float = 0.0
+}
+
+class SubClass : BaseClass {}
+
+// CHECK-LABEL: @testElementAddressPhiAccess
+// CHECK: [read] [no_nested_conflict] Class %{{.*}} = upcast %0 : $SubClass to $BaseClass
+// CHECK: Field: @_hasInitialValue var f: Float
+sil @testElementAddressPhiAccess : $@convention(thin) (@guaranteed SubClass) -> () {
+bb0(%0 : $SubClass):
+  %base = upcast %0 : $SubClass to $BaseClass
+  cond_br undef, bb1, bb2
+
+bb1:
+  %ref1 = ref_element_addr %base : $BaseClass, #BaseClass.f
+  br bb3(%ref1 : $*Float)
+
+bb2:
+  %ref2 = ref_element_addr %base : $BaseClass, #BaseClass.f
+  br bb3(%ref2 : $*Float)
+
+bb3(%phi : $*Float):
+  %access = begin_access [read] [dynamic] [no_nested_conflict] %phi : $*Float
+  %addr = struct_element_addr %access : $*Float, #Float._value
+  %val = load %addr : $*Builtin.FPIEEE32
+  end_access %access : $*Float
+  %v = tuple ()
+  return %v : $()
+}


### PR DESCRIPTION
The SIL verifier was asserting while attempting to prove that all
formal accesses are well-formed. This is necessary because
unrecognized access could lead to invalid whole-module optimization.

We would like to eliminate address-phis from SIL, but there are still
optimizer passes that produce them. For now, the best we can do is
hope to recover the original base of each phi value and prove they are
actually the same value. They should be because the optimizer
produced the phi through block cloning.

Fixes <rdar://problem/46114512> SIL verification failed: Unknown
formal access pattern: storage
