### PR TITLE
[stdlib] Unchecked subscript on UnsafeBufferPointer

### DIFF
--- a/stdlib/public/core/FixedArray.swift.gyb
+++ b/stdlib/public/core/FixedArray.swift.gyb
@@ -74,7 +74,7 @@ extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
         let bufPtr = UnsafeBufferPointer(
           start: rawPtr.baseAddress!.assumingMemoryBound(to: T.self),
           count: count)
-        return bufPtr[i]
+        return bufPtr[_unchecked: i]
       }
       return res
     }
@@ -82,7 +82,7 @@ extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
     set {
       _internalInvariant(i >= 0 && i < count)
       self.withUnsafeMutableBufferPointer { buffer in
-        buffer[i] = newValue
+        buffer[_unchecked: i] = newValue
       }
     }
   }

--- a/stdlib/public/core/NormalizedCodeUnitIterator.swift
+++ b/stdlib/public/core/NormalizedCodeUnitIterator.swift
@@ -132,7 +132,7 @@ extension UnsafeBufferPointer where Element == UInt8 {
       return true
     }
 
-    assert(!_isContinuation(self[index]))
+    assert(!_isContinuation(self[_unchecked: index]))
 
     let cu = _decodeScalar(self, startingAt: index).0
     return cu._hasNormalizationBoundaryBefore

--- a/stdlib/public/core/SmallBuffer.swift
+++ b/stdlib/public/core/SmallBuffer.swift
@@ -51,7 +51,7 @@ extension _SmallBuffer {
         let rawPtr = $0.baseAddress._unsafelyUnwrappedUnchecked
         let bufPtr = UnsafeBufferPointer(
           start: rawPtr.assumingMemoryBound(to: T.self), count: capacity)
-        return bufPtr[i]
+        return bufPtr[_unchecked: i]
       }
     }
     set {
@@ -61,7 +61,7 @@ extension _SmallBuffer {
         let rawPtr = $0.baseAddress._unsafelyUnwrappedUnchecked
         let bufPtr = UnsafeMutableBufferPointer(
           start: rawPtr.assumingMemoryBound(to: T.self), count: capacity)
-        bufPtr[i] = newValue
+        bufPtr[_unchecked: i] = newValue
       }
     }
   }

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -124,11 +124,11 @@ internal func _stringCompare(
 
   // Back up to nearest scalar boundary and check if normal and end of segment.
   // If so, we have our answer.
-  while _isContinuation(left[idx]) && idx > 0 { idx &-= 1 }
+  while _isContinuation(left[_unchecked: idx]) && idx > 0 { idx &-= 1 }
 
   // TODO: Refactor this into a function, handle these boundary condition as
   // early returns...
-  if !_isContinuation(right[idx]) {
+  if !_isContinuation(right[_unchecked: idx]) {
     let (leftScalar, leftLen) = _decodeScalar(left, startingAt: idx)
     let (rightScalar, rightLen) = _decodeScalar(right, startingAt: idx)
     _internalInvariant(leftScalar != rightScalar)

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -510,7 +510,7 @@ extension String.UTF16View {
       }
 
       while true {
-        let len = _utf8ScalarLength(utf8[readIdx])
+        let len = _utf8ScalarLength(utf8[_unchecked: readIdx])
         let utf16Len = len == 4 ? 2 : 1
         utf16I &+= utf16Len
 

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -214,7 +214,7 @@ extension String.UTF8View: BidirectionalCollection {
     @inline(__always) get {
       String(_guts)._boundsCheck(i)
       if _fastPath(_guts.isFastUTF8) {
-        return _guts.withFastUTF8 { utf8 in utf8[i.encodedOffset] }
+        return _guts.withFastUTF8 { utf8 in utf8[_unchecked: i.encodedOffset] }
       }
 
       return _foreignSubscript(position: i)

--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -88,14 +88,20 @@ internal func _decodeUTF8(
 internal func _decodeScalar(
   _ utf8: UnsafeBufferPointer<UInt8>, startingAt i: Int
 ) -> (Unicode.Scalar, scalarLength: Int) {
-  let cu0 = utf8[i]
+  let cu0 = utf8[_unchecked: i]
   let len = _utf8ScalarLength(cu0)
   switch  len {
   case 1: return (_decodeUTF8(cu0), len)
-  case 2: return (_decodeUTF8(cu0, utf8[i &+ 1]), len)
-  case 3: return (_decodeUTF8(cu0, utf8[i &+ 1], utf8[i &+ 2]), len)
+  case 2: return (_decodeUTF8(cu0, utf8[_unchecked: i &+ 1]), len)
+  case 3: return (_decodeUTF8(
+    cu0, utf8[_unchecked: i &+ 1], utf8[_unchecked: i &+ 2]), len)
   case 4:
-    return (_decodeUTF8(cu0, utf8[i &+ 1], utf8[i &+ 2], utf8[i &+ 3]), len)
+    return (_decodeUTF8(
+      cu0,
+      utf8[_unchecked: i &+ 1],
+      utf8[_unchecked: i &+ 2],
+      utf8[_unchecked: i &+ 3]),
+    len)
   default: Builtin.unreachable()
   }
 }
@@ -123,7 +129,7 @@ internal func _utf8ScalarLength(
   _ utf8: UnsafeBufferPointer<UInt8>, endingAt i: Int
   ) -> Int {
   var len = 1
-  while _isContinuation(utf8[i &- len]) {
+  while _isContinuation(utf8[_unchecked: i &- len]) {
     len += 1
   }
   _internalInvariant(len == _utf8ScalarLength(utf8[i &- len]))
@@ -187,7 +193,7 @@ extension _StringGuts {
 
     return self.withFastUTF8 { utf8 in
       var i = idx.encodedOffset
-      while _slowPath(_isContinuation(utf8[i])) {
+      while _slowPath(_isContinuation(utf8[_unchecked: i])) {
         i -= 1
         _internalInvariant(
           i >= 0, "Malformed contents: starts with continuation byte")

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -281,6 +281,23 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
 %end
   }
 
+  // Skip all debug and runtime checks
+  @inlinable // unsafe-performance
+  internal subscript(_unchecked i: Int) -> Element {
+    get {
+      _internalInvariant(i >= 0)
+      _internalInvariant(i < endIndex)
+      return _position._unsafelyUnwrappedUnchecked[i]
+    }
+%if Mutable:
+    nonmutating _modify {
+      _internalInvariant(i >= 0)
+      _internalInvariant(i < endIndex)
+      yield &_position._unsafelyUnwrappedUnchecked[i]
+    }
+%end
+  }
+
   /// Accesses a contiguous subrange of the buffer's elements.
   ///
   /// The accessed slice uses the same indices for the same elements as the


### PR DESCRIPTION
Add a use an unchecked subscript on UnsafeBufferPointer, which skips
debugPrecondition checks (in case we're not inlined) as well as a
force-unwrap check.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
