### PR TITLE
Allow TypeReference to refer to protocol descriptors

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2083,10 +2083,10 @@ public:
   const TargetTypeContextDescriptor<Runtime> *
   getTypeContextDescriptor() const {
     switch (getTypeKind()) {
-    case TypeReferenceKind::DirectNominalTypeDescriptor:
+    case TypeReferenceKind::DirectTypeDescriptor:
       return DirectNominalTypeDescriptor.getPointer();
 
-    case TypeReferenceKind::IndirectNominalTypeDescriptor:
+    case TypeReferenceKind::IndirectTypeDescriptor:
       return *IndirectNominalTypeDescriptor.getPointer();
 
     // These types (and any others we might add to TypeReferenceKind
@@ -2172,14 +2172,14 @@ public:
 template <typename Runtime>
 struct TargetTypeReference {
   union {
-    /// A direct reference to a nominal type descriptor.
-    RelativeDirectPointer<TargetTypeContextDescriptor<Runtime>>
-      DirectNominalTypeDescriptor;
+    /// A direct reference to a TypeContextDescriptor or ProtocolDescriptor.
+    RelativeDirectPointer<TargetContextDescriptor<Runtime>>
+      DirectTypeDescriptor;
 
-    /// An indirect reference to a nominal type descriptor.
+    /// An indirect reference to a TypeContextDescriptor or ProtocolDescriptor.
     RelativeDirectPointer<
-        ConstTargetMetadataPointer<Runtime, TargetTypeContextDescriptor>>
-      IndirectNominalTypeDescriptor;
+        ConstTargetMetadataPointer<Runtime, TargetContextDescriptor>>
+      IndirectTypeDescriptor;
 
     /// An indirect reference to an Objective-C class.
     RelativeDirectPointer<
@@ -2191,14 +2191,14 @@ struct TargetTypeReference {
       DirectObjCClassName;
   };
 
-  const TargetTypeContextDescriptor<Runtime> *
-  getTypeContextDescriptor(TypeReferenceKind kind) const {
+  const TargetContextDescriptor<Runtime> *
+  getTypeDescriptor(TypeReferenceKind kind) const {
     switch (kind) {
-    case TypeReferenceKind::DirectNominalTypeDescriptor:
-      return DirectNominalTypeDescriptor;
+    case TypeReferenceKind::DirectTypeDescriptor:
+      return DirectTypeDescriptor;
 
-    case TypeReferenceKind::IndirectNominalTypeDescriptor:
-      return *IndirectNominalTypeDescriptor;
+    case TypeReferenceKind::IndirectTypeDescriptor:
+      return *IndirectTypeDescriptor;
 
     case TypeReferenceKind::DirectObjCClassName:
     case TypeReferenceKind::IndirectObjCClass:
@@ -2305,8 +2305,8 @@ public:
     return TypeRef.getIndirectObjCClass(getTypeKind());
   }
   
-  const TargetTypeContextDescriptor<Runtime> *getTypeContextDescriptor() const {
-    return TypeRef.getTypeContextDescriptor(getTypeKind());
+  const TargetContextDescriptor<Runtime> *getTypeDescriptor() const {
+    return TypeRef.getTypeDescriptor(getTypeKind());
   }
 
   /// Retrieve the context of a retroactive conformance.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -380,12 +380,12 @@ enum : unsigned {
 /// Kinds of type metadata/protocol conformance records.
 enum class TypeReferenceKind : unsigned {
   /// The conformance is for a nominal type referenced directly;
-  /// getNominalTypeDescriptor() points to the nominal type descriptor.
-  DirectNominalTypeDescriptor = 0x00,
+  /// getTypeDescriptor() points to the type context descriptor.
+  DirectTypeDescriptor = 0x00,
 
   /// The conformance is for a nominal type referenced indirectly;
-  /// getNominalTypeDescriptor() points to the nominal type descriptor.
-  IndirectNominalTypeDescriptor = 0x01,
+  /// getTypeDescriptor() points to the type context descriptor.
+  IndirectTypeDescriptor = 0x01,
 
   /// The conformance is for an Objective-C class that should be looked up
   /// by class name.
@@ -402,7 +402,7 @@ enum class TypeReferenceKind : unsigned {
 
   // We only reserve three bits for this in the various places we store it.
 
-  First_Kind = DirectNominalTypeDescriptor,
+  First_Kind = DirectTypeDescriptor,
   Last_Kind = IndirectObjCClass,
 };
 

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -790,7 +790,7 @@ public:
                    const MetadataFn &metadataFn,
                    const ClassNameFn &classNameFn) {
     switch (refKind) {
-    case TypeReferenceKind::IndirectNominalTypeDescriptor: {
+    case TypeReferenceKind::IndirectTypeDescriptor: {
       StoredPointer descriptorAddress = 0;
       if (!Reader->readInteger(RemoteAddress(ref), &descriptorAddress))
         return None;
@@ -799,7 +799,7 @@ public:
       LLVM_FALLTHROUGH;
     }
 
-    case TypeReferenceKind::DirectNominalTypeDescriptor: {
+    case TypeReferenceKind::DirectTypeDescriptor: {
       auto descriptor = readContextDescriptor(ref);
       if (!descriptor)
         return None;

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -218,7 +218,7 @@ public:
   _contextDescriptorMatchesMangling(const ContextDescriptor *context,
                                     Demangle::NodePointer node);
   
-  const TypeContextDescriptor *
+  const ContextDescriptor *
   _searchConformancesByMangledTypeName(Demangle::NodePointer node);
 
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type,
@@ -470,6 +470,10 @@ public:
                            const Metadata *type,
                            ProtocolDescriptorRef protocol,
                            const WitnessTable **conformance);
+
+  /// Construct type metadata for the given protocol.
+  const Metadata *
+  _getSimpleProtocolTypeMetadata(const ProtocolDescriptor *protocol);
 
   /// Given a type that we know can be used with the given conformance, find
   /// the superclass that introduced the conformance.

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -80,9 +80,9 @@ template<> void ProtocolConformanceDescriptor::dump() const {
            class_getName(*getIndirectObjCClass()));
     break;
 
-  case TypeReferenceKind::DirectNominalTypeDescriptor:
-  case TypeReferenceKind::IndirectNominalTypeDescriptor:
-    printf("unique nominal type descriptor %s", symbolName(getTypeContextDescriptor()));
+  case TypeReferenceKind::DirectTypeDescriptor:
+  case TypeReferenceKind::IndirectTypeDescriptor:
+    printf("unique nominal type descriptor %s", symbolName(getTypeDescriptor()));
     break;
   }
   
@@ -112,8 +112,8 @@ const ClassMetadata *TypeReference::getObjCClass(TypeReferenceKind kind) const {
     return reinterpret_cast<const ClassMetadata *>(
               objc_lookUpClass(getDirectObjCClassName(kind)));
 
-  case TypeReferenceKind::DirectNominalTypeDescriptor:
-  case TypeReferenceKind::IndirectNominalTypeDescriptor:
+  case TypeReferenceKind::DirectTypeDescriptor:
+  case TypeReferenceKind::IndirectTypeDescriptor:
     return nullptr;
   }
 
@@ -139,12 +139,16 @@ ProtocolConformanceDescriptor::getCanonicalTypeMetadata() const {
 #endif
     return nullptr;
 
-  case TypeReferenceKind::DirectNominalTypeDescriptor:
-  case TypeReferenceKind::IndirectNominalTypeDescriptor: {
-    auto type = getTypeContextDescriptor();
-    if (!type->isGeneric()) {
-      if (auto accessFn = type->getAccessFunction())
-        return accessFn(MetadataState::Abstract).Value;
+  case TypeReferenceKind::DirectTypeDescriptor:
+  case TypeReferenceKind::IndirectTypeDescriptor: {
+    auto anyType = getTypeDescriptor();
+    if (auto type = dyn_cast<TypeContextDescriptor>(anyType)) {
+      if (!type->isGeneric()) {
+        if (auto accessFn = type->getAccessFunction())
+          return accessFn(MetadataState::Abstract).Value;
+      }
+    } else if (auto protocol = dyn_cast<ProtocolDescriptor>(anyType)) {
+      return _getSimpleProtocolTypeMetadata(protocol);
     }
 
     return nullptr;
@@ -475,7 +479,7 @@ namespace {
         return;
       }
 
-      if (auto description = conformance.getTypeContextDescriptor()) {
+      if (auto description = conformance.getTypeDescriptor()) {
         candidate = description;
         candidateIsMetadata = false;
         return;
@@ -500,7 +504,7 @@ namespace {
       if (!candidateIsMetadata) {
         const auto *description = conformingType->getTypeContextDescriptor();
         auto candidateDescription =
-          static_cast<const TypeContextDescriptor *>(candidate);
+          static_cast<const ContextDescriptor *>(candidate);
         if (description && equalContexts(description, candidateDescription))
           return true;
       }
@@ -601,13 +605,13 @@ swift_conformsToProtocolImpl(const Metadata * const type,
   }
 }
 
-const TypeContextDescriptor *
+const ContextDescriptor *
 swift::_searchConformancesByMangledTypeName(Demangle::NodePointer node) {
   auto &C = Conformances.get();
 
   for (auto &section : C.SectionsToScan.snapshot()) {
     for (const auto &record : section) {
-      if (auto ntd = record->getTypeContextDescriptor()) {
+      if (auto ntd = record->getTypeDescriptor()) {
         if (_contextDescriptorMatchesMangling(ntd, node))
           return ntd;
       }


### PR DESCRIPTION
We should also add manglings just to cover the general case, but this is useful on its own.