### PR TITLE
[ConstraintSystem] Add Array as a designated type for `+` and `+=`.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1948,12 +1948,18 @@ Constraint *ConstraintSystem::selectDisjunction() {
   if (disjunctions.empty())
     return nullptr;
 
-  if (auto *disjunction = selectBestBindingDisjunction(*this, disjunctions))
-    return disjunction;
-
+  // Attempt apply disjunctions first. When we have operators with
+  // designated types, this is important, because it allows us to
+  // select all the preferred operator overloads prior to other
+  // disjunctions that we may not be able to short-circuit, allowing
+  // us to eliminate behavior that is exponential in the number of
+  // operators in the expression.
   if (getASTContext().isSwiftVersionAtLeast(5))
     if (auto *disjunction = selectApplyDisjunction())
       return disjunction;
+
+  if (auto *disjunction = selectBestBindingDisjunction(*this, disjunctions))
+    return disjunction;
 
   // Pick the disjunction with the smallest number of active choices.
   auto minDisjunction =

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1290,6 +1290,25 @@ extension Array: RangeReplaceableCollection {
   }
 }
 
+// Implementations of + and += for same-type arrays. This combined
+// with the operator declarations for these operators designating this
+// type as a place to prefer this operator help the expression type
+// checker speed up cases where there is a large number of uses of the
+// operator in the same expression.
+extension Array {
+  @inlinable // FIXME(sil-serialize-all)
+  public static func + (lhs: Array, rhs: Array) -> Array {
+    var lhs = lhs
+    lhs.append(contentsOf: rhs)
+    return lhs
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public static func += (lhs: inout Array, rhs: Array) {
+    lhs.append(contentsOf: rhs)
+  }
+}
+
 extension Array: CustomReflectable {
   /// A mirror that reflects the array.
   public var customMirror: Mirror {

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1296,14 +1296,14 @@ extension Array: RangeReplaceableCollection {
 // checker speed up cases where there is a large number of uses of the
 // operator in the same expression.
 extension Array {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public static func + (lhs: Array, rhs: Array) -> Array {
     var lhs = lhs
     lhs.append(contentsOf: rhs)
     return lhs
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public static func += (lhs: inout Array, rhs: Array) {
     lhs.append(contentsOf: rhs)
   }

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -420,7 +420,7 @@ infix operator   & : MultiplicationPrecedence, BinaryInteger
 
 // "Additive"
 
-infix operator   + : AdditionPrecedence, AdditiveArithmetic, String, Strideable
+infix operator   + : AdditionPrecedence, AdditiveArithmetic, String, Array, Strideable
 infix operator  &+ : AdditionPrecedence, FixedWidthInteger
 infix operator   - : AdditionPrecedence, AdditiveArithmetic, Strideable
 infix operator  &- : AdditionPrecedence, FixedWidthInteger
@@ -474,7 +474,7 @@ infix operator   *= : AssignmentPrecedence, Numeric
 infix operator  &*= : AssignmentPrecedence, FixedWidthInteger
 infix operator   /= : AssignmentPrecedence, BinaryInteger
 infix operator   %= : AssignmentPrecedence, BinaryInteger
-infix operator   += : AssignmentPrecedence, AdditiveArithmetic, String, Strideable
+infix operator   += : AssignmentPrecedence, AdditiveArithmetic, String, Array, Strideable
 infix operator  &+= : AssignmentPrecedence, FixedWidthInteger
 infix operator   -= : AssignmentPrecedence, AdditiveArithmetic, Strideable
 infix operator  &-= : AssignmentPrecedence, FixedWidthInteger

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -269,7 +269,7 @@ func rdar19831698() {
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}
   // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}
   var v73 = true + [] // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and '[Any]'}}
-  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Self, Other), (Other, Self)}}
+  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Array<Element>, Array<Element>), (Self, Other), (Other, Self)}}
   var v75 = true + "str" // expected-error {{binary operator '+' cannot be applied to operands of type 'Bool' and 'String'}} expected-note {{expected an argument list of type '(String, String)'}}
 }
 

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -103,11 +103,14 @@ func test17875634() {
   var col = 2
   var coord = (row, col)
 
-  match += (1, 2) // expected-error{{argument type '(Int, Int)' does not conform to expected type 'Sequence'}}
+  match += (1, 2) // expected-error{{binary operator '+=' cannot be applied to operands of type '[(Int, Int)]' and '(Int, Int)'}}
+  // expected-note@-1 {{overloads for '+=' exist with these partially matching parameter lists: (inout Array<Element>, Array<Element>), (inout Self, Other)}}
 
-  match += (row, col) // expected-error{{argument type '(@lvalue Int, @lvalue Int)' does not conform to expected type 'Sequence'}}
+  match += (row, col) // expected-error{{binary operator '+=' cannot be applied to operands of type '[(Int, Int)]' and '(Int, Int)}}
+  // expected-note@-1 {{overloads for '+=' exist with these partially matching parameter lists: (inout Array<Element>, Array<Element>), (inout Self, Other)}}
 
-  match += coord // expected-error{{argument type '@lvalue (Int, Int)' does not conform to expected type 'Sequence'}}
+  match += coord // expected-error{{binary operator '+=' cannot be applied to operands of type '[(Int, Int)]' and '(Int, Int)'}}
+  // expected-note@-1 {{overloads for '+=' exist with these partially matching parameter lists: (inout Array<Element>, Array<Element>), (inout Self, Other)}}
 
   match.append(row, col) // expected-error {{instance method 'append' expects a single parameter of type '(Int, Int)'}} {{16-16=(}} {{24-24=)}}
 

--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -15,7 +15,8 @@ struct TakesArray<T> {
 // CHECK: assign_expr
 // CHECK-NOT: collection_upcast_expr
 // CHECK: array_expr type='[(X) -> Void]'
-// CHECK-NEXT: function_conversion_expr implicit type='(X) -> Void'
+// CHECK: semantic_expr
+// CHECK: function_conversion_expr implicit type='(X) -> Void'
 // CHECK-NEXT: {{declref_expr.*x1}}
 // CHECK-NEXT: function_conversion_expr implicit type='(X) -> Void'
 // CHECK-NEXT: {{declref_expr.*x2}}

--- a/validation-test/Sema/type_checker_perf/fast/rdar18360240.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18360240.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 10 --step 2 --select NumConstraintScopes --polynomial-threshold 1.5 %s
+// RUN: %scale-test --begin 2 --end 10 --step 2 --select NumConstraintScopes --polynomial-threshold 1.5 %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// REQUIRES: tools-release,no_asserts
+
+let _ = [0].reduce([Int]()) {
+  return $0.count == 0 && ($1 == 0 || $1 == 2 || $1 == 3) ? [] : $0 + [$1]
+}

--- a/validation-test/Sema/type_checker_perf/fast/rdar24543332.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar24543332.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 5 --end 20 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 5 --end 20 --step 1 --select NumLeafScopes %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar25866240.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar25866240.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 10 --step 1 --select NumConstraintScopes %s
+// RUN: %scale-test --begin 2 --end 10 --step 1 --select NumConstraintScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar23429943.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar23429943.swift
@@ -1,7 +1,0 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
-
-let _ = [0].reduce([Int]()) {
-  // expected-error@-1 {{reasonable time}}
-  return $0.count == 0 && ($1 == 0 || $1 == 2 || $1 == 3) ? [] : $0 + [$1]
-}


### PR DESCRIPTION
Also add overloads for these operators to an extension of Array.

This allows us to typecheck array concatenation quickly with
designated type support enabled and the remaining type checker hacks
disabled.