### PR TITLE
Extract a function to check whether to diagnose a self-conformance failure

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -237,7 +237,9 @@ bool MissingConformanceFailure::diagnoseAsError() {
     }
   }
 
-  if (nonConformingType->isExistentialType()) {
+  if (TypeChecker::shouldDiagnoseSelfNonConformance(nonConformingType,
+                               protocolType->castTo<ProtocolType>()->getDecl(),
+                                                    getDC())) {
     auto diagnostic = diag::protocol_does_not_conform_objc;
     if (nonConformingType->isObjCExistentialType())
       diagnostic = diag::protocol_does_not_conform_static;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1707,6 +1707,9 @@ public:
                                              DeclContext *DC,
                                              ConformanceCheckOptions options);
 
+  static bool shouldDiagnoseSelfNonConformance(Type type, ProtocolDecl *proto,
+                                               DeclContext *dc);
+
   /// \brief Determine whether the given type conforms to the given protocol.
   ///
   /// Unlike subTypeOfProtocol(), this will return false for existentials of


### PR DESCRIPTION
Noticed by inspection; I couldn't find a simple test case which ended up with obviously bad diagnostics without this.