### PR TITLE
Fix block merging after inlining to be linear, not quadratic.

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -21,7 +21,9 @@
 #include <thread>
 #include <tuple>
 
-#define SWIFT_FUNC_STAT                                                 \
+#define SWIFT_FUNC_STAT SWIFT_FUNC_STAT_NAMED(DEBUG_TYPE)
+
+#define SWIFT_FUNC_STAT_NAMED(DEBUG_TYPE)                               \
   do {                                                                  \
     static llvm::Statistic FStat =                                      \
       {DEBUG_TYPE, __func__, __func__, {0}, {false}};                   \

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -67,6 +67,10 @@ private:
   /// Set of basic blocks where unreachable was inserted.
   SmallPtrSet<SILBasicBlock *, 32> BlocksWithUnreachables;
 
+  // Keep track of the last cloned block in function order. For single block
+  // regions, this will be the start block.
+  SILBasicBlock *lastClonedBB = nullptr;
+
 public:
   using SILInstructionVisitor<ImplClass>::asImpl;
 
@@ -101,6 +105,10 @@ public:
   }
 
   SILBuilder &getBuilder() { return Builder; }
+
+  // After cloning, returns a non-null pointer to the last cloned block in
+  // function order. For single block regions, this will be the start block.
+  SILBasicBlock *getLastClonedBB() { return lastClonedBB; }
 
   /// Visit all blocks reachable from the given `StartBB` and all instructions
   /// in those blocks.
@@ -655,7 +663,7 @@ void SILCloner<ImplClass>::visitBlocksDepthFirst(SILBasicBlock *startBB) {
   // order they are created, which differs from the order they are
   // cloned. Blocks are created in BFS order but cloned in DFS preorder (when no
   // critical edges are present).
-  SILBasicBlock *lastClonedBB = BBMap[startBB];
+  lastClonedBB = BBMap[startBB];
   while (!dfsWorklist.empty()) {
     auto *BB = dfsWorklist.pop_back_val();
     preorderBlocks.push_back(BB);

--- a/include/swift/SILOptimizer/Utils/CFG.h
+++ b/include/swift/SILOptimizer/Utils/CFG.h
@@ -127,6 +127,16 @@ bool splitAllCondBrCriticalEdgesWithNonTrivialArgs(SILFunction &Fn,
 bool mergeBasicBlockWithSuccessor(SILBasicBlock *BB, DominanceInfo *DT,
                                   SILLoopInfo *LI);
 
+/// Merge basic blocks in the given function by eliminating all unconditional
+/// branches to single-predecessor branch targets.
+///
+/// During optimization, SimplifyCFG also handles this, but this is a basic
+/// canonicalization after any pass that splits blocks, such as inlining. This
+/// is not done on-the-fly after splitting blocks because merging is linear in
+/// the number of instructions, so interleaved merging and splitting is
+/// quadratic.
+bool mergeBasicBlocks(SILFunction *F);
+
 /// Given a list of \p UserBlocks and a list of \p DefBlocks, find a set of
 /// blocks that together with \p UserBlocks joint-postdominate \p
 /// DefBlocks. This is in a sense finding a set of blocks that "complete" \p

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -80,18 +80,32 @@ public:
   /// iterator to the first inlined instruction (or first instruction after the
   /// call for an empty function).
   ///
-  /// This may split basic blocks and delete instructions.
-  ///
   /// This only performs one step of inlining: it does not recursively
   /// inline functions called by the callee.
+  ///
+  /// This may split basic blocks and delete instructions anywhere.
+  ///
+  /// All inlined instructions must be either inside the original call block or
+  /// inside new basic blocks laid out after the original call block.
+  ///
+  /// Any instructions in the original call block after the inlined call must be
+  /// in a new basic block laid out after all inlined blocks.
+  ///
+  /// The above guarantees ensure that inlining is liner in the number of
+  /// instructions and that inlined instructions are revisited exactly once.
   ///
   /// *NOTE*: This attempts to perform inlining unconditionally and thus asserts
   /// if inlining will fail. All users /must/ check that a function is allowed
   /// to be inlined using SILInliner::canInlineApplySite before calling this
   /// function.
-  SILBasicBlock::iterator inlineFunction(SILFunction *calleeFunction,
-                                         FullApplySite apply,
-                                         ArrayRef<SILValue> appliedArgs);
+  ///
+  /// Returns an iterator to the first inlined instruction (or the end of the
+  /// caller block for empty functions) and the last block in function order
+  /// containing inlined instructions (the original caller block for
+  /// single-block functions).
+  std::pair<SILBasicBlock::iterator, SILBasicBlock *>
+  inlineFunction(SILFunction *calleeFunction, FullApplySite apply,
+                 ArrayRef<SILValue> appliedArgs);
 };
 
 } // end namespace swift

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -86,8 +86,10 @@ transferNodesFromList(llvm::ilist_traits<SILInstruction> &L2,
   if (ThisParent == L2.getContainingBlock()) return;
 
   // Update the parent fields in the instructions.
-  for (; first != last; ++first)
+  for (; first != last; ++first) {
+    SWIFT_FUNC_STAT_NAMED("sil");
     first->ParentBB = ThisParent;
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -49,7 +49,7 @@ static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
 /// and that the function implementing the closure consumes its capture
 /// arguments.
 static void fixupReferenceCounts(
-    SILBasicBlock::iterator I, SILValue CalleeValue,
+    SILInstruction *I, SILValue CalleeValue,
     SmallVectorImpl<std::pair<SILValue, ParameterConvention>> &CaptureArgs,
     bool isCalleeGuaranteed) {
   // Add a copy of each non-address type capture argument to lifetime extend the
@@ -60,7 +60,7 @@ static void fixupReferenceCounts(
     if (!CaptureArg.first->getType().isAddress() &&
         CaptureArg.second != ParameterConvention::Direct_Guaranteed &&
         CaptureArg.second != ParameterConvention::Direct_Unowned) {
-      createIncrementBefore(CaptureArg.first, &*I);
+      createIncrementBefore(CaptureArg.first, I);
     } else {
       // FIXME: What about indirectly owned parameters? The invocation of the
       // closure would perform an indirect copy which we should mimick here.
@@ -190,34 +190,30 @@ namespace {
 class ClosureCleanup {
   using DeadInstSet = SmallBlotSetVector<SILInstruction *, 4>;
 
-  /// A helper class to update an instruction iterator if
-  /// removal of instructions would invalidate it.
+  /// A helper class to update the set of dead instructions.
   ///
   /// Since this is called by the SILModule callback, the instruction may longer
   /// be well-formed. Do not visit its operands. However, it's position in the
   /// basic block is still valid.
   ///
-  /// FIXME: Using the Module's callback mechanism is undesirable. Instead,
-  /// cleanupCalleeValue could be easily rewritten to use its own instruction
-  /// deletion helper and pass a callback to tryDeleteDeadClosure and
-  /// recursivelyDeleteTriviallyDeadInstructions.
-  class IteratorUpdateHandler : public DeleteNotificationHandler {
+  /// FIXME: Using the Module's callback mechanism for this is terrible.
+  /// Instead, cleanupCalleeValue could be easily rewritten to use its own
+  /// instruction deletion helper and pass a callback to tryDeleteDeadClosure
+  /// and recursivelyDeleteTriviallyDeadInstructions.
+  class DeleteUpdateHandler : public DeleteNotificationHandler {
     SILModule &Module;
-    SILBasicBlock::iterator CurrentI;
     DeadInstSet &DeadInsts;
 
   public:
-    IteratorUpdateHandler(SILBasicBlock::iterator I, DeadInstSet &DeadInsts)
-        : Module(I->getModule()), CurrentI(I), DeadInsts(DeadInsts) {
+    DeleteUpdateHandler(SILModule &M, DeadInstSet &DeadInsts)
+        : Module(M), DeadInsts(DeadInsts) {
       Module.registerDeleteNotificationHandler(this);
     }
 
-    ~IteratorUpdateHandler() override {
+    ~DeleteUpdateHandler() override {
       // Unregister the handler.
       Module.removeDeleteNotificationHandler(this);
     }
-
-    SILBasicBlock::iterator getIterator() const { return CurrentI; }
 
     // Handling of instruction removal notifications.
     bool needsNotifications() override { return true; }
@@ -229,9 +225,6 @@ class ClosureCleanup {
         return;
 
       DeadInsts.erase(deletedI);
-
-      if (CurrentI == SILBasicBlock::iterator(deletedI))
-        ++CurrentI;
     }
   };
 
@@ -260,8 +253,8 @@ public:
   // Note: instructions in the `deadFunctionVals` set may use each other, so the
   // set needs to continue to be updated (by this handler) when deleting
   // instructions. This assumes that DeadFunctionValSet::erase() is stable.
-  SILBasicBlock::iterator cleanupDeadClosures(SILBasicBlock::iterator II) {
-    IteratorUpdateHandler iteratorUpdate(II, deadFunctionVals);
+  void cleanupDeadClosures(SILFunction *F) {
+    DeleteUpdateHandler deleteUpdate(F->getModule(), deadFunctionVals);
     for (Optional<SILInstruction *> I : deadFunctionVals) {
       if (!I.hasValue())
         continue;
@@ -269,7 +262,6 @@ public:
       if (auto *SVI = dyn_cast<SingleValueInstruction>(I.getValue()))
         cleanupCalleeValue(SVI);
     }
-    return iteratorUpdate.getIterator();
   }
 };
 } // end of namespace
@@ -472,21 +464,21 @@ static SILFunction *getCalleeFunction(
   return CalleeFunction;
 }
 
-static std::tuple<FullApplySite, SILBasicBlock::iterator>
-tryDevirtualizeApplyHelper(FullApplySite InnerAI, SILBasicBlock::iterator I,
-                           ClassHierarchyAnalysis *CHA) {
+static SILInstruction *tryDevirtualizeApplyHelper(FullApplySite InnerAI,
+                                                  ClassHierarchyAnalysis *CHA) {
   auto NewInst = tryDevirtualizeApply(InnerAI, CHA);
-  if (!NewInst) {
-    return std::make_tuple(InnerAI, I);
-  }
+  if (!NewInst)
+    return InnerAI.getInstruction();
 
   deleteDevirtualizedApply(InnerAI);
 
+  // FIXME: Comments at the use of this helper indicate that devirtualization
+  // may return SILArgument. Yet here we assert that it must return an
+  // instruction.
   auto newApplyAI = NewInst.getInstruction();
   assert(newApplyAI && "devirtualized but removed apply site?");
 
-  return std::make_tuple(FullApplySite::isa(newApplyAI),
-                         newApplyAI->getIterator());
+  return newApplyAI;
 }
 
 /// \brief Inlines all mandatory inlined functions into the body of a function,
@@ -532,23 +524,34 @@ runOnFunctionRecursively(SILOptFunctionBuilder &FuncBuilder,
   SmallVector<std::pair<SILValue, ParameterConvention>, 16> CaptureArgs;
   SmallVector<SILValue, 32> FullArgs;
 
-  for (auto BI = F->begin(), BE = F->end(); BI != BE; ++BI) {
+  // Visiting blocks in reverse order avoids revisiting instructions after block
+  // splitting, which would be quadratic.
+  for (auto BI = F->rbegin(), BE = F->rend(), nextBB = BI; BI != BE;
+       BI = nextBB) {
+    // After inlining, the block iterator will be adjusted to point to the last
+    // block containing inlined instructions. This way, the inlined function
+    // body will be reprocessed within the caller's context without revisiting
+    // any original instructions.
+    nextBB = std::next(BI);
+
     // While iterating over this block, instructions are inserted and deleted.
-    for (auto II = BI->begin(), nextI = II; II != BI->end(); II = nextI) {
-      nextI = std::next(II);
-
+    // To avoid quadratic block splitting, instructions must be processed in
+    // reverse order (block splitting reassigned the parent pointer of all
+    // instructions below the split point).
+    for (auto II = BI->rbegin(); II != BI->rend(); ++II) {
       FullApplySite InnerAI = FullApplySite::isa(&*II);
-
       if (!InnerAI)
         continue;
 
-      auto *ApplyBlock = InnerAI.getParent();
-
-      // *NOTE* If devirtualization succeeds, sometimes II will not be InnerAI,
+      // *NOTE* If devirtualization succeeds, devirtInst may not be InnerAI,
       // but a casted result of InnerAI or even a block argument due to
-      // abstraction changes when calling the witness or class method. We still
-      // know that InnerAI dominates II though.
-      std::tie(InnerAI, II) = tryDevirtualizeApplyHelper(InnerAI, II, CHA);
+      // abstraction changes when calling the witness or class method.
+      auto *devirtInst = tryDevirtualizeApplyHelper(InnerAI, CHA);
+      // Restore II to the current apply site.
+      II = devirtInst->getReverseIterator();
+      // If the devirtualized call result is no longer a invalid FullApplySite,
+      // then it has succeeded, but the result is not immediately inlinable.
+      InnerAI = FullApplySite::isa(devirtInst);
       if (!InnerAI)
         continue;
 
@@ -597,13 +600,8 @@ runOnFunctionRecursively(SILOptFunctionBuilder &FuncBuilder,
 
       SILInliner Inliner(FuncBuilder, SILInliner::InlineKind::MandatoryInline,
                          Subs, OpenedArchetypesTracker);
-      if (!Inliner.canInlineApplySite(InnerAI)) {
-        // See comment above about casting when devirtualizing and how this
-        // sometimes causes II and InnerAI to be different and even in different
-        // blocks.
-        II = InnerAI.getInstruction()->getIterator();
+      if (!Inliner.canInlineApplySite(InnerAI))
         continue;
-      }
 
       // Inline function at I, which also changes I to refer to the first
       // instruction inlined in the case that it succeeds. We purposely
@@ -620,7 +618,8 @@ runOnFunctionRecursively(SILOptFunctionBuilder &FuncBuilder,
         bool IsCalleeGuaranteed =
             PAI &&
             PAI->getType().castTo<SILFunctionType>()->isCalleeGuaranteed();
-        fixupReferenceCounts(II, CalleeValue, CaptureArgs, IsCalleeGuaranteed);
+        fixupReferenceCounts(InnerAI.getInstruction(), CalleeValue, CaptureArgs,
+                             IsCalleeGuaranteed);
       }
 
       // Register a callback to record potentially unused function values after
@@ -632,20 +631,23 @@ runOnFunctionRecursively(SILOptFunctionBuilder &FuncBuilder,
 
       // Inlining deletes the apply, and can introduce multiple new basic
       // blocks. After this, CalleeValue and other instructions may be invalid.
-      nextI = Inliner.inlineFunction(CalleeFunction, InnerAI, FullArgs);
+      // nextBB will point to the last inlined block
+      auto firstInlinedInstAndLastBB =
+          Inliner.inlineFunction(CalleeFunction, InnerAI, FullArgs);
+      nextBB = firstInlinedInstAndLastBB.second->getReverseIterator();
       ++NumMandatoryInlines;
 
       // The IR is now valid, and trivial dead arguments are removed. However,
       // we may be able to remove dead callee computations (e.g. dead
       // partial_apply closures).
-      nextI = closureCleanup.cleanupDeadClosures(nextI);
+      closureCleanup.cleanupDeadClosures(F);
 
-      assert(nextI == ApplyBlock->end()
-             || nextI->getParent() == ApplyBlock
-                    && "Mismatch between the instruction and basic block");
+      // Resume inlining within nextBB, which contains only the inlined
+      // instructions and possibly instructions in the original call block that
+      // have not yet been visited.
+      break;
     }
   }
-
   // Keep track of full inlined functions so we don't waste time recursively
   // reprocessing them.
   FullyInlinedSet.insert(F);

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -680,6 +680,9 @@ class MandatoryInlining : public SILModuleTransform {
       runOnFunctionRecursively(FuncBuilder, &F,
                                FullApplySite(), FullyInlinedSet, SetFactory,
                                SetFactory.getEmptySet(), CHA);
+      // The inliner splits blocks at call sites. Re-merge trivial branches
+      // to reestablish a canonical CFG.
+      mergeBasicBlocks(&F);
     }
 
     if (!ShouldCleanup)

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -17,6 +17,7 @@
 #include "swift/SILOptimizer/Analysis/SideEffectAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFG.h"
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
 #include "swift/SILOptimizer/Utils/Generics.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
@@ -903,6 +904,9 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
     Inliner.inlineFunction(Callee, AI, Args);
     NumFunctionsInlined++;
   }
+  // The inliner splits blocks at call sites. Re-merge trivial branches to
+  // reestablish a canonical CFG.
+  mergeBasicBlocks(Caller);
   return true;
 }
 

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -493,6 +493,19 @@ bool swift::mergeBasicBlockWithSuccessor(SILBasicBlock *BB, DominanceInfo *DT,
   return true;
 }
 
+bool swift::mergeBasicBlocks(SILFunction *F) {
+  bool merged = false;
+  for (auto BBIter = F->begin(); BBIter != F->end();) {
+    if (mergeBasicBlockWithSuccessor(&*BBIter, /*DT*/ nullptr, /*LI*/ nullptr)) {
+      merged = true;
+      // Continue to merge the current block without advancing.
+      continue;
+    }
+    ++BBIter;
+  }
+  return merged;
+}
+
 /// Splits the critical edges between from and to. This code assumes there is
 /// only one edge between the two basic blocks.
 SILBasicBlock *swift::splitIfCriticalEdge(SILBasicBlock *From,

--- a/test/DebugInfo/returnlocation.swift
+++ b/test/DebugInfo/returnlocation.swift
@@ -184,7 +184,7 @@ public class Class1 {
   public required init?() {
     print("hello")
     // CHECK_INIT: call {{.*}}@"$ss5print_9separator10terminatoryypd_S2StF"{{.*}}, !dbg [[printLoc:![0-9]+]]
-    // CHECK_INIT: ret i64 0, !dbg [[retnLoc:![0-9]+]]
+    // CHECK_INIT: ret i{{32|64}} 0, !dbg [[retnLoc:![0-9]+]]
 
     // CHECK_INIT: [[retnLoc]] = !DILocation(line: 0
     // CHECK_INIT: [[printLoc]] = !DILocation(line: [[@LINE-5]]

--- a/test/DebugInfo/returnlocation.swift
+++ b/test/DebugInfo/returnlocation.swift
@@ -184,10 +184,10 @@ public class Class1 {
   public required init?() {
     print("hello")
     // CHECK_INIT: call {{.*}}@"$ss5print_9separator10terminatoryypd_S2StF"{{.*}}, !dbg [[printLoc:![0-9]+]]
-    // CHECK_INIT: br label {{.*}}, !dbg [[retnLoc:![0-9]+]]
+    // CHECK_INIT: ret i64 0, !dbg [[retnLoc:![0-9]+]]
 
-    // CHECK_INIT: [[printLoc]] = !DILocation(line: [[@LINE-4]]
-    // CHECK_INIT: [[retnLoc]] = !DILocation(line: [[@LINE+1]]
+    // CHECK_INIT: [[retnLoc]] = !DILocation(line: 0
+    // CHECK_INIT: [[printLoc]] = !DILocation(line: [[@LINE-5]]
     return nil
   }
 }

--- a/test/IRGen/nondominant.sil
+++ b/test/IRGen/nondominant.sil
@@ -16,11 +16,9 @@ bb1:
   br bb2
 }
 // CHECK:   define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @test0()
-// CHECK:     br
 // CHECK-NOT: }
 // CHECK:     ret i8 7
 // CHECK-NOT: }
-// CHECK:     br
 // CHECK:   }
 
 // Just don't crash on this one.

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -38,12 +38,8 @@ struct FailableStruct {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers14FailableStructV24failBeforeInitializationACSgyt_tcfC
 // CHECK:       bb0(%0 : $@thin FailableStruct.Type):
 // CHECK:         [[SELF_BOX:%.*]] = alloc_stack $FailableStruct
-// CHECK:         br bb1
-// CHECK:       bb1:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
+// CHECK:         dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK-NEXT:    return [[SELF]]
   init?(failBeforeInitialization: ()) {
     return nil
@@ -57,14 +53,10 @@ struct FailableStruct {
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[WRITE]]
 // CHECK-NEXT:    store [[CANARY]] to [[X_ADDR]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableStruct
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
 // CHECK-NEXT:    destroy_addr [[X_ADDR]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK-NEXT:    return [[SELF]]
   init?(failAfterPartialInitialization: ()) {
     x = Canary()
@@ -84,13 +76,9 @@ struct FailableStruct {
 // CHECK-NEXT:    [[Y_ADDR:%.*]] = struct_element_addr [[WRITE]]
 // CHECK-NEXT:    store [[CANARY2]] to [[Y_ADDR]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableStruct
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK-NEXT:    return [[NEW_SELF]]
   init?(failAfterFullInitialization: ()) {
     x = Canary()
@@ -105,13 +93,9 @@ struct FailableStruct {
 // CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableStruct
 // CHECK-NEXT:    store [[CANARY]] to [[WRITE]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableStruct
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK-NEXT:    return [[SELF_VALUE]]
   init?(failAfterWholeObjectInitializationByAssignment: ()) {
     self = FailableStruct(noFail: ())
@@ -124,13 +108,9 @@ struct FailableStruct {
 // CHECK:         [[INIT_FN:%.*]] = function_ref @$s35definite_init_failable_initializers14FailableStructV6noFailACyt_tcfC
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = apply [[INIT_FN]](%0)
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK-NEXT:    return [[NEW_SELF]]
   init?(failAfterWholeObjectInitializationByDelegation: ()) {
     self.init(noFail: ())
@@ -147,7 +127,9 @@ struct FailableStruct {
 //
 // CHECK:       [[FAIL_BB]]:
 // CHECK-NEXT:    release_value [[SELF_OPTIONAL]]
-// CHECK-NEXT:    br [[FAIL_EPILOG_BB:bb[0-9]+]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
+// CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
+// CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableStruct>)
 //
 // CHECK:       [[SUCC_BB]]:
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
@@ -157,11 +139,6 @@ struct FailableStruct {
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableStruct>)
-//
-// CHECK:       [[FAIL_EPILOG_BB]]:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
-// CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
-// CHECK-NEXT:    br [[EPILOG_BB]]([[NEW_SELF]] : $Optional<FailableStruct>)
 //
 // CHECK:       [[EPILOG_BB]]([[NEW_SELF:%.*]] : $Optional<FailableStruct>)
 // CHECK-NEXT:    return [[NEW_SELF]]
@@ -212,12 +189,8 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers22FailableAddrOnlyStructV{{[_0-9a-zA-Z]*}}failBeforeInitialization{{.*}}tcfC
 // CHECK:       bb0(%0 : $*Optional<FailableAddrOnlyStruct<T>>, %1 : $@thin FailableAddrOnlyStruct<T>.Type):
 // CHECK:         [[SELF_BOX:%.*]] = alloc_stack $FailableAddrOnlyStruct<T>
-// CHECK:         br bb1
-// CHECK:       bb1:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
+// CHECK:         dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    inject_enum_addr %0
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK:         return
   init?(failBeforeInitialization: ()) {
     return nil
@@ -235,14 +208,10 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK-NEXT:    copy_addr [take] [[X_BOX]] to [initialization] [[X_ADDR]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    dealloc_stack [[X_BOX]]
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
 // CHECK-NEXT:    destroy_addr [[X_ADDR]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    inject_enum_addr %0
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK:         return
   init?(failAfterPartialInitialization: ()) {
     x = T()
@@ -270,13 +239,9 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK-NEXT:    copy_addr [take] [[Y_BOX]] to [initialization] [[Y_ADDR]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    dealloc_stack [[Y_BOX]]
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    inject_enum_addr %0
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK:         return
   init?(failAfterFullInitialization: ()) {
     x = T()
@@ -548,8 +513,10 @@ struct ThrowStruct {
 // CHECK-NEXT:    cond_br [[COND]], [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
 //
 // CHECK:       [[FAIL_BB]]:
-// CHECK-NEXT:    release_value [[SELF_OPTIONAL]]
-// CHECK-NEXT:    br [[FAIL_EPILOG_BB:bb[0-9]+]]
+// CHECK:         release_value [[SELF_OPTIONAL]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
+// CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<ThrowStruct>, #Optional.none!enumelt
+// CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<ThrowStruct>)
 //
 // CHECK:       [[SUCC_BB]]:
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
@@ -560,21 +527,13 @@ struct ThrowStruct {
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<ThrowStruct>)
 //
-// CHECK:       [[FAIL_EPILOG_BB]]:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
-// CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<ThrowStruct>, #Optional.none!enumelt
-// CHECK-NEXT:    br [[EPILOG_BB]]([[NEW_SELF]] : $Optional<ThrowStruct>)
-//
 // CHECK:       [[EPILOG_BB]]([[NEW_SELF:%.*]] : $Optional<ThrowStruct>):
 // CHECK-NEXT:    return [[NEW_SELF]] : $Optional<ThrowStruct>
 //
-// CHECK:       [[TRY_APPLY_FAIL_TRAMPOLINE_BB:bb[0-9]+]]:
+// CHECK:       [[TRY_APPLY_FAIL_BB]]([[ERROR]] : $Error):
 // CHECK-NEXT:    strong_release [[ERROR:%.*]] : $Error
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<ThrowStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br [[TRY_APPLY_CONT]]([[NEW_SELF]] : $Optional<ThrowStruct>)
-//
-// CHECK:       [[TRY_APPLY_FAIL_BB]]([[ERROR]] : $Error):
-// CHECK-NEXT:    br [[TRY_APPLY_FAIL_TRAMPOLINE_BB]]
   init?(throwsToOptional: Int) {
     try? self.init(failDuringDelegation: throwsToOptional)
   }
@@ -767,12 +726,8 @@ class FailableBaseClass {
 // CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [dynamic] [[MEMBER_ADDR]] : $*Canary
 // CHECK-NEXT:    store [[CANARY]] to [[WRITE]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*Canary
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    strong_release %0
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK-NEXT:    return [[NEW_SELF]]
   init?(failAfterFullInitialization: ()) {
     member = Canary()
@@ -782,12 +737,8 @@ class FailableBaseClass {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers17FailableBaseClassC20failBeforeDelegationACSgyt_tcfC
 // CHECK:       bb0(%0 : $@thick FailableBaseClass.Type):
 // CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $FailableBaseClass
-// CHECK:         br bb1
-// CHECK:       bb1:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
+// CHECK:         dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK-NEXT:    return [[RESULT]]
   convenience init?(failBeforeDelegation: ()) {
     return nil
@@ -799,13 +750,9 @@ class FailableBaseClass {
 // CHECK:         [[INIT_FN:%.*]] = class_method %0
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = apply [[INIT_FN]](%0)
 // CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK-NEXT:    return [[RESULT]]
   convenience init?(failAfterDelegation: ()) {
     self.init(noFail: ())
@@ -834,8 +781,8 @@ class FailableBaseClass {
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableBaseClass>)
 //
 // CHECK:       [[FAIL_TRAMPOLINE_BB]]:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
-// CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
+// CHECK:         dealloc_stack [[SELF_BOX]]
+// CHECK:         [[NEW_SELF:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
 // CHECK-NEXT:    br [[EPILOG_BB]]([[NEW_SELF]] : $Optional<FailableBaseClass>)
 //
 // CHECK:       [[EPILOG_BB]]([[NEW_SELF:%.*]] : $Optional<FailableBaseClass>):
@@ -875,14 +822,10 @@ class FailableDerivedClass : FailableBaseClass {
 // CHECK:       bb0(%0 : $FailableDerivedClass):
 // CHECK:         [[SELF_BOX:%.*]] = alloc_stack $FailableDerivedClass
 // CHECK:         store %0 to [[SELF_BOX]]
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thick FailableDerivedClass.Type
 // CHECK-NEXT:    dealloc_partial_ref %0 : $FailableDerivedClass, [[METATYPE]] : $@thick FailableDerivedClass.Type
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[RESULT:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.none!enumelt
-// CHECK-NEXT:    br bb2
-// CHECK:       bb2:
 // CHECK-NEXT:    return [[RESULT]]
   init?(derivedFailBeforeDelegation: ()) {
     return nil
@@ -905,7 +848,9 @@ class FailableDerivedClass : FailableBaseClass {
 //
 // CHECK:       [[FAIL_BB]]:
 // CHECK-NEXT:    release_value [[SELF_OPTIONAL]]
-// CHECK-NEXT:    br [[FAIL_TRAMPOLINE_BB:bb[0-9]+]]
+// CHECK:         dealloc_stack [[SELF_BOX]]
+// CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.none!enumelt
+// CHECK-NEXT:    br [[EPILOG_BB]]([[NEW_SELF]] : $Optional<FailableDerivedClass>)
 //
 // CHECK:       [[SUCC_BB]]:
 // CHECK-NEXT:    [[BASE_SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
@@ -916,11 +861,6 @@ class FailableDerivedClass : FailableBaseClass {
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableDerivedClass>)
-//
-// CHECK:       [[FAIL_TRAMPOLINE_BB]]:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
-// CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.none!enumelt
-// CHECK-NEXT:    br [[EPILOG_BB]]([[NEW_SELF]] : $Optional<FailableDerivedClass>)
 //
 // CHECK:       [[EPILOG_BB]]([[NEW_SELF:%.*]] : $Optional<FailableDerivedClass>):
 // CHECK-NEXT:    return [[NEW_SELF]] : $Optional<FailableDerivedClass>

--- a/test/SILOptimizer/definite_init_failable_initializers_objc.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_objc.swift
@@ -39,12 +39,15 @@ class Cat : FakeNSObject {
     // CHECK-NEXT: cond_br [[COND]], bb1, bb2
 
   // CHECK: bb1:
-    // CHECK-NEXT: br bb4
+    // CHECK-NEXT: [[FIELD_ADDR:%.*]] = ref_element_addr %2 : $Cat, #Cat.x
+    // CHECK-NEXT: destroy_addr [[FIELD_ADDR]] : $*LifetimeTracked
+    // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick Cat.Type
+    // CHECK-NEXT: dealloc_partial_ref %2 : $Cat, [[METATYPE]] : $@thick Cat.Type
+    // CHECK-NEXT: dealloc_stack [[SELF_BOX]] : $*Cat
+    // CHECK-NEXT: [[RESULT:%.*]] = enum $Optional<Cat>, #Optional.none!enumelt
+    // CHECK-NEXT: br bb3([[RESULT]] : $Optional<Cat>)
 
   // CHECK: bb2:
-    // ChECK-NEXT br bb3
-
-  // CHECK: bb3:
     // CHECK-NEXT: [[SUPER:%.*]] = upcast %2 : $Cat to $FakeNSObject
     // CHECK-NEXT: [[SUB:%.*]] = unchecked_ref_cast [[SUPER]] : $FakeNSObject to $Cat
     // CHECK-NEXT: [[SUPER_FN:%.*]] = objc_super_method [[SUB]] : $Cat, #FakeNSObject.init!initializer.1.foreign : (FakeNSObject.Type) -> () -> FakeNSObject, $@convention(objc_method) (@owned FakeNSObject) -> @owned FakeNSObject
@@ -56,18 +59,9 @@ class Cat : FakeNSObject {
     // CHECK-NEXT: [[RESULT:%.*]] = enum $Optional<Cat>, #Optional.some!enumelt.1, [[NEW_SELF]] : $Cat
     // CHECK-NEXT: destroy_addr [[SELF_BOX]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]] : $*Cat
-    // CHECK-NEXT: br bb5([[RESULT]] : $Optional<Cat>)
+    // CHECK-NEXT: br bb3([[RESULT]] : $Optional<Cat>)
 
-  // CHECK: bb4:
-    // CHECK-NEXT: [[FIELD_ADDR:%.*]] = ref_element_addr %2 : $Cat, #Cat.x
-    // CHECK-NEXT: destroy_addr [[FIELD_ADDR]] : $*LifetimeTracked
-    // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick Cat.Type
-    // CHECK-NEXT: dealloc_partial_ref %2 : $Cat, [[METATYPE]] : $@thick Cat.Type
-    // CHECK-NEXT: dealloc_stack [[SELF_BOX]] : $*Cat
-    // CHECK-NEXT: [[RESULT:%.*]] = enum $Optional<Cat>, #Optional.none!enumelt
-    // CHECK-NEXT: br bb5([[RESULT]] : $Optional<Cat>)
-
-  // CHECK: bb5([[RESULT:%.*]] : $Optional<Cat>):
+  // CHECK: bb3([[RESULT:%.*]] : $Optional<Cat>):
     // CHECK-NEXT: return [[RESULT]] : $Optional<Cat>
 
   init?(n: Int, after: Bool) {

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -54,41 +54,29 @@ unwind:
 // CHECK:  [[MK_IND:%.*]] = function_ref @make_indirect
 // CHECK:  apply [[MK_IND]]<SomeSubclass>([[TEMP]])
 // CHECK:  destroy_addr [[TEMP]] : $*Indirect<SomeSubclass>
-// CHECK:  cond_br %0, bb3, bb5
+// CHECK:  cond_br %0, bb1, bb2
 
-// CHECK:bb1:
+// CHECK: bb1:
+// CHECK:   [[I4:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:   apply [[MARKER]]([[I4]])
 // CHECK:  [[I2:%.*]] = integer_literal $Builtin.Int32, 2000
 // CHECK:  apply [[MARKER2]]([[I2]])
 // CHECK:  dealloc_stack [[TEMP]] : $*Indirect<SomeSubclass>
-// CHECK:  br bb4
+// CHECK:   [[I5:%.*]] = integer_literal $Builtin.Int32, 20
+// CHECK:   apply [[MARKER]]([[I5]])
+// CHECK:  br bb3
 
 // CHECK: bb2:
+// CHECK:   [[I6:%.*]] = integer_literal $Builtin.Int32, 11
+// CHECK:   apply [[MARKER]]([[I6]])
 // CHECK:  [[I3:%.*]] = integer_literal $Builtin.Int32, 3000
 // CHECK:  apply [[MARKER2]]([[I3]])
 // CHECK:  dealloc_stack [[TEMP]] : $*Indirect<SomeSubclass>
-// CHECK:  br bb6
-
-// CHECK: bb3:
-// CHECK:   [[I4:%.*]] = integer_literal $Builtin.Int32, 10
-// CHECK:   apply [[MARKER]]([[I4]])
-// CHECK:   br bb1
-
-// CHECK: bb4:
-// CHECK:   [[I5:%.*]] = integer_literal $Builtin.Int32, 20
-// CHECK:   apply [[MARKER]]([[I5]])
-// CHECK:  br bb7
-
-// CHECK: bb5:
-// CHECK:   [[I6:%.*]] = integer_literal $Builtin.Int32, 11
-// CHECK:   apply [[MARKER]]([[I6]])
-// CHECK:   br bb2
-
-// CHECK: bb6:
 // CHECK:   [[I7:%.*]] = integer_literal $Builtin.Int32, 21
 // CHECK:   [[MARKER]]([[I7]])
-// CHECK:  br bb7
+// CHECK:  br bb3
 
-// CHECK:bb7:
+// CHECK:bb3:
 // CHECK:  return
 // CHECK:}
 
@@ -197,34 +185,19 @@ cont:
 // CHECK-NEXT:   %2 = function_ref @marker
 // CHECK-NEXT:   %3 = integer_literal $Builtin.Int32, 1000
 // CHECK-NEXT:   %4 = apply %2(%3)
-// CHECK-NEXT:   cond_br %0, bb3, bb5
-
+// CHECK-NEXT:   cond_br %0, bb1, bb2
 // CHECK:      bb1:
 // CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int32, 2000
 // CHECK-NEXT:   apply %2([[T0]])
 // CHECK-NEXT:   destroy_value %1 : $SomeClass
 // CHECK-NEXT:   tuple ()
-// CHECK-NEXT:   br bb4
-
+// CHECK-NEXT:   br bb3
 // CHECK:      bb2:
 // CHECK-NEXT:   [[T1:%.*]] = integer_literal $Builtin.Int32, 3000
 // CHECK-NEXT:   apply %2([[T1]])
 // CHECK-NEXT:   destroy_value %1 : $SomeClass
-// CHECK-NEXT:   br bb6
-
+// CHECK-NEXT:   br bb3
 // CHECK:      bb3:
-// CHECK-NEXT:   br bb1
-
-// CHECK:      bb4:
-// CHECK-NEXT:   br bb7
-
-// CHECK:      bb5:
-// CHECK-NEXT:   br bb2
-
-// CHECK:      bb6:
-// CHECK-NEXT:   br bb7
-
-// CHECK:      bb7:
 // CHECK-NEXT:   [[T0:%.*]] = tuple ()
 // CHECK-NEXT:   return [[T0]] : $()
 
@@ -298,15 +271,17 @@ unwind:
 // CHECK-NEXT:   %1 = alloc_stack $Builtin.Int8
 // CHECK-NEXT:   %2 = integer_literal $Builtin.Int8, 8
 // CHECK-NEXT:   store %2 to [trivial] %1 : $*Builtin.Int8
-// CHECK-NEXT:   cond_br %0, bb3, bb5
+// CHECK-NEXT:   cond_br %0, bb1, bb2
 
 // CHECK:      bb1:
+// CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int8, 8
+// CHECK-NEXT:   store [[T0]] to [trivial] %1 : $*Builtin.Int8
 // CHECK-NEXT:   // function_ref
 // CHECK-NEXT:   [[USE:%.*]] = function_ref @use : $@convention(thin) (@in Builtin.Int8) -> ()
 // CHECK-NEXT:   apply [[USE]](%1) : $@convention(thin) (@in Builtin.Int8) -> ()
 // CHECK-NEXT:   dealloc_stack %1 : $*Builtin.Int8
 // CHECK-NEXT:   tuple ()
-// CHECK-NEXT:   br bb4
+// CHECK-NEXT:   br bb3
 
 // CHECK:      bb2:
 // CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int32, 3000
@@ -314,23 +289,9 @@ unwind:
 // CHECK-NEXT:   [[MARKER:%.*]] = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK-NEXT:   apply [[MARKER]]([[T0]]) : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK-NEXT:   dealloc_stack %1 : $*Builtin.Int8
-// CHECK-NEXT:   br bb6
+// CHECK-NEXT:   br bb3
 
 // CHECK:      bb3:
-// CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int8, 8
-// CHECK-NEXT:   store [[T0]] to [trivial] %1 : $*Builtin.Int8
-// CHECK-NEXT:   br bb1
-
-// CHECK:      bb4:
-// CHECK-NEXT:   br bb7
-
-// CHECK:      bb5:
-// CHECK-NEXT:   br bb2
-
-// CHECK:      bb6:
-// CHECK-NEXT:   br bb7
-
-// CHECK:      bb7:
 // CHECK-NEXT:   [[T0:%.*]] = tuple ()
 // CHECK-NEXT:   return [[T0]] : $()
 // CHECK:      }
@@ -471,8 +432,6 @@ unwind:
 // CHECK-NEXT:    store [[I1000]] to [trivial] [[A32]]
 // CHECK-NEXT:    [[I2000:%.*]] = integer_literal $Builtin.Int32, 2000
 // CHECK-NEXT:    apply [[MARKER]]([[I2000]])
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    [[I3000:%.*]] = integer_literal $Builtin.Int32, 3000
 // CHECK-NEXT:    apply [[MARKER]]([[I3000]])
 // CHECK-NEXT:    dealloc_stack [[A32]] : $*Builtin.Int32
@@ -481,8 +440,6 @@ unwind:
 // CHECK-NEXT:    [[I4000:%.*]] = integer_literal $Builtin.Int32, 4000
 // CHECK-NEXT:    apply [[MARKER]]([[I4000]])
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    br [[END:bb[0-9]+]]
-// CHECK:       [[END]]:
 // CHECK-NEXT:    [[RET:%.*]] = tuple ()
 // CHECK-NEXT:    return [[RET]] : $()
 // CHECK-LABEL: // end sil function 'test_stack_overlap_dealloc'
@@ -507,15 +464,11 @@ bb0:
 // CHECK-NEXT:    [[I2000:%.*]] = integer_literal $Builtin.Int32, 2000
 // CHECK-NEXT:    apply [[MARKER]]([[I2000]])
 // CHECK-NEXT:    [[A16:%.*]] = alloc_stack $Builtin.Int16
-// CHECK-NEXT:    br bb1
-// CHECK:       bb1:
 // CHECK-NEXT:    [[I3000:%.*]] = integer_literal $Builtin.Int32, 3000
 // CHECK-NEXT:    apply [[MARKER]]([[I3000]])
 // CHECK-NEXT:    [[I4000:%.*]] = integer_literal $Builtin.Int32, 4000
 // CHECK-NEXT:    apply [[MARKER]]([[I4000]])
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    br [[END:bb[0-9]+]]
-// CHECK:       [[END]]:
 // CHECK-NEXT:    dealloc_stack [[A16]] : $*Builtin.Int16
 //   Note that this has been delayed to follow stack discipline.
 // CHECK-NEXT:    dealloc_stack [[A32]] : $*Builtin.Int32

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -353,19 +353,13 @@ sil @inline_test_control_flow : $@convention(thin) (Float) -> Float {
 
 // CHECK: [[BB5]]:
   // CHECK: [[VAL50:%.*]] = load [[PB16]]
-  // CHECK: br [[BB6:.*]]([[VAL50]]
-
-// CHECK: [[BB6]]([[VAL52:%.*]] : $Float):
   // CHECK: strong_release [[VAL16]]
   // CHECK: strong_release [[VAL15]]
-  // CHECK: br [[BB7:.*]]([[VAL52]]
-
-// CHECK: [[BB7]]([[VAL56:%.*]] : $Float):
   // CHECK: [[VAL57:%.*]] = function_ref @convertFromBuiltinFloatLiteral
   // CHECK: [[VAL58:%.*]] = metatype $@thin Float.Type
   // CHECK: [[VAL59:%.*]] = float_literal $Builtin.FPIEEE64, 0x4008000000000000
   // CHECK: [[VAL60:%.*]] = apply [[VAL57]]([[VAL59]], [[VAL58]])
-  // CHECK: [[VAL61:%.*]] = apply [[VAL3]]([[VAL56]], [[VAL60]])
+  // CHECK: [[VAL61:%.*]] = apply [[VAL3]]([[VAL50]], [[VAL60]])
   // CHECK: strong_release [[VAL1]]
   // CHECK: return [[VAL61]]
 
@@ -512,22 +506,14 @@ bb0(%0 : $@callee_owned (@owned Builtin.NativeObject) -> @owned Builtin.NativeOb
 // CHECK-LABEL: sil [transparent] @test_partial_nativeobject_foo : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 // CHECK: bb0([[ARG:%.*]] : $Builtin.NativeObject):
 // CHECK:   [[FN:%.*]] = function_ref @test_partial_nativeobject_baz :
-// CHECK:   br bb1
-//
-// CHECK: bb1:
 // CHECK:   strong_retain [[ARG]]
 // CHECK:   [[PAI:%.*]] = partial_apply [[FN]]([[ARG]])
-// CHECK:   br bb2
-//
-// CHECK: bb2:
 // CHECK:   strong_retain [[ARG]]
 // CHECK:   strong_retain [[PAI]]
 // CHECK:   strong_retain [[ARG]]
 // CHECK:   strong_release [[PAI]]
 // CHECK:   [[FN2:%.*]] = function_ref @nativeobject_plus :
 // CHECK:   [[RESULT:%.*]] = apply [[FN2]]([[ARG]], [[ARG]])
-//
-// CHECK: bb3:
 // CHECK:   strong_retain [[PAI]]
 // CHECK:   [[OPAQUE_FN:%.*]] = function_ref @partial_apply_user
 // CHECK:   apply [[OPAQUE_FN]]([[PAI]])
@@ -631,9 +617,6 @@ sil @test_short_circuit : $@convention(thin) (Bool, Bool) -> Bool {
   // CHECK: br [[BB3]](
 
 // CHECK: [[BB3]](
-  // CHECK: br [[BB4:.*]](
-
-// CHECK: [[BB4]](
   // CHECK: strong_release [[VAL4]]
   // CHECK: return {{.*}}
 
@@ -681,9 +664,6 @@ sil @test_short_circuit2 : $@convention(thin) (Bool, Bool) -> Bool {
   // CHECK: br [[BB3]](
 
 // CHECK: [[BB3]](
-  // CHECK: br [[BB4:.*]](
-
-// CHECK: [[BB4]](
   // CHECK: strong_release [[VAL3]]
   // CHECK: return {{.*}}
 

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -57,14 +57,15 @@ bb2:
 // CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $C
 // CHECK:   [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $C, #C.i
 // CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Builtin.Int64
-// CHECK: bb{{.*}}([[RET:%.*]] : @trivial $Builtin.Int64):
-// CHECK:   end_borrow [[BORROW]] : $C
-// CHECK:   destroy_value %0 : $C
-// CHECK:   return [[RET]] : $Builtin.Int64
-// CHECK: bb{{.*}}([[ERR:%.*]] : @owned $Error):
+// CHECK: bb{{.*}}:
+// CHECK:   [[ERR:%.*]] = alloc_existential_box $Error, $MyError
 // CHECK:   end_borrow [[BORROW]] : $C
 // CHECK:   destroy_value %0 : $C
 // CHECK:   throw [[ERR]] : $Error
+// CHECK: bb{{.*}}:
+// CHECK:   end_borrow [[BORROW]] : $C
+// CHECK:   destroy_value %0 : $C
+// CHECK:   return [[VAL]] : $Builtin.Int64
 // CHECK-LABEL: } // end sil function 'callerWithThrow'
 sil @callerWithThrow : $@convention(thin) (@owned C) -> (Builtin.Int64, @error Error) {
 bb(%0 : @owned $C):

--- a/validation-test/compiler_scale/array_init.swift.gyb
+++ b/validation-test/compiler_scale/array_init.swift.gyb
@@ -1,0 +1,13 @@
+// RUN: %scale-test -Onone --begin 0 --end 10 --step 1 --select transferNodesFromList %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+// Test that mandatory inlining is linear on a long series of integer
+// initialization calls.
+
+ let _: [Int] = [
+ %for i in range(0, N):
+   1,
+ %end
+   1
+ ]


### PR DESCRIPTION
A recent SILCloner rewrite removed a special case hack for single
basic block callee functions:

commit c6865c0dff6bca722d6847e4ce8327203760b726
Merge: 76e6c4157e 9e440d13a6
Author: Andrew Trick <atrick@apple.com>
Date:   Thu Oct 11 14:23:32 2018

    Merge pull request #19786 from atrick/silcloner-cleanup

    SILCloner and SILInliner rewrite.

Instead, the new inliner simply merges trivial unconditional branches
after inlining the return block. This way, the CFG is always in
canonical state after inlining. This is more robust, and avoids
interfering with subsequent SIL passes when non-single-block callees
are inlined.

The problem is that inlining a series of calls within a large block
could result in interleaved block splitting and merging operations,
which is quadratic in the block size. This showed up when inlining the
tens of thousands of array subscript calls emitted for a large array
initialization.

The fix is to simply defer block merging until all calls are
inlined. This both solves the original problem of canonicalizing the
inliner output and eliminates the quadratic behavior.

We can't expect SimplifyCFG to run immediately after inlining, nor
would we want to do that, *especially* for mandatory inlining. This
fix instead exposes block merging as a trivial utility.

Fixes SR-9223: Inliner exhibits slow compilation time with a large
static array.

Note: by eliminating some unconditional branches, this change could
reduce the number of debug locations emitted. This does not
fundamentally change any debug information guarantee, and I was unable
to observe any behavior difference in the debugger.
