### PR TITLE
runtime: adjust LLVMSupport for Windows

### DIFF
--- a/stdlib/public/runtime/LLVMSupport.cpp
+++ b/stdlib/public/runtime/LLVMSupport.cpp
@@ -16,8 +16,18 @@
 // to link.
 #if defined(swiftCore_EXPORTS)
 namespace llvm {
+#if defined(_WIN32)
+extern void report_bad_alloc_error(const char *Reason, bool GenCrashDiag);
+void _report_bad_alloc_error(const char *Reason, bool GenCrashDiag) {}
+#if defined(_WIN64)
+#pragma comment(linker, "/alternatename:?report_bad_alloc_error@llvm@@YAXPEBD_N@Z=?_report_bad_alloc_error@llvm@@YAXPEBD_N@Z")
+#else
+#pragma comment(linker, "/alternatename:?report_bad_alloc_error@llvm@@YAXPBD_N@Z=?_report_bad_alloc_error@llvm@@YAXPBD_N@Z")
+#endif
+#else
 void __attribute__((__weak__, __visibility__("hidden")))
 report_bad_alloc_error(const char *Reason, bool GenCrashDiag) {}
+#endif
 } // end namespace llvm
 #endif
 


### PR DESCRIPTION
Windows does not support weak linking.  Use an undocumented linker
feature to provide a default implementation for report_bad_alloc_error
in the case that we are not linking against LLVMSupport.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
