### PR TITLE
unittests: provide additional metadata stubs

### DIFF
--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -180,6 +180,9 @@ void *$ss32_getErrorEmbeddedNSErrorIndirectyyXlSgSPyxGs0B0RzlF(void *) {
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $SkMp[1] = {0};
 
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSHMp[1] = {0};
+
 // Array
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
@@ -190,10 +193,16 @@ const long long $sSaMn[1] = {0};
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $ssSdVMn[1] = {0};
 
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSDMn[1] = {0};
+
 // Set
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $ssSeVMn[1] = {0};
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sShMn[1] = {0};
 
 // Mirror
 
@@ -270,4 +279,9 @@ SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift) swift_closure
 MANGLE_SYM(s20_playgroundPrintHookySScSgvg)() {
   return {nullptr, nullptr};
 }
+
+// ObjectiveC Bridgeable
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $ss21_ObjectiveCBridgeableMp[1] = {0};
 


### PR DESCRIPTION
Provide additional stubs for known metadata.  These are used in the unit
tests which do not link against the standard library and thus do not
have the known metadata.  Augment the existing metadata stubs with the
new decorated names and entries.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
