### PR TITLE
swift-reflection-test: correct typo in windows function name

### DIFF
--- a/tools/swift-reflection-test/swift-reflection-test.c
+++ b/tools/swift-reflection-test/swift-reflection-test.c
@@ -200,9 +200,9 @@ static
 PipeMemoryReader createPipeMemoryReader() {
   PipeMemoryReader Reader;
 #if defined(_WIN32)
-  if (pipe(Reader.to_child, 256, _O_BINARY))
+  if (_pipe(Reader.to_child, 256, _O_BINARY))
     errnoAndExit("Couldn't create pipes to child process");
-  if (pipe(Reader.from_child, 256, _O_BINARY))
+  if (_pipe(Reader.from_child, 256, _O_BINARY))
     errnoAndExit("Couldn't create pipes from child process");
 #else
   if (pipe(Reader.to_child))


### PR DESCRIPTION
Correct the spelling for the pipe function.  Windows prefixes the
remnant POSIX functions with `_`.  Fix the spelling to build on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
