### PR TITLE
Revert "[ParseableInterfaces] Skip value witnesses of resilient conformances"

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1173,6 +1173,23 @@ bool WitnessChecker::findBestWitness(
   }
 
   if (numViable == 0) {
+    // Assume any missing value witnesses for a conformance in a parseable
+    // interface can be treated as opaque.
+    // FIXME: ...but we should do something better about types.
+    if (conformance && !conformance->isInvalid()) {
+      if (auto *SF = DC->getParentSourceFile()) {
+        if (SF->Kind == SourceFileKind::Interface) {
+          auto match = matchWitness(TC, ReqEnvironmentCache, Proto,
+                                    conformance, DC, requirement, requirement);
+          assert(match.isViable());
+          numViable = 1;
+          bestIdx = matches.size();
+          matches.push_back(std::move(match));
+          return true;
+        }
+      }
+    }
+
     if (anyFromUnconstrainedExtension &&
         conformance != nullptr &&
         conformance->isInvalid()) {
@@ -2893,23 +2910,6 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
 }
 
 ResolveWitnessResult
-ConformanceChecker::resolveWitnessAsOpaque(ValueDecl *requirement) {
-  assert(!isa<AssociatedTypeDecl>(requirement) && "Use resolveTypeWitnessVia*");
-  auto match = matchWitness(TC, ReqEnvironmentCache, Proto,
-                            Conformance, DC, requirement, requirement);
-  recordWitness(requirement, match);
-  return ResolveWitnessResult::Success;
-}
-
-static bool isConformanceFromParseableInterface(
-    const NormalProtocolConformance *conformance) {
-  auto *containingSF = conformance->getDeclContext()->getParentSourceFile();
-  if (!containingSF)
-    return false;
-  return containingSF->Kind == SourceFileKind::Interface;
-}
-
-ResolveWitnessResult
 ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   assert(!isa<AssociatedTypeDecl>(requirement) && "Use resolveTypeWitnessVia*");
 
@@ -2926,33 +2926,25 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     }
   }
 
-  // Determine whether we can get a witness for this requirement some other way.
-  bool hasFallbacks = false;
-  if (!hasFallbacks)
-    hasFallbacks = requirement->getAttrs().hasAttribute<OptionalAttr>();
-  if (!hasFallbacks)
-    hasFallbacks = requirement->getAttrs().isUnavailable(TC.Context);
-  if (!hasFallbacks)
-    hasFallbacks = isConformanceFromParseableInterface(Conformance);
+  // Determine whether we can derive a witness for this requirement.
+  bool canDerive = false;
 
-  if (!hasFallbacks) {
-    // Can a witness for this requirement be derived for this nominal type?
-    if (auto derivable = DerivedConformance::getDerivableRequirement(
-                           TC,
-                           nominal,
-                           requirement)) {
-      if (derivable == requirement) {
-        // If it's the same requirement, we can derive it here.
-        hasFallbacks = true;
-      } else {
-        // Otherwise, go satisfy the derivable requirement, which can introduce
-        // a member that could in turn satisfy *this* requirement.
-        auto derivableProto = cast<ProtocolDecl>(derivable->getDeclContext());
-        if (auto conformance =
-              TC.conformsToProtocol(Adoptee, derivableProto, DC, None)) {
-          if (conformance->isConcrete())
-            (void)conformance->getConcrete()->getWitnessDecl(derivable, &TC);
-        }
+  // Can a witness for this requirement be derived for this nominal type?
+  if (auto derivable = DerivedConformance::getDerivableRequirement(
+                         TC,
+                         nominal,
+                         requirement)) {
+    if (derivable == requirement) {
+      // If it's the same requirement, we can derive it here.
+      canDerive = true;
+    } else {
+      // Otherwise, go satisfy the derivable requirement, which can introduce
+      // a member that could in turn satisfy *this* requirement.
+      auto derivableProto = cast<ProtocolDecl>(derivable->getDeclContext());
+      if (auto conformance =
+            TC.conformsToProtocol(Adoptee, derivableProto, DC, None)) {
+        if (conformance->isConcrete())
+          (void)conformance->getConcrete()->getWitnessDecl(derivable, &TC);
       }
     }
   }
@@ -2963,7 +2955,11 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   unsigned bestIdx = 0;
   bool doNotDiagnoseMatches = false;
   bool ignoringNames = false;
-  if (findBestWitness(requirement, hasFallbacks ? nullptr : &ignoringNames,
+  bool considerRenames =
+    !canDerive && !requirement->getAttrs().hasAttribute<OptionalAttr>() &&
+    !requirement->getAttrs().isUnavailable(TC.Context);
+  if (findBestWitness(requirement,
+                      considerRenames ? &ignoringNames : nullptr,
                       Conformance,
                       /* out parameters: */
                       matches, numViable, bestIdx, doNotDiagnoseMatches)) {
@@ -3181,7 +3177,19 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   // We have either no matches or an ambiguous match.
 
   // If we can derive a definition for this requirement, just call it missing.
-  if (hasFallbacks) {
+  if (canDerive) {
+    return ResolveWitnessResult::Missing;
+  }
+
+  // If the requirement is optional, it's okay. We'll satisfy this via
+  // our handling of default definitions.
+  //
+  // FIXME: revisit this once we get default definitions in protocol bodies.
+  //
+  // Treat 'unavailable' implicitly as if it were 'optional'.
+  // The compiler will reject actual uses.
+  auto Attrs = requirement->getAttrs();
+  if (Attrs.hasAttribute<OptionalAttr>() || Attrs.isUnavailable(TC.Context)) {
     return ResolveWitnessResult::Missing;
   }
 
@@ -3344,29 +3352,10 @@ CheckTypeWitnessResult swift::checkTypeWitness(TypeChecker &tc, DeclContext *dc,
 
 ResolveWitnessResult
 ConformanceChecker::resolveWitnessTryingAllStrategies(ValueDecl *requirement) {
-  using ResolveWitnessStrategy =
-      decltype(&ConformanceChecker::resolveWitnessViaLookup);
-  static const constexpr ResolveWitnessStrategy defaultStrategies[] = {
+  decltype(&ConformanceChecker::resolveWitnessViaLookup) strategies[] = {
       &ConformanceChecker::resolveWitnessViaLookup,
       &ConformanceChecker::resolveWitnessViaDerivation,
       &ConformanceChecker::resolveWitnessViaDefault};
-  ArrayRef<ResolveWitnessStrategy> strategies = defaultStrategies;
-
-  // Don't try any sort of derivation when processing a parseable interface.
-  if (isConformanceFromParseableInterface(Conformance)) {
-    if (Conformance->isResilient()) {
-      // Resilient conformances don't allow any sort of devirtualization, so
-      // don't bother looking up witnesses at all.
-      static const constexpr ResolveWitnessStrategy resilientStrategies[] = {
-          &ConformanceChecker::resolveWitnessAsOpaque};
-      strategies = resilientStrategies;
-    } else {
-      static const constexpr ResolveWitnessStrategy interfaceStrategies[] = {
-          &ConformanceChecker::resolveWitnessViaLookup,
-          &ConformanceChecker::resolveWitnessAsOpaque};
-      strategies = interfaceStrategies;
-    }
-  }
 
   for (auto strategy : strategies) {
     ResolveWitnessResult result = (this->*strategy)(requirement);

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -620,9 +620,6 @@ class ConformanceChecker : public WitnessChecker {
   void checkNonFinalClassWitness(ValueDecl *requirement,
                                  ValueDecl *witness);
 
-  /// Resolve the (non-type) witness as requiring dynamic dispatch.
-  ResolveWitnessResult resolveWitnessAsOpaque(ValueDecl *requirement);
-
   /// Resolve a (non-type) witness via name lookup.
   ResolveWitnessResult resolveWitnessViaLookup(ValueDecl *requirement);
 

--- a/test/ParseableInterface/Conformances.swiftinterface
+++ b/test/ParseableInterface/Conformances.swiftinterface
@@ -48,18 +48,6 @@ public struct OpaqueStructImpl: MyProto {}
 // CHECK: function_ref @$s12Conformances7MyProtoPyS2icig
 // CHECK: end sil function '$s16ConformancesUser10testOpaqueSiyF'
 
-public struct ResilientStructImpl: MyProto {
-  @available(*, unavailable) // Ignore this, because the conformance is resilient.
-  public init()
-}
-
-// CHECK-LABEL: sil @$s16ConformancesUser13testResilientSiyF
-// CHECK: witness_method $ResilientStructImpl, #MyProto.init!allocator.1
-// CHECK: witness_method $ResilientStructImpl, #MyProto.method!1
-// CHECK: witness_method $ResilientStructImpl, #MyProto.prop!setter.1
-// CHECK: witness_method $ResilientStructImpl, #MyProto.subscript!getter.1
-// CHECK: end sil function '$s16ConformancesUser13testResilientSiyF'
-
 
 @objc public protocol OptionalReqs {
   @objc optional func method()

--- a/test/ParseableInterface/Inputs/ConformancesUser.swift
+++ b/test/ParseableInterface/Inputs/ConformancesUser.swift
@@ -15,10 +15,6 @@ public func testOpaque() -> Int {
   return testGeneric(OpaqueStructImpl.self)
 }
 
-public func testResilient() -> Int {
-  return testGeneric(ResilientStructImpl.self)
-}
-
 
 func testOptionalGeneric<T: OptionalReqs>(_ obj: T) -> Bool {
   return obj.method?() != nil


### PR DESCRIPTION
This reverts commit 61dd307b3b468dac341c5eba65e3a8dcc157ed2c, the effective part of #20419. It causes problems in a few places, and with #20485 it's no longer necessary for correctness. I'll add test cases later, and possibly revisit this optimization at some point.

rdar://problem/43824088