### PR TITLE
 [ABI] Use generic environment to handle mangled generic keypath types.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -90,9 +90,9 @@ The following symbolic reference kinds are currently implemented:
    dependent-associated-conformance ::= '\x05' .{4}  // Reference points directly to associated conformance descriptor (NOT IMPLEMENTED)
    dependent-associated-conformance ::= '\x06' .{4}  // Reference points indirectly to associated conformance descriptor (NOT IMPLEMENTED)
 
-   associated-conformance-acceess-function ::= '\x07' .{4}  // Reference points directly to associated conformance access function relative to the protocol
-   associated-conformance-acceess-function ::= '\x08' .{4}  // Reference points directly to associated conformance access function relative to the conforming type
-   keypath-metadata-access-function ::= '\x09' {.4}  // Reference points directly to keypath type metadata access function
+   associated-conformance-access-function ::= '\x07' .{4}  // Reference points directly to associated conformance access function relative to the protocol
+   associated-conformance-access-function ::= '\x08' .{4}  // Reference points directly to associated conformance access function relative to the conforming type
+   keypath-metadata-access-function ::= '\x09' {.4}  // Reference points directly to keypath conformance access function
 
 Globals
 ~~~~~~~

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1508,6 +1508,45 @@ enum class GenericRequirementLayoutKind : uint32_t {
   Class = 0,
 };
 
+class GenericEnvironmentFlags {
+  uint32_t Value;
+
+  enum : uint32_t {
+    NumGenericParameterLevelsMask = 0xFFF,
+    NumGenericRequirementsShift = 12,
+    NumGenericRequirementsMask = 0xFFFF << NumGenericRequirementsShift,
+  };
+
+  constexpr explicit GenericEnvironmentFlags(uint32_t value) : Value(value) { }
+
+public:
+  constexpr GenericEnvironmentFlags() : Value(0) { }
+
+  constexpr GenericEnvironmentFlags
+  withNumGenericParameterLevels(uint16_t numGenericParameterLevels) const {
+    return GenericEnvironmentFlags((Value &~ NumGenericParameterLevelsMask)
+                                   | numGenericParameterLevels);
+  }
+
+  constexpr GenericEnvironmentFlags
+  withNumGenericRequirements(uint16_t numGenericRequirements) const {
+    return GenericEnvironmentFlags((Value &~ NumGenericParameterLevelsMask)
+             | (numGenericRequirements << NumGenericRequirementsShift));
+  }
+
+  constexpr unsigned getNumGenericParameterLevels() const {
+    return Value & NumGenericParameterLevelsMask;
+  }
+
+  constexpr unsigned getNumGenericRequirements() const {
+    return (Value & NumGenericRequirementsMask) >> NumGenericRequirementsShift;
+  }
+
+  constexpr uint32_t getIntValue() const {
+    return Value;
+  }
+};
+
 /// Flags used by generic metadata patterns.
 class GenericMetadataPatternFlags : public FlagSet<uint32_t> {
   enum {

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1530,7 +1530,7 @@ public:
 
   constexpr GenericEnvironmentFlags
   withNumGenericRequirements(uint16_t numGenericRequirements) const {
-    return GenericEnvironmentFlags((Value &~ NumGenericParameterLevelsMask)
+    return GenericEnvironmentFlags((Value &~ NumGenericRequirementsMask)
              | (numGenericRequirements << NumGenericRequirementsShift));
   }
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -136,7 +136,7 @@ swift::Demangle::makeSymbolicMangledNameStringRef(const char *base) {
     // Skip over symbolic references.
     if (*end >= '\x01' && *end <= '\x17')
       end += sizeof(uint32_t);
-    if (*end >= '\x18' && *end <= '\x1F')
+    else if (*end >= '\x18' && *end <= '\x1F')
       end += sizeof(void*);
     ++end;
   }

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -657,7 +657,7 @@ emitGeneratorForKeyPath(IRGenModule &IGM,
                         ArrayRef<GenericRequirement> requirements,
                         llvm::function_ref<void(IRGenFunction&,CanType)> emit) {
 
-  return IGM.getAddrOfStringForMetadataRef(name,
+  return IGM.getAddrOfStringForMetadataRef(name, /*alignment=*/2,
       /*shouldSetLowBit=*/true,
       [&](ConstantInitBuilder &B) {
         // Build a stub that loads the necessary bindings from the key path's
@@ -1171,6 +1171,9 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
     fields.addInt32(0);
   }
 
+  // Add the generic environment.
+  fields.addRelativeAddressOrNull(
+    getAddrOfGenericEnvironment(pattern->getGenericSignature()));
   // Store type references for the root and leaf.
   fields.addRelativeAddress(
     emitMetadataGeneratorForKeyPath(*this, rootTy, genericEnv, requirements));

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -707,34 +707,11 @@ emitMetadataGeneratorForKeyPath(IRGenModule &IGM,
                                 CanType type,
                                 GenericEnvironment *genericEnv,
                                 ArrayRef<GenericRequirement> requirements) {
-  // If we have a non-dependent type, use a normal mangled type name.
-  if (!type->hasTypeParameter()) {
-    auto constant = IGM.getTypeRef(type, MangledTypeRefRole::Metadata);
-    auto bitConstant = llvm::ConstantInt::get(IGM.IntPtrTy, 1);
-    return llvm::ConstantExpr::getGetElementPtr(nullptr, constant, bitConstant);
-  }
-
-  // Otherwise, create an accessor.
-  CanGenericSignature genericSig;
-  if (genericEnv)
-    genericSig = genericEnv->getGenericSignature()->getCanonicalSignature();
-
-  IRGenMangler mangler;
-  std::string symbolName =
-    mangler.mangleSymbolNameForKeyPathMetadata(
-      "keypath_get_type", genericSig, type,
-      ProtocolConformanceRef::forInvalid());
-
-  // TODO: Use the standard metadata accessor when there are no arguments
-  // and the metadata accessor is defined.
-  return emitGeneratorForKeyPath(IGM, symbolName, type,
-    IGM.TypeMetadataPtrTy,
-    genericEnv, requirements,
-    [&](IRGenFunction &IGF, CanType substType) {
-      auto ret = IGF.emitTypeMetadataRef(substType);
-      IGF.Builder.CreateRet(ret);
-    });
-};
+  // Produce a mangled name for the type.
+  auto constant = IGM.getTypeRef(type, MangledTypeRefRole::Metadata);
+  auto bitConstant = llvm::ConstantInt::get(IGM.IntPtrTy, 1);
+  return llvm::ConstantExpr::getGetElementPtr(nullptr, constant, bitConstant);
+}
 
 static llvm::Constant *
 emitWitnessTableGeneratorForKeyPath(IRGenModule &IGM,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -67,6 +67,7 @@
 #include "GenericRequirement.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
+#include "IRGenMangler.h"
 #include "IRGenModule.h"
 #include "MetadataPath.h"
 #include "MetadataRequest.h"
@@ -3418,4 +3419,59 @@ llvm::Value *irgen::emitProtocolDescriptorRef(IRGenFunction &IGF,
   val = IGF.Builder.CreateOr(val, isObjCBit);
 
   return val;
+}
+
+llvm::Constant *IRGenModule::getAddrOfGenericEnvironment(
+                                                CanGenericSignature signature) {
+  if (!signature)
+    return nullptr;
+
+  IRGenMangler mangler;
+  auto symbolName = mangler.mangleSymbolNameForGenericEnvironment(signature);
+  return getAddrOfStringForMetadataRef(symbolName, /*alignment=*/0, false,
+      [&] (ConstantInitBuilder &builder) -> ConstantInitFuture {
+        /// Collect the cumulative count of parameters at each level.
+        llvm::SmallVector<uint16_t, 4> genericParamCounts;
+        unsigned curDepth = 0;
+        unsigned genericParamCount = 0;
+        for (const auto gp : signature->getGenericParams()) {
+          if (curDepth != gp->getDepth()) {
+            genericParamCounts.push_back(genericParamCount);
+            curDepth = gp->getDepth();
+          }
+
+          ++genericParamCount;
+        }
+        genericParamCounts.push_back(genericParamCount);
+
+        auto flags = GenericEnvironmentFlags()
+          .withNumGenericParameterLevels(genericParamCounts.size())
+          .withNumGenericRequirements(signature->getRequirements().size());
+
+        ConstantStructBuilder fields = builder.beginStruct();
+        fields.setPacked(true);
+
+        // Flags
+        fields.addInt32(flags.getIntValue());
+
+        // Parameter counts.
+        for (auto count : genericParamCounts) {
+          fields.addInt16(count);
+        }
+
+        // Generic parameters.
+        signature->forEachParam([&](GenericTypeParamType *param,
+                                    bool canonical) {
+          fields.addInt(Int8Ty,
+                        GenericParamDescriptor(GenericParamKind::Type,
+                                               canonical,
+                                               false)
+                          .getIntValue());
+        });
+
+        // Generic requirements
+        irgen::addGenericRequirements(*this, fields, signature,
+                                      signature->getRequirements());
+        return fields.finishAndCreateFuture();
+      });
 }

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -294,3 +294,11 @@ std::string IRGenMangler::mangleSymbolNameForKeyPathMetadata(
     assert(conformance.isInvalid() && "Unknown protocol conformance");
   return finalize();
 }
+
+std::string IRGenMangler::mangleSymbolNameForGenericEnvironment(
+                                              CanGenericSignature genericSig) {
+  beginManglingWithoutPrefix();
+  Buffer << "generic environment ";
+  appendGenericSignature(genericSig);
+  return finalize();
+}

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -416,6 +416,8 @@ public:
                                            CanType type,
                                            ProtocolConformanceRef conformance);
 
+  std::string mangleSymbolNameForGenericEnvironment(
+                                                CanGenericSignature genericSig);
 protected:
   SymbolicMangling
   withSymbolicReferences(IRGenModule &IGM,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1032,6 +1032,7 @@ public:
   ///
   /// \param symbolName The name of the symbol that describes the metadata
   /// being referenced.
+  /// \param alignment If non-zero, the alignment of the requested variable.
   /// \param shouldSetLowBit Whether to set the low bit of the result
   /// constant, which is used by some clients to indicate that the result is
   /// a mangled name.
@@ -1041,6 +1042,7 @@ public:
   /// \returns the address of the global variable describing this metadata.
   llvm::Constant *getAddrOfStringForMetadataRef(
       StringRef symbolName,
+      unsigned alignment,
       bool shouldSetLowBit,
       llvm::function_ref<ConstantInitFuture(ConstantInitBuilder &)> body);
 
@@ -1276,6 +1278,7 @@ public:
   llvm::Constant *getAddrOfObjCModuleContextDescriptor();
   llvm::Constant *getAddrOfClangImporterModuleContextDescriptor();
   ConstantReference getAddrOfParentContextDescriptor(DeclContext *from);
+  llvm::Constant *getAddrOfGenericEnvironment(CanGenericSignature signature);
   llvm::Constant *getAddrOfProtocolRequirementsBaseDescriptor(
                                                   ProtocolDecl *proto);
   llvm::GlobalValue *defineProtocolRequirementsBaseDescriptor(

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -220,6 +220,7 @@ MetadataDependency MetadataDependencyCollector::finish(IRGenFunction &IGF) {
 
 llvm::Constant *IRGenModule::getAddrOfStringForMetadataRef(
     StringRef symbolName,
+    unsigned alignment,
     bool shouldSetLowBit,
     llvm::function_ref<ConstantInitFuture (ConstantInitBuilder &)> body) {
   // Call this to form the return value.
@@ -251,7 +252,8 @@ llvm::Constant *IRGenModule::getAddrOfStringForMetadataRef(
     llvm::GlobalValue::HiddenVisibility,
     llvm::GlobalValue::DefaultStorageClass})
   .to(var);
-  var->setAlignment(2);
+  if (alignment)
+    var->setAlignment(alignment);
   setTrueConstGlobal(var);
   var->setSection(getReflectionTypeRefSectionName());
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -723,9 +723,9 @@ internal final class NonmutatingWritebackBuffer<CurValue, NewValue> {
 }
 
 internal typealias KeyPathComputedArgumentLayoutFn = @convention(thin)
-  (_ patternArguments: UnsafeRawPointer) -> (size: Int, alignmentMask: Int)
+  (_ patternArguments: UnsafeRawPointer?) -> (size: Int, alignmentMask: Int)
 internal typealias KeyPathComputedArgumentInitializerFn = @convention(thin)
-  (_ patternArguments: UnsafeRawPointer,
+  (_ patternArguments: UnsafeRawPointer?,
    _ instanceArguments: UnsafeMutableRawPointer) -> ()
 
 internal enum KeyPathComputedIDKind {
@@ -2397,8 +2397,10 @@ internal func _getSymbolicMangledNameLength(_ base: UnsafeRawPointer) -> Int {
 }
 
 // Resolve the given generic argument reference to a generic argument.
-internal func _resolveKeyPathGenericArgReference(_ reference: UnsafeRawPointer,
-                                                 arguments: UnsafeRawPointer)
+internal func _resolveKeyPathGenericArgReference(
+    _ reference: UnsafeRawPointer,
+    genericEnvironment: UnsafeRawPointer?,
+    arguments: UnsafeRawPointer?)
     -> UnsafeRawPointer {
   // If the low bit is clear, it's a direct reference to the argument.
   if (UInt(bitPattern: reference) & 0x01 == 0) {
@@ -2412,7 +2414,7 @@ internal func _resolveKeyPathGenericArgReference(_ reference: UnsafeRawPointer,
   let first = referenceStart.load(as: UInt8.self)
   if first == 255 && reference.load(as: UInt8.self) == 9 {
     typealias MetadataAccessor =
-      @convention(c) (UnsafeRawPointer) -> UnsafeRawPointer
+      @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer
 
     // Unaligned load of the offset.
     let pointerReference = reference + 1
@@ -2428,7 +2430,10 @@ internal func _resolveKeyPathGenericArgReference(_ reference: UnsafeRawPointer,
   let namePtr = referenceStart.bindMemory(to: UInt8.self,
                                           capacity: nameLength + 1)
   // FIXME: Could extract this information from the mangled name.
-  guard let result = _getTypeByMangledName(namePtr, UInt(nameLength))
+  guard let result =
+    _getTypeByMangledName(namePtr, UInt(nameLength),
+                         genericEnvironment: genericEnvironment,
+                         genericArguments: arguments)
     else {
       let nameStr = String._fromUTF8Repairing(
         UnsafeBufferPointer(start: namePtr, count: nameLength)
@@ -2441,11 +2446,16 @@ internal func _resolveKeyPathGenericArgReference(_ reference: UnsafeRawPointer,
 }
 
 // Resolve the given metadata reference to (type) metadata.
-internal func _resolveKeyPathMetadataReference(_ reference: UnsafeRawPointer,
-                                               arguments: UnsafeRawPointer)
+internal func _resolveKeyPathMetadataReference(
+    _ reference: UnsafeRawPointer,
+    genericEnvironment: UnsafeRawPointer?,
+    arguments: UnsafeRawPointer?)
     -> Any.Type {
   return unsafeBitCast(
-           _resolveKeyPathGenericArgReference(reference, arguments: arguments),
+           _resolveKeyPathGenericArgReference(
+             reference,
+             genericEnvironment: genericEnvironment,
+             arguments: arguments),
            to: Any.Type.self)
 }
 
@@ -2797,9 +2807,10 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
   var didChain: Bool = false
   var root: Any.Type!
   var leaf: Any.Type!
-  let patternArgs: UnsafeRawPointer
+  var genericEnvironment: UnsafeRawPointer?
+  let patternArgs: UnsafeRawPointer?
 
-  init(patternArgs: UnsafeRawPointer) {
+  init(patternArgs: UnsafeRawPointer?) {
     self.patternArgs = patternArgs
   }
 
@@ -2811,12 +2822,17 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
                             rootMetadataRef: MetadataReference,
                             leafMetadataRef: MetadataReference,
                             kvcCompatibilityString: UnsafeRawPointer?) {
+    self.genericEnvironment = genericEnvironment
     // Get the root and leaf type metadata so we can form the class type
     // for the entire key path.
-    root = _resolveKeyPathMetadataReference(rootMetadataRef,
-                                            arguments: patternArgs)
-    leaf = _resolveKeyPathMetadataReference(leafMetadataRef,
-                                            arguments: patternArgs)
+    root = _resolveKeyPathMetadataReference(
+              rootMetadataRef,
+              genericEnvironment: genericEnvironment,
+              arguments: patternArgs)
+    leaf = _resolveKeyPathMetadataReference(
+              leafMetadataRef,
+              genericEnvironment: genericEnvironment,
+              arguments: patternArgs)
   }
 
   mutating func visitStoredComponent(kind: KeyPathStructOrClass,
@@ -2997,11 +3013,12 @@ internal func _getKeyPathClassAndInstanceSizeFromPattern(
 
 internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
   var destData: UnsafeMutableRawBufferPointer
-  let patternArgs: UnsafeRawPointer
+  var genericEnvironment: UnsafeRawPointer?
+  let patternArgs: UnsafeRawPointer?
   var base: Any.Type
 
   init(destData: UnsafeMutableRawBufferPointer,
-       patternArgs: UnsafeRawPointer,
+       patternArgs: UnsafeRawPointer?,
        root: Any.Type) {
     self.destData = destData
     self.patternArgs = patternArgs
@@ -3044,6 +3061,7 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
                             rootMetadataRef: MetadataReference,
                             leafMetadataRef: MetadataReference,
                             kvcCompatibilityString: UnsafeRawPointer?) {
+    self.genericEnvironment = genericEnvironment
   }
 
   mutating func visitStoredComponent(kind: KeyPathStructOrClass,
@@ -3213,8 +3231,10 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
         let base = externalArgs.baseAddress.unsafelyUnwrapped + i
         let offset = base.pointee
         let metadataRef = UnsafeRawPointer(base) + Int(offset)
-        let result = _resolveKeyPathGenericArgReference(metadataRef,
-                                                       arguments: patternArgs)
+        let result = _resolveKeyPathGenericArgReference(
+                       metadataRef,
+                       genericEnvironment: genericEnvironment,
+                       arguments: patternArgs)
         pushDest(result)
       }
     }
@@ -3238,8 +3258,10 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
 
   mutating func visitIntermediateComponentType(metadataRef: MetadataReference) {
     // Get the metadata for the intermediate type.
-    let metadata = _resolveKeyPathMetadataReference(metadataRef,
-                                                    arguments: patternArgs)
+    let metadata = _resolveKeyPathMetadataReference(
+                     metadataRef,
+                     genericEnvironment: genericEnvironment,
+                     arguments: patternArgs)
     pushDest(metadata)
     base = metadata
   }

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -85,12 +85,16 @@ func _typeByName(_ name: String) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)
   return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
     return  _getTypeByMangledName(nameUTF8.baseAddress!,
-                                  UInt(nameUTF8.endIndex))
+                                  UInt(nameUTF8.endIndex),
+                                  genericEnvironment: nil,
+                                  genericArguments: nil)
   }
 }
 
 @_silgen_name("swift_stdlib_getTypeByMangledName")
 internal func _getTypeByMangledName(
   _ name: UnsafePointer<UInt8>,
-  _ nameLength: UInt)
+  _ nameLength: UInt,
+  genericEnvironment: UnsafeRawPointer?,
+  genericArguments: UnsafeRawPointer?)
   -> Any.Type?

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1326,6 +1326,9 @@ buildEnvironmentPath(
   unsigned totalKeyParamCount = 0;
   auto genericParams = environment->getGenericParameters();
   for (unsigned numLocalParams : environment->getGenericParameterCounts()) {
+    // Adkjust totalParamCount so we have the # of local parameters.
+    numLocalParams -= totalParamCount;
+
     // Get the local generic parameters.
     auto localGenericParams = genericParams.slice(0, numLocalParams);
     genericParams = genericParams.slice(numLocalParams);

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -243,10 +243,16 @@ public:
   class SWIFT_RUNTIME_LIBRARY_VISIBILITY SubstGenericParametersFromMetadata {
     const Metadata *base;
 
+    /// The generic arguments.
+    const void * const *genericArgs;
+
     /// An element in the descriptor path.
     struct PathElement {
-      /// The context described by this path element.
-      const ContextDescriptor *context;
+      /// The generic parameters local to this element.
+      ArrayRef<GenericParamDescriptor> localGenericParams;
+
+      /// The total number of generic parameters.
+      unsigned numTotalGenericParams;
 
       /// The number of key parameters in the parent.
       unsigned numKeyGenericParamsInParent;
@@ -277,7 +283,9 @@ public:
   public:
     /// Produce substitutions entirely from the given metadata.
     explicit SubstGenericParametersFromMetadata(const Metadata *base)
-      : base(base) { }
+      : base(base),
+        genericArgs(base ? (const void * const *)base->getGenericArgs()
+                         : nullptr) { }
 
     const Metadata *operator()(unsigned depth, unsigned index) const;
     const WitnessTable *operator()(const Metadata *type, unsigned index) const;

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -206,7 +206,7 @@ sil_vtable C2 {}
 // CHECK-64-SAME: i32 36 }>
 
 // CHECK-LABEL: @"generic environment SHRzSHR_r0_l" = linkonce_odr hidden constant
-// CHECK-SAME: i32 8192, i16 2, i8 -128, i8 -128, i32 128
+// CHECK-SAME: i32 8193, i16 2, i8 -128, i8 -128, i32 128
 
 // -- %t
 // CHECK: [[KP_T:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 1, {{.*}} @"got.$s8keypaths1GV1xxvpMV"

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -195,6 +195,7 @@ sil_vtable C2 {}
 // -- %j: Gen<A>.y
 // CHECK: [[KP_J:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: i32 0
+// CHECK-SAME: @"generic environment l"
 // CHECK-SAME: @"keypath_get_type
 // CHECK-SAME: @"keypath_get_type
 //             -- size 8
@@ -203,6 +204,9 @@ sil_vtable C2 {}
 // CHECK-SAME: <i32 0x01fffffe>,
 // CHECK-32-SAME: i32 20 }>
 // CHECK-64-SAME: i32 36 }>
+
+// CHECK-LABEL: @"generic environment SHRzSHR_r0_l" = linkonce_odr hidden constant
+// CHECK-SAME: i32 8192, i16 2, i8 -128, i8 -128, i32 128
 
 // -- %t
 // CHECK: [[KP_T:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 1, {{.*}} @"got.$s8keypaths1GV1xxvpMV"

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -183,8 +183,9 @@ sil_vtable C2 {}
 // -- %i: Gen<A>.x
 // CHECK: [[KP_I:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: i32 0
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"generic environment l"
+// CHECK-SAME: @"symbolic 8keypaths3GenVyxxG"
+// CHECK-SAME: @"symbolic x"
 //             -- size 8
 // CHECK-SAME: i32 8,
 //             -- struct with runtime-resolved offset, mutable
@@ -196,8 +197,8 @@ sil_vtable C2 {}
 // CHECK: [[KP_J:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: i32 0
 // CHECK-SAME: @"generic environment l"
-// CHECK-SAME: @"keypath_get_type
-// CHECK-SAME: @"keypath_get_type
+// CHECK-SAME: @"symbolic 8keypaths3GenVyxxG"
+// CHECK-SAME: @"symbolic x"
 //             -- size 8
 // CHECK-SAME: i32 8,
 //             -- struct with runtime-resolved offset
@@ -210,14 +211,14 @@ sil_vtable C2 {}
 
 // -- %t
 // CHECK: [[KP_T:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 1, {{.*}} @"got.$s8keypaths1GV1xxvpMV"
-// CHECK-SAME:   @"keypath_get_type
+// CHECK-SAME:   @"symbolic x"
 //            -- computed get-only property, identified by indirect pointer
 // CHECK-SAME:   <i32 0x0208_0002>
 
 // -- %u
 // CHECK: [[KP_U:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 3, {{.*}} @"got.$s8keypaths1GVyxqd__cSHRd__luipMV"
-// CHECK-SAME:   @"keypath_get_type
-// CHECK-SAME:   @"keypath_get_type
+// CHECK-SAME:   @"symbolic q_"
+// CHECK-SAME:   @"symbolic x"
 // CHECK-SAME:   @"keypath_get_witness_table
 //            -- computed get-only property, identified by indirect pointer
 // CHECK-SAME:   <i32 0x0208_0002>

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -768,6 +768,34 @@ keyPath.test("optional chaining component that needs generic instantiation") {
   Value6096<Int>().doSomething()
 }
 
+// Nested generics.
+protocol HasAssoc {
+  associatedtype A
+}
+
+struct Outer<T, U> {
+  struct Middle<V, W, X> {
+  }
+}
+
+extension Outer.Middle where V: HasAssoc, U == V.A, W == X {
+  struct Inner<Y: Hashable> {
+    func foo() ->  AnyKeyPath {
+      return \[Y?: [U]].values
+    }
+  }
+}
+
+extension Double: HasAssoc {
+  typealias A = Float
+}
+
+keyPath.test("nested generics") {
+  let nested = Outer<Int, Float>.Middle<Double, String, String>.Inner<UInt>()
+  let nestedKeyPath = nested.foo()
+  typealias DictType = [UInt? : [Float]]
+  expectTrue(nestedKeyPath is KeyPath<DictType, DictType.Values>)
+}
 
 runAllTests()
 

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -256,7 +256,9 @@ const long long $ss12_ClassMirrorVMa[1] = {0};
 // KeyPath
 
 SWIFT_RUNTIME_STDLIB_SPI
-const HeapObject *swift_getKeyPathImpl(const void *p, const void *a) {
+const HeapObject *swift_getKeyPathImpl(const void *p,
+                                       const void *e,
+                                       const void *a) {
   abort();
 }
 


### PR DESCRIPTION
Always use mangled type names to represent type metadata in keypath patterns.
For generic types, use the generic environment to pull substituted types
from the instantiation arguments.

Finishes the type metadata part of rdar://problem/38038799.