### PR TITLE
[TypeChecker] NFC: Switch @autoclosure compatibility test to pass swi…

### DIFF
--- a/test/Compatibility/attr_autoclosure.swift
+++ b/test/Compatibility/attr_autoclosure.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
-// REQUIRES: SWIFT_VERSION=4
+// RUN: %target-swift-frontend -swift-version 4 -emit-sil -verify %s | %FileCheck %s
 
 do {
   func a(_ x: @autoclosure () -> Int) {}


### PR DESCRIPTION
…ft version to RUN

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
