### PR TITLE
[Misc] NFC: Fix -Wdefaulted-function-deleted warnings

### DIFF
--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -26,8 +26,8 @@ struct SingleRawComment {
     BlockDoc,      ///< \code /** stuff */ \endcode
   };
 
-  const CharSourceRange Range;
-  const StringRef RawText;
+  CharSourceRange Range;
+  StringRef RawText;
 
   unsigned Kind : 8;
   unsigned StartColumn : 16;

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -130,7 +130,9 @@ class CharSourceRange {
 
 public:
   /// \brief Constructs an invalid range.
-  CharSourceRange() {}
+  CharSourceRange() = default;
+
+  CharSourceRange &operator=(const CharSourceRange &) = default;
 
   CharSourceRange(SourceLoc Start, unsigned ByteLength)
     : Start(Start), ByteLength(ByteLength) {}

--- a/include/swift/Basic/TreeScopedHashTable.h
+++ b/include/swift/Basic/TreeScopedHashTable.h
@@ -37,6 +37,11 @@ template <typename K, typename V> class TreeScopedHashTableVal {
   TreeScopedHashTableVal(const K &Key, const V &Val) : Key(Key), Val(Val) {}
 
 public:
+  TreeScopedHashTableVal(const TreeScopedHashTableVal &) = delete;
+  TreeScopedHashTableVal(TreeScopedHashTableVal &&) = delete;
+  TreeScopedHashTableVal &operator=(const TreeScopedHashTableVal &) = delete;
+  TreeScopedHashTableVal &operator=(TreeScopedHashTableVal &&) = delete;
+
   const K &getKey() const { return Key; }
   const V &getValue() const { return Val; }
   V &getValue() { return Val; }
@@ -144,6 +149,11 @@ class TreeScopedHashTableDetachedScope {
   const ImplTy *getImpl() { return DetachedImpl; }
 
 public:
+  TreeScopedHashTableDetachedScope &operator=(
+                            const TreeScopedHashTableDetachedScope &) = default;
+  TreeScopedHashTableDetachedScope &operator=(
+                                 TreeScopedHashTableDetachedScope &&) = default;
+
   TreeScopedHashTableDetachedScope() : DetachedImpl(0) {}
 
   TreeScopedHashTableDetachedScope(TreeScopedHashTableDetachedScope &&Other)

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -835,10 +835,10 @@ private:
 class ProjectionTree {
   friend class ProjectionTreeNode;
 
-  SILModule &Mod;
+  SILModule *Mod;
 
   /// The allocator we use to allocate ProjectionTreeNodes in the tree.
-  llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> &Allocator;
+  llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> *Allocator;
 
   // A common pattern is a 3 field struct.
   llvm::SmallVector<ProjectionTreeNode *, 4> ProjectionTreeNodes;
@@ -854,7 +854,7 @@ public:
   /// initialized by initializeWithExistingTree.
   ProjectionTree(SILModule &Mod,
                  llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> &Allocator)
-      : Mod(Mod), Allocator(Allocator) {}
+      : Mod(&Mod), Allocator(&Allocator) {}
   ~ProjectionTree();
   ProjectionTree(const ProjectionTree &) = delete;
   ProjectionTree(ProjectionTree &&) = default;
@@ -876,7 +876,7 @@ public:
                                              LeafValueMapTy &LeafValues);
 
   /// Return the module associated with this tree.
-  SILModule &getModule() const { return Mod; }
+  SILModule &getModule() const { return *Mod; }
 
   llvm::ArrayRef<ProjectionTreeNode *> getProjectionTreeNodes() {
     return llvm::makeArrayRef(ProjectionTreeNodes);
@@ -960,7 +960,7 @@ private:
   void createRoot(SILType BaseTy) {
     assert(ProjectionTreeNodes.empty() &&
            "Should only create root when ProjectionTreeNodes is empty");
-    auto *Node = new (Allocator.Allocate()) ProjectionTreeNode(BaseTy);
+    auto *Node = new (Allocator->Allocate()) ProjectionTreeNode(BaseTy);
     ProjectionTreeNodes.push_back(Node);
   }
 
@@ -968,8 +968,8 @@ private:
                                      SILType BaseTy,
                                      const Projection &P) {
     unsigned Index = ProjectionTreeNodes.size();
-    auto *Node = new (Allocator.Allocate()) ProjectionTreeNode(Parent, Index,
-                                                               BaseTy, P);
+    auto *Node = new (Allocator->Allocate()) ProjectionTreeNode(Parent, Index,
+                                                                BaseTy, P);
     ProjectionTreeNodes.push_back(Node);
     return ProjectionTreeNodes[Index];
   }

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -1127,7 +1127,7 @@ public:
 ProjectionTree::ProjectionTree(
     SILModule &Mod, SILType BaseTy,
     llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> &Allocator)
-    : Mod(Mod), Allocator(Allocator) {
+    : Mod(&Mod), Allocator(&Allocator) {
   LLVM_DEBUG(llvm::dbgs() << "Constructing Projection Tree For : " << BaseTy
                           << "\n");
 

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -524,7 +524,6 @@ struct LLVM_LIBRARY_VISIBILITY ExclusiveBorrowFormalAccess : FormalAccess {
   ExclusiveBorrowFormalAccess &
   operator=(ExclusiveBorrowFormalAccess &&) = default;
 
-  ExclusiveBorrowFormalAccess() = default;
   ExclusiveBorrowFormalAccess(SILLocation loc,
                               std::unique_ptr<LogicalPathComponent> &&comp,
                               ManagedValue base,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -283,7 +283,7 @@ public:
     DynamicMethod,
   };
 
-  const Kind kind;
+  Kind kind;
 
   // Move, don't copy.
   Callee(const Callee &) = delete;

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -494,7 +494,9 @@ public:
              EpilogueARCFunctionInfo *EAFI, bool disableArrayLoads);
 
   RLEContext(const RLEContext &) = delete;
-  RLEContext(RLEContext &&) = default;
+  RLEContext(RLEContext &&) = delete;
+  RLEContext &operator=(const RLEContext &) = delete;
+  RLEContext &operator=(RLEContext &&) = delete;
   ~RLEContext() = default;
 
   /// Entry point to redundant load elimination.


### PR DESCRIPTION
Top-of-tree clang enables `-Wdefaulted-function-deleted`, therefore the following changes are needed for warning free builds.