### PR TITLE
tools: use target_link_libraries like clang (NFC)

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -4,12 +4,12 @@ add_swift_host_tool(swift
   autolink_extract_main.cpp
   modulewrap_main.cpp
   swift_format_main.cpp
-  LINK_LIBRARIES
-    swiftDriver
-    swiftFrontendTool
   SWIFT_COMPONENT compiler
 )
-
+target_link_libraries(swift
+                      PRIVATE
+                        swiftDriver
+                        swiftFrontendTool)
 if(HAVE_UNICODE_LIBEDIT)
   target_link_libraries(swift PRIVATE edit)
 endif()

--- a/tools/lldb-moduleimport-test/CMakeLists.txt
+++ b/tools/lldb-moduleimport-test/CMakeLists.txt
@@ -1,7 +1,10 @@
 add_swift_host_tool(lldb-moduleimport-test
   lldb-moduleimport-test.cpp
-  LINK_LIBRARIES
-    swiftASTSectionImporter swiftFrontend swiftClangImporter
   SWIFT_COMPONENT tools
 )
+target_link_libraries(lldb-moduleimport-test
+                      PRIVATE
+                        swiftASTSectionImporter
+                        swiftClangImporter
+                        swiftFrontend)
 

--- a/tools/sil-func-extractor/CMakeLists.txt
+++ b/tools/sil-func-extractor/CMakeLists.txt
@@ -1,10 +1,11 @@
 add_swift_host_tool(sil-func-extractor
   SILFunctionExtractor.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftSILGen
-    swiftSILOptimizer
-    swiftSerialization
-    swiftClangImporter
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-func-extractor
+                      PRIVATE
+                        swiftClangImporter
+                        swiftFrontend
+                        swiftSerialization
+                        swiftSILGen
+                        swiftSILOptimizer)

--- a/tools/sil-llvm-gen/CMakeLists.txt
+++ b/tools/sil-llvm-gen/CMakeLists.txt
@@ -1,12 +1,13 @@
 add_swift_host_tool(sil-llvm-gen
   SILLLVMGen.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftIRGen
-    swiftSILGen
-    swiftSILOptimizer
-    # Clang libraries included to appease the linker on linux.
-    clangBasic
-    clangCodeGen
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-llvm-gen
+                      PRIVATE
+                        swiftFrontend
+                        swiftIRGen
+                        swiftSILGen
+                        swiftSILOptimizer
+                        # Clang libraries included to appease the linker on linux.
+                        clangBasic
+                        clangCodeGen)

--- a/tools/sil-nm/CMakeLists.txt
+++ b/tools/sil-nm/CMakeLists.txt
@@ -1,10 +1,11 @@
 add_swift_host_tool(sil-nm
   SILNM.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftSILGen
-    swiftSILOptimizer
-    swiftSerialization
-    swiftClangImporter
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-nm
+                      PRIVATE
+                        swiftClangImporter
+                        swiftFrontend
+                        swiftSerialization
+                        swiftSILGen
+                        swiftSILOptimizer)

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -1,12 +1,13 @@
 add_swift_host_tool(sil-opt
   SILOpt.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftIRGen
-    swiftSILGen
-    swiftSILOptimizer
-    # Clang libraries included to appease the linker on linux.
-    clangBasic
-    clangCodeGen
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-opt
+                      PRIVATE
+                        swiftFrontend
+                        swiftIRGen
+                        swiftSILGen
+                        swiftSILOptimizer
+                        # Clang libraries included to appease the linker on linux.
+                        clangBasic
+                        clangCodeGen)

--- a/tools/sil-passpipeline-dumper/CMakeLists.txt
+++ b/tools/sil-passpipeline-dumper/CMakeLists.txt
@@ -1,13 +1,14 @@
 add_swift_host_tool(sil-passpipeline-dumper
   SILPassPipelineDumper.cpp
-  LINK_LIBRARIES
-    swiftFrontend
-    swiftSILGen
-    swiftSILOptimizer
-    swiftSerialization
-    swiftClangImporter
-    # FIXME: Circular dependencies require re-listing these libraries.
-    swiftSema
-    swiftAST
   SWIFT_COMPONENT tools
 )
+target_link_libraries(sil-passpipeline-dumper
+                      PRIVATE
+                        swiftClangImporter
+                        swiftFrontend
+                        swiftSerialization
+                        swiftSILGen
+                        swiftSILOptimizer
+                        # FIXME: Circular dependencies require re-listing these libraries.
+                        swiftAST
+                        swiftSema)

--- a/tools/swift-api-digester/CMakeLists.txt
+++ b/tools/swift-api-digester/CMakeLists.txt
@@ -2,6 +2,9 @@ add_swift_host_tool(swift-api-digester
   swift-api-digester.cpp
   ModuleAnalyzerNodes.cpp
   ModuleDiagsConsumer.cpp
-  LINK_LIBRARIES swiftFrontend swiftIDE
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-api-digester
+                      PRIVATE
+                        swiftFrontend
+                        swiftIDE)

--- a/tools/swift-demangle-fuzzer/CMakeLists.txt
+++ b/tools/swift-demangle-fuzzer/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_swift_fuzzer_host_tool(swift-demangle-fuzzer
   swift-demangle-fuzzer.cpp
-  LINK_LIBRARIES swiftDemangling
   LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT compiler
   )
+target_link_libraries(swift-demangle-fuzzer
+                      PRIVATE
+                        swiftDemangling)

--- a/tools/swift-demangle-yamldump/CMakeLists.txt
+++ b/tools/swift-demangle-yamldump/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_swift_host_tool(swift-demangle-yamldump
   swift-demangle-yamldump.cpp
-  LINK_LIBRARIES swiftDemangling
   LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT tools
   )
+target_link_libraries(swift-demangle-yamldump
+                      PRIVATE
+                        swiftDemangling)

--- a/tools/swift-demangle/CMakeLists.txt
+++ b/tools/swift-demangle/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_swift_host_tool(swift-demangle
   swift-demangle.cpp
-  LINK_LIBRARIES swiftDemangling
   LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT compiler
   )
+target_link_libraries(swift-demangle
+                      PRIVATE
+                        swiftDemangling)

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -2,12 +2,13 @@ add_swift_host_tool(swift-ide-test
   swift-ide-test.cpp
   ModuleAPIDiff.cpp
   XMLValidator.cpp
-  LINK_LIBRARIES
-    swiftDriver
-    swiftFrontend
-    swiftIDE
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-ide-test
+                      PRIVATE
+                        swiftDriver
+                        swiftFrontend
+                        swiftIDE)
 
 # If libxml2 is available, make it available for swift-ide-test.
 if(SWIFT_HAVE_LIBXML)

--- a/tools/swift-llvm-opt/CMakeLists.txt
+++ b/tools/swift-llvm-opt/CMakeLists.txt
@@ -1,15 +1,13 @@
 add_swift_host_tool(swift-llvm-opt
   LLVMOpt.cpp
-  LINK_LIBRARIES
-  swiftIRGen
-
-  # Swift libraries included to appease the linker on linux.
-  swiftSema
-  swiftAST
-
-  # Clang libraries included to appease the linker on linux.
-  clangBasic
-  clangCodeGen
-
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-llvm-opt
+                      PRIVATE
+                        swiftIRGen
+                        # Swift libraries included to appease the linker on linux.
+                        swiftSema
+                        swiftAST
+                        # Clang libraries included to appease the linker on linux.
+                        clangBasic
+                        clangCodeGen)

--- a/tools/swift-refactor/CMakeLists.txt
+++ b/tools/swift-refactor/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_swift_host_tool(swift-refactor
   swift-refactor.cpp
-  LINK_LIBRARIES swiftDriver swiftFrontend swiftIDE
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-refactor
+                      PRIVATE
+                        swiftDriver
+                        swiftFrontend
+                        swiftIDE)

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_swift_host_tool(swift-remoteast-test
   swift-remoteast-test.cpp
-  LINK_LIBRARIES
-    swiftFrontendTool
-    swiftRemoteAST
   SWIFT_COMPONENT tools
 )
-
+target_link_libraries(swift-remoteast-test
+                      PRIVATE
+                        swiftFrontendTool
+                        swiftRemoteAST)
 set_target_properties(swift-remoteast-test PROPERTIES ENABLE_EXPORTS 1)
 if(HAVE_UNICODE_LIBEDIT)
   target_link_libraries(swift-remoteast-test PRIVATE edit)

--- a/tools/swift-syntax-test/CMakeLists.txt
+++ b/tools/swift-syntax-test/CMakeLists.txt
@@ -1,12 +1,13 @@
 add_swift_host_tool(swift-syntax-test
   swift-syntax-test.cpp
-  LINK_LIBRARIES
-    swiftAST
-    swiftDriver
-    swiftFrontend
-    swiftSema
-    swiftSyntax
   LLVM_COMPONENT_DEPENDS
     Support
   SWIFT_COMPONENT tools
 )
+target_link_libraries(swift-syntax-test
+                      PRIVATE
+                        swiftAST
+                        swiftDriver
+                        swiftFrontend
+                        swiftSema
+                        swiftSyntax)


### PR DESCRIPTION
Rather than using the `LINK_LIBRARIES` option, use target_link_libraries
like clang does.  Because these are all host tools, there is no name
mangling done for the libraries making this a no-op change.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
