### PR TITLE
new struct and utilities for ast-level paramter indices

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1338,6 +1338,8 @@ private:
   FuncDecl *PrimalFunction = nullptr;
   /// The adjoint function, to be resolved by the type checker.
   FuncDecl *AdjointFunction = nullptr;
+  /// Checked parameter indices, to be resolved by the type checker.
+  AutoDiffParameterIndices *CheckedParameterIndices = nullptr;
 
   explicit DifferentiableAttr(SourceLoc atLoc, SourceRange baseRange,
                               AutoDiffMode mode, SourceLoc modeLoc,
@@ -1359,6 +1361,13 @@ public:
   SourceLoc getModeLoc() const { return ModeLoc; }
   Optional<DeclNameWithLoc> getPrimal() const { return Primal; }
   Optional<DeclNameWithLoc> getAdjoint() const { return Adjoint; }
+
+  AutoDiffParameterIndices *getCheckedParameterIndices() const {
+    return CheckedParameterIndices;
+  }
+  void setCheckedParameterIndices(AutoDiffParameterIndices *pi) {
+    CheckedParameterIndices = pi;
+  }
 
   TrailingWhereClause *getWhereClause() const { return WhereClause; }
 

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -118,9 +118,8 @@ public:
   /// Allocates and initializes an empty `AutoDiffParameterIndices` for the
   /// given `functionType`. `isMethod` specifies whether to treat the function
   /// as a method.
-  static AutoDiffParameterIndices *create(ASTContext &C,
-                                          AnyFunctionType *functionType,
-                                          bool isMethod);
+  static AutoDiffParameterIndices *
+  create(ASTContext &C, AnyFunctionType *functionType, bool isMethod);
 
   bool isMethod() const { return isMethodFlag; }
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3856,6 +3856,13 @@ public:
            E->getKind() == ExprKind::ValueAndGradient;
   }
 
+  AutoDiffParameterIndices *getCheckedParameterIndices() const {
+    return CheckedParameterIndices;
+  }
+  void setCheckedParameterIndices(AutoDiffParameterIndices *pi) {
+    CheckedParameterIndices = pi;
+  }
+
 private:
   /// The start location of this expression.
   SourceLoc Loc;
@@ -3869,6 +3876,8 @@ private:
   unsigned ResultIndex;
   /// The location of ')'.
   SourceLoc RParenLoc;
+  /// Checked parameter indices, to be resolved by the type checker.
+  AutoDiffParameterIndices *CheckedParameterIndices = nullptr;
 
 protected:
   explicit ReverseAutoDiffExpr(ExprKind kind, SourceLoc loc,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3047,6 +3047,9 @@ public:
   Differentiability getDifferentiability() const {
     return getExtInfo().getDifferentiability();
   }
+
+  AnyFunctionType *getAutoDiffAdjointFunctionType(
+      const AutoDiffParameterIndices &indices, const TupleType *primalResultTy);
   
   /// \brief True if this type allows an implicit conversion from a function
   /// argument expression of type T to a function of type () -> T.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3048,9 +3048,10 @@ public:
     return getExtInfo().getDifferentiability();
   }
 
-  AnyFunctionType *getAutoDiffAdjointFunctionType(
-      const AutoDiffParameterIndices &indices, const TupleType *primalResultTy);
-  
+  AnyFunctionType *
+  getAutoDiffAdjointFunctionType(const AutoDiffParameterIndices &indices,
+                                 const TupleType *primalResultTy);
+
   /// \brief True if this type allows an implicit conversion from a function
   /// argument expression of type T to a function of type () -> T.
   bool isAutoClosure() const {

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -103,10 +103,9 @@ static AnyFunctionType *unwrapSelfParameter(AnyFunctionType *functionType,
 /// Allocates and initializes an empty `AutoDiffParameterIndices` for the
 /// given `functionType`. `isMethod` specifies whether to treat the function
 /// as a method.
-AutoDiffParameterIndices
-*AutoDiffParameterIndices::create(ASTContext &C,
-                                  AnyFunctionType *functionType,
-                                  bool isMethod) {
+AutoDiffParameterIndices *
+AutoDiffParameterIndices::create(ASTContext &C, AnyFunctionType *functionType,
+                                 bool isMethod) {
   // TODO(SR-9290): Note that the AutoDiffParameterIndices' destructor never
   // gets called, which causes a small memory leak in the case that the
   // SmallBitVector decides to allocate some heap space.
@@ -178,8 +177,7 @@ void AutoDiffParameterIndices::setSelfParameter() {
 ///   ==> pushes {Self, C} to `paramTypes`.
 ///
 void AutoDiffParameterIndices::getSubsetParameterTypes(
-    AnyFunctionType *functionType,
-    SmallVectorImpl<Type> &paramTypes) const {
+    AnyFunctionType *functionType, SmallVectorImpl<Type> &paramTypes) const {
   AnyFunctionType *unwrapped = unwrapSelfParameter(functionType, isMethodFlag);
   if (isMethodFlag && indices[indices.size() - 1])
     paramTypes.push_back(functionType->getParams()[0].getPlainType());
@@ -190,10 +188,10 @@ void AutoDiffParameterIndices::getSubsetParameterTypes(
 
 static unsigned countNumFlattenedElementTypes(Type type) {
   if (auto *tupleTy = type->getCanonicalType()->getAs<TupleType>())
-    return accumulate(tupleTy->getElementTypes(), 0, [&](unsigned num,
-                                                         Type type) {
-      return num + countNumFlattenedElementTypes(type);
-    });
+    return accumulate(tupleTy->getElementTypes(), 0,
+                      [&](unsigned num, Type type) {
+                        return num + countNumFlattenedElementTypes(type);
+                      });
   return 1;
 }
 
@@ -216,8 +214,8 @@ static unsigned countNumFlattenedElementTypes(Type type) {
 ///   ==> returns 1110
 ///   (because the lowered SIL type is (A, B, C, D) -> R)
 ///
-llvm::SmallBitVector AutoDiffParameterIndices::getLowered(
-    AnyFunctionType *functionType) const {
+llvm::SmallBitVector
+AutoDiffParameterIndices::getLowered(AnyFunctionType *functionType) const {
   // Calculate the lowered sizes of all the parameters.
   AnyFunctionType *unwrapped = unwrapSelfParameter(functionType, isMethodFlag);
   SmallVector<unsigned, 8> paramLoweredSizes;

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -13,6 +13,7 @@
 #include "swift/AST/AutoDiff.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/Range.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 
@@ -84,4 +85,163 @@ Differentiability::Differentiability(AutoDiffMode mode,
 unsigned autodiff::getOffsetForAutoDiffAssociatedFunction(
     unsigned order, AutoDiffAssociatedFunctionKind kind) {
   return (order - 1) * 2 + kind.rawValue;
+}
+
+/// If `isMethod` is true, returns the non-self part of `functionType`. (e.g.
+/// "(Self) -> (A, B) -> R" becomes "(A, B) -> R"). Otherwise, returns
+/// `functionType` unmodified.
+static AnyFunctionType *unwrapSelfParameter(AnyFunctionType *functionType,
+                                            bool isMethod) {
+  if (isMethod) {
+    assert(functionType->getNumParams() == 1 &&
+           "unexpected num params for method");
+    return functionType->getResult()->castTo<AnyFunctionType>();
+  }
+  return functionType;
+}
+
+/// Allocates and initializes an empty `AutoDiffParameterIndices` for the
+/// given `functionType`. `isMethod` specifies whether to treat the function
+/// as a method.
+AutoDiffParameterIndices
+*AutoDiffParameterIndices::create(ASTContext &C,
+                                  AnyFunctionType *functionType,
+                                  bool isMethod) {
+  // TODO(SR-9290): Note that the AutoDiffParameterIndices' destructor never
+  // gets called, which causes a small memory leak in the case that the
+  // SmallBitVector decides to allocate some heap space.
+  void *mem = C.Allocate(sizeof(AutoDiffParameterIndices),
+                         alignof(AutoDiffParameterIndices));
+  unsigned paramCount =
+      unwrapSelfParameter(functionType, isMethod)->getNumParams() +
+      (isMethod ? 1 : 0);
+  return ::new (mem) AutoDiffParameterIndices(paramCount, isMethod);
+}
+
+unsigned AutoDiffParameterIndices::getNumNonSelfParameters() const {
+  return indices.size() - (isMethodFlag ? 1 : 0);
+}
+
+/// Adds the indexed parameter to the set. When `isMethodFlag` is not set, the
+/// indices index into the first parameter list. For example,
+///
+///   functionType = (A, B, C) -> R
+///   paramIndex = 0
+///   ==> adds "A" to the set.
+///
+/// When `isMethodFlag` is set, the indices index into the first non-self
+/// parameter list. For example,
+///
+///   functionType = (Self) -> (A, B, C) -> R
+///   paramIndex = 0
+///   ==> adds "A" to the set.
+///
+void AutoDiffParameterIndices::setNonSelfParameter(unsigned paramIndex) {
+  assert(paramIndex < getNumNonSelfParameters() && "paramIndex out of bounds");
+  indices.set(paramIndex);
+}
+
+/// Adds all the paramaters from the first non-self parameter list to the set.
+/// For example,
+///
+///   functionType = (A, B, C) -> R
+///   ==> adds "A", B", and "C" to the set.
+///
+///   functionType = (Self) -> (A, B, C) -> R
+///   ==> adds "A", B", and "C" to the set.
+///
+void AutoDiffParameterIndices::setAllNonSelfParameters() {
+  indices.set(0, getNumNonSelfParameters());
+}
+
+/// Adds the self parameter to the set. `isMethodFlag` must be set. For
+/// example,
+///
+///   functionType = (Self) -> (A, B, C) -> R
+///   ==> adds "Self" to the set
+///
+void AutoDiffParameterIndices::setSelfParameter() {
+  assert(isMethodFlag &&
+         "trying to add self param to non-method parameter indices");
+  indices.set(indices.size() - 1);
+}
+
+/// Pushes the subset's parameter's types to `paramTypes`, in the order in
+/// which they appear in the function type. For example,
+///
+///   functionType = (A, B, C) -> R
+///   if "A" and "C" are in the set,
+///   ==> pushes {A, C} to `paramTypes`.
+///
+///   functionType = (Self) -> (A, B, C) -> R
+///   if "Self" and "C" are in the set,
+///   ==> pushes {Self, C} to `paramTypes`.
+///
+void AutoDiffParameterIndices::getSubsetParameterTypes(
+    AnyFunctionType *functionType,
+    SmallVectorImpl<Type> &paramTypes) const {
+  AnyFunctionType *unwrapped = unwrapSelfParameter(functionType, isMethodFlag);
+  if (isMethodFlag && indices[indices.size() - 1])
+    paramTypes.push_back(functionType->getParams()[0].getPlainType());
+  for (unsigned paramIndex : range(unwrapped->getNumParams()))
+    if (indices[paramIndex])
+      paramTypes.push_back(unwrapped->getParams()[paramIndex].getPlainType());
+}
+
+static unsigned countNumFlattenedElementTypes(Type type) {
+  if (auto *tupleTy = type->getCanonicalType()->getAs<TupleType>())
+    return accumulate(tupleTy->getElementTypes(), 0, [&](unsigned num,
+                                                         Type type) {
+      return num + countNumFlattenedElementTypes(type);
+    });
+  return 1;
+}
+
+/// Returns a bitvector for the SILFunction parameters corresponding to the
+/// parameters in this set. In particular, this explodes tuples and puts the
+/// method self parameter at the end. For example,
+///
+///   functionType = (A, B, C) -> R
+///   if "A" and "C" are in the set,
+///   ==> returns 101
+///   (because the lowered SIL type is (A, B, C) -> R)
+///
+///   functionType = (Self) -> (A, B, C) -> R
+///   if "Self" and "C" are in the set,
+///   ==> returns 0011
+///   (because the lowered SIL type is (A, B, C, Self) -> R)
+///
+///   functionType = (A, (B, C), D) -> R
+///   if "A" and "(B, C)" are in the set,
+///   ==> returns 1110
+///   (because the lowered SIL type is (A, B, C, D) -> R)
+///
+llvm::SmallBitVector AutoDiffParameterIndices::getLowered(
+    AnyFunctionType *functionType) const {
+  // Calculate the lowered sizes of all the parameters.
+  AnyFunctionType *unwrapped = unwrapSelfParameter(functionType, isMethodFlag);
+  SmallVector<unsigned, 8> paramLoweredSizes;
+  unsigned totalLoweredSize = 0;
+  auto addLoweredParamInfo = [&](Type type) {
+    unsigned paramLoweredSize = countNumFlattenedElementTypes(type);
+    paramLoweredSizes.push_back(paramLoweredSize);
+    totalLoweredSize += paramLoweredSize;
+  };
+  for (auto &param : unwrapped->getParams())
+    addLoweredParamInfo(param.getPlainType());
+  if (isMethodFlag)
+    addLoweredParamInfo(functionType->getParams()[0].getPlainType());
+
+  // Construct the result by setting each range of bits that corresponds to each
+  // "on" parameter.
+  llvm::SmallBitVector result(totalLoweredSize);
+  unsigned currentBitIndex = 0;
+  for (unsigned i : range(indices.size())) {
+    auto paramLoweredSize = paramLoweredSizes[i];
+    if (indices[i])
+      result.set(currentBitIndex, currentBitIndex + paramLoweredSize);
+    currentBitIndex += paramLoweredSize;
+  }
+
+  return result;
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4085,3 +4085,69 @@ Type TypeBase::openAnyExistentialType(ArchetypeType *&opened) {
   opened = ArchetypeType::getOpened(this);
   return opened;
 }
+
+// SWIFT_ENABLE_TENSORFLOW
+AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
+    const AutoDiffParameterIndices &indices, const TupleType *primalResultTy) {
+  assert(!indices.isEmpty() && "there must be at least one wrt index");
+
+  // Makes a function with the same generic signature as `copy`, but with
+  // `params` parameters and `retTy` return type.
+  auto makeFunctionType = [&](AnyFunctionType *copy,
+                              ArrayRef<AnyFunctionType::Param> params,
+                              Type retTy) -> AnyFunctionType * {
+    if (auto *genFunctionType = copy->getAs<GenericFunctionType>()) {
+      return GenericFunctionType::get(genFunctionType->getGenericSignature(),
+                                      params, retTy);
+    }
+    return FunctionType::get(params, retTy);
+  };
+
+  // Compute the return type of the adjoint.
+  SmallVector<TupleTypeElt, 8> retElts;
+  SmallVector<Type, 8> wrtParamTypes;
+  indices.getSubsetParameterTypes(this, wrtParamTypes);
+  for (auto wrtParamType : wrtParamTypes)
+    retElts.push_back(wrtParamType);
+
+  // If collected `retElts` has only 1 element, use that element as adjoint's
+  // return type. Otherwise, make a tuple out of `retElts` as adjoint's return
+  // type.
+  Type retTy = retElts.size() > 1
+      ? TupleType::get(retElts, getASTContext())
+      : retElts[0].getType();
+
+  // If this is a method, unwrap the function type so that we can see the
+  // non-self parameters.
+  AnyFunctionType *unwrapped = this;
+  if (indices.isMethod())
+    unwrapped = unwrapped->getResult()->castTo<AnyFunctionType>();
+
+  // Compute the adjoint parameters.
+  SmallVector<AnyFunctionType::Param, 8> adjointParams;
+
+  // The first parameters are the same as those of the original function.
+  for (auto &param : unwrapped->getParams())
+    adjointParams.push_back(param);
+
+  // If the primal exists, the checkpoints type is the primal result type.
+  if (primalResultTy) {
+    auto checkpointsTy = primalResultTy->getElement(0).getType();
+    adjointParams.push_back(AnyFunctionType::Param(checkpointsTy));
+  }
+
+  // The original result and the seed have the same type as the original
+  // return type.
+  adjointParams.append(2, AnyFunctionType::Param(unwrapped->getResult()));
+
+  // Build the adjoint type.
+  AnyFunctionType *adjoint = makeFunctionType(unwrapped, adjointParams,
+                                              retTy);
+
+  // If this is a method, wrap the adjoint type in an additional "(Self) ->"
+  // curry level.
+  if (indices.isMethod())
+    adjoint = makeFunctionType(this, getParams(), adjoint);
+
+  return adjoint;
+}

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4113,9 +4113,8 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
   // If collected `retElts` has only 1 element, use that element as adjoint's
   // return type. Otherwise, make a tuple out of `retElts` as adjoint's return
   // type.
-  Type retTy = retElts.size() > 1
-      ? TupleType::get(retElts, getASTContext())
-      : retElts[0].getType();
+  Type retTy = retElts.size() > 1 ? TupleType::get(retElts, getASTContext())
+                                  : retElts[0].getType();
 
   // If this is a method, unwrap the function type so that we can see the
   // non-self parameters.
@@ -4141,8 +4140,7 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
   adjointParams.append(2, AnyFunctionType::Param(unwrapped->getResult()));
 
   // Build the adjoint type.
-  AnyFunctionType *adjoint = makeFunctionType(unwrapped, adjointParams,
-                                              retTy);
+  AnyFunctionType *adjoint = makeFunctionType(unwrapped, adjointParams, retTy);
 
   // If this is a method, wrap the adjoint type in an additional "(Self) ->"
   // curry level.

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -452,17 +452,6 @@ public:
   /// Emit a property descriptor for the given storage decl if it needs one.
   void tryEmitPropertyDescriptor(AbstractStorageDecl *decl);
 
-  /// SWIFT_ENABLE_TENSORFLOW
-  /// Get the range of corresponding SIL parameter indices for the given Swift
-  /// parameter index. For example,
-  ///   func foo(x: (Float, Float), y: Float) -> Float
-  ///            ^ index 0
-  ///   sil @foo : $@convention(thin) (Float, Float, Float) -> Float
-  ///                                  ^      ^ 
-  ///                                  corresponding indices 0...1
-  IntRange<unsigned>
-  getLoweredFunctionParameterIndex(unsigned paramIndex, AnyFunctionType *ty);
-
   /// Get or create the shared profiler instance for a type's constructors.
   /// This takes care to create separate profilers for extensions, which may
   /// reside in a different file than the one where the base type is defined.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1314,8 +1314,8 @@ namespace {
       auto *checkedWrtParamIndices = AutoDiffParameterIndices::create(
           CS.getASTContext(), originalTy, /*isMethod=*/false);
 
-      // If no parameters are given, then differentiation is done with respect to
-      // all parameters in the first parameter group.
+      // If no parameters are given, then differentiation is done with respect
+      // to all parameters in the first parameter group.
       if (GE->getParameters().empty())
         checkedWrtParamIndices->setAllNonSelfParameters();
       // If parameters indices are specified, collect those parameters.
@@ -1345,7 +1345,8 @@ namespace {
       // Collect differentiation parameter types.
       SmallVector<Type, 8> diffParamTypes;
       SmallVector<TupleTypeElt, 8> resultTypes;
-      checkedWrtParamIndices->getSubsetParameterTypes(originalTy, diffParamTypes);
+      checkedWrtParamIndices->getSubsetParameterTypes(originalTy,
+                                                      diffParamTypes);
       resultTypes.append(diffParamTypes.begin(), diffParamTypes.end());
 
       // Check that the differentiation parameter types are allowed.
@@ -1367,8 +1368,8 @@ namespace {
       // signature as the original function. The gradient's result types are
       // what we collected in `diffParamTypes`.
       Type gradResult = resultTypes.size() == 1
-        ? resultTypes.front().getType()
-        : TupleType::get(resultTypes, TC.Context);
+                            ? resultTypes.front().getType()
+                            : TupleType::get(resultTypes, TC.Context);
       // If preserving original result, then the gradient's result type is a tuple
       // of the original result type with label "value" and `diffParamTypes` with
       // label "gradient".

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1310,18 +1310,15 @@ namespace {
         return nullptr;
       }
 
-      // Compute the gradient type.
-      auto originalParams = originalTy->getParams();
-      auto *genSig = originalTy->getOptGenericSignature();
-      // Collect differentiation parameter types.
-      SmallVector<TupleTypeElt, 8> diffParamTypes;
+      // Collect differentiation parameter indices.
+      auto *checkedWrtParamIndices = AutoDiffParameterIndices::create(
+          CS.getASTContext(), originalTy, /*isMethod=*/false);
+
       // If no parameters are given, then differentiation is done with respect to
-      // all parameters (except self). The gradient's result type is all of the
-      // original parameters' types.
+      // all parameters in the first parameter group.
       if (GE->getParameters().empty())
-        for (auto &originalParam : originalParams)
-          diffParamTypes.push_back(originalParam.getPlainType());
-      // If parameters are specified, collect and type-check those parameters.
+        checkedWrtParamIndices->setAllNonSelfParameters();
+      // If parameters indices are specified, collect those parameters.
       else {
         int lastIndex = -1;
         for (auto &param : GE->getParameters()) {
@@ -1334,32 +1331,44 @@ namespace {
           }
           // Indices cannot exceed the number of parameters in the original
           // function.
-          if (index >= originalParams.size()) {
+          if (index >= originalTy->getNumParams()) {
             TC.diagnose(param.loc,
                         diag::gradient_expr_parameter_index_out_of_bounds,
-                        originalTy, originalParams.size());
+                        originalTy, originalTy->getNumParams());
             return nullptr;
           }
-          // The parameter cannot be a reference object or a protocol
-          // existential.
-          auto paramTy = originalParams[index].getPlainType();
-          if (paramTy->isAnyClassReferenceType() ||
-              paramTy->isExistentialType()) {
-            TC.diagnose(param.loc, diag::gradient_expr_parameter_not_value_type,
-                        paramTy);
-            return nullptr;
-          }
+          checkedWrtParamIndices->setNonSelfParameter(index);
           lastIndex = index;
-          diffParamTypes.push_back(paramTy);
         }
       }
+
+      // Collect differentiation parameter types.
+      SmallVector<Type, 8> diffParamTypes;
+      SmallVector<TupleTypeElt, 8> resultTypes;
+      checkedWrtParamIndices->getSubsetParameterTypes(originalTy, diffParamTypes);
+      resultTypes.append(diffParamTypes.begin(), diffParamTypes.end());
+
+      // Check that the differentiation parameter types are allowed.
+      for (auto paramAndParamTy : zip(GE->getParameters(), diffParamTypes)) {
+        auto param = std::get<0>(paramAndParamTy);
+        auto paramTy = std::get<1>(paramAndParamTy);
+        if (paramTy->isAnyClassReferenceType() ||
+            paramTy->isExistentialType()) {
+          TC.diagnose(param.loc, diag::gradient_expr_parameter_not_value_type,
+                      paramTy);
+          return nullptr;
+        }
+      }
+
+      // Memorize `checkedWrtParamIndices` in the expr.
+      GE->setCheckedParameterIndices(checkedWrtParamIndices);
 
       // Create a type for the gradient. The gradient has the same generic
       // signature as the original function. The gradient's result types are
       // what we collected in `diffParamTypes`.
-      Type gradResult = diffParamTypes.size() == 1
-        ? diffParamTypes.front().getType()
-        : TupleType::get(diffParamTypes, TC.Context);
+      Type gradResult = resultTypes.size() == 1
+        ? resultTypes.front().getType()
+        : TupleType::get(resultTypes, TC.Context);
       // If preserving original result, then the gradient's result type is a tuple
       // of the original result type with label "value" and `diffParamTypes` with
       // label "gradient".
@@ -1371,11 +1380,12 @@ namespace {
         }, TC.Context);
       }
       AnyFunctionType *gradTy;
+      auto *genSig = originalTy->getOptGenericSignature();
       if (genSig)
-        gradTy = GenericFunctionType::get(genSig, originalParams,
+        gradTy = GenericFunctionType::get(genSig, originalTy->getParams(),
                                           gradResult, originalTy->getExtInfo());
       else
-        gradTy = FunctionType::get(originalParams, gradResult,
+        gradTy = FunctionType::get(originalTy->getParams(), gradResult,
                                    originalTy->getExtInfo());
 
       // Gradient expressions with generic originals must have a type that is

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2299,7 +2299,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   // We will put the checked wrt param indices here.
   auto *checkedWrtParamIndices = AutoDiffParameterIndices::create(
       ctx, originalFnTy,
-      /*isMethod*/original->getImplicitSelfDecl() ? true : false);
+      /*isMethod*/ original->getImplicitSelfDecl() ? true : false);
 
   if (uncheckedWrtParams.empty()) {
     // If 'wrt:' is not specified, the wrt parameters are all the parameters in
@@ -2391,9 +2391,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   if (!adjointSpecifier)
     return;
 
-  TupleType *primalResultTy = primal ?
-      primal->getResultInterfaceType()->getAs<TupleType>() :
-      nullptr;
+  TupleType *primalResultTy =
+      primal ? primal->getResultInterfaceType()->getAs<TupleType>() : nullptr;
   AnyFunctionType *expectedAdjointFnTy =
       originalFnTy->getAutoDiffAdjointFunctionType(*checkedWrtParamIndices,
                                                    primalResultTy);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2562,6 +2562,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
             : AutoDiffParameter::getIndexParameter(loc, paramValue >> 1);
           parameters.push_back(parameter);
         }
+        // TODO: Deserialize CheckedParameterIndices.
         // TODO: Deserialize trailing where clause.
         auto diffAttr =
           DifferentiableAttr::create(ctx, loc, SourceRange(), autodiffMode,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2419,6 +2419,7 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
     DifferentiableDeclAttrLayout::emitRecord(
       Out, ScratchRecord, abbrCode, (unsigned) attr->getMode(), primalName,
       primalRef, adjointName, adjointRef, parameters);
+    // TODO: Serialize CheckedParameterIndices.
     // TODO: Serialize trailing where clause.
     // Type-checking where clause should be done first (mimicking the
     // @_specialize attribute).


### PR DESCRIPTION
* Adds a new struct `AutoDiffParameterIndices` for representing wrt indices that haven't been lowered to SIL yet. This is different from the existing AST-level indices (`AutoDiffIndexParameter` and `AutoDiffIndexParameter`) because it's fully-validated, easier to use, more uniform, and more compact. This is different from the existing SIL-level indices because tuples haven't been exploded yet.
* Teaches TypeCheckAttr to create an `AutoDiffParameterIndices` for the differentiable attr.
* Teaches CSGen to create an `AutoDiffParameterIndices` for `#gradient` exprs.
* Teaches SILGen to lower `AutoDiffParameterIndices` to SIL.

My motivation for doing this is that I need to write an `AnyFunctionType::getAutoDiffAssociatedFunctionType` function that calculates types for VJPs and JVPs. This `AnyFunctionType::getAutoDiffAssociatedFunctionType` needs to take wrt indices as an arguments. None of the existing types are suitable for this because the existing AST-level ones (`AutoDiffIndexParameter` and `AutoDiffIndexParameter`) are unvalidated and complicated to process, while the existing SIL-level ones are too lowered to be usable.