### PR TITLE
[ConstraintSystem] Enable disjunction ordering change when use of des…

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1842,8 +1842,7 @@ void ConstraintSystem::partitionDisjunction(
     PartitionBeginning.push_back(0);
   };
 
-  if (!getASTContext().isSwiftVersionAtLeast(5) ||
-      !TC.getLangOpts().SolverEnableOperatorDesignatedTypes ||
+  if (!TC.getLangOpts().SolverEnableOperatorDesignatedTypes ||
       !isOperatorBindOverload(Choices[0])) {
     originalOrdering();
     return;
@@ -1954,7 +1953,8 @@ Constraint *ConstraintSystem::selectDisjunction() {
   // disjunctions that we may not be able to short-circuit, allowing
   // us to eliminate behavior that is exponential in the number of
   // operators in the expression.
-  if (getASTContext().isSwiftVersionAtLeast(5))
+  if (getASTContext().isSwiftVersionAtLeast(5) ||
+      TC.getLangOpts().SolverEnableOperatorDesignatedTypes)
     if (auto *disjunction = selectApplyDisjunction())
       return disjunction;
 

--- a/validation-test/Sema/type_checker_perf/fast/array_of_tuples.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/array_of_tuples.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
+++ b/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -swift-version 4 -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(_ i: Int, _ j: Int) -> Int {

--- a/validation-test/Sema/type_checker_perf/fast/more_specialized_generic_func.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/more_specialized_generic_func.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 8 --end 40 --step 2 --select NumLeafScopes %s --expected-exit-code 0 -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 8 --end 40 --step 2 --select NumLeafScopes %s --expected-exit-code 0 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 _ = (2...100).reversed().filter({ $0 % 11 == 0 }).map {

--- a/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func memoize<A: Hashable, R>(

--- a/validation-test/Sema/type_checker_perf/fast/rdar17170728.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17170728.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let i: Int? = 1

--- a/validation-test/Sema/type_checker_perf/fast/rdar18360240.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18360240.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 10 --step 2 --select NumConstraintScopes --polynomial-threshold 1.5 %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 10 --step 2 --select NumConstraintScopes --polynomial-threshold 1.5 %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar18522024.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18522024.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(a: [String], b: String, c: String) -> [String] {

--- a/validation-test/Sema/type_checker_perf/fast/rdar18699199.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18699199.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 public enum E

--- a/validation-test/Sema/type_checker_perf/fast/rdar18724501.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18724501.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19181998.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19181998.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19181998_nominals.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19181998_nominals.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(strings: [String]) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar19394804.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19394804.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 7 --end 12 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 7 --end 12 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 // REQUIRES: rdar42650365

--- a/validation-test/Sema/type_checker_perf/fast/rdar19777895.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19777895.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let _: (Character) -> Bool = { c in

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_any.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_any.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_explicit_overloads.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_explicit_overloads.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_named.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_named.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_typed.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_typed.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_weak.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_weak.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-verify -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-verify -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar20875936.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20875936.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let _ = Array([0].lazy.reversed().filter { $0 % 2 == 0 }.map { $0 / 2 })

--- a/validation-test/Sema/type_checker_perf/fast/rdar21070413.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21070413.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar21328584.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21328584.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar21374729.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21374729.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 protocol P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar21398466.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21398466.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 // This problem is related to renaming,

--- a/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar21930551.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21930551.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 _ = [1, 3, 5, 7, 11].filter{ $0 == 1 || $0 == 3 || $0 == 11 || $0 == 1 || $0 == 3 || $0 == 11 } == [ 1, 3, 11 ]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22249571.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22249571.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func rdar22249571() -> [UInt8] {

--- a/validation-test/Sema/type_checker_perf/fast/rdar22282851.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22282851.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 struct S {

--- a/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 _ = (1...10).map(String.init) + [": hi"]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22532650.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22532650.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 10 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 10 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar22626740.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22626740.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(n: Int) -> Int {

--- a/validation-test/Sema/type_checker_perf/fast/rdar22810685.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22810685.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 8 --end 16 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 8 --end 16 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let _ = [0].reduce([Int]()) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 // REQUIRES: rdar38378503
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar25866240.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar25866240.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 10 --step 1 --select NumConstraintScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 10 --step 1 --select NumConstraintScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar26939465.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar26939465.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar28018866.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar28018866.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 struct P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar29025667.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar29025667.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar30213053.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30213053.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar30389602.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30389602.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 15 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let a = 1

--- a/validation-test/Sema/type_checker_perf/fast/rdar31563957.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31563957.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar31742586.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31742586.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func rdar31742586() -> Double {

--- a/validation-test/Sema/type_checker_perf/fast/rdar32221800.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32221800.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(header_field_mark: Bool?, header_value_mark: Bool?,

--- a/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func rdar32998180(value: UInt16) -> UInt16 {

--- a/validation-test/Sema/type_checker_perf/fast/rdar32999041.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32999041.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 3 --end 8 --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 3 --end 8 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 // FIXME: https://bugs.swift.org/browse/SR-6997

--- a/validation-test/Sema/type_checker_perf/fast/rdar33688063.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33688063.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let _ = 1 | UInt32(0) << 0 | UInt32(1) << 1 | UInt32(2) << 2 | UInt32(3) << 3 | UInt32(4) << 4

--- a/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 class P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test() {

--- a/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 struct T {

--- a/validation-test/Sema/type_checker_perf/fast/rdar40344044.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar40344044.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 3 --end 20  --step 1 --select NumLeafScopes %s -Xfrontend=-swift-version -Xfrontend=5 -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 3 --end 20  --step 1 --select NumLeafScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar42672946.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar42672946.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 func f(tail: UInt64, byteCount: UInt64) {
   if tail & ~(1 << ((byteCount & 7) << 3) - 1) == 0 { }
 }


### PR DESCRIPTION
…ignated types are enabled.

We try to work more-or-less bottom up in the expression when we
attempt apply disjunctions first. This is very helpful to get good
results with designated types enabled in the solver. Rather than
forcing tests to specify both `-swift-version 5` (which also enables
this bottom-up behavior) and enabling designated types, allow them to
just enable the later to get the behavior.

We'll eventually have to revisit this when we decide the specific
conditions that we'll enable the use of designated types under.
