### PR TITLE
[benchmark] run_smoke_bench tweaks

### DIFF
--- a/benchmark/scripts/run_smoke_bench
+++ b/benchmark/scripts/run_smoke_bench
@@ -139,7 +139,7 @@ def test_performance(opt_level, old_dir, new_dir, threshold, num_samples,
     new_lines = ""
 
     # #,TEST,SAMPLES,MIN(μs),MAX(μs),MEAN(μs),SD(μs),MEDIAN(μs),PEAK_MEMORY(B)
-    score_re = re.compile(r"(\d+),(\w+),\d+,(\d+)")
+    score_re = re.compile(r"(\d+),([\w.\-]+),\d+,(\d+)")
 
     while to_test is None or len(to_test) > 0:
         tested_benchmarks = set()

--- a/benchmark/scripts/run_smoke_bench
+++ b/benchmark/scripts/run_smoke_bench
@@ -221,7 +221,8 @@ def get_results(bench_dir, opt_level, num_samples, to_test):
         if to_test:
             args += to_test
         env = {'DYLD_LIBRARY_PATH': os.path.join(bench_dir, 'lib', 'swift',
-               'macos')}
+               'macos'),
+               'SWIFT_DETERMINISTIC_HASHING': '1'}
         output = subprocess.check_output(args, env=env)
     except subprocess.CalledProcessError as e:
         sys.stderr.write(e.output)

--- a/benchmark/scripts/run_smoke_bench.py
+++ b/benchmark/scripts/run_smoke_bench.py
@@ -96,7 +96,7 @@ def test_opt_level(opt_level, old_dir, new_dir, threshold, num_samples):
     new_logf = open(log_filename(new_dir), 'w')
 
     # #,TEST,SAMPLES,MIN(μs),MAX(μs),MEAN(μs),SD(μs),MEDIAN(μs),PEAK_MEMORY(B)
-    score_re = re.compile(r"(\d+),(\w+),\d+,(\d+)")
+    score_re = re.compile(r"(\d+),([\w.\-]+),\d+,(\d+)")
 
     while to_test is None or len(to_test) > 0:
         tested_benchmarks = set()

--- a/benchmark/scripts/run_smoke_bench.py
+++ b/benchmark/scripts/run_smoke_bench.py
@@ -180,7 +180,8 @@ def get_results(bench_dir, opt_level, num_samples, to_test):
         if to_test:
             args += to_test
         env = {'DYLD_LIBRARY_PATH': os.path.join(bench_dir, 'lib', 'swift',
-               'macos')}
+               'macos'),
+               'SWIFT_DETERMINISTIC_HASHING': '1'}
         output = subprocess.check_output(args, env=env)
     except subprocess.CalledProcessError as e:
         sys.stderr.write(e.output)


### PR DESCRIPTION
Two small fixes:
* use SWIFT_DETERMINISTIC_HASHING
* allow running tests with dot and dash in the name

The naming change is to allow for measuring tests conforming to proposed naming convention in  #20334 (only partial support for `.` and `-`, for now without `!` and `?`), like the #20552 and #20666.

If these get accepted, the Apple-internal script that measures benchmarks and submits them to LNT should also be updated to work with such names.