### PR TITLE
Added support for loading Python at runtime (supports both Python 3 and 2)

### DIFF
--- a/stdlib/public/Python/NumpyConversion.swift
+++ b/stdlib/public/Python/NumpyConversion.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -111,7 +111,7 @@ public struct PythonObject {
   }
 }
 
-/// Make `print(python)` print a pretty form of the `PythonObject`.
+// Make `print(python)` print a pretty form of the `PythonObject`.
 extension PythonObject : CustomStringConvertible {
   /// A textual description of this `PythonObject`, produced by `Python.str`.
   public var description: String {
@@ -125,9 +125,9 @@ extension PythonObject : CustomStringConvertible {
 }
 
 // Make `PythonObject` show up nicely in the Xcode Playground results sidebar.
-extension PythonObject : CustomPlaygroundDisplayConvertible {
-  public var playgroundDescription: Any {
-    return description
+extension PythonObject : CustomPlaygroundQuickLookable {
+  public var customPlaygroundQuickLook: PlaygroundQuickLook {
+    return .text(description)
   }
 }
 
@@ -172,7 +172,7 @@ fileprivate extension PythonConvertible {
   }
 }
 
-/// `PythonObject` is trivially `PythonConvertible`.
+// `PythonObject` is trivially `PythonConvertible`.
 extension PythonObject : PythonConvertible {
   public init(_ object: PythonObject) {
     self.init(owning: object.ownedPyObject)
@@ -655,13 +655,6 @@ public struct PythonInterface {
     return try! attemptImport(name)
   }
 
-  /*public func updatePath(to path: String) {
-    var cStr = path.utf8CString
-    cStr.withUnsafeMutableBufferPointer { buffPtr in
-      PySys_SetPath(buffPtr.baseAddress)
-    }
-  }*/
-
   public subscript(dynamicMember name: String) -> PythonObject {
     return builtins[name]
   }
@@ -872,8 +865,8 @@ extension Double : PythonConvertible {
 // `PythonConvertible` conformances for `FixedWidthInteger` and `Float`
 //===----------------------------------------------------------------------===//
 
-/// Any `FixedWidthInteger` type is `PythonConvertible` via the `Int`/`UInt`
-/// implementation.
+// Any `FixedWidthInteger` type is `PythonConvertible` via the `Int`/`UInt`
+// implementation.
 
 extension Int8 : PythonConvertible {
   public init?(_ pythonObject: PythonObject) {
@@ -963,7 +956,7 @@ extension UInt64 : PythonConvertible {
   }
 }
 
-/// `Float` is `PythonConvertible` via the `Double` implementation.
+// `Float` is `PythonConvertible` via the `Double` implementation.
 
 extension Float : PythonConvertible {
   public init?(_ pythonObject: PythonObject) {
@@ -996,7 +989,7 @@ extension Array : PythonConvertible where Element : PythonConvertible {
     let list = PyList_New(count)!
     for (index, element) in enumerated() {
       // `PyList_SetItem` steals the reference of the object stored.
-      let _ = PyList_SetItem(list, index, element.ownedPyObject)
+      _ = PyList_SetItem(list, index, element.ownedPyObject)
     }
     return PythonObject(owning: list)
   }

--- a/stdlib/public/Python/PythonLibrary+Symbols.swift
+++ b/stdlib/public/Python/PythonLibrary+Symbols.swift
@@ -21,7 +21,7 @@
 typealias PyObjectPointer = UnsafeMutableRawPointer
 typealias PyCCharPointer = UnsafePointer<Int8>
 typealias PyBinaryOperation =
-  (@convention(c) (PyObjectPointer?, PyObjectPointer?) -> PyObjectPointer?)
+  @convention(c) (PyObjectPointer?, PyObjectPointer?) -> PyObjectPointer?
 
 let Py_LT: Int32 = 0
 let Py_LE: Int32 = 1
@@ -34,42 +34,42 @@ let Py_GE: Int32 = 5
 // Python library symbols lazily loaded at runtime.
 //===----------------------------------------------------------------------===//
 
-let Py_Initialize = PythonLibrary.getSymbol(
+let Py_Initialize = PythonLibrary.loadSymbol(
   name: "Py_Initialize",
   signature: (@convention(c) () -> ()).self
 )
 
-let Py_IncRef = PythonLibrary.getSymbol(
+let Py_IncRef = PythonLibrary.loadSymbol(
   name: "Py_IncRef",
   signature: (@convention(c) (PyObjectPointer?) -> ()).self
 )
 
-let Py_DecRef = PythonLibrary.getSymbol(
+let Py_DecRef = PythonLibrary.loadSymbol(
   name: "Py_DecRef",
   signature: (@convention(c) (PyObjectPointer?) -> ()).self
 )
 
-let PyImport_ImportModule = PythonLibrary.getSymbol(
+let PyImport_ImportModule = PythonLibrary.loadSymbol(
   name: "PyImport_ImportModule",
   signature: (@convention(c) (PyCCharPointer) -> PyObjectPointer?).self
 )
 
-let PyEval_GetBuiltins = PythonLibrary.getSymbol(
+let PyEval_GetBuiltins = PythonLibrary.loadSymbol(
   name: "PyEval_GetBuiltins",
   signature: (@convention(c) () -> PyObjectPointer).self
 )
 
-let PyErr_Occurred = PythonLibrary.getSymbol(
+let PyErr_Occurred = PythonLibrary.loadSymbol(
   name: "PyErr_Occurred",
   signature: (@convention(c) () -> PyObjectPointer?).self
 )
 
-let PyErr_Clear = PythonLibrary.getSymbol(
+let PyErr_Clear = PythonLibrary.loadSymbol(
   name: "PyErr_Clear",
   signature: (@convention(c) () -> ()).self
 )
 
-let PyErr_Fetch = PythonLibrary.getSymbol(
+let PyErr_Fetch = PythonLibrary.loadSymbol(
   name: "PyErr_Fetch",
   signature: (@convention(c) (
     UnsafeMutablePointer<PyObjectPointer?>,
@@ -77,72 +77,97 @@ let PyErr_Fetch = PythonLibrary.getSymbol(
     UnsafeMutablePointer<PyObjectPointer?>) -> ()).self
 )
 
-let PyDict_New = PythonLibrary.getSymbol(
+let PyDict_New = PythonLibrary.loadSymbol(
   name: "PyDict_New",
   signature: (@convention(c) () -> PyObjectPointer?).self
 )
 
-let PyDict_SetItem = PythonLibrary.getSymbol(
+let PyDict_SetItem = PythonLibrary.loadSymbol(
   name: "PyDict_SetItem",
-  signature: (@convention(c) (PyObjectPointer?, PyObjectPointer, PyObjectPointer) -> ()).self
+  signature: (@convention(c) (
+    PyObjectPointer?,
+    PyObjectPointer,
+    PyObjectPointer) -> ()).self
 )
 
-let PyObject_GetItem = PythonLibrary.getSymbol(
+let PyObject_GetItem = PythonLibrary.loadSymbol(
   name: "PyObject_GetItem",
-  signature: (@convention(c) (PyObjectPointer, PyObjectPointer) -> PyObjectPointer?).self
+  signature: (@convention(c) (
+    PyObjectPointer,
+    PyObjectPointer) -> PyObjectPointer?).self
 )
 
-let PyObject_SetItem = PythonLibrary.getSymbol(
+let PyObject_SetItem = PythonLibrary.loadSymbol(
   name: "PyObject_SetItem",
-  signature: (@convention(c) (PyObjectPointer, PyObjectPointer, PyObjectPointer) -> ()).self
+  signature: (@convention(c) (
+    PyObjectPointer,
+    PyObjectPointer,
+    PyObjectPointer) -> ()).self
 )
 
-let PyObject_DelItem = PythonLibrary.getSymbol(
+let PyObject_DelItem = PythonLibrary.loadSymbol(
   name: "PyObject_DelItem",
-  signature: (@convention(c) (PyObjectPointer, PyObjectPointer) -> ()).self
+  signature: (@convention(c) (
+    PyObjectPointer,
+    PyObjectPointer) -> ()).self
 )
 
-let PyObject_Call = PythonLibrary.getSymbol(
+let PyObject_Call = PythonLibrary.loadSymbol(
   name: "PyObject_Call",
-  signature: (@convention(c) (PyObjectPointer, PyObjectPointer, PyObjectPointer?) -> (PyObjectPointer?)).self
+  signature: (@convention(c) (
+    PyObjectPointer,
+    PyObjectPointer,
+    PyObjectPointer?) -> (PyObjectPointer?)).self
 )
 
-let PyObject_CallObject = PythonLibrary.getSymbol(
+let PyObject_CallObject = PythonLibrary.loadSymbol(
   name: "PyObject_CallObject",
-  signature: (@convention(c) (PyObjectPointer, PyObjectPointer) -> (PyObjectPointer?)).self
+  signature: (@convention(c) (
+    PyObjectPointer,
+    PyObjectPointer) -> (PyObjectPointer?)).self
 )
 
-let PyObject_GetAttrString = PythonLibrary.getSymbol(
+let PyObject_GetAttrString = PythonLibrary.loadSymbol(
   name: "PyObject_GetAttrString",
-  signature: (@convention(c) (PyObjectPointer, PyCCharPointer) -> (PyObjectPointer?)).self
+  signature: (@convention(c) (
+    PyObjectPointer,
+    PyCCharPointer) -> (PyObjectPointer?)).self
 )
 
-let PyObject_SetAttrString = PythonLibrary.getSymbol(
+let PyObject_SetAttrString = PythonLibrary.loadSymbol(
   name: "PyObject_SetAttrString",
-  signature: (@convention(c) (PyObjectPointer, PyCCharPointer, PyObjectPointer) -> (Int)).self
+  signature: (@convention(c) (
+    PyObjectPointer,
+    PyCCharPointer,
+    PyObjectPointer) -> (Int)).self
 )
 
-let PySlice_New = PythonLibrary.getSymbol(
+let PySlice_New = PythonLibrary.loadSymbol(
   name: "PySlice_New",
-  signature: (@convention(c) (PyObjectPointer?, PyObjectPointer?, PyObjectPointer?) -> (PyObjectPointer?)).self
+  signature: (@convention(c) (
+    PyObjectPointer?,
+    PyObjectPointer?,
+    PyObjectPointer?) -> (PyObjectPointer?)).self
 )
 
-let PyTuple_New = PythonLibrary.getSymbol(
+let PyTuple_New = PythonLibrary.loadSymbol(
   name: "PyTuple_New",
   signature: (@convention(c) (Int) -> (PyObjectPointer?)).self
 )
 
-let PyTuple_SetItem = PythonLibrary.getSymbol(
+let PyTuple_SetItem = PythonLibrary.loadSymbol(
   name: "PyTuple_SetItem",
-  signature: (@convention(c) (PyObjectPointer, Int, PyObjectPointer) -> ()).self
+  signature: (@convention(c) (
+    PyObjectPointer, Int, PyObjectPointer) -> ()).self
 )
 
-let PyObject_RichCompareBool = PythonLibrary.getSymbol(
+let PyObject_RichCompareBool = PythonLibrary.loadSymbol(
   name: "PyObject_RichCompareBool",
-  signature: (@convention(c) (PyObjectPointer, PyObjectPointer, Int32) -> (Int32)).self
+  signature: (@convention(c) (
+    PyObjectPointer, PyObjectPointer, Int32) -> (Int32)).self
 )
 
-let PyDict_Next = PythonLibrary.getSymbol(
+let PyDict_Next = PythonLibrary.loadSymbol(
   name: "PyDict_Next",
   signature: (@convention(c) (
     PyObjectPointer, UnsafeMutablePointer<Int>,
@@ -150,128 +175,131 @@ let PyDict_Next = PythonLibrary.getSymbol(
     UnsafeMutablePointer<PyObjectPointer?>) -> (Int32)).self
 )
 
-let PyList_New = PythonLibrary.getSymbol(
+let PyList_New = PythonLibrary.loadSymbol(
   name: "PyList_New",
   signature: (@convention(c) (Int) -> (PyObjectPointer?)).self
 )
 
-let PyList_SetItem = PythonLibrary.getSymbol(
+let PyList_SetItem = PythonLibrary.loadSymbol(
   name: "PyList_SetItem",
-  signature: (@convention(c) (PyObjectPointer, Int, PyObjectPointer) -> (Int32)).self
+  signature: (@convention(c) (
+    PyObjectPointer, Int, PyObjectPointer) -> (Int32)).self
 )
 
-let PyBool_FromLong = PythonLibrary.getSymbol(
+let PyBool_FromLong = PythonLibrary.loadSymbol(
   name: "PyBool_FromLong",
   signature: (@convention(c) (Int) -> (PyObjectPointer)).self
 )
 
-let PyFloat_AsDouble = PythonLibrary.getSymbol(
+let PyFloat_AsDouble = PythonLibrary.loadSymbol(
   name: "PyFloat_AsDouble",
   signature: (@convention(c) (PyObjectPointer) -> (Double)).self
 )
 
-let PyFloat_FromDouble = PythonLibrary.getSymbol(
+let PyFloat_FromDouble = PythonLibrary.loadSymbol(
   name: "PyFloat_FromDouble",
   signature: (@convention(c) (Double) -> (PyObjectPointer)).self
 )
 
-let PyInt_AsLong = PythonLibrary.getSymbol(
+let PyInt_AsLong = PythonLibrary.loadSymbol(
   name: "PyLong_AsLong",
   legacyName: "PyInt_AsLong",
   signature: (@convention(c) (PyObjectPointer) -> (Int)).self
 )
 
-let PyInt_FromLong = PythonLibrary.getSymbol(
+let PyInt_FromLong = PythonLibrary.loadSymbol(
   name: "PyLong_FromLong",
   legacyName: "PyInt_FromLong",
   signature: (@convention(c) (Int) -> (PyObjectPointer)).self
 )
 
-let PyInt_AsUnsignedLongMask = PythonLibrary.getSymbol(
+let PyInt_AsUnsignedLongMask = PythonLibrary.loadSymbol(
   name: "PyLong_AsUnsignedLongMask",
   legacyName: "PyInt_AsUnsignedLongMask",
   signature: (@convention(c) (PyObjectPointer) -> (UInt)).self
 )
 
-let PyInt_FromSize_t = PythonLibrary.getSymbol(
+let PyInt_FromSize_t = PythonLibrary.loadSymbol(
   name: "PyInt_FromLong",
   legacyName: "PyInt_FromSize_t",
   signature: (@convention(c) (Int) -> (PyObjectPointer)).self
 )
 
-let PyString_AsString = PythonLibrary.getSymbol(
+let PyString_AsString = PythonLibrary.loadSymbol(
   name: "PyUnicode_AsUTF8",
   legacyName: "PyString_AsString",
-  signature: (@convention(c) (PyObjectPointer) -> (PyCCharPointer?)).self
+  signature: (@convention(c) (
+    PyObjectPointer) -> (PyCCharPointer?)).self
 )
 
-let PyString_FromStringAndSize = PythonLibrary.getSymbol(
+let PyString_FromStringAndSize = PythonLibrary.loadSymbol(
   name: "PyUnicode_DecodeUTF8",
   legacyName: "PyString_FromStringAndSize",
-  signature: (@convention(c) (PyCCharPointer?, Int) -> (PyObjectPointer?)).self
+  signature: (@convention(c) (
+    PyCCharPointer?, Int) -> (PyObjectPointer?)).self
 )
 
-var _Py_ZeroStruct = PythonLibrary.getSymbol(
+var _Py_ZeroStruct = PythonLibrary.loadSymbol(
   name: "_Py_ZeroStruct",
   signature: PyObjectPointer.self
 )
 
-var _Py_TrueStruct = PythonLibrary.getSymbol(
+var _Py_TrueStruct = PythonLibrary.loadSymbol(
   name: "_Py_TrueStruct",
   signature: PyObjectPointer.self
 )
 
-var _Py_TrueStructb = PythonLibrary.getSymbol(
+var _Py_TrueStructb = PythonLibrary.loadSymbol(
   name: "_Py_TrueStructb",
   signature: PyObjectPointer.self
 )
 
-var PyBool_Type = PythonLibrary.getSymbol(
+var PyBool_Type = PythonLibrary.loadSymbol(
   name: "PyBool_Type",
   signature: PyObjectPointer.self
 )
 
-var PySlice_Type = PythonLibrary.getSymbol(
+var PySlice_Type = PythonLibrary.loadSymbol(
   name: "PySlice_Type",
   signature: PyObjectPointer.self
 )
 
-let PyNumber_Add = PythonLibrary.getSymbol(
+let PyNumber_Add = PythonLibrary.loadSymbol(
   name: "PyNumber_Add",
   signature: PyBinaryOperation.self
 )
 
-let PyNumber_Subtract = PythonLibrary.getSymbol(
+let PyNumber_Subtract = PythonLibrary.loadSymbol(
   name: "PyNumber_Subtract",
   signature: PyBinaryOperation.self
 )
 
-let PyNumber_Multiply = PythonLibrary.getSymbol(
+let PyNumber_Multiply = PythonLibrary.loadSymbol(
   name: "PyNumber_Multiply",
   signature: PyBinaryOperation.self
 )
 
-let PyNumber_TrueDivide = PythonLibrary.getSymbol(
+let PyNumber_TrueDivide = PythonLibrary.loadSymbol(
   name: "PyNumber_TrueDivide",
   signature: PyBinaryOperation.self
 )
 
-let PyNumber_InPlaceAdd = PythonLibrary.getSymbol(
+let PyNumber_InPlaceAdd = PythonLibrary.loadSymbol(
   name: "PyNumber_InPlaceAdd",
   signature: PyBinaryOperation.self
 )
 
-let PyNumber_InPlaceSubtract = PythonLibrary.getSymbol(
+let PyNumber_InPlaceSubtract = PythonLibrary.loadSymbol(
   name: "PyNumber_InPlaceSubtract",
   signature: PyBinaryOperation.self
 )
 
-let PyNumber_InPlaceMultiply = PythonLibrary.getSymbol(
+let PyNumber_InPlaceMultiply = PythonLibrary.loadSymbol(
   name: "PyNumber_InPlaceMultiply",
   signature: PyBinaryOperation.self
 )
 
-let PyNumber_InPlaceTrueDivide = PythonLibrary.getSymbol(
+let PyNumber_InPlaceTrueDivide = PythonLibrary.loadSymbol(
   name: "PyNumber_InPlaceTrueDivide",
   signature: PyBinaryOperation.self
 )

--- a/stdlib/public/Python/PythonLibrary+Symbols.swift
+++ b/stdlib/public/Python/PythonLibrary+Symbols.swift
@@ -1,0 +1,277 @@
+//===-- PythonLibrary+Symbols.swift ---------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the Python symbols required for the interoperability layer.
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Required Python typealias and constants.
+//===----------------------------------------------------------------------===//
+
+typealias PyObjectPointer = UnsafeMutableRawPointer
+typealias PyCCharPointer = UnsafePointer<Int8>
+typealias PyBinaryOperation =
+  (@convention(c) (PyObjectPointer?, PyObjectPointer?) -> PyObjectPointer?)
+
+let Py_LT: Int32 = 0
+let Py_LE: Int32 = 1
+let Py_EQ: Int32 = 2
+let Py_NE: Int32 = 3
+let Py_GT: Int32 = 4
+let Py_GE: Int32 = 5
+
+//===----------------------------------------------------------------------===//
+// Python library symbols lazily loaded at runtime.
+//===----------------------------------------------------------------------===//
+
+let Py_Initialize = PythonLibrary.getSymbol(
+  name: "Py_Initialize",
+  signature: (@convention(c) () -> ()).self
+)
+
+let Py_IncRef = PythonLibrary.getSymbol(
+  name: "Py_IncRef",
+  signature: (@convention(c) (PyObjectPointer?) -> ()).self
+)
+
+let Py_DecRef = PythonLibrary.getSymbol(
+  name: "Py_DecRef",
+  signature: (@convention(c) (PyObjectPointer?) -> ()).self
+)
+
+let PyImport_ImportModule = PythonLibrary.getSymbol(
+  name: "PyImport_ImportModule",
+  signature: (@convention(c) (PyCCharPointer) -> PyObjectPointer?).self
+)
+
+let PyEval_GetBuiltins = PythonLibrary.getSymbol(
+  name: "PyEval_GetBuiltins",
+  signature: (@convention(c) () -> PyObjectPointer).self
+)
+
+let PyErr_Occurred = PythonLibrary.getSymbol(
+  name: "PyErr_Occurred",
+  signature: (@convention(c) () -> PyObjectPointer?).self
+)
+
+let PyErr_Clear = PythonLibrary.getSymbol(
+  name: "PyErr_Clear",
+  signature: (@convention(c) () -> ()).self
+)
+
+let PyErr_Fetch = PythonLibrary.getSymbol(
+  name: "PyErr_Fetch",
+  signature: (@convention(c) (
+    UnsafeMutablePointer<PyObjectPointer?>,
+    UnsafeMutablePointer<PyObjectPointer?>,
+    UnsafeMutablePointer<PyObjectPointer?>) -> ()).self
+)
+
+let PyDict_New = PythonLibrary.getSymbol(
+  name: "PyDict_New",
+  signature: (@convention(c) () -> PyObjectPointer?).self
+)
+
+let PyDict_SetItem = PythonLibrary.getSymbol(
+  name: "PyDict_SetItem",
+  signature: (@convention(c) (PyObjectPointer?, PyObjectPointer, PyObjectPointer) -> ()).self
+)
+
+let PyObject_GetItem = PythonLibrary.getSymbol(
+  name: "PyObject_GetItem",
+  signature: (@convention(c) (PyObjectPointer, PyObjectPointer) -> PyObjectPointer?).self
+)
+
+let PyObject_SetItem = PythonLibrary.getSymbol(
+  name: "PyObject_SetItem",
+  signature: (@convention(c) (PyObjectPointer, PyObjectPointer, PyObjectPointer) -> ()).self
+)
+
+let PyObject_DelItem = PythonLibrary.getSymbol(
+  name: "PyObject_DelItem",
+  signature: (@convention(c) (PyObjectPointer, PyObjectPointer) -> ()).self
+)
+
+let PyObject_Call = PythonLibrary.getSymbol(
+  name: "PyObject_Call",
+  signature: (@convention(c) (PyObjectPointer, PyObjectPointer, PyObjectPointer?) -> (PyObjectPointer?)).self
+)
+
+let PyObject_CallObject = PythonLibrary.getSymbol(
+  name: "PyObject_CallObject",
+  signature: (@convention(c) (PyObjectPointer, PyObjectPointer) -> (PyObjectPointer?)).self
+)
+
+let PyObject_GetAttrString = PythonLibrary.getSymbol(
+  name: "PyObject_GetAttrString",
+  signature: (@convention(c) (PyObjectPointer, PyCCharPointer) -> (PyObjectPointer?)).self
+)
+
+let PyObject_SetAttrString = PythonLibrary.getSymbol(
+  name: "PyObject_SetAttrString",
+  signature: (@convention(c) (PyObjectPointer, PyCCharPointer, PyObjectPointer) -> (Int)).self
+)
+
+let PySlice_New = PythonLibrary.getSymbol(
+  name: "PySlice_New",
+  signature: (@convention(c) (PyObjectPointer?, PyObjectPointer?, PyObjectPointer?) -> (PyObjectPointer?)).self
+)
+
+let PyTuple_New = PythonLibrary.getSymbol(
+  name: "PyTuple_New",
+  signature: (@convention(c) (Int) -> (PyObjectPointer?)).self
+)
+
+let PyTuple_SetItem = PythonLibrary.getSymbol(
+  name: "PyTuple_SetItem",
+  signature: (@convention(c) (PyObjectPointer, Int, PyObjectPointer) -> ()).self
+)
+
+let PyObject_RichCompareBool = PythonLibrary.getSymbol(
+  name: "PyObject_RichCompareBool",
+  signature: (@convention(c) (PyObjectPointer, PyObjectPointer, Int32) -> (Int32)).self
+)
+
+let PyDict_Next = PythonLibrary.getSymbol(
+  name: "PyDict_Next",
+  signature: (@convention(c) (
+    PyObjectPointer, UnsafeMutablePointer<Int>,
+    UnsafeMutablePointer<PyObjectPointer?>,
+    UnsafeMutablePointer<PyObjectPointer?>) -> (Int32)).self
+)
+
+let PyList_New = PythonLibrary.getSymbol(
+  name: "PyList_New",
+  signature: (@convention(c) (Int) -> (PyObjectPointer?)).self
+)
+
+let PyList_SetItem = PythonLibrary.getSymbol(
+  name: "PyList_SetItem",
+  signature: (@convention(c) (PyObjectPointer, Int, PyObjectPointer) -> (Int32)).self
+)
+
+let PyBool_FromLong = PythonLibrary.getSymbol(
+  name: "PyBool_FromLong",
+  signature: (@convention(c) (Int) -> (PyObjectPointer)).self
+)
+
+let PyFloat_AsDouble = PythonLibrary.getSymbol(
+  name: "PyFloat_AsDouble",
+  signature: (@convention(c) (PyObjectPointer) -> (Double)).self
+)
+
+let PyFloat_FromDouble = PythonLibrary.getSymbol(
+  name: "PyFloat_FromDouble",
+  signature: (@convention(c) (Double) -> (PyObjectPointer)).self
+)
+
+let PyInt_AsLong = PythonLibrary.getSymbol(
+  name: "PyLong_AsLong",
+  legacyName: "PyInt_AsLong",
+  signature: (@convention(c) (PyObjectPointer) -> (Int)).self
+)
+
+let PyInt_FromLong = PythonLibrary.getSymbol(
+  name: "PyLong_FromLong",
+  legacyName: "PyInt_FromLong",
+  signature: (@convention(c) (Int) -> (PyObjectPointer)).self
+)
+
+let PyInt_AsUnsignedLongMask = PythonLibrary.getSymbol(
+  name: "PyLong_AsUnsignedLongMask",
+  legacyName: "PyInt_AsUnsignedLongMask",
+  signature: (@convention(c) (PyObjectPointer) -> (UInt)).self
+)
+
+let PyInt_FromSize_t = PythonLibrary.getSymbol(
+  name: "PyInt_FromLong",
+  legacyName: "PyInt_FromSize_t",
+  signature: (@convention(c) (Int) -> (PyObjectPointer)).self
+)
+
+let PyString_AsString = PythonLibrary.getSymbol(
+  name: "PyUnicode_AsUTF8",
+  legacyName: "PyString_AsString",
+  signature: (@convention(c) (PyObjectPointer) -> (PyCCharPointer?)).self
+)
+
+let PyString_FromStringAndSize = PythonLibrary.getSymbol(
+  name: "PyUnicode_DecodeUTF8",
+  legacyName: "PyString_FromStringAndSize",
+  signature: (@convention(c) (PyCCharPointer?, Int) -> (PyObjectPointer?)).self
+)
+
+var _Py_ZeroStruct = PythonLibrary.getSymbol(
+  name: "_Py_ZeroStruct",
+  signature: PyObjectPointer.self
+)
+
+var _Py_TrueStruct = PythonLibrary.getSymbol(
+  name: "_Py_TrueStruct",
+  signature: PyObjectPointer.self
+)
+
+var _Py_TrueStructb = PythonLibrary.getSymbol(
+  name: "_Py_TrueStructb",
+  signature: PyObjectPointer.self
+)
+
+var PyBool_Type = PythonLibrary.getSymbol(
+  name: "PyBool_Type",
+  signature: PyObjectPointer.self
+)
+
+var PySlice_Type = PythonLibrary.getSymbol(
+  name: "PySlice_Type",
+  signature: PyObjectPointer.self
+)
+
+let PyNumber_Add = PythonLibrary.getSymbol(
+  name: "PyNumber_Add",
+  signature: PyBinaryOperation.self
+)
+
+let PyNumber_Subtract = PythonLibrary.getSymbol(
+  name: "PyNumber_Subtract",
+  signature: PyBinaryOperation.self
+)
+
+let PyNumber_Multiply = PythonLibrary.getSymbol(
+  name: "PyNumber_Multiply",
+  signature: PyBinaryOperation.self
+)
+
+let PyNumber_TrueDivide = PythonLibrary.getSymbol(
+  name: "PyNumber_TrueDivide",
+  signature: PyBinaryOperation.self
+)
+
+let PyNumber_InPlaceAdd = PythonLibrary.getSymbol(
+  name: "PyNumber_InPlaceAdd",
+  signature: PyBinaryOperation.self
+)
+
+let PyNumber_InPlaceSubtract = PythonLibrary.getSymbol(
+  name: "PyNumber_InPlaceSubtract",
+  signature: PyBinaryOperation.self
+)
+
+let PyNumber_InPlaceMultiply = PythonLibrary.getSymbol(
+  name: "PyNumber_InPlaceMultiply",
+  signature: PyBinaryOperation.self
+)
+
+let PyNumber_InPlaceTrueDivide = PythonLibrary.getSymbol(
+  name: "PyNumber_InPlaceTrueDivide",
+  signature: PyBinaryOperation.self
+)

--- a/stdlib/public/Python/PythonLibrary.swift
+++ b/stdlib/public/Python/PythonLibrary.swift
@@ -35,8 +35,8 @@ struct PythonLibrary {
     guard let pythonLibraryHandle =
       PythonLibrary.getPythonLibraryHandle() else {
       fatalError("""
-        Python library not found. Set the \(Environment.library.key) \
-        environment variable with the path to the Python Library.
+      Python library not found. Set the \(Environment.library.key) \
+      environment variable with the path to the Python Library.
       """)
     }
     

--- a/stdlib/public/Python/PythonLibrary.swift
+++ b/stdlib/public/Python/PythonLibrary.swift
@@ -1,0 +1,200 @@
+//===-- PythonLibrary.swift -----------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the logic for dynamically loading Python at runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+//===----------------------------------------------------------------------===//
+// The `PythonLibrary` struct that loads Python symbols at runtime.
+//===----------------------------------------------------------------------===//
+
+struct PythonLibrary {
+  
+  private static let shared = PythonLibrary()
+  private static let pythonLegacySymbolName = "PyString_AsString"
+  
+  private let pythonLibraryHandle: UnsafeMutableRawPointer
+  private let isLegacyPython: Bool
+  
+  fileprivate init() {
+    guard let pythonLibraryHandle = PythonLibrary.getPythonLibraryHandle() else {
+      fatalError(
+        "Python library not found. Set the \(Environment.library.key) " +
+        "environment variable with the path to the Python Library."
+      )
+    }
+    
+    self.pythonLibraryHandle = pythonLibraryHandle
+    
+    // Check if Python is legacy (Python 2)
+    self.isLegacyPython = dlsym(pythonLibraryHandle, PythonLibrary.pythonLegacySymbolName) != nil
+    
+    if self.isLegacyPython {
+      PythonLibrary.log(message: "Loaded legacy Python library, using legacy symbols...")
+    }
+  }
+  
+  static func getSymbol<T>(name: String, legacyName: String? = nil, signature: T.Type) -> T {
+    var name = name
+    
+    if let legacyName = legacyName, PythonLibrary.shared.isLegacyPython {
+      name = legacyName
+    }
+    
+    let symbol = unsafeBitCast(
+      dlsym(PythonLibrary.shared.pythonLibraryHandle, name),
+      to: signature
+    )
+    
+    return symbol
+  }
+}
+
+/// Methods of `PythonLibrary` required to load the Python library.
+extension PythonLibrary {
+  
+  private static let supportedMajorVersions: [Int] = Array(2...3).reversed()
+  private static let supportedMinorVersions: [Int?] = [nil] + Array(0...30).reversed()
+  
+  private static let libraryPathVersionCharacter: Character = ":"
+  
+  #if canImport(Darwin)
+  private static var libraryNames = ["Python.framework/Versions/:/Python"]
+  private static var libraryPathExtensions = [""]
+  private static var librarySearchPaths = ["", "/usr/local/Frameworks/"]
+  #elseif os(Linux)
+  private static var libraryNames = ["libpython:", "libpython:m"]
+  private static var libraryPathExtensions = [".so"]
+  private static var librarySearchPaths = [""]
+  #endif
+  
+  private static let libraryPaths: [String] = {
+    var libraryPaths: [String] = []
+    
+    for librarySearchPath in librarySearchPaths {
+      for libraryName in libraryNames {
+        for libraryPathExtension in libraryPathExtensions {
+          let libraryPath =
+            librarySearchPath + libraryName + libraryPathExtension
+          libraryPaths.append(libraryPath)
+        }
+      }
+    }
+    
+    return libraryPaths
+  }()
+  
+  private static func loadPythonLibrary(
+    at path: String, majorVersion: Int, minorVersion: Int? = nil) -> UnsafeMutableRawPointer? {
+    
+    var versionString = String(majorVersion)
+    
+    if let minorVersion = minorVersion {
+      versionString += ".\(minorVersion)"
+    }
+    
+    if let requiredPythonVersion = Environment.version.value {
+      let requiredMajorVersion = Int(requiredPythonVersion)
+      
+      if requiredPythonVersion != versionString &&
+        requiredMajorVersion != majorVersion {
+        return nil
+      }
+    }
+    
+    let path = path.split(separator: libraryPathVersionCharacter)
+      .joined(separator: versionString)
+    
+    return loadPythonLibrary(at: path)
+  }
+  
+  private static func loadPythonLibrary(at path: String) -> UnsafeMutableRawPointer? {
+    log(message: "Trying to load library at '\(path)'... ")
+    
+    let pythonLibraryHandle = dlopen(path, RTLD_NOW)
+    
+    if pythonLibraryHandle != nil {
+      log(message: "Library at '\(path)' was sucessfully loaded.")
+    }
+    
+    return pythonLibraryHandle
+  }
+  
+  private static func getPythonLibraryHandle() -> UnsafeMutableRawPointer? {
+    if let pythonLibraryPath = Environment.library.value {
+      return loadPythonLibrary(at: pythonLibraryPath)
+    }
+    
+    for majorVersion in supportedMajorVersions {
+      for minorVersion in supportedMinorVersions {
+        for libraryPath in libraryPaths {
+          
+          guard let pythonLibraryHandle = loadPythonLibrary(
+            at: libraryPath, majorVersion: majorVersion, minorVersion: minorVersion) else {
+              continue
+          }
+          
+          return pythonLibraryHandle
+        }
+      }
+    }
+    
+    return nil
+  }
+}
+
+/// Methods of `PythonLibrary` used for logging messages.
+extension PythonLibrary {
+  
+  static func log(message: String) {
+    guard Environment.loaderLogging.value != nil else {
+      return
+    }
+    
+    fputs(message + "\n", stderr)
+  }
+}
+
+/// Methods of `PythonLibrary` required to read the environment variables.
+extension PythonLibrary {
+  
+  enum Environment: String {
+    private static let pythonEnvironmentKeyPrefix = "PYTHON"
+    private static let pythonEnvironmentKeySeparator = "_"
+    
+    case library = "LIBRARY"
+    case version = "VERSION"
+    case loaderLogging = "LOADER_LOGGING"
+    
+    var key: String {
+      return [Environment.pythonEnvironmentKeyPrefix, self.rawValue]
+        .joined(separator: Environment.pythonEnvironmentKeySeparator)
+    }
+    
+    var value: String? {
+      let optionalValue = getenv(self.key)
+      
+      guard let value = optionalValue else {
+        return nil
+      }
+      
+      return String(cString: value)
+    }
+  }
+}

--- a/stdlib/public/Python/PythonLibrary.swift
+++ b/stdlib/public/Python/PythonLibrary.swift
@@ -146,7 +146,6 @@ extension PythonLibrary {
             majorVersion: majorVersion, minorVersion: minorVersion) else {
               continue
           }
-          
           return pythonLibraryHandle
         }
       }
@@ -179,10 +178,7 @@ extension PythonLibrary {
     }
     
     var value: String? {
-      guard let value = getenv(key) else {
-        return nil
-      }
-      
+      guard let value = getenv(key) else { return nil }
       return String(cString: value)
     }
   }


### PR DESCRIPTION
Added new `PythonLibrary` struct to load Python library and symbols dynamically at runtime

- This adds support for both Python 3 and 2 with the same codebase.
- You can force a version of Python with the PYTHON_VERSION environment variable, a Python library path with PYTHON_LIBRARY and enable logging with PYTHON_LOADER_LOGGING.
- The implementation comes from the PythonKit Swift package (https://github.com/pvieito/PythonKit) removing the Foundation dependency.