### PR TITLE
Added a swift-syntax entry to the tensorflow config section.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -212,6 +212,7 @@
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2018-10-22-a",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2018-10-22-a",
                 "compiler-rt": "swift-DEVELOPMENT-SNAPSHOT-2018-10-22-a",
+                "swift-syntax": "master",
                 "swift-corelibs-xctest": "swift-DEVELOPMENT-SNAPSHOT-2018-10-22-a",
                 "swift-corelibs-foundation": "swift-DEVELOPMENT-SNAPSHOT-2018-10-22-a",
                 "swift-corelibs-libdispatch": "swift-DEVELOPMENT-SNAPSHOT-2018-10-22-a",


### PR DESCRIPTION
This appears needed to complete `./swift/utils/update-checkout --clone-with-ssh --scheme tensorflow --skip-repository=swift`

I have not tested this on Mac.
