### PR TITLE
[AutoDiff] Don't try to differentiate generic functions before it's supported

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -376,6 +376,8 @@ ERROR(autodiff_unsupported_type,none,
       "differentiating '%0' is not supported yet", (Type))
 ERROR(autodiff_function_not_differentiable,none,
       "function is not differentiable", ())
+NOTE(autodiff_function_generic_functions_unsupported,none,
+     "differentiating generic functions is not supported yet", ())
 NOTE(autodiff_value_defined_here,none,
      "value defined here", ())
 NOTE(autodiff_when_differentiating_function_call,none,

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -2411,7 +2411,9 @@ public:
     auto *newTask =
         context.lookUpMinimalDifferentiationTask(calleeOriginalFn, indices);
     if (!newTask) {
-      // If the callee function does not have a primitive declaration that
+      // If the callee function is generic and does not have a primitive
+      // declaration that covers the required indices, we cannot differentiate it
+      // yet so we bail out instead of registering a new differentiation task.
       // covers the required indices and is generic, we cannot differentiate it
       // yet so we bail out instead of registering a new differentiation task.
       if (calleeOriginFnRef->getFunctionType()->getGenericSignature()) {

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -21,6 +21,17 @@ func one_to_one_0(_ x: Float) -> Float {
 _ = #gradient(one_to_one_0) // okay!
 
 //===----------------------------------------------------------------------===//
+// Generics
+//===----------------------------------------------------------------------===//
+
+// expected-note @+3 {{differentiating generic functions is not supported yet}}
+// expected-error @+2 {{function is not differentiable}}
+@differentiable(reverse)
+func generic<T: FloatingPoint>(_ x: T) -> T {
+  return x + 1
+}
+
+//===----------------------------------------------------------------------===//
 // Function composition
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Differentiating generic functions is not supported yet. This patch teaches AD to bail out instead of running primal synthesis on the generic function, which might lead to either zero derivatives or a crasher.

Zero derivatives are caused by incorrect activity analysis. Activity analysis does not recognize loads, stores, and indirect returns yet.

This patch does not cover all cases (e.g. zero derivatives) because we really need to fix activity analysis first. I'll send a more comprehensive patch that will cover more test cases later.