### PR TITLE
Allow %target-run-simple-swift to optionally take arbitrary driver args

### DIFF
--- a/test/Interpreter/strong_retain_unowned_mispairing.swift
+++ b/test/Interpreter/strong_retain_unowned_mispairing.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-opt-O-swift
+// RUN: %target-run-simple-swift(-O)
 // REQUIRES: executable_test
 
 // We were crashing here due to not preserving rc identity. 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -576,7 +576,7 @@ config.target_runtime = "unknown"
 swift_reflection_test_name = 'swift-reflection-test' + config.variant_suffix
 
 def use_interpreter_for_simple_runs():
-    def make_simple_target_run(gyb=False, stdlib=False, opt=""):
+    def make_simple_target_run(gyb=False, stdlib=False, parameterized=False):
         result = ''
         if gyb:
             result += ('%empty-directory(%t) && '
@@ -592,8 +592,8 @@ def use_interpreter_for_simple_runs():
                swift_execution_tests_extra_flags))
         if stdlib:
             result += '-Xfrontend -disable-access-control '
-        if opt:
-            result += opt + ' '
+        if parameterized:
+            result += ' \\1 '
         if gyb:
             result += '%t/main.swift'
         else:
@@ -602,9 +602,8 @@ def use_interpreter_for_simple_runs():
     config.target_run_stdlib_swiftgyb = make_simple_target_run(gyb=True)
     config.target_run_simple_swiftgyb = make_simple_target_run(gyb=True)
     config.target_run_stdlib_swift = make_simple_target_run(stdlib=True)
-    config.target_run_simple_opt_Osize_swift = make_simple_target_run(opt='-Osize')
-    config.target_run_simple_opt_O_swift = make_simple_target_run(opt='-O')
     config.target_run_simple_swift = make_simple_target_run()
+    config.target_run_simple_swift_parameterized = make_simple_target_run(parameterized=True)
     config.available_features.add('interpret')
 
 if run_vendor == 'apple':
@@ -1081,21 +1080,15 @@ config.substitutions.append(('%sftp-server',
 
 
 if not getattr(config, 'target_run_simple_swift', None):
+    config.target_run_simple_swift_parameterized = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s \\1 -o %%t/a.out -module-name main && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
     config.target_run_simple_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_simple_opt_O_swift = (
-        '%%empty-directory(%%t) && '
-        '%s %s -O %%s -o %%t/a.out -module-name main && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_simple_opt_Osize_swift = (
-        '%%empty-directory(%%t) && '
-        '%s %s -Osize %%s -o %%t/a.out -module-name main && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
@@ -1189,9 +1182,8 @@ config.substitutions.append(('%target-swift-frontend', config.target_swift_front
 
 
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
+config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)', config.target_run_simple_swift_parameterized))
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
-config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))
-config.substitutions.append(('%target-run-simple-opt-Osize-swift', config.target_run_simple_opt_Osize_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb', config.target_run_stdlib_swiftgyb))
 config.substitutions.append(('%target-run-stdlib-swift', config.target_run_stdlib_swift))
 config.substitutions.append(('%target-repl-run-simple-swift', subst_target_repl_run_simple_swift))


### PR DESCRIPTION
Use this to remove the existing hard-coded `-O` and `-Osize` variants.