### PR TITLE
[CodeCompletion] Don't suggest values before declaration

### DIFF
--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -53,6 +53,7 @@ protected:
   ObjCSelectorContext CompleteExprSelectorContext = ObjCSelectorContext::None;
 
   std::vector<Expr *> leadingSequenceExprs;
+  std::vector<VarDecl *> disabledVars;
 
 public:
   CodeCompletionCallbacks(Parser &P)
@@ -78,6 +79,10 @@ public:
 
   void setLeadingSequenceExprs(ArrayRef<Expr *> exprs) {
     leadingSequenceExprs.assign(exprs.begin(), exprs.end());
+  }
+
+  void setDisabledVars(ArrayRef<VarDecl *> vars) {
+    disabledVars.assign(vars.begin(), vars.end());
   }
 
   class InEnumElementRawValueRAII {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -64,8 +64,11 @@ ParserResult<Expr> Parser::parseExprImpl(Diag<> Message,
   
   auto expr = parseExprSequence(Message, isExprBasic,
                                 /*forConditionalDirective*/false);
-  if (expr.hasCodeCompletion())
+  if (expr.hasCodeCompletion()) {
+    if (CodeCompletion)
+      CodeCompletion->setDisabledVars(DisabledVars);
     return expr;
+  }
   if (expr.isNull())
     return nullptr;
   

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -75,6 +75,14 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_1 | %FileCheck %s -check-prefix=IN_TUPLE_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_2 | %FileCheck %s -check-prefix=IN_TUPLE_2
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_1 | %FileCheck %s -check-prefix=OWN_INIT_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_2 | %FileCheck %s -check-prefix=OWN_INIT_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_3 | %FileCheck %s -check-prefix=OWN_INIT_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_4 | %FileCheck %s -check-prefix=OWN_INIT_4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_5 | %FileCheck %s -check-prefix=OWN_INIT_5
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_6 | %FileCheck %s -check-prefix=OWN_INIT_6
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_7 | %FileCheck %s -check-prefix=OWN_INIT_7
+
 //
 // Test code completion at the beginning of expr-postfix.
 //
@@ -435,8 +443,7 @@ func testInForEach1(arg: Int) {
   let after = 4
 // IN_FOR_EACH_1-NOT: Decl[LocalVar]
 // IN_FOR_EACH_1: Decl[LocalVar]/Local:               local[#Int#];
-// FIXME: shouldn't show 'after' here.
-// IN_FOR_EACH_1: Decl[LocalVar]/Local:               after[#Int#];
+// IN_FOR_EACH_1-NOT: after
 // IN_FOR_EACH_1: Decl[LocalVar]/Local:               arg[#Int#];
 // IN_FOR_EACH_1-NOT: Decl[LocalVar]
 }
@@ -448,8 +455,7 @@ func testInForEach2(arg: Int) {
   let after = 4
 // IN_FOR_EACH_2-NOT: Decl[LocalVar]
 // IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: local[#Int#];
-// FIXME: shouldn't show 'after' here.
-// IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: after[#Int#];
+// IN_FOR_EACH_2-NOT: after
 // IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: arg[#Int#];
 // IN_FOR_EACH_2-NOT: Decl[LocalVar]
 }
@@ -463,8 +469,7 @@ func testInForEach3(arg: Int) {
 // IN_FOR_EACH_3: Decl[LocalVar]/Local:               index[#Int#];
 // IN_FOR_EACH_3-NOT: Decl[LocalVar]
 // IN_FOR_EACH_3: Decl[LocalVar]/Local:               local[#Int#];
-// FIXME: shouldn't show 'after' here.
-// IN_FOR_EACH_3: Decl[LocalVar]/Local:               after[#Int#];
+// IN_FOR_EACH_3-NOT: after
 // IN_FOR_EACH_3: Decl[LocalVar]/Local:               arg[#Int#];
 // IN_FOR_EACH_3-NOT: Decl[LocalVar]
 }
@@ -503,8 +508,7 @@ func testInForEach9(arg: Int) {
 // NOTE: [Convertible] to AnyHashable.
 // IN_FOR_EACH_4-NOT: Decl[LocalVar]
 // IN_FOR_EACH_4: Decl[LocalVar]/Local/TypeRelation[Convertible]: local[#Int#];
-// FIXME: shouldn't show 'after' here.
-// IN_FOR_EACH_4: Decl[LocalVar]/Local/TypeRelation[Convertible]: after[#Int#];
+// IN_FOR_EACH_4-NOT: after
 // IN_FOR_EACH_4: Decl[LocalVar]/Local/TypeRelation[Convertible]: arg[#Int#];
 // IN_FOR_EACH_4-NOT: Decl[LocalVar]
 }
@@ -555,3 +559,31 @@ func testTuple(localInt: Int) {
 // IN_TUPLE_2: Decl[LocalVar]/Local:               localStr[#String#]; name=localStr
 // IN_TUPLE_2: Decl[LocalVar]/Local/TypeRelation[Identical]: localInt[#Int#]; name=localInt
 // IN_TUPLE_2: End completions
+
+var ownInit1: Int = #^OWN_INIT_1^#
+// OWN_INIT_1: Begin completions
+// OWN_INIT_1-NOT: ownInit1
+var ownInit2: () -> Void = { #^OWN_INIT_2^# }
+// OWN_INIT_2: Begin completions
+// OWN_INIT_2-NOT: ownInit2
+struct OwnInitTester {
+  var ownInit3: Int = #^OWN_INIT_3^#
+  // OWN_INIT_3: Begin completions
+  // OWN_INIT_3-NOT: ownInit3
+  var ownInit4: () -> Void = { #^OWN_INIT_4^# }
+  // OWN_INIT_4: Begin completions
+  // OWN_INIT_4-NOT: ownInit4
+}
+func ownInitTesting() {
+  var ownInit5: Int = #^OWN_INIT_5^#
+  // OWN_INIT_5: Begin completions
+  // OWN_INIT_5-NOT: ownInit5
+  var ownInit6: () -> Void = { #^OWN_INIT_6^# }
+  // OWN_INIT_6: Begin completions
+  // OWN_INIT_6-NOT: ownInit6
+}
+func ownInitTestingShadow(ownInit7: Int) {
+  var ownInit7: Int = #^OWN_INIT_7^#
+  // OWN_INIT_7: Begin completions
+  // OWN_INIT_7: Decl[LocalVar]/Local/TypeRelation[Identical]: ownInit7[#Int#];
+}


### PR DESCRIPTION
Filter out unusable local value decls from completions. Note that local types are usable even before declaration. E.g. the following code is legal.
```swift
  func foo() {
    _ = SAlias()
    typealias SAlias = S
    struct S {}
  }
```
rdar://problem/25068938
