### PR TITLE
tests: stub out more of the stdlib

### DIFF
--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -287,3 +287,8 @@ MANGLE_SYM(s20_playgroundPrintHookySScSgvg)() {
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $ss21_ObjectiveCBridgeableMp[1] = {0};
 
+// Key Path
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $ss7KeyPathCMo[1] = {0};
+


### PR DESCRIPTION
Key paths need metadata stubbed out for the unit tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
