### PR TITLE
[Parse] Fix SIL-deserialization

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -937,9 +937,11 @@ void Lexer::lexDollarIdent() {
   }
 
   if (CurPtr == tokStart + 1) {
-    // It is an error to see a standalone '$'. Offer to replace '$' with '`$`'.
-    diagnose(tokStart, diag::standalone_dollar_identifier)
-      .fixItReplaceChars(getSourceLoc(tokStart), getSourceLoc(CurPtr), "`$`");
+    if (!InSILBody) {
+      // It is an error to see a standalone '$'. Offer to replace '$' with '`$`'.
+      diagnose(tokStart, diag::standalone_dollar_identifier)
+        .fixItReplaceChars(getSourceLoc(tokStart), getSourceLoc(CurPtr), "`$`");
+    }
     return formToken(tok::identifier, tokStart);
   }
 


### PR DESCRIPTION
Hi Apple,

This is a minor follow-up to https://github.com/apple/swift/pull/17788 to reinstate the ability to de-serialize SIL in the Lexer. You may also need to specify the -assume-parsing-unqualified-ownership-sil flag but it should work now.

Thanks.