### PR TITLE
IRGen: adjust for SVN r347239

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1868,8 +1868,6 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
   llvm::DISubprogram *Decl = nullptr;
 
   // Various flags.
-  bool IsLocalToUnit = Fn ? Fn->hasInternalLinkage() : true;
-  bool IsDefinition = true;
   llvm::DINode::DIFlags Flags = llvm::DINode::FlagZero;
   // Mark everything that is not visible from the source code (i.e.,
   // does not have a Swift name) as artificial, so the debugger can
@@ -1900,10 +1898,14 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
       Error = DBuilder.getOrCreateArray({getOrCreateType(DTI)}).get();
     }
 
+  llvm::DISubprogram::DISPFlags SPFlags = llvm::DISubprogram::toSPFlags(
+      /*IsLocalToUnit=*/Fn ? Fn->hasInternalLinkage() : true,
+      /*IsDefinition=*/true, /*IsOptimized=*/Opts.shouldOptimize());
+
   // Construct the DISubprogram.
   llvm::DISubprogram *SP = DBuilder.createFunction(
-      Scope, Name, LinkageName, File, Line, DIFnTy, IsLocalToUnit, IsDefinition,
-      ScopeLine, Flags, Opts.shouldOptimize(), TemplateParameters, Decl, Error);
+      Scope, Name, LinkageName, File, Line, DIFnTy, ScopeLine, Flags, SPFlags,
+      TemplateParameters, Decl, Error);
 
   if (Fn && !Fn->isDeclaration())
     Fn->setSubprogram(SP);


### PR DESCRIPTION
DW_TAG_subprogram has its own flag word now.  Adjust building the debug info.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
