### PR TITLE
[WASM] Add minimal support for targeting wasm32-unknown-unknown-wasm.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -316,6 +316,8 @@ namespace swift {
                  Target.isPS4() || Target.isOSHaiku() ||
                  Target.getTriple().empty()) {
         major = minor = revision = 0;
+      } else if (Target.isOSBinFormatWasm()) {
+        major = minor = revision = 0;
       } else {
         llvm_unreachable("Unsupported target OS");
       }

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -192,6 +192,8 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     addPlatformConditionValue(PlatformConditionKind::OS, "PS4");
   else if (Target.isOSHaiku())
     addPlatformConditionValue(PlatformConditionKind::OS, "Haiku");
+  else if (Target.isOSBinFormatWasm())
+    addPlatformConditionValue(PlatformConditionKind::OS, "WebAssembly");
   else
     UnsupportedOS = true;
 
@@ -220,6 +222,12 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     break;
   case llvm::Triple::ArchType::systemz:
     addPlatformConditionValue(PlatformConditionKind::Arch, "s390x");
+    break;
+  case llvm::Triple::ArchType::wasm32:
+    addPlatformConditionValue(PlatformConditionKind::Arch, "wasm32");
+    break;
+  case llvm::Triple::ArchType::wasm64:
+    addPlatformConditionValue(PlatformConditionKind::Arch, "wasm64");
     break;
   default:
     UnsupportedArch = true;
@@ -251,6 +259,10 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     break;
   case llvm::Triple::ArchType::systemz:
     addPlatformConditionValue(PlatformConditionKind::Endianness, "big");
+    break;
+  case llvm::Triple::ArchType::wasm32:
+  case llvm::Triple::ArchType::wasm64:
+    addPlatformConditionValue(PlatformConditionKind::Endianness, "little");
     break;
   default:
     llvm_unreachable("undefined architecture endianness");

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -116,6 +116,11 @@ static StringRef getPlatformNameForDarwin(const DarwinPlatformKind platform) {
 StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   switch (triple.getOS()) {
   case llvm::Triple::UnknownOS:
+    // NOTE: WebAssembly doesn't yet have a defined OS convention in triples.
+    if (triple.isOSBinFormatWasm()) {
+      return "wasm";
+    }
+  
     llvm_unreachable("unknown OS");
   case llvm::Triple::Ananas:
   case llvm::Triple::CloudABI:

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -286,6 +286,11 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
   case llvm::Triple::Haiku:
     return llvm::make_unique<toolchains::GenericUnix>(*this, target);
   default:
+    // NOTE: WebAssembly doesn't yet have a defined OS convention in triples.
+    if (target.isOSBinFormatWasm()) {
+      return llvm::make_unique<toolchains::GenericUnix>(*this, target);
+    }
+  
     Diags.diagnose(SourceLoc(), diag::error_unknown_target,
                    ArgList.getLastArg(options::OPT_target)->getValue());
     break;


### PR DESCRIPTION
 - This is nothing beyond preventing the compiler from rejecting this target
   triple.

 - There doesn't yet appear to be a well-defined convention around a triple
   which detects WASM based on an "OS" field, so we use the "wasm" indicator in
   the environment component.
