### PR TITLE
stdlib: pass along alignment for dealloc

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -580,7 +580,8 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   /// block. The memory must not be initialized or `Pointee` must be a trivial type.
   @inlinable
   public func deallocate() {
-    Builtin.deallocRaw(_rawValue, (-1)._builtinWordValue, (-1)._builtinWordValue)
+    Builtin.deallocRaw(_rawValue, (-1)._builtinWordValue,
+                       Builtin.alignof(Pointee.self))
   }
 
   /// Accesses the instance referenced by this pointer.


### PR DESCRIPTION
Ensure that UnsafeMutablePointer.deallocate has the alignment that was
used when invoking UnsafeMutablePointer.allocate.  This is required to
ensure that the appropriate `free` function is invoked.  We would
previously fail on Windows as the allocation would use `malloc` and due
to the value being `-1`, use `_aligned_free` instead when deallocating.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
