### PR TITLE
allow @differentiable to specify JVP and VJP

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2671,10 +2671,9 @@ ERROR(differentiable_attr_no_parameters,none,
       "%0 has no parameters to differentiate with respect to", (DeclName))
 ERROR(differentiable_attr_void_result,none,
       "cannot differentiate void function %0", (DeclName))
-ERROR(differentiable_attr_primal_no_definition,none,
-      "cannot specify primal on protocol requirement", ())
-ERROR(differentiable_attr_adjoint_no_definition,none,
-      "cannot specify adjoint on protocol requirement", ())
+ERROR(differentiable_attr_associated_function_protocol,none,
+      "cannot specify associated differentiation function on protocol "
+      "requirement", ())
 ERROR(differentiable_attr_has_primal_but_not_adjoint,none,
       "a corresponding adjoint must be specified when the primal is provided; "
       "if you want this function to be automatically differentiated, do not "
@@ -2683,7 +2682,7 @@ ERROR(differentiable_attr_wrt_nothing,none,
       "specify at least one parameter to differentiate with respect to", (DeclName))
 ERROR(differentiable_attr_primal_overload_not_found,none,
       "%0 does not have expected parameters' type %1", (DeclName, Type))
-ERROR(differentiable_attr_adjoint_overload_not_found,none,
+ERROR(differentiable_attr_overload_not_found,none,
       "%0 does not have expected type %1", (DeclName, Type))
 ERROR(differentiable_attr_wrt_self_must_be_first,none,
       "'self' parameter must come first in the parameter list", ())
@@ -2699,17 +2698,23 @@ ERROR(differentiable_attr_cannot_diff_wrt_objects_or_existentials,none,
 ERROR(differentiable_attr_function_not_same_type_context,none,
       "%0 is not defined in the current type context", (DeclName))
 ERROR(differentiable_attr_specified_not_function,none,
-      "%0 is not a function to be used as %select{adjoint|primal}1",
-      (DeclName, bool))
+      "%0 is not a function to be used as associated differentiation function",
+      (DeclName))
 ERROR(differentiable_attr_ambiguous_function_identifier,none,
       "ambiguous or overloaded identifier %0 cannot be used in @differentiable "
       "attribute", (DeclName))
 ERROR(differentiable_attr_forward_mode_unsupported,none,
       "forward-mode automatic differentiation is not supported yet", ())
 ERROR(differentiable_attr_invalid_access,none,
-      "%select{adjoint|primal}2 %0 is required to either be public or "
-      "@usableFromInline because the original function %1 is public or "
-      "@usableFromInline", (DeclName, DeclName, bool))
+      "associated differentiation function %0 is required to either be public "
+      "or @usableFromInline because the original function %1 is public or "
+      "@usableFromInline", (DeclName, DeclName))
+ERROR(differentiable_attr_wrt_not_differentiable,none,
+      "can only differentiate with respect to parameters that conform to "
+      "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
+ERROR(differentiable_attr_result_not_differentiable,none,
+      "can only differentiate functions with results that conform to "
+      "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
 
 ERROR(compiler_evaluable_bad_context,none,
       "@compilerEvaluable functions not allowed here", ())

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3048,6 +3048,9 @@ public:
     return getExtInfo().getDifferentiability();
   }
 
+  AnyFunctionType *getAutoDiffAssociatedFunctionType(
+      const AutoDiffParameterIndices &indices, unsigned differentiationOrder,
+      AutoDiffAssociatedFunctionKind kind);
   AnyFunctionType *
   getAutoDiffAdjointFunctionType(const AutoDiffParameterIndices &indices,
                                  const TupleType *primalResultTy);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -852,6 +852,8 @@ public:
       SmallVectorImpl<AutoDiffParameter> &params,
       Optional<DifferentiableAttr::DeclNameWithLoc> &primalSpec,
       Optional<DifferentiableAttr::DeclNameWithLoc> &adjointSpec,
+      Optional<DifferentiableAttr::DeclNameWithLoc> &jvpSpec,
+      Optional<DifferentiableAttr::DeclNameWithLoc> &vjpSpec,
       TrailingWhereClause *&whereClause);
 
   /// Parse a specific attribute.

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 455; // Last change: multiple nominal types for operators
+const uint16_t VERSION_MINOR = 456; // Last change: add jvp and vjp to @differentiable
 
 using DeclIDField = BCFixed<31>;
 
@@ -1592,6 +1592,10 @@ namespace decls_block {
     DeclIDField, // Primal function declaration.
     IdentifierIDField, // Adjoint name.
     DeclIDField, // Adjoint function declaration.
+    IdentifierIDField, // JVP name.
+    DeclIDField, // JVP function declaration.
+    IdentifierIDField, // VJP name.
+    DeclIDField, // VJP function declaration.
     BCArray<BCFixed<32>> // Differentiation parameters.
   >;
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -583,6 +583,12 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     // Print adjoint function name.
     if (auto adjoint = attr->getAdjoint())
       Printer << ", adjoint: " << adjoint->Name;
+    // Print jvp function name.
+    if (auto jvp = attr->getJVP())
+      Printer << ", jvp: " << jvp->Name;
+    // Print vjp function name.
+    if (auto vjp = attr->getVJP())
+      Printer << ", vjp: " << vjp->Name;
     // FIXME: Print 'where' clause, if any.
     Printer << ")";
     break;
@@ -998,11 +1004,13 @@ DifferentiableAttr::DifferentiableAttr(SourceLoc atLoc, SourceRange baseRange,
                                        ArrayRef<AutoDiffParameter> parameters,
                                        Optional<DeclNameWithLoc> primal,
                                        Optional<DeclNameWithLoc> adjoint,
+                                       Optional<DeclNameWithLoc> jvp,
+                                       Optional<DeclNameWithLoc> vjp,
                                        TrailingWhereClause *clause)
   : DeclAttribute(DAK_Differentiable, atLoc, baseRange, /*Implicit*/false),
     Mode(mode), ModeLoc(modeLoc), NumParameters(parameters.size()),
     Primal(std::move(primal)), Adjoint(std::move(adjoint)),
-    WhereClause(clause) {
+    JVP(std::move(jvp)), VJP(std::move(vjp)), WhereClause(clause) {
   std::copy(parameters.begin(), parameters.end(), getParametersData());
 }
 
@@ -1013,6 +1021,8 @@ DifferentiableAttr::create(ASTContext &context, SourceLoc atLoc,
                            ArrayRef<AutoDiffParameter> parameters,
                            Optional<DeclNameWithLoc> primal,
                            Optional<DeclNameWithLoc> adjoint,
+                           Optional<DeclNameWithLoc> jvp,
+                           Optional<DeclNameWithLoc> vjp,
                            TrailingWhereClause *clause) {
   unsigned numParams = parameters.size();
   unsigned size = sizeof(DifferentiableAttr) +
@@ -1020,7 +1030,8 @@ DifferentiableAttr::create(ASTContext &context, SourceLoc atLoc,
   void *mem = context.Allocate(size, alignof(DifferentiableAttr));
   return new (mem) DifferentiableAttr(atLoc, baseRange, mode, modeLoc,
                                       parameters, std::move(primal),
-                                      std::move(adjoint), clause);
+                                      std::move(adjoint), std::move(jvp),
+                                      std::move(vjp), clause);
 }
 
 ArrayRef<AutoDiffParameter>

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4087,21 +4087,21 @@ Type TypeBase::openAnyExistentialType(ArchetypeType *&opened) {
 }
 
 // SWIFT_ENABLE_TENSORFLOW
+// Makes a function with the same generic signature as `copy`, but with
+// `params` parameters and `retTy` return type.
+static AnyFunctionType *
+makeFunctionType(AnyFunctionType *copy, ArrayRef<AnyFunctionType::Param> params,
+                 Type retTy) {
+  if (auto *genFunctionType = copy->getAs<GenericFunctionType>()) {
+    return GenericFunctionType::get(genFunctionType->getGenericSignature(),
+                                    params, retTy);
+  }
+  return FunctionType::get(params, retTy);
+}
+
 AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
     const AutoDiffParameterIndices &indices, const TupleType *primalResultTy) {
   assert(!indices.isEmpty() && "there must be at least one wrt index");
-
-  // Makes a function with the same generic signature as `copy`, but with
-  // `params` parameters and `retTy` return type.
-  auto makeFunctionType = [&](AnyFunctionType *copy,
-                              ArrayRef<AnyFunctionType::Param> params,
-                              Type retTy) -> AnyFunctionType * {
-    if (auto *genFunctionType = copy->getAs<GenericFunctionType>()) {
-      return GenericFunctionType::get(genFunctionType->getGenericSignature(),
-                                      params, retTy);
-    }
-    return FunctionType::get(params, retTy);
-  };
 
   // Compute the return type of the adjoint.
   SmallVector<TupleTypeElt, 8> retElts;
@@ -4148,4 +4148,113 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
     adjoint = makeFunctionType(this, getParams(), adjoint);
 
   return adjoint;
+}
+
+AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
+    const AutoDiffParameterIndices &indices, unsigned differentiationOrder,
+    AutoDiffAssociatedFunctionKind kind) {
+  // JVP: (T...) -> ((R...),
+  //                 (T.TangentVector...) -> (R.TangentVector...))
+  // VJP: (T...) -> ((R...),
+  //                 (R.CotangentVector...) -> (T.CotangentVector...))
+  //
+  // Note that both can be written as "(T...) -> ((R...), Closure)", so we build
+  // "Closure" and then use common code to wrap "Closure" in the outer function
+  // type.
+
+  assert(differentiationOrder == 1 && "only order 1 currently supported");
+  assert(!indices.isEmpty() && "there must be at least one wrt index");
+
+  auto getAssociatedType = [this](CanType type, StringRef name) -> CanType {
+    auto *nomTy = type->getAnyNominal();
+    assert(nomTy);
+    auto *assocTyDecl =
+        nomTy->lookupDirect(getASTContext().getIdentifier(name)).front();
+    auto assocTy = assocTyDecl->getInterfaceType()
+                       ->castTo<MetatypeType>()
+                       ->getMetatypeInstanceType();
+    auto subMap = type->getMemberSubstitutionMap(
+        assocTyDecl->getModuleContext(), assocTyDecl);
+    return assocTy.subst(subMap)->getCanonicalType();
+  };
+
+  SmallVector<Type, 8> wrtParamTypes;
+  indices.getSubsetParameterTypes(this, wrtParamTypes);
+
+  // If this is a method, unwrap the function type so that we can see the
+  // non-self parameters and the final result.
+  AnyFunctionType *unwrapped = this;
+  if (indices.isMethod())
+    unwrapped = unwrapped->getResult()->castTo<AnyFunctionType>();
+  Type originalResult = unwrapped->getResult();
+
+  // Build the closure type, which is different depending on whether this is a
+  // JVP or VJP.
+  Type closure;
+  switch (kind) {
+  case AutoDiffAssociatedFunctionKind::JVP: {
+    // closure is the JVP "differential":
+    //   (T.TangentVector...) -> (R.TangentVector...)
+    SmallVector<AnyFunctionType::Param, 8> differentialParams;
+    for (auto wrtParamType : wrtParamTypes)
+      differentialParams.push_back(AnyFunctionType::Param(getAssociatedType(
+          wrtParamType->getCanonicalType(), "TangentVector")));
+
+    SmallVector<TupleTypeElt, 8> differentialResults;
+    if (auto *resultTuple = originalResult->getAs<TupleType>())
+      for (auto &resultTupleElt : resultTuple->getElements())
+        differentialResults.push_back(getAssociatedType(
+            resultTupleElt.getType()->getCanonicalType(), "TangentVector"));
+    else
+      differentialResults.push_back(getAssociatedType(
+          originalResult->getCanonicalType(), "TangentVector"));
+    Type differentialResult =
+        differentialResults.size() > 1
+            ? TupleType::get(differentialResults, getASTContext())
+            : differentialResults[0].getType();
+
+    closure = makeFunctionType(this, differentialParams, differentialResult);
+    break;
+  }
+  case AutoDiffAssociatedFunctionKind::VJP: {
+    // closure is the VJP "pullback":
+    //   (R.CotangentVector...) -> (T.CotangentVector...)
+    SmallVector<AnyFunctionType::Param, 8> pullbackParams;
+    if (auto *resultTuple = originalResult->getAs<TupleType>())
+      for (auto &resultTupleElt : resultTuple->getElements())
+        pullbackParams.push_back(AnyFunctionType::Param(getAssociatedType(
+            resultTupleElt.getType()->getCanonicalType(), "CotangentVector")));
+    else
+      pullbackParams.push_back(AnyFunctionType::Param(getAssociatedType(
+          originalResult->getCanonicalType(), "CotangentVector")));
+
+    SmallVector<TupleTypeElt, 8> pullbackResults;
+    for (auto wrtParamType : wrtParamTypes)
+      pullbackResults.push_back(getAssociatedType(
+          wrtParamType->getCanonicalType(), "CotangentVector"));
+    Type pullbackResult = pullbackResults.size() > 1
+                              ? TupleType::get(pullbackResults, getASTContext())
+                              : pullbackResults[0].getType();
+
+    closure = makeFunctionType(this, pullbackParams, pullbackResult);
+    break;
+  }
+  }
+  assert(closure && "should have built a closure");
+
+  // Build "(T...) -> ((R...), Closure)".
+  SmallVector<TupleTypeElt, 2> retElts;
+  retElts.push_back(originalResult);
+  retElts.push_back(closure);
+  auto retTy = TupleType::get(retElts, getASTContext());
+  auto *associatedFunction =
+      makeFunctionType(unwrapped, unwrapped->getParams(), retTy);
+
+  // If this is a method, wrap the associated function type in an additional
+  // "(Self) ->" curry level.
+  if (indices.isMethod())
+    associatedFunction =
+        makeFunctionType(this, getParams(), associatedFunction);
+
+  return associatedFunction;
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2103,48 +2103,38 @@ void AttributeChecker::visitNonOverrideAttr(NonOverrideAttr *attr) {
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
-  // Forward mode is unsupported.
-  if (attr->getMode() == AutoDiffMode::Forward) {
-    TC.diagnose(attr->getModeLoc(),
-                diag::differentiable_attr_forward_mode_unsupported);
-    return;
-  }
+static FuncDecl *resolveAutoDiffAssociatedFunction(
+    TypeChecker &TC, DifferentiableAttr::DeclNameWithLoc specifier,
+    FuncDecl *original, bool isPrimal, Type expectedTy,
+    std::function<bool(FuncDecl *)> isValid) {
+  auto nameLoc = specifier.Loc.getBaseNameLoc();
+  auto overloadDiagnostic = [&]() {
+    if (isPrimal) {
+      TC.diagnose(nameLoc, diag::differentiable_attr_primal_overload_not_found,
+                  specifier.Name, expectedTy);
+    } else {
+      TC.diagnose(nameLoc, diag::differentiable_attr_overload_not_found,
+                  specifier.Name, expectedTy);
+    }
+  };
+  auto ambiguousDiagnostic = [&]() {
+    TC.diagnose(nameLoc,
+                diag::differentiable_attr_ambiguous_function_identifier,
+                specifier.Name);
+  };
+  auto notFunctionDiagnostic = [&]() {
+    TC.diagnose(nameLoc, diag::differentiable_attr_specified_not_function,
+                specifier.Name);
+  };
+  std::function<void()> invalidTypeContextDiagnostic = [&]() {
+    TC.diagnose(nameLoc,
+                diag::differentiable_attr_function_not_same_type_context,
+                specifier.Name);
+  };
 
-  // '@differentiable' attribute is OnFunc only, rejected by the early checker.
-  auto *original = cast<FuncDecl>(D);
-  auto isInstanceMethod = original->isInstanceMember();
-  auto &ctx = original->getASTContext();
-  auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
-
-  // If the original function has no parameters or returns the empty tuple
-  // type, there's nothing to differentiate from or with-respect-to.
-  auto &originalParams = *original->getParameters();
-  if (!isInstanceMethod && originalParams.size() == 0) {
-    TC.diagnose(attr->getLocation(), diag::differentiable_attr_no_parameters,
-                original->getName())
-      .highlight(original->getSourceRange());
-    attr->setInvalid();
-    return;
-  }
-  auto originalResultTy = original->getResultInterfaceType();
-  if (originalResultTy->isEqual(ctx.TheEmptyTupleType)) {
-    TC.diagnose(attr->getLocation(), diag::differentiable_attr_void_result,
-                original->getName())
-      .highlight(original->getSourceRange());
-    attr->setInvalid();
-    return;
-  }
-
-  auto originalParamTypes = map<SmallVector<TupleTypeElt, 8>>(
-      originalParams.getArray(),
-      [&](ParamDecl *decl) { return decl->getInterfaceType(); });
-  auto originalParamsTy = TupleType::get(originalParamTypes, ctx);
-
-  // If the original function and the primal/adjoint have different parents, or
-  // if they both have no type context and are in different modules, then it's
-  // an error.
-  // Returns true on error.
+  // If the original function and the associated functions different parents,
+  // or if they both have no type context and are in different modules, then
+  // it's an error. Returns true on error.
   std::function<bool(FuncDecl *)> hasValidTypeContext = [&](FuncDecl *func) {
     // Check if both are top-level.
     if (!original->getInnermostTypeContext() &&
@@ -2165,17 +2155,15 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   };
 
   // If the original function is exported (i.e. it is public or
-  // @usableFromInline), then the primal/adjoint must also be exported.
+  // @usableFromInline), then the associated functions must also be exported.
   // Returns true on error.
-  using FuncSpecifier = DifferentiableAttr::DeclNameWithLoc;
-  auto checkAccessControl = [&](FuncDecl *func, FuncSpecifier funcSpec,
-                                bool isPrimal) {
-    if (!isABIPublic(original)) return false;
-    if (isABIPublic(func)) return false;
-    TC.diagnose(funcSpec.Loc.getBaseNameLoc(),
-                diag::differentiable_attr_invalid_access,
-                funcSpec.Name, original->getFullName(), isPrimal);
-    attr->setInvalid();
+  auto checkAccessControl = [&](FuncDecl *func) {
+    if (!isABIPublic(original))
+      return false;
+    if (isABIPublic(func))
+      return false;
+    TC.diagnose(nameLoc, diag::differentiable_attr_invalid_access,
+                specifier.Name, original->getFullName());
     return true;
   };
 
@@ -2186,22 +2174,67 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   // Set lookup options.
   auto lookupOptions = defaultMemberLookupOptions
       | NameLookupFlags::IgnoreAccessControl;
-  
+
+  auto candidate = TC.lookupFuncDecl(
+      specifier.Name, nameLoc, /*baseType*/ Type(), originalTypeCtx, isValid,
+      overloadDiagnostic, ambiguousDiagnostic, notFunctionDiagnostic,
+      lookupOptions, hasValidTypeContext, invalidTypeContextDiagnostic);
+
+  if (checkAccessControl(candidate))
+    return nullptr;
+
+  return candidate;
+}
+
+void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
+  // Forward mode is unsupported.
+  if (attr->getMode() == AutoDiffMode::Forward) {
+    TC.diagnose(attr->getModeLoc(),
+                diag::differentiable_attr_forward_mode_unsupported);
+    return;
+  }
+
+  // '@differentiable' attribute is OnFunc only, rejected by the early checker.
+  auto *original = cast<FuncDecl>(D);
+  auto isInstanceMethod = original->isInstanceMember();
+  auto &ctx = original->getASTContext();
+  AnyFunctionType *originalFnTy =
+      original->getInterfaceType()->castTo<AnyFunctionType>();
+
+  // If the original function has no parameters or returns the empty tuple
+  // type, there's nothing to differentiate from or with-respect-to.
+  auto &originalParams = *original->getParameters();
+  if (!isInstanceMethod && originalParams.size() == 0) {
+    TC.diagnose(attr->getLocation(), diag::differentiable_attr_no_parameters,
+                original->getName())
+        .highlight(original->getSourceRange());
+    attr->setInvalid();
+    return;
+  }
+  auto originalResultTy = original->getResultInterfaceType();
+  if (originalResultTy->isEqual(ctx.TheEmptyTupleType)) {
+    TC.diagnose(attr->getLocation(), diag::differentiable_attr_void_result,
+                original->getName())
+        .highlight(original->getSourceRange());
+    attr->setInvalid();
+    return;
+  }
+
+  auto originalParamTypes = map<SmallVector<TupleTypeElt, 8>>(
+      originalParams.getArray(),
+      [&](ParamDecl *decl) { return decl->getInterfaceType(); });
+  auto originalParamsTy = TupleType::get(originalParamTypes, ctx);
+
   // Start type-checking the arguments of the @differentiable attribute. This
-  // covers 'wrt:', 'primal:' and 'adjoint:', all of which are optional.
+  // covers 'wrt:', 'primal:', 'adjoint:', and 'vjp:', all of which are
+  // optional.
 
   // If the declaration has no definition (e.g. it is a protocol requirement),
-  // then you are not allowed to specify a primal or adjoint.
+  // then you are not allowed to specify any associated functions.
   if (!original->hasBody()) {
-    if (attr->getPrimal()) {
-      TC.diagnose(attr->getPrimal()->Loc,
-                  diag::differentiable_attr_primal_no_definition);
-      attr->setInvalid();
-      return;
-    }
-    if (attr->getAdjoint()) {
-      TC.diagnose(attr->getAdjoint()->Loc,
-                  diag::differentiable_attr_adjoint_no_definition);
+    if (attr->getPrimal() || attr->getAdjoint()) {
+      TC.diagnose(attr->getLocation(),
+                  diag::differentiable_attr_associated_function_protocol);
       attr->setInvalid();
       return;
     }
@@ -2218,30 +2251,6 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   // Resolve the primal declaration, if it exists.
   FuncDecl *primal = nullptr;
   if (attr->getPrimal()) {
-    auto primalSpecifier = attr->getPrimal().getValue();
-    auto primalNameLoc = primalSpecifier.Loc.getBaseNameLoc();
-
-    auto primalOverloadDiagnostic = [&]() {
-      TC.diagnose(primalNameLoc,
-                  diag::differentiable_attr_primal_overload_not_found,
-                  primalSpecifier.Name, originalParamsTy);
-    };
-    auto primalAmbiguousDiagnostic = [&]() {
-      TC.diagnose(primalNameLoc,
-                  diag::differentiable_attr_ambiguous_function_identifier,
-                  primalSpecifier.Name);
-    };
-    auto primalNotFunctionDiagnostic = [&]() {
-      TC.diagnose(primalNameLoc,
-                  diag::differentiable_attr_specified_not_function,
-                  primalSpecifier.Name, /*isPrimal*/ true);
-    };
-    std::function<void()> primalInvalidTypeContextDiagnostic = [&]() {
-      TC.diagnose(primalNameLoc,
-                  diag::differentiable_attr_function_not_same_type_context,
-                  primalSpecifier.Name);
-    };
-
     auto isValidPrimal = [&](FuncDecl *primalCandidate) {
       // Returns true if the primal candidate
       // - has the same parameter types as the original function,
@@ -2274,18 +2283,14 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
       return true;
     };
 
-    primal = TC.lookupFuncDecl(
-      primalSpecifier.Name, primalNameLoc, /*baseType*/ Type(),
-      originalTypeCtx, isValidPrimal, primalOverloadDiagnostic,
-      primalAmbiguousDiagnostic, primalNotFunctionDiagnostic, lookupOptions,
-      hasValidTypeContext, primalInvalidTypeContextDiagnostic);
+    primal = resolveAutoDiffAssociatedFunction(TC, attr->getPrimal().getValue(),
+                                               original, /*isPrimal*/ true,
+                                               originalParamsTy, isValidPrimal);
 
     if (!primal) {
       attr->setInvalid();
       return;
     }
-    // Check primal access control.
-    if (checkAccessControl(primal, primalSpecifier, /*isPrimal*/ true)) return;
     // Memorize the primal reference in the attribute.
     attr->setPrimalFunction(primal);
   }
@@ -2359,6 +2364,19 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
+  // Predicate checking if a type conforms to Differentiable.
+  auto *differentiableProtocol =
+      ctx.getProtocol(KnownProtocolKind::Differentiable);
+  assert(differentiableProtocol && "could not find differentiable protocol");
+  auto conformsToDifferentiable = [&](Type type) -> bool {
+    auto *nomTy = type->getAnyNominal();
+    if (!nomTy)
+      return false;
+    SmallVector<ProtocolConformance *, 2> conformances;
+    return nomTy->lookupConformance(D->getDeclContext()->getParentModule(),
+                                    differentiableProtocol, conformances);
+  };
+
   // Check that the user has only selected wrt params with allowed types.
   SmallVector<Type, 4> wrtParamTypes;
   checkedWrtParamIndices->getSubsetParameterTypes(originalFnTy, wrtParamTypes);
@@ -2379,57 +2397,58 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
       attr->setInvalid();
       return;
     }
+
+    // We also require that all the wrt params conform to Differentiable. But
+    // only for attrs that have JVP or VJP, because there are a lot of attrs
+    // using the legacy primal/adjoint whose wrt params do not conform.
+    bool hasJVPorVJP = attr->getJVP() || attr->getVJP();
+    if (hasJVPorVJP && !conformsToDifferentiable(wrtParamType)) {
+      TC.diagnose(loc, diag::differentiable_attr_wrt_not_differentiable,
+                  wrtParamType);
+      attr->setInvalid();
+      return;
+    }
+  }
+
+  // Check that all the result types are differentiable. But only for attrs that
+  // have JVP or VJP, because there are a lot of attrs using the legacy
+  // primal/adjoint whose results do not conform.
+  if (attr->getJVP() || attr->getVJP()) {
+    auto *unwrapped = originalFnTy;
+    if (checkedWrtParamIndices->isMethod())
+      unwrapped = unwrapped->getResult()->castTo<AnyFunctionType>();
+    Type originalResult = unwrapped->getResult();
+    if (auto *resultTuple = originalResult->getAs<TupleType>()) {
+      for (auto &resultTupleElt : resultTuple->getElements()) {
+        if (!conformsToDifferentiable(resultTupleElt.getType())) {
+          TC.diagnose(attr->getLocation(),
+                      diag::differentiable_attr_result_not_differentiable,
+                      resultTupleElt.getType());
+          attr->setInvalid();
+          return;
+        }
+      }
+    } else {
+      if (!conformsToDifferentiable(originalResult)) {
+        TC.diagnose(attr->getLocation(),
+                    diag::differentiable_attr_result_not_differentiable,
+                    originalResult);
+        attr->setInvalid();
+        return;
+      }
+    }
   }
 
   // Memorize the checked parameter indices in the attribute.
   attr->setCheckedParameterIndices(checkedWrtParamIndices);
 
-  // Resolve the adjoint declaration.
-  FuncDecl *adjoint = nullptr;
-  auto adjointSpecifier = attr->getAdjoint();
-  // If the adjoint is not specified, back out.
-  if (!adjointSpecifier)
-    return;
-
-  TupleType *primalResultTy =
-      primal ? primal->getResultInterfaceType()->getAs<TupleType>() : nullptr;
-  AnyFunctionType *expectedAdjointFnTy =
-      originalFnTy->getAutoDiffAdjointFunctionType(*checkedWrtParamIndices,
-                                                   primalResultTy);
-
-  auto adjointNameLoc = adjointSpecifier->Loc.getBaseNameLoc();
-  auto adjointOverloadDiagnostic = [&]() {
-    TC.diagnose(adjointNameLoc,
-                diag::differentiable_attr_adjoint_overload_not_found,
-                adjointSpecifier->Name, expectedAdjointFnTy);
-    attr->setInvalid();
-  };
-  auto adjointAmbiguousDiagnostic = [&]() {
-    TC.diagnose(adjointNameLoc,
-                diag::differentiable_attr_ambiguous_function_identifier,
-                adjointSpecifier->Name);
-    attr->setInvalid();
-  };
-  auto adjointNotFunctionDiagnostic = [&]() {
-    TC.diagnose(adjointNameLoc,
-                diag::differentiable_attr_specified_not_function,
-                adjointSpecifier->Name, /*isPrimal*/ false);
-    attr->setInvalid();
-  };
-  std::function<void()> adjointInvalidTypeContextDiagnostic = [&]() {
-    TC.diagnose(adjointNameLoc,
-                diag::differentiable_attr_function_not_same_type_context,
-                adjointSpecifier->Name);
-    attr->setInvalid();
-  };
-
   // Checks that the `candidate` function type equals the `required` function
   // type, disregarding parameter labels.
   //
   // Precondition: `required` has no parameter labels.
-  std::function<bool(CanAnyFunctionType, CanType)> checkAdjointSignature;
-  checkAdjointSignature = [&](CanAnyFunctionType required,
-                              CanType candidate) -> bool {
+  std::function<bool(CanAnyFunctionType, CanType)> checkFunctionSignature;
+  checkFunctionSignature = [&](CanAnyFunctionType required,
+                               CanType candidate) -> bool {
 
     // Check that candidate is actually a function.
     CanAnyFunctionType candidateFnTy = dyn_cast<AnyFunctionType>(candidate);
@@ -2456,31 +2475,87 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
       return required.getResult() == candidateFnTy.getResult();
 
     // Required result type is a function. Recurse.
-    return checkAdjointSignature(requiredResultFnTy,
-                                 candidateFnTy.getResult());
+    return checkFunctionSignature(requiredResultFnTy,
+                                  candidateFnTy.getResult());
   };
 
-  auto isValidAdjoint = [&](FuncDecl *adjointCandidate) {
-    TC.validateDeclForNameLookup(adjointCandidate);
-    return checkAdjointSignature(
-        cast<AnyFunctionType>(expectedAdjointFnTy->getCanonicalType()),
-        adjointCandidate->getInterfaceType()->getCanonicalType());
-  };
+  // Resolve the adjoint declaration, if it exists.
+  if (attr->getAdjoint()) {
+    // Compute the expected adjoint function type.
+    TupleType *primalResultTy =
+        primal ? primal->getResultInterfaceType()->getAs<TupleType>() : nullptr;
+    AnyFunctionType *expectedAdjointFnTy =
+        originalFnTy->getAutoDiffAdjointFunctionType(*checkedWrtParamIndices,
+                                                     primalResultTy);
 
-  adjoint =
-    TC.lookupFuncDecl(adjointSpecifier->Name, adjointNameLoc,
-                      /*baseType*/ Type(), originalTypeCtx, isValidAdjoint,
-                      adjointOverloadDiagnostic, adjointAmbiguousDiagnostic,
-                      adjointNotFunctionDiagnostic, lookupOptions,
-                      hasValidTypeContext,
-                      adjointInvalidTypeContextDiagnostic);
+    auto isValidAdjoint = [&](FuncDecl *adjointCandidate) {
+      TC.validateDeclForNameLookup(adjointCandidate);
+      return checkFunctionSignature(
+          cast<AnyFunctionType>(expectedAdjointFnTy->getCanonicalType()),
+          adjointCandidate->getInterfaceType()->getCanonicalType());
+    };
 
-  // Check adjoint access control.
-  if (checkAccessControl(adjoint, *adjointSpecifier, /*isPrimal*/ false))
-    return;
-  // Done checking @differentiable attribute.
-  // Memorize the adjoint reference in the attribute.
-  attr->setAdjointFunction(adjoint);
+    FuncDecl *adjoint = resolveAutoDiffAssociatedFunction(
+        TC, attr->getAdjoint().getValue(), original, /*isPrimal*/ false,
+        expectedAdjointFnTy, isValidAdjoint);
+
+    if (!adjoint) {
+      attr->setInvalid();
+      return;
+    }
+    // Memorize the adjoint reference in the attribute.
+    attr->setAdjointFunction(adjoint);
+  }
+
+  // Resolve the JVP declaration, if it exists.
+  if (attr->getJVP()) {
+    AnyFunctionType *expectedJVPFnTy =
+        originalFnTy->getAutoDiffAssociatedFunctionType(
+            *checkedWrtParamIndices, 1, AutoDiffAssociatedFunctionKind::JVP);
+
+    auto isValidJVP = [&](FuncDecl *jvpCandidate) {
+      TC.validateDeclForNameLookup(jvpCandidate);
+      return checkFunctionSignature(
+          cast<AnyFunctionType>(expectedJVPFnTy->getCanonicalType()),
+          jvpCandidate->getInterfaceType()->getCanonicalType());
+    };
+
+    FuncDecl *jvp = resolveAutoDiffAssociatedFunction(
+        TC, attr->getJVP().getValue(), original, /*isPrimal*/ false,
+        expectedJVPFnTy, isValidJVP);
+
+    if (!jvp) {
+      attr->setInvalid();
+      return;
+    }
+    // Memorize the jvp reference in the attribute.
+    attr->setJVPFunction(jvp);
+  }
+
+  // Resolve the VJP declaration, if it exists.
+  if (attr->getVJP()) {
+    AnyFunctionType *expectedVJPFnTy =
+        originalFnTy->getAutoDiffAssociatedFunctionType(
+            *checkedWrtParamIndices, 1, AutoDiffAssociatedFunctionKind::VJP);
+
+    auto isValidVJP = [&](FuncDecl *vjpCandidate) {
+      TC.validateDeclForNameLookup(vjpCandidate);
+      return checkFunctionSignature(
+          cast<AnyFunctionType>(expectedVJPFnTy->getCanonicalType()),
+          vjpCandidate->getInterfaceType()->getCanonicalType());
+    };
+
+    FuncDecl *vjp = resolveAutoDiffAssociatedFunction(
+        TC, attr->getVJP().getValue(), original, /*isPrimal*/ false,
+        expectedVJPFnTy, isValidVJP);
+
+    if (!vjp) {
+      attr->setInvalid();
+      return;
+    }
+    // Memorize the vjp reference in the attribute.
+    attr->setVJPFunction(vjp);
+  }
 }
 
 static bool

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2126,7 +2126,7 @@ static FuncDecl *resolveAutoDiffAssociatedFunction(
     TC.diagnose(nameLoc, diag::differentiable_attr_specified_not_function,
                 specifier.Name);
   };
-  auto invalidTypeContextDiagnostic = [&]() {
+  std::function<void()> invalidTypeContextDiagnostic = [&]() {
     TC.diagnose(nameLoc,
                 diag::differentiable_attr_function_not_same_type_context,
                 specifier.Name);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2126,7 +2126,7 @@ static FuncDecl *resolveAutoDiffAssociatedFunction(
     TC.diagnose(nameLoc, diag::differentiable_attr_specified_not_function,
                 specifier.Name);
   };
-  std::function<void()> invalidTypeContextDiagnostic = [&]() {
+  auto invalidTypeContextDiagnostic = [&]() {
     TC.diagnose(nameLoc,
                 diag::differentiable_attr_function_not_same_type_context,
                 specifier.Name);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2401,6 +2401,18 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
       adjointName = addDeclBaseNameRef(adjoint->Name.getBaseName());
       adjointRef = addDeclRef(attr->getAdjointFunction());
     }
+    IdentifierID jvpName = 0;
+    DeclID jvpRef = 0;
+    if (auto jvp = attr->getJVP()) {
+      jvpName = addDeclBaseNameRef(jvp->Name.getBaseName());
+      jvpRef = addDeclRef(attr->getJVPFunction());
+    }
+    IdentifierID vjpName = 0;
+    DeclID vjpRef = 0;
+    if (auto vjp = attr->getVJP()) {
+      vjpName = addDeclBaseNameRef(vjp->Name.getBaseName());
+      vjpRef = addDeclRef(attr->getVJPFunction());
+    }
 
     SmallVector<uint32_t, 4> parameters;
     for (auto param : attr->getParameters()) {
@@ -2418,7 +2430,8 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
 
     DifferentiableDeclAttrLayout::emitRecord(
       Out, ScratchRecord, abbrCode, (unsigned) attr->getMode(), primalName,
-      primalRef, adjointName, adjointRef, parameters);
+      primalRef, adjointName, adjointRef, jvpName, jvpRef, vjpName, vjpRef,
+      parameters);
     // TODO: Serialize CheckedParameterIndices.
     // TODO: Serialize trailing where clause.
     // Type-checking where clause should be done first (mimicking the

--- a/test/AutoDiff/differentiable_attr_access_control.swift
+++ b/test/AutoDiff/differentiable_attr_access_control.swift
@@ -21,12 +21,12 @@ private func foo3(_ x: Float) -> Float { return 1 }
 private func dfoo3(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
 
 // Error: adjoint not exported.
-@differentiable(reverse, adjoint: dbar1(_:primal:seed:)) // expected-error {{adjoint 'dbar1(_:primal:seed:)' is required to either be public or @usableFromInline because the original function 'bar1' is public or @usableFromInline}}
+@differentiable(reverse, adjoint: dbar1(_:primal:seed:)) // expected-error {{associated differentiation function 'dbar1(_:primal:seed:)' is required to either be public or @usableFromInline because the original function 'bar1' is public or @usableFromInline}}
 public func bar1(_ x: Float) -> Float { return 1 }
 private func dbar1(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
 
 // Error: primal not exported.
-@differentiable(reverse, primal: pbar2(_:), adjoint: dbar2(_:checkpoints:originalValue:seed:)) // expected-error {{primal 'pbar2' is required to either be public or @usableFromInline because the original function 'bar2' is public or @usableFromInline}}
+@differentiable(reverse, primal: pbar2(_:), adjoint: dbar2(_:checkpoints:originalValue:seed:)) // expected-error {{associated differentiation function 'pbar2' is required to either be public or @usableFromInline because the original function 'bar2' is public or @usableFromInline}}
 @usableFromInline func bar2(_ x: Float) -> Float { return 1 }
 func pbar2(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) { return (CheckpointsFoo(), 1) }
 func dbar2(_ x: Float, checkpoints: CheckpointsFoo, originalValue: Float, seed: Float) -> Float { return 1 }

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -66,3 +66,25 @@ func dbaz2_checkpointed<T : FloatingPoint>(_ x: T, _ y: T, primal: CheckpointsFP
 func baz2_checkpointed<T : FloatingPoint>(_ x: T, _ y: T) -> T {
   return x
 }
+
+@differentiable(reverse, jvp: jvpSimpleJVP)
+func jvpSimple(x: Float) -> Float {
+  return x
+}
+
+// CHECK-DAG: @differentiable(reverse, jvp: jvpSimpleJVP)
+// CHECK-DAG: func jvpSimpleJVP(x: Float) -> (Float, (Float) -> Float)
+func jvpSimpleJVP(x: Float) -> (Float, (Float) -> Float) {
+  return (x, { v in v })
+}
+
+@differentiable(reverse, vjp: vjpSimpleVJP)
+func vjpSimple(x: Float) -> Float {
+  return x
+}
+
+// CHECK-DAG: @differentiable(reverse, vjp: vjpSimpleVJP)
+// CHECK-DAG: func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float)
+func vjpSimpleVJP(x: Float) -> (Float, (Float) -> Float) {
+  return (x, { v in v })
+}


### PR DESCRIPTION
This PR allows users to specify JVP and VJP in the `@differentiable` attr, and adds typechecking for it.

This PR leaves `@differentiable` in a weird state where you can specify primal/adjoint and/or jvp/vjp but where only primal/adjoint are fully plumbed through everything. I think that this is acceptable as a temporary intermediate state for switching from primal/adjoint to jvp/vjp.

Note that having JVP and VJP in the `@differentiable` attr is throwaway work because our long-term design does away with using `@differentiable` to specify custom associated functions. This throwaway work will unblock my ability to put the JVP and VJP in the witness table though. Also, the type calculations in this PR should not be throwaway.