### PR TITLE
[AutoDiff] [SILVerifier] Verify `autodiff_function` instruction

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -252,9 +252,9 @@ struct SILAutoDiffConfig {
 /// `autodiff_function_extract` instructions in SIL.
 struct AutoDiffAssociatedFunctionKind {
   enum innerty : uint8_t {
-     // The vector-Jacobian products operator.
+     // The Jacobian-vector products function.
      JVP = 0,
-     // The Jacobian-vector products operator.
+     // The vector-Jacobian products function.
      VJP = 1
   } rawValue;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4077,7 +4077,7 @@ public:
   CanSILFunctionType getWithDifferentiability(
       unsigned differentiationOrder, const SmallBitVector &parameterIndices);
 
-  /// Returns the type of a differentiation fucntion that is associated with
+  /// Returns the type of a differentiation function that is associated with
   /// a function of this type.
   CanSILFunctionType getAutoDiffAssociatedFunctionType(
       const SmallBitVector &parameterIndices, unsigned differentiationOrder,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4077,8 +4077,8 @@ public:
   CanSILFunctionType getWithDifferentiability(
       unsigned differentiationOrder, const SmallBitVector &parameterIndices);
 
-  /// Returns the differentiation function type associated functions with this
-  /// function type.
+  /// Returns the type of a differentiation fucntion that is associated with
+  /// a function of this type.
   CanSILFunctionType getAutoDiffAssociatedFunctionType(
       const SmallBitVector &parameterIndices, unsigned differentiationOrder,
       AutoDiffAssociatedFunctionKind kind, SILModule &module);

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7621,6 +7621,10 @@ public:
     return numOperands - 1;
   }
 
+  bool hasAssociatedFunctions() const {
+    return numOperands > 1;
+  }
+
   ArrayRef<Operand> getAssociatedFunctions() const {
     return getAllOperands().drop_front();
   }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -267,8 +267,8 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
       });
     auto differentialType = SILFunctionType::get(
         getGenericSignature(), ExtInfo(), SILCoroutineKind::None,
-        ParameterConvention::Direct_Guaranteed, tangentParams, {}, tangentResults,
-        None, getASTContext());
+        ParameterConvention::Direct_Guaranteed, tangentParams, {},
+        tangentResults, None, getASTContext());
     SmallVector<SILResultInfo, 8> jvpResults(getResults().begin(),
                                              getResults().end());
     jvpResults.push_back({differentialType, ResultConvention::Owned});
@@ -288,12 +288,10 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
       cotangentResults.push_back(
           getFormalResultInfo(
               getAssociatedType(param.getType(), "CotangentVector")));
-    auto pullbackType = SILFunctionType::get(getGenericSignature(),
-                                             ExtInfo(), SILCoroutineKind::None,
-                                         ParameterConvention::Direct_Guaranteed,
-                                             cotangentParams, {},
-                                             cotangentResults, {},
-                                             getASTContext());
+    auto pullbackType = SILFunctionType::get(
+        getGenericSignature(), ExtInfo(), SILCoroutineKind::None,
+        ParameterConvention::Direct_Guaranteed, cotangentParams, {},
+        cotangentResults, {}, getASTContext());
     SmallVector<SILResultInfo, 8> vjpResults(getResults().begin(),
                                              getResults().end());
     vjpResults.push_back({pullbackType, ResultConvention::Owned});

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -267,7 +267,7 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
       });
     auto differentialType = SILFunctionType::get(
         getGenericSignature(), ExtInfo(), SILCoroutineKind::None,
-        ParameterConvention::Direct_Owned, tangentParams, {}, tangentResults,
+        ParameterConvention::Direct_Guaranteed, tangentParams, {}, tangentResults,
         None, getASTContext());
     SmallVector<SILResultInfo, 8> jvpResults(getResults().begin(),
                                              getResults().end());
@@ -290,7 +290,7 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
               getAssociatedType(param.getType(), "CotangentVector")));
     auto pullbackType = SILFunctionType::get(getGenericSignature(),
                                              ExtInfo(), SILCoroutineKind::None,
-                                             ParameterConvention::Direct_Owned,
+                                         ParameterConvention::Direct_Guaranteed,
                                              cotangentParams, {},
                                              cotangentResults, {},
                                              getASTContext());

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -649,6 +649,8 @@ std::pair<SILValue, SILValue> AutoDiffFunctionInst::
 getAssociatedFunctionPair(unsigned differentiationOrder) const {
   assert(differentiationOrder > 0 &&
          differentiationOrder <= this->differentiationOrder);
+  assert(!getAssociatedFunctions().empty() &&
+         "Associated functions may not exist in raw SIL");
   auto offset = (differentiationOrder - 1) * 2;
   auto assocFns = getAssociatedFunctions();
   return {assocFns[offset].get(), assocFns[offset+1].get()};

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -649,8 +649,8 @@ std::pair<SILValue, SILValue> AutoDiffFunctionInst::
 getAssociatedFunctionPair(unsigned differentiationOrder) const {
   assert(differentiationOrder > 0 &&
          differentiationOrder <= this->differentiationOrder);
-  assert(!getAssociatedFunctions().empty() &&
-         "Associated functions may not exist in raw SIL");
+  assert(!getAssociatedFunctions().empty() && "No associated functions. Maybe "
+         "the differentiation pass has not run?");
   auto offset = (differentiationOrder - 1) * 2;
   auto assocFns = getAssociatedFunctions();
   return {assocFns[offset].get(), assocFns[offset+1].get()};

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1262,14 +1262,14 @@ public:
             "The original function must not be @autodiff");
     if (F.getModule().getStage() == SILStage::Canonical ||
         adfi->hasAssociatedFunctions()) {
-      for (auto i : range(1, adfi->getDifferentiationOrder() + 1)) {
-        auto pair = adfi->getAssociatedFunctionPair(i);
+      for (auto order : range(1, adfi->getDifferentiationOrder() + 1)) {
+        auto pair = adfi->getAssociatedFunctionPair(order);
         auto jvpType = pair.first->getType().getAs<SILFunctionType>();
         require(jvpType, "The JVP function must have a function type");
         require(!jvpType->isDifferentiable(),
                 "The JVP function must not be @autodiff");
         auto expectedJVPType = origTy->getAutoDiffAssociatedFunctionType(
-            adfi->getParameterIndices(), adfi->getDifferentiationOrder(),
+            adfi->getParameterIndices(), order,
             AutoDiffAssociatedFunctionKind::JVP, F.getModule());
         require(expectedJVPType == jvpType, "Unexpected JVP function type");
         auto vjpType = pair.second->getType().getAs<SILFunctionType>();
@@ -1277,9 +1277,8 @@ public:
         require(!vjpType->isDifferentiable(),
                 "The VJP function must not be @autodiff");
         auto expectedVJPType = origTy->getAutoDiffAssociatedFunctionType(
-            adfi->getParameterIndices(), adfi->getDifferentiationOrder(),
+            adfi->getParameterIndices(), order,
             AutoDiffAssociatedFunctionKind::VJP, F.getModule());
-        llvm::outs() << "Expected JVP type: " << expectedJVPType << '\n';
         require(expectedVJPType == vjpType, "Unexpected VJP function type");
       }
     }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1255,13 +1255,34 @@ public:
 
   void checkAutoDiffFunctionInst(AutoDiffFunctionInst *adfi) {
     // FIXME(rxwei): Complete verification.
-    for (auto &op : adfi->getAllOperands())
-      require(op.get()->getType().is<SILFunctionType>(),
-              "All operands must have a function type");
-    auto fnTy = adfi->getOriginalFunction()
-        ->getType().castTo<SILFunctionType>();
-    require(!fnTy->isDifferentiable(),
-            "The original function operand must not be '@autodiff'");
+    auto origTy =
+        adfi->getOriginalFunction()->getType().getAs<SILFunctionType>();
+    require(origTy, "The original function must have a function type");
+    require(!origTy->isDifferentiable(),
+            "The original function must not be @autodiff");
+    if (F.getModule().getStage() == SILStage::Canonical ||
+        adfi->hasAssociatedFunctions()) {
+      for (auto i : range(1, adfi->getDifferentiationOrder() + 1)) {
+        auto pair = adfi->getAssociatedFunctionPair(i);
+        auto jvpType = pair.first->getType().getAs<SILFunctionType>();
+        require(jvpType, "The JVP function must have a function type");
+        require(!jvpType->isDifferentiable(),
+                "The JVP function must not be @autodiff");
+        auto expectedJVPType = origTy->getAutoDiffAssociatedFunctionType(
+            adfi->getParameterIndices(), adfi->getDifferentiationOrder(),
+            AutoDiffAssociatedFunctionKind::JVP, F.getModule());
+        require(expectedJVPType == jvpType, "Unexpected JVP function type");
+        auto vjpType = pair.second->getType().getAs<SILFunctionType>();
+        require(vjpType, "The VJP function must have a function type");
+        require(!vjpType->isDifferentiable(),
+                "The VJP function must not be @autodiff");
+        auto expectedVJPType = origTy->getAutoDiffAssociatedFunctionType(
+            adfi->getParameterIndices(), adfi->getDifferentiationOrder(),
+            AutoDiffAssociatedFunctionKind::VJP, F.getModule());
+        llvm::outs() << "Expected JVP type: " << expectedJVPType << '\n';
+        require(expectedVJPType == vjpType, "Unexpected VJP function type");
+      }
+    }
   }
   
   void checkAutoDiffFunctionExtractInst(AutoDiffFunctionExtractInst *adfei) {

--- a/test/AutoDiff/autodiff_function_inst.sil
+++ b/test/AutoDiff/autodiff_function_inst.sil
@@ -5,30 +5,47 @@ sil_stage raw
 import Swift
 import Builtin
 
+// The pullback function emitted by the compiler. Parameter are a vector, as in
+// vector-Jacobian products, and primal values. The function is not itself a
+// pullback, but to be partially applied to form a pullback, which takes a
+// vector and returns vector-Jacobian products evaluated at the original
+// parameter.
 sil hidden @foo_adj : $@convention(thin) (Float, Float, Float) -> Float {
 bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float):
   return %2 : $Float
 }
 
+// The original function with an attribute that specifies the compiler-emitted pullback.
 sil hidden [reverse_differentiable source 0 wrt 0 primal @foo adjoint @foo_adj primitive] @foo : $@convention(thin) (Float) -> Float {
 bb0(%0 : @trivial $Float):
   return %0 : $Float
 }
 
-sil @make_diff_func : $@convention(thin) () -> @autodiff @convention(thin) (Float) -> Float {
-bb0:
-  %0 = function_ref @foo : $@convention(thin) (Float) -> Float
-  %1 = autodiff_function [wrt 0 1] [order 1] %0 : $@convention(thin) (Float) -> Float
-  %2 = function_ref @foo_adj : $@convention(thin) (Float, Float, Float) -> Float
-  %3 = autodiff_function [wrt 0 1] [order 1] %0 : $@convention(thin) (Float) -> Float with {%0 : $@convention(thin) (Float) -> Float, %2 : $@convention(thin) (Float, Float, Float) -> Float}
-  %4 = autodiff_function_extract [vjp] [order 1] %3 : $@autodiff @convention(thin) (Float) -> Float
-  return %1 : $@autodiff @convention(thin) (Float) -> Float
+// The vector-Jacobian product function, which returns the original result and a pullback.
+sil hidden @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : @trivial $Float):
+  %1 = function_ref @foo : $@convention(thin) (Float) -> Float
+  %2 = apply %1(%0) : $@convention(thin) (Float) -> Float
+  %3 = function_ref @foo_adj : $@convention(thin) (Float, Float, Float) -> Float
+  %4 = partial_apply [callee_guaranteed] %3(%0, %2) : $@convention(thin) (Float, Float, Float) -> Float
+  %5 = tuple (%2 : $Float, %4 : $@callee_guaranteed (Float) -> Float)
+  return %5 : $(Float, @callee_guaranteed (Float) -> Float)
 }
 
-// CHECK-LABEL: @make_diff_func
-// CHECK: %0 = function_ref @foo : $@convention(thin) (Float) -> Float
-// CHECK: %1 = autodiff_function [wrt 0 1] [order 1] %0 : $@convention(thin) (Float) -> Float
-// CHECK: %2 = function_ref @foo_adj : $@convention(thin) (Float, Float, Float) -> Float
-// CHECK: %3 = autodiff_function [wrt 0 1] [order 1] %0 : $@convention(thin) (Float) -> Float with {%0 : $@convention(thin) (Float) -> Float, %2 : $@convention(thin) (Float, Float, Float) -> Float}
-// CHECK: %4 = autodiff_function_extract [vjp] [order 1] %3 : $@autodiff @convention(thin) (Float) -> Float
-// CHECK: return %1 : $@autodiff @convention(thin) (Float) -> Float
+sil @make_diff_func : $@convention(thin) () -> @autodiff @convention(thin) (Float) -> Float {
+bb0:
+  %orig = function_ref @foo : $@convention(thin) (Float) -> Float
+  %undiffedFunc = autodiff_function [wrt 0] [order 1] %orig : $@convention(thin) (Float) -> Float
+  %vjp = function_ref @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+  %diffFunc = autodiff_function [wrt 0] [order 1] %orig : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
+  %extractedVJP = autodiff_function_extract [vjp] [order 1] %diffFunc : $@autodiff @convention(thin) (Float) -> Float
+  return %undiffedFunc : $@autodiff @convention(thin) (Float) -> Float
+}
+
+// CHECK-LABEL: @make_diff_func : $@convention(thin) () -> @autodiff @convention(thin) (Float) -> Float
+// CHECK:   [[FOO:%.*]] = function_ref @foo : $@convention(thin) (Float) -> Float
+// CHECK:   [[UNDIFFED_FOO:%.*]] = autodiff_function [wrt 0] [order 1] [[FOO]] : $@convention(thin) (Float) -> Float
+// CHECK:   [[FOO_VJP:%.*]] = function_ref @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:   [[DIFFED_FOO:%.*]] = autodiff_function [wrt 0] [order 1] [[FOO]] : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), [[FOO_VJP]] : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
+// CHECK:   [[EXTRACTED_VJP:%.*]] = autodiff_function_extract [vjp] [order 1] [[DIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float
+// CHECK:   return [[UNDIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float // id: %5

--- a/test/AutoDiff/autodiff_function_inst.sil
+++ b/test/AutoDiff/autodiff_function_inst.sil
@@ -48,4 +48,4 @@ bb0:
 // CHECK:   [[FOO_VJP:%.*]] = function_ref @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // CHECK:   [[DIFFED_FOO:%.*]] = autodiff_function [wrt 0] [order 1] [[FOO]] : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), [[FOO_VJP]] : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
 // CHECK:   [[EXTRACTED_VJP:%.*]] = autodiff_function_extract [vjp] [order 1] [[DIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float
-// CHECK:   return [[UNDIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float // id: %5
+// CHECK:   return [[UNDIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float


### PR DESCRIPTION
* Verify the JVP type and VJP type in an `autodiff_function` instruction.
* Correct the associated function type calculator utility to produce closures with `@callee_guaranteed` callee convention.
* Add example code (/test/AutoDiff/autodiff_function_inst.sil) that demonstrates how we emit a thunk that forms a VJP function.