### PR TITLE
[vim] Fix default label problem

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -144,7 +144,7 @@ syn match swiftKeyword
 syn region swiftCaseLabelRegion
       \ matchgroup=swiftKeyword start=/\<case\>/ matchgroup=Delimiter end=/:/ oneline contains=TOP
 syn region swiftDefaultLabelRegion
-      \ matchgroup=swiftKeyword start=/\<default\>/ matchgroup=Delimiter end=/:/
+      \ matchgroup=swiftKeyword start=/\<default\>/ matchgroup=Delimiter end=/:/ oneline
 
 syn region swiftParenthesisRegion matchgroup=NONE start=/(/ end=/)/ contains=TOP
 


### PR DESCRIPTION
**Update only utils/vim/syntax/swift.vim**

Fix the problem that the subsequent lines are not highlighted when using `default` without colon.



## Problematic patterns

<img width="665" alt="2018-11-21 11 17 31" src="https://user-images.githubusercontent.com/629993/48814692-12fcff80-ed7f-11e8-80d8-e244c2d2191a.png">

## Expects

<img width="673" alt="2018-11-21 11 17 02" src="https://user-images.githubusercontent.com/629993/48814700-1b553a80-ed7f-11e8-82e8-fd182a7b257e.png">
