### PR TITLE
IRGen: adjust the replacements section for Windows

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1233,7 +1233,7 @@ static std::string getDynamicReplacementSection(IRGenModule &IGM) {
     sectionName = "swift5_replace";
     break;
   case llvm::Triple::COFF:
-    sectionName = ".sw5repl";
+    sectionName = ".sw5repl$B";
     break;
   default:
     llvm_unreachable("Don't know how to emit field records table for "


### PR DESCRIPTION
Group the section for the replacements on PE/COFF.  The group is needed
to ensure that we are able to order the marker for the start and stop
properly.  Without the grouping there is no way to guarantee the
ordering.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
