### PR TITLE
[vim] Remove a-z from swiftType

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -116,7 +116,7 @@ syn match swiftImplicitVarName
 
 " TypeName[Optionality]?
 syn match swiftType contained skipwhite skipempty nextgroup=swiftTypeParameters
-      \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>[!?]\?/
+      \ /\<[A-Z_][A-Za-z_0-9\.]*\>[!?]\?/
 " [Type:Type] (dictionary) or [Type] (array)
 syn region swiftType contained contains=swiftTypePair,swiftType
       \ matchgroup=Delimiter start=/\[/ end=/\]/


### PR DESCRIPTION
**Update only utils/vim/syntax/swift.vim**

Fix the problem that the subsequent characters are highlighted as `swiftTypeParameters` when using `<` without `>`.

This fix is not perfect, because Swift identifer-head allows a-z. But by avoiding this I think that more cases will be saved.

In addition to this, I considered how to add `contained` to `swiftTypeDeclaration`, but stopped to cause another problem.

## Problematic patterns

<img width="583" alt="problems" src="https://user-images.githubusercontent.com/629993/48879497-59219400-ee4f-11e8-98bc-38ced808ca6d.png">

## Expects

<img width="319" alt="2018-11-22 12 02 39" src="https://user-images.githubusercontent.com/629993/48879501-62aafc00-ee4f-11e8-99c7-87145a0aa664.png">
