### PR TITLE
[Runtime] Diagnose conflicting retroactive conformances

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2309,11 +2309,17 @@ public:
     return TypeRef.getTypeDescriptor(getTypeKind());
   }
 
+  /// Whether this is a retroactive conformance.
+  bool isRetroactive() const {
+    return Flags.isRetroactive();
+  }
+
   /// Retrieve the context of a retroactive conformance.
-  const TargetContextDescriptor<Runtime> *getRetroactiveContext() const {
+  ConstTargetPointer<Runtime, TargetContextDescriptor<Runtime>>
+  getRetroactiveContext() const {
     if (!Flags.isRetroactive()) return nullptr;
 
-    return this->template getTrailingObjects<RelativeContextPointer<Runtime>>();
+    return *this->template getTrailingObjects<RelativeContextPointer<Runtime>>();
   }
 
   /// Whether this conformance is non-unique because it has been synthesized

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -527,7 +527,7 @@ swift::swift_getGenericMetadata(MetadataRequest request,
   auto &generics = description->getFullGenericContextHeader();
   size_t numGenericArgs = generics.Base.NumKeyArguments;
 
-  auto key = MetadataCacheKey(arguments, numGenericArgs);
+  auto key = MetadataCacheKey(description, arguments, numGenericArgs);
   auto result =
     getCache(generics).getOrInsert(key, request, description, arguments);
 
@@ -4338,7 +4338,7 @@ static Result performOnMetadataCache(const Metadata *metadata,
     reinterpret_cast<const void * const *>(
                                     description->getGenericArguments(metadata));
   size_t numGenericArgs = generics.Base.NumKeyArguments;
-  auto key = MetadataCacheKey(genericArgs, numGenericArgs);
+  auto key = MetadataCacheKey(description, genericArgs, numGenericArgs);
 
   return std::move(callbacks).forGenericMetadata(metadata, description,
                                                  getCache(generics), key);

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -507,6 +507,12 @@ public:
                              const Metadata *type,
                              const ProtocolConformanceDescriptor *conformance);
 
+  /// Determine whether the given type conforms to the given Swift protocol,
+  /// returning the appropriate protocol conformance descriptor when it does.
+  const ProtocolConformanceDescriptor *
+  _conformsToSwiftProtocol(const Metadata * const type,
+                           const ProtocolDescriptor *protocol);
+
   /// Retrieve an associated type witness from the given witness table.
   ///
   /// \param wtable The witness table.

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -497,6 +497,7 @@ public:
                            ProtocolDescriptorRef protocol,
                            const WitnessTable **conformance);
 
+
   /// Construct type metadata for the given protocol.
   const Metadata *
   _getSimpleProtocolTypeMetadata(const ProtocolDescriptor *protocol);
@@ -511,7 +512,8 @@ public:
   /// returning the appropriate protocol conformance descriptor when it does.
   const ProtocolConformanceDescriptor *
   _conformsToSwiftProtocol(const Metadata * const type,
-                           const ProtocolDescriptor *protocol);
+                           const ProtocolDescriptor *protocol,
+                           StringRef module);
 
   /// Retrieve an associated type witness from the given witness table.
   ///

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -597,6 +597,11 @@ static StringRef getRetroactiveModuleName(
   return moduleContext->Name.get();
 }
 
+static bool shouldWarnAboutConflictingConformances() {
+  return SWIFT_LAZY_CONSTANT(
+           (bool)getenv("SWIFT_ENABLE_CONFLICTING_CONFORMANCES_CHECK"));
+}
+
 const ProtocolConformanceDescriptor *
 swift::_conformsToSwiftProtocol(const Metadata * const type,
                                 const ProtocolDescriptor *protocol,
@@ -742,7 +747,7 @@ swift::_conformsToSwiftProtocol(const Metadata * const type,
       // If we have only retroactive conformances, complain about the
       // conflict.
       // FIXME: Only do this once per type descriptor/protocol combination.
-      if (!foundNonRetroactive) {
+      if (!foundNonRetroactive && shouldWarnAboutConflictingConformances()) {
         // Form the list of modules in which we found retroactive conformances.
         std::string moduleNamesStr;
         StringRef firstModuleName;

--- a/test/Runtime/Inputs/RetroactiveA.swift
+++ b/test/Runtime/Inputs/RetroactiveA.swift
@@ -1,0 +1,9 @@
+import RetroactiveCommon
+
+extension CommonStruct : CommonP1 {
+  public typealias AssocType = Int
+}
+
+public func getCommonRequiresP1_Struct() -> Any.Type {
+  return CommonRequiresP1<CommonStruct>.self
+}

--- a/test/Runtime/Inputs/RetroactiveB.swift
+++ b/test/Runtime/Inputs/RetroactiveB.swift
@@ -1,0 +1,9 @@
+import RetroactiveCommon
+
+extension CommonStruct : CommonP1 {
+  public typealias AssocType = String
+}
+
+public func getCommonRequiresP1_Struct() -> Any.Type {
+  return CommonRequiresP1<CommonStruct>.self
+}

--- a/test/Runtime/Inputs/RetroactiveCommon.swift
+++ b/test/Runtime/Inputs/RetroactiveCommon.swift
@@ -1,0 +1,9 @@
+public struct CommonStruct { }
+
+public protocol CommonP1 {
+  associatedtype AssocType
+}
+
+public struct CommonRequiresP1<T: CommonP1> {
+  public init() { }
+}

--- a/test/Runtime/Inputs/synthesized_decl_uniqueness.swift
+++ b/test/Runtime/Inputs/synthesized_decl_uniqueness.swift
@@ -1,4 +1,5 @@
 import CoreLocation
+import Foundation
 
 public func getCLError() -> Any.Type {
   return CLError.self
@@ -6,4 +7,8 @@ public func getCLError() -> Any.Type {
 
 public func getCLErrorCode() -> Any.Type {
   return CLError.Code.self
+}
+
+public func getNotificationNameSet() -> Any.Type {
+  return Set<NSNotification.Name>.self
 }

--- a/test/Runtime/multiple_conformances.swift
+++ b/test/Runtime/multiple_conformances.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation %S/Inputs/RetroactiveCommon.swift -emit-module-path %t/RetroactiveCommon.swiftmodule -emit-object -o %t/RetroactiveCommon.o
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveA.swift -emit-module-path %t/RetroactiveA.swiftmodule -emit-object -o %t/RetroactiveA.o
+// RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveB.swift -emit-module-path %t/RetroactiveB.swiftmodule -emit-object -o %t/RetroactiveB.o
+// RUN: %target-build-swift -I %t %s %t/RetroactiveCommon.o %t/RetroactiveA.o %t/RetroactiveB.o -module-name main -o %t/a.out 
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out > %t.log 2>&1
+// RUN: %FileCheck %s < %t.log
+
+// REQUIRES: executable_test
+
+import RetroactiveCommon
+import RetroactiveA
+import RetroactiveB
+
+// CHECK: Swift runtime warning: multiple conformances for 'RetroactiveCommon.CommonStruct: CommonP1' found in modules 'RetroactiveA' and 'RetroactiveB'. Arbitrarily selecting conformance from module 'RetroactiveA'
+let demangled1 = _typeByName("17RetroactiveCommon16CommonRequiresP1Vy17RetroactiveCommon12CommonStructVG")!

--- a/test/Runtime/multiple_conformances.swift
+++ b/test/Runtime/multiple_conformances.swift
@@ -4,7 +4,7 @@
 // RUN: %target-build-swift -parse-as-library -force-single-frontend-invocation -I %t %S/Inputs/RetroactiveB.swift -emit-module-path %t/RetroactiveB.swiftmodule -emit-object -o %t/RetroactiveB.o
 // RUN: %target-build-swift -I %t %s %t/RetroactiveCommon.o %t/RetroactiveA.o %t/RetroactiveB.o -module-name main -o %t/a.out 
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out > %t.log 2>&1
+// RUN: env SWIFT_ENABLE_CONFLICTING_CONFORMANCES_CHECK=1 %target-run %t/a.out > %t.log 2>&1
 // RUN: %FileCheck %s < %t.log
 
 // REQUIRES: executable_test

--- a/test/Runtime/synthesized_decl_uniqueness.swift
+++ b/test/Runtime/synthesized_decl_uniqueness.swift
@@ -17,6 +17,7 @@ var tests = TestSuite("metadata identity for synthesized types")
 tests.test("synthesized type identity across modules") {
   expectEqual(A.getCLError(), B.getCLError())
   expectEqual(A.getCLErrorCode(), B.getCLErrorCode())
+  expectEqual(A.getNotificationNameSet(), B.getNotificationNameSet())
 }
 
 runAllTests()

--- a/validation-test/stdlib/SetAnyHashableExtensions.swift
+++ b/validation-test/stdlib/SetAnyHashableExtensions.swift
@@ -126,7 +126,10 @@ SetTests.test("insert<Hashable>(_:)") {
   expectEqual(expected, s)
 }
 
-SetTests.test("insert<Hashable>(_:)/FormerCastTrap") {
+SetTests.test("insert<Hashable>(_:)/CastTrap")
+  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
+  .crashOutputMatches("to 'main.TestHashableDerivedB'")
+  .code {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
   ]
@@ -138,6 +141,7 @@ SetTests.test("insert<Hashable>(_:)/FormerCastTrap") {
     expectEqual(1, memberAfterInsert.identity)
   }
 
+  expectCrashLater()
   _ = s.insert(TestHashableDerivedB(1010, identity: 3))
 }
 
@@ -177,7 +181,10 @@ SetTests.test("update<Hashable>(with:)") {
   expectEqual(expected, s)
 }
 
-SetTests.test("update<Hashable>(with:)/FormerCastTrap") {
+SetTests.test("update<Hashable>(with:)/CastTrap")
+  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
+  .crashOutputMatches("to 'main.TestHashableDerivedB'")
+  .code {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
   ]
@@ -187,6 +194,7 @@ SetTests.test("update<Hashable>(with:)/FormerCastTrap") {
     expectEqual(1, old.identity)
   }
 
+  expectCrashLater()
   s.update(with: TestHashableDerivedB(1010, identity: 3))
 }
 
@@ -220,7 +228,10 @@ SetTests.test("remove<Hashable>(_:)") {
   }
 }
 
-SetTests.test("remove<Hashable>(_:)/FormerCastTrap") {
+SetTests.test("remove<Hashable>(_:)/CastTrap")
+  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
+  .crashOutputMatches("to 'main.TestHashableDerivedB'")
+  .code {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
     AnyHashable(TestHashableDerivedA(2020, identity: 1)),
@@ -232,6 +243,7 @@ SetTests.test("remove<Hashable>(_:)/FormerCastTrap") {
     expectEqual(1, old.identity)
   }
 
+  expectCrashLater()
   s.remove(TestHashableDerivedB(2020, identity: 2))
 }
 


### PR DESCRIPTION
When the environment variable `SWIFT_ENABLE_CONFLICTING_CONFORMANCES_CHECK` is set, and runtime conformance lookup finds more than one retroactive conformance, produce a warning like this:

```
***Swift runtime warning: multiple conformances for
'RetroactiveCommon.CommonStruct: CommonP1' found in modules
'RetroactiveA' and 'RetroactiveB'. Arbitrarily selecting conformance
from module 'RetroactiveA'
```

