### PR TITLE
[ModuleInterface] <rdar://46081260> Fallback behaviour and testing env vars.

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -276,6 +276,9 @@ ERROR(missing_dependency_of_parseable_module_interface,none,
 ERROR(error_extracting_dependencies_from_cached_module,none,
       "error extracting dependencies from cached module '%0'",
       (StringRef))
+ERROR(unknown_forced_module_loading_mode,none,
+      "unknown value for SWIFT_FORCE_MODULE_LOADING variable: '%0'",
+      (StringRef))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/Frontend/ParseableInterfaceSupport.h
+++ b/include/swift/Frontend/ParseableInterfaceSupport.h
@@ -61,8 +61,9 @@ getModuleCachePathFromClang(const clang::CompilerInstance &Instance);
 /// directory, and loading the serialized .swiftmodules from there.
 class ParseableInterfaceModuleLoader : public SerializedModuleLoaderBase {
   explicit ParseableInterfaceModuleLoader(ASTContext &ctx, StringRef cacheDir,
-                                          DependencyTracker *tracker)
-    : SerializedModuleLoaderBase(ctx, tracker),
+                                          DependencyTracker *tracker,
+                                          ModuleLoadingMode loadMode)
+    : SerializedModuleLoaderBase(ctx, tracker, loadMode),
       CacheDir(cacheDir)
   {}
 
@@ -83,9 +84,10 @@ class ParseableInterfaceModuleLoader : public SerializedModuleLoaderBase {
 public:
   static std::unique_ptr<ParseableInterfaceModuleLoader>
   create(ASTContext &ctx, StringRef cacheDir,
-         DependencyTracker *tracker = nullptr) {
+         DependencyTracker *tracker,
+         ModuleLoadingMode loadMode) {
     return std::unique_ptr<ParseableInterfaceModuleLoader>(
-        new ParseableInterfaceModuleLoader(ctx, cacheDir, tracker));
+        new ParseableInterfaceModuleLoader(ctx, cacheDir, tracker, loadMode));
   }
 };
 

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -372,17 +372,42 @@ std::error_code ParseableInterfaceModuleLoader::openModuleFiles(
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     llvm::SmallVectorImpl<char> &Scratch) {
 
+  // If running in OnlySerialized mode, ParseableInterfaceModuleLoader
+  // should not have been constructed at all.
+  assert(LoadMode != ModuleLoadingMode::OnlySerialized);
+
   auto &FS = *Ctx.SourceMgr.getFileSystem();
   auto &Diags = Ctx.Diags;
-  llvm::SmallString<128> InPath, OutPath;
+  llvm::SmallString<128> ModPath, InPath, OutPath;
 
   // First check to see if the .swiftinterface exists at all. Bail if not.
-  InPath = DirName;
-  llvm::sys::path::append(InPath, ModuleFilename);
+  ModPath = DirName;
+  llvm::sys::path::append(ModPath, ModuleFilename);
+
   auto Ext = file_types::getExtension(file_types::TY_SwiftParseableInterfaceFile);
+  InPath = ModPath;
   llvm::sys::path::replace_extension(InPath, Ext);
   if (!FS.exists(InPath))
     return std::make_error_code(std::errc::no_such_file_or_directory);
+
+  // Next, if we're in the load mode that prefers .swiftmodules, see if there's
+  // one here we can _likely_ load (validates OK). If so, bail early with
+  // errc::not_supported, so the next (serialized) loader in the chain will load
+  // it.
+  if (LoadMode == ModuleLoadingMode::PreferSerialized) {
+    if (FS.exists(ModPath)) {
+      auto ModBuf = FS.getBufferForFile(ModPath, /*FileSize=*/-1,
+                                        /*RequiresNullTerminator=*/false);
+      auto VI = serialization::validateSerializedAST(ModBuf.get()->getBuffer());
+      if (VI.status == serialization::Status::Valid) {
+        return std::make_error_code(std::errc::not_supported);
+      }
+    }
+  }
+
+  // At this point we're either in PreferParseable mode or there's no credible
+  // adjacent .swiftmodule so we'll go ahead and start trying to convert the
+  // .swiftinterface.
 
   // Set up a _potential_ sub-invocation to consume the .swiftinterface and emit
   // the .swiftmodule.


### PR DESCRIPTION
Rough cut of two sets of additions to parseable-interfaces that @jrose-apple wanted:

  - Probe for a plausible .swiftmodule adjacent to a .swiftinterface and only _fall back_ to the .swiftinterface when the .swiftmodule has the wrong version or whatever.
  - Allow various enable/disable scenarios of swiftmodules / swiftinterfaces from environment variables (I included "prefer parseable", "prefer serialized", "only parseable" and "only serialized" modes).

Passes existing tests, will work on a few new ones (while writing this I found it happily compiles Swift.swiftinterface into the cache and uses it if I set the variable wrong!) but I figured I'd post this for early feedback in case you want me to rework it.

rdar://problem/46081260