### PR TITLE
[5.0][stdlib] _StringObject: Use a full 8-bit discriminator on 32-bit platforms

### DIFF
--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -194,17 +194,19 @@ internal struct _StringObject {
   enum Nibbles {}
 }
 
-#if !(arch(i386) || arch(arm))
 extension _StringObject {
   @inlinable
-  internal var _discriminator: Discriminator {
+  internal var discriminator: Discriminator {
     @inline(__always) get {
+#if arch(i386) || arch(arm)
+      return _discriminator
+#else
       let d = objectRawBits &>> Nibbles.discriminatorShift
       return Discriminator(UInt8(truncatingIfNeeded: d))
+#endif
     }
   }
 }
-#endif
 
 // Raw
 extension _StringObject {
@@ -749,7 +751,7 @@ extension _StringObject {
     @inline(__always)
     get {
       _internalInvariant(isSmall)
-      return _discriminator.smallCount
+      return discriminator.smallCount
     }
   }
 

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -137,7 +137,7 @@ internal struct _StringObject {
   internal var _variant: Variant
 
   @usableFromInline
-  internal var _discriminator: Builtin.Int7
+  internal var _discriminator: Discriminator
 
   @usableFromInline
   internal var _flags: Flags
@@ -149,11 +149,9 @@ internal struct _StringObject {
     discriminator: Discriminator,
     flags: Flags
   ) {
-    _internalInvariant(variant.isImmortal == discriminator.isImmortal)
     self._count = count
     self._variant = variant
-    self._discriminator =
-      Builtin.truncOrBitCast_Int8_Int7(discriminator._value._value)
+    self._discriminator = discriminator
     self._flags = flags
   }
 
@@ -196,28 +194,17 @@ internal struct _StringObject {
   enum Nibbles {}
 }
 
+#if !(arch(i386) || arch(arm))
 extension _StringObject {
-#if arch(i386) || arch(arm)
-  @inlinable @inline(__always)
-  internal func discriminator(isImmortal: Bool) -> Discriminator {
-    let lowBits = UInt8(Builtin.zextOrBitCast_Int7_Int8(_discriminator))
-    guard isImmortal else { return Discriminator(lowBits) }
-    return Discriminator(lowBits | 0x80)
-  }
-#endif
-
   @inlinable
-  internal var discriminator: Discriminator {
+  internal var _discriminator: Discriminator {
     @inline(__always) get {
-#if arch(i386) || arch(arm)
-      return self.discriminator(isImmortal: _variant.isImmortal)
-#else
       let d = objectRawBits &>> Nibbles.discriminatorShift
       return Discriminator(UInt8(truncatingIfNeeded: d))
-#endif
     }
   }
 }
+#endif
 
 // Raw
 extension _StringObject {
@@ -233,7 +220,7 @@ extension _StringObject {
       let count = UInt64(truncatingIfNeeded: UInt(bitPattern: _count))
       let payload = UInt64(truncatingIfNeeded: undiscriminatedObjectRawBits)
       let flags = UInt64(truncatingIfNeeded: _flags._value)
-      let discr = UInt64(truncatingIfNeeded: discriminator._value)
+      let discr = UInt64(truncatingIfNeeded: _discriminator._value)
       if isSmall {
         // Rearrange small strings in a different way, compacting bytes into a
         // contiguous sequence. See comment on small string layout below.
@@ -636,9 +623,7 @@ extension _StringObject {
   internal var isSmall: Bool {
     @inline(__always) get {
 #if arch(i386) || arch(arm)
-      // Note: This assumes that the `isSmall` predicate doesn't look at the
-      // immortal bit. We may or may not actually be immortal.
-      return discriminator(isImmortal: true).isSmall
+      return _discriminator.isSmall
 #else
       return (objectRawBits & 0x2000_0000_0000_0000) != 0
 #endif
@@ -658,9 +643,7 @@ extension _StringObject {
   internal var providesFastUTF8: Bool {
     @inline(__always) get {
 #if arch(i386) || arch(arm)
-      // Note: This assumes that the `providesFastUTF8` predicate doesn't look
-      // at the immortal bit. We may or may not actually be immortal.
-      return discriminator(isImmortal: false).providesFastUTF8
+      return _discriminator.providesFastUTF8
 #else
       return (objectRawBits & 0x1000_0000_0000_0000) == 0
 #endif
@@ -677,7 +660,7 @@ extension _StringObject {
   internal var hasNativeStorage: Bool {
     @inline(__always) get {
 #if arch(i386) || arch(arm)
-      return discriminator.hasNativeStorage
+      return _discriminator.hasNativeStorage
 #else
       return (objectRawBits & 0xF800_0000_0000_0000) == 0
 #endif
@@ -688,7 +671,7 @@ extension _StringObject {
   internal var hasSharedStorage: Bool {
     @inline(__always) get {
 #if arch(i386) || arch(arm)
-      return discriminator.hasSharedStorage
+      return _discriminator.hasSharedStorage
 #else
       return (objectRawBits & 0xF800_0000_0000_0000)
         == Nibbles.largeSharedMortal()
@@ -705,9 +688,7 @@ extension _StringObject {
     @inline(__always) get {
       _internalInvariant(isLarge && providesFastUTF8)
 #if arch(i386) || arch(arm)
-      // Note: This assumes that the `largeFastIsNative` predicate doesn't look
-      // at the immortal bit. We may or may not actually be immortal.
-      return discriminator(isImmortal: false).largeFastIsNative
+      return _discriminator.largeFastIsNative
 #else
       return (objectRawBits & 0x0800_0000_0000_0000) == 0
 #endif
@@ -726,9 +707,7 @@ extension _StringObject {
     @inline(__always) get {
       _internalInvariant(isLarge)
 #if arch(i386) || arch(arm)
-      // Note: This assumes that the `largeIsCocoa` predicate doesn't look at
-      // the immortal bit. We may or may not actually be immortal.
-      return discriminator(isImmortal: false).largeIsCocoa
+      return _discriminator.largeIsCocoa
 #else
       return (objectRawBits & 0x4000_0000_0000_0000) != 0
 #endif
@@ -770,12 +749,7 @@ extension _StringObject {
     @inline(__always)
     get {
       _internalInvariant(isSmall)
-#if arch(i386) || arch(arm)
-      // Note: This assumes that `isSmall` implies that we're immortal.
-      return discriminator(isImmortal: true).smallCount
-#else
-      return discriminator.smallCount
-#endif
+      return _discriminator.smallCount
     }
   }
 
@@ -785,8 +759,7 @@ extension _StringObject {
     get {
       _internalInvariant(isSmall)
 #if arch(i386) || arch(arm)
-      // Note: This assumes that `isSmall` implies that we're immortal.
-      return discriminator(isImmortal: true).smallIsASCII
+      return _discriminator.smallIsASCII
 #else
       return objectRawBits & 0x4000_0000_0000_0000 != 0
 #endif
@@ -1320,7 +1293,7 @@ extension _StringObject {
       <\(word0) \(word1)> \
       count: \(String(_count, radix: 16)), \
       variant: \(_variant), \
-      discriminator: \(discriminator), \
+      discriminator: \(_discriminator), \
       flags: \(_flags))
       """)
 #else

--- a/test/SILOptimizer/concat_string_literals.32.swift
+++ b/test/SILOptimizer/concat_string_literals.32.swift
@@ -9,7 +9,7 @@
 
 // NOTE: 25185.byteSwapped = 0x62 'a', 0x61 'b'
 // CHECK-LABEL: test_ascii_scalar_scalar2
-// CHECK: insertvalue { i32, i32, i32 } { i32 25185,
+// CHECK: ret { i32, i32, i32 } { i32 25185, i32 0, i32 {{[0-9]+}} }
 public func test_ascii_scalar_scalar2() -> String {
   return "a" + "b"
 }
@@ -17,7 +17,7 @@ public func test_ascii_scalar_scalar2() -> String {
 
 // NOTE: 11125601.byteSwapped = 0x61 'a', 0xC3 0xA9 'é'
 // CHECK-LABEL: test_scalar_otherscalar
-// CHECK: insertvalue { i32, i32, i32 } { i32 11125601,
+// CHECK: ret { i32, i32, i32 } { i32 11125601, i32 0, i32 {{[0-9]+}} }
 public func test_scalar_otherscalar() -> String {
   return "a" + "é"
 }
@@ -26,7 +26,7 @@ public func test_scalar_otherscalar() -> String {
 // NOTE: -8097488946593795999 = 0x8f9ff0b4959ff061
 // NOTE: -1784680351 = 0x959ff061, -1885343564 = 0x8f9ff0b4
 // CHECK-LABEL: test_scalar_char
-// CHECK: insertvalue { i32, i32, i32 } { i32 -1784680351, i32 -1885343564,
+// CHECK: ret { i32, i32, i32 } { i32 -1784680351, i32 -1885343564, i32 {{[0-9]+}} }
 public func test_scalar_char() -> String {
   return "a" + "🕴🏿"
 }
@@ -34,14 +34,15 @@ public func test_scalar_char() -> String {
 // NOTE: 112585666577249.byteSwapped = 0x61 'a', 0xc3 0xa9 'é', 0x64 'd', 0x65 'e', 0x66 'f'
 // NOTE: 112585666577249 = 1688847201 + (26213 << 32)
 // CHECK-LABEL: test_strng_strng2
-// CHECK: insertvalue { i32, i32, i32 } { i32 1688847201, i32 26213,
+// CHECK: ret { i32, i32, i32 } { i32 1688847201, i32 26213, i32 {{[0-9]+}} }
 public func test_strng_strng2() -> String {
   return "aé" + "def"
 }
 
 // NOTE: 43 = code-unit length
+// NOTE: 20 = native bias
 // CHECK-LABEL: test_scalar_strng
-// CHECK: insertvalue { i32, i32, i32 } { i32 43, i32 sub
+// CHECK: ret { i32, i32, i32 } { i32 43, i32 sub (i32 {{.*}}, i32 20)
 public func test_scalar_strng() -> String {
   return "a" + "👨🏿‍💼+🧙🏿‍♂️=🕴🏿"
 }
@@ -49,21 +50,23 @@ public func test_scalar_strng() -> String {
 // NOTE: 7450828190687388257.byteSwapped = 0x61 'a', 0x62 'b', 0x63 'c', 0x64 'd', 0xC3 0xA8 'è', 0x66 'f', 0x67 'g', ...
 // NOTE: 1684234849 = 0x64636261, 1734781123 = 0x6766a8c3
 // CHECK-LABEL test_strng_concat_smol
-// CHECK: insertvalue { i32, i32, i32 } { i32 1684234849, i32 1734781123,
+// CHECK: ret { i32, i32, i32 } { i32 1684234849, i32 1734781123,
 public func test_strng_concat_smol() -> String {
   return "a" + "bc" + "dèf" + "gĥ"
 }
 
 // NOTE: 11 = code-unit length
+// NOTE: 20 = native bias
 // CHECK-LABEL test_strng_concat_not_quite_smol
-// CHECK: insertvalue { i32, i32, i32 } { i32 11, i32 sub
+// CHECK: ret { i32, i32, i32 } { i32 11, i32 sub (i32 {{.*}}, i32 20)
 public func test_strng_concat_not_quite_smol() -> String {
   return "a" + "bc" + "dèf" + "ghī"
 }
 
 // NOTE: 23 = code-unit length
+// NOTE: 20 = native bias
 // CHECK-LABEL test_strng_concat_large
-// CHECK: insertvalue { i32, i32, i32 } { i32 23, i32 sub
+// CHECK: ret { i32, i32, i32 } { i32 23, i32 sub (i32 {{.*}}, i32 20)
 public func test_strng_concat_large() -> String {
   return "a" + "bc" + "dèf" + "ghī" + "jklmn" + "o" + "𝛒qr"
 }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -483,6 +483,8 @@ Protocol _NSEnumerator has been removed
 Protocol _NSFastEnumeration has been removed
 Protocol _ShadowProtocol has been removed
 
+Var _StringObject.discriminator has been renamed to Var _StringObject._discriminator
+
 Func ManagedBufferPointer._sanityCheckValidBufferClass(_:creating:) has been removed
 Func _sanityCheck(_:_:file:line:) has been removed
 Func _sanityCheckFailure(_:file:line:) has been removed

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -483,8 +483,6 @@ Protocol _NSEnumerator has been removed
 Protocol _NSFastEnumeration has been removed
 Protocol _ShadowProtocol has been removed
 
-Var _StringObject.discriminator has been renamed to Var _StringObject._discriminator
-
 Func ManagedBufferPointer._sanityCheckValidBufferClass(_:creating:) has been removed
 Func _sanityCheck(_:_:file:line:) has been removed
 Func _sanityCheckFailure(_:file:line:) has been removed

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -49,7 +49,7 @@ reflect(object: obj)
 // CHECK-32-NEXT:                 (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=253 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:               (field name=_discriminator offset=9
-// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=128 bitwise_takable=1
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:               (field name=_flags offset=10
 // CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1


### PR DESCRIPTION
#20561 gave us plenty of extra inhabitants in the variant enum, so we can get rid of the 7-bit hack.

It’d also be possible now to increase small string capacity to a spacious 11 bytes; however this needs a full overhaul of the 32-bit String representation, so it needs a little bit more time in the oven.

Cherry picked from #20643, reviewed by @milseman
rdar://problem/44232093