### PR TITLE
[CodeCompletion][NFC] Move collectArgumentExpectation()

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3765,226 +3765,6 @@ public:
     }
   }
 
-  using FunctionParams = ArrayRef<AnyFunctionType::Param>;
-
-  static void collectPossibleParamListByQualifiedLookup(
-      DeclContext &DC, Type baseTy, DeclBaseName name,
-      SmallVectorImpl<FunctionParams> &candidates) {
-
-    SmallVector<ValueDecl *, 2> decls;
-    auto resolver = DC.getASTContext().getLazyResolver();
-    if (!DC.lookupQualified(baseTy, name, NL_QualifiedDefault, resolver, decls))
-      return;
-
-    for (auto *VD : decls) {
-      if ((!isa<AbstractFunctionDecl>(VD) && !isa<SubscriptDecl>(VD)) ||
-          shouldHideDeclFromCompletionResults(VD))
-        continue;
-      resolver->resolveDeclSignature(VD);
-      if (!VD->hasInterfaceType())
-        continue;
-      Type declaredMemberType = VD->getInterfaceType();
-      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD))
-        if (AFD->getDeclContext()->isTypeContext())
-          declaredMemberType = AFD->getMethodInterfaceType();
-
-      auto fnType =
-          baseTy->getTypeOfMember(DC.getParentModule(), VD, declaredMemberType);
-
-      if (!fnType || fnType->hasError())
-        continue;
-      if (auto *AFT = fnType->getAs<AnyFunctionType>()) {
-        candidates.push_back(AFT->getParams());
-      }
-    }
-  }
-
-  static void collectPossibleParamListByQualifiedLookup(
-      DeclContext &DC, Expr *baseExpr, DeclBaseName name,
-      SmallVectorImpl<FunctionParams> &candidates) {
-    ConcreteDeclRef ref = nullptr;
-    auto baseTyOpt = getTypeOfCompletionContextExpr(
-        DC.getASTContext(), &DC, CompletionTypeCheckKind::Normal, baseExpr,
-        ref);
-    if (!baseTyOpt)
-      return;
-    auto baseTy = (*baseTyOpt)->getRValueType()->getMetatypeInstanceType();
-    if (!baseTy->mayHaveMembers())
-      return;
-
-    collectPossibleParamListByQualifiedLookup(DC, baseTy, name, candidates);
-  }
-
-  static bool
-  collectPossibleParamListsApply(DeclContext &DC, ApplyExpr *callExpr,
-                                 SmallVectorImpl<FunctionParams> &candidates) {
-    auto *fnExpr = callExpr->getFn();
-
-    if (auto type = fnExpr->getType()) {
-      if (auto *funcType = type->getAs<AnyFunctionType>())
-        candidates.push_back(funcType->getParams());
-    } else if (auto *DRE = dyn_cast<DeclRefExpr>(fnExpr)) {
-      if (auto *decl = DRE->getDecl()) {
-        auto declType = decl->getInterfaceType();
-        if (auto *funcType = declType->getAs<AnyFunctionType>())
-          candidates.push_back(funcType->getParams());
-      }
-    } else if (auto *OSRE = dyn_cast<OverloadSetRefExpr>(fnExpr)) {
-      for (auto *decl : OSRE->getDecls()) {
-        auto declType = decl->getInterfaceType();
-        if (auto *funcType = declType->getAs<AnyFunctionType>())
-          candidates.push_back(funcType->getParams());
-      }
-    } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(fnExpr)) {
-      collectPossibleParamListByQualifiedLookup(
-          DC, UDE->getBase(), UDE->getName().getBaseName(), candidates);
-    }
-
-    if (candidates.empty()) {
-      ConcreteDeclRef ref = nullptr;
-      auto fnType = getTypeOfCompletionContextExpr(
-          DC.getASTContext(), &DC, CompletionTypeCheckKind::Normal, fnExpr,
-          ref);
-      if (!fnType)
-        return false;
-
-      if (auto *AFT = (*fnType)->getAs<AnyFunctionType>()) {
-        candidates.push_back(AFT->getParams());
-      } else if (auto *AMT = (*fnType)->getAs<AnyMetatypeType>()) {
-        auto baseTy = AMT->getInstanceType();
-        if (baseTy->mayHaveMembers())
-          collectPossibleParamListByQualifiedLookup(
-              DC, baseTy, DeclBaseName::createConstructor(), candidates);
-      }
-    }
-
-    return !candidates.empty();
-  }
-
-  static bool collectPossibleParamListsSubscript(
-      DeclContext &DC, SubscriptExpr *subscriptExpr,
-      SmallVectorImpl<FunctionParams> &candidates) {
-    if (subscriptExpr->hasDecl()) {
-      if (auto SD =
-              dyn_cast<SubscriptDecl>(subscriptExpr->getDecl().getDecl())) {
-        auto declType = SD->getInterfaceType();
-        if (auto *funcType = declType->getAs<AnyFunctionType>())
-          candidates.push_back(funcType->getParams());
-      }
-    } else {
-      collectPossibleParamListByQualifiedLookup(DC, subscriptExpr->getBase(),
-                                                DeclBaseName::createSubscript(),
-                                                candidates);
-    }
-    return !candidates.empty();
-  }
-
-  static bool getPositionInArgs(DeclContext &DC, Expr *Args, Expr *CCExpr,
-                                unsigned &Position, bool &HasName) {
-    if (auto TSE = dyn_cast<TupleShuffleExpr>(Args))
-      Args = TSE->getSubExpr();
-
-    if (isa<ParenExpr>(Args)) {
-      HasName = false;
-      Position = 0;
-      return true;
-    }
-
-    auto *tuple = dyn_cast<TupleExpr>(Args);
-    if (!tuple)
-      return false;
-
-    auto &SM = DC.getASTContext().SourceMgr;
-    for (unsigned i = 0, n = tuple->getNumElements(); i != n; ++i) {
-      if (SM.isBeforeInBuffer(tuple->getElement(i)->getEndLoc(),
-                              CCExpr->getStartLoc()))
-        continue;
-      HasName = tuple->getElementNameLoc(i).isValid();
-      Position = i;
-      return true;
-    }
-    return false;
-  }
-
-  /// Translate argument index in \p Args to parameter index.
-  /// Does nothing unless \p Args is \c TupleShuffleExpr.
-  static bool translateArgIndexToParamIndex(Expr *Args,
-                                            unsigned &Position, bool &HasName) {
-    auto TSE = dyn_cast<TupleShuffleExpr>(Args);
-    if (!TSE)
-      return true;
-
-    auto mapping = TSE->getElementMapping();
-    for (unsigned destIdx = 0, e = mapping.size(); destIdx != e; ++destIdx) {
-      auto srcIdx = mapping[destIdx];
-      if (srcIdx == (signed)Position) {
-        Position = destIdx;
-        return true;
-      }
-      if (srcIdx == TupleShuffleExpr::Variadic &&
-          llvm::is_contained(TSE->getVariadicArgs(), Position)) {
-        // The arg is a part of variadic args.
-        Position = destIdx;
-        HasName = false;
-        if (auto Args = dyn_cast<TupleExpr>(TSE->getSubExpr())) {
-          // Check if the first variadiac argument has the label.
-          auto firstVarArgIdx = TSE->getVariadicArgs().front();
-          HasName = Args->getElementNameLoc(firstVarArgIdx).isValid();
-        }
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  static bool
-  collectArgumentExpectation(DeclContext &DC, Expr *E, Expr *CCExpr,
-                             std::vector<Type> &ExpectedTypes,
-                             std::vector<StringRef> &ExpectedNames) {
-    // Collect parameter lists for possible func decls.
-    SmallVector<FunctionParams, 4> Candidates;
-    Expr *Arg = nullptr;
-    if (auto *applyExpr = dyn_cast<ApplyExpr>(E)) {
-      if (!collectPossibleParamListsApply(DC, applyExpr, Candidates))
-        return false;
-      Arg = applyExpr->getArg();
-    } else if (auto *subscriptExpr = dyn_cast<SubscriptExpr>(E)) {
-      if (!collectPossibleParamListsSubscript(DC, subscriptExpr, Candidates))
-        return false;
-      Arg = subscriptExpr->getIndex();
-    }
-
-    // Determine the position of code completion token in call argument.
-    unsigned Position;
-    bool HasName;
-    if (!getPositionInArgs(DC, Arg, CCExpr, Position, HasName))
-      return false;
-    if (!translateArgIndexToParamIndex(Arg, Position, HasName))
-      return false;
-
-    // Collect possible types (or labels) at the position.
-    {
-      bool MayNeedName = !HasName && !E->isImplicit() &&
-                         (isa<CallExpr>(E) | isa<SubscriptExpr>(E));
-      SmallPtrSet<TypeBase *, 4> seenTypes;
-      SmallPtrSet<Identifier, 4> seenNames;
-      for (auto Params : Candidates) {
-        if (Position >= Params.size())
-          continue;
-        const auto &Param = Params[Position];
-        if (Param.hasLabel() && MayNeedName) {
-          if (seenNames.insert(Param.getLabel()).second)
-            ExpectedNames.push_back(Param.getLabel().str());
-        } else {
-          if (seenTypes.insert(Param.getOldType().getPointer()).second)
-            ExpectedTypes.push_back(Param.getOldType());
-        }
-      }
-    }
-    return !ExpectedTypes.empty() || !ExpectedNames.empty();
-  }
-
   void getTypeContextEnumElementCompletions(SourceLoc Loc) {
     llvm::SaveAndRestore<LookupKind> ChangeLookupKind(
         Kind, LookupKind::EnumElement);
@@ -5190,6 +4970,177 @@ namespace  {
   };
 } // end anonymous namespace
 
+namespace {
+using FunctionParams = ArrayRef<AnyFunctionType::Param>;
+
+void collectPossibleParamListByQualifiedLookup(
+    DeclContext &DC, Type baseTy, DeclBaseName name,
+    SmallVectorImpl<FunctionParams> &candidates) {
+
+  SmallVector<ValueDecl *, 2> decls;
+  auto resolver = DC.getASTContext().getLazyResolver();
+  if (!DC.lookupQualified(baseTy, name, NL_QualifiedDefault, resolver, decls))
+    return;
+
+  for (auto *VD : decls) {
+    if ((!isa<AbstractFunctionDecl>(VD) && !isa<SubscriptDecl>(VD)) ||
+        shouldHideDeclFromCompletionResults(VD))
+      continue;
+    resolver->resolveDeclSignature(VD);
+    if (!VD->hasInterfaceType())
+      continue;
+    Type declaredMemberType = VD->getInterfaceType();
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD))
+      if (AFD->getDeclContext()->isTypeContext())
+        declaredMemberType = AFD->getMethodInterfaceType();
+
+    auto fnType =
+        baseTy->getTypeOfMember(DC.getParentModule(), VD, declaredMemberType);
+
+    if (!fnType || fnType->hasError())
+      continue;
+    if (auto *AFT = fnType->getAs<AnyFunctionType>()) {
+      candidates.push_back(AFT->getParams());
+    }
+  }
+}
+
+void collectPossibleParamListByQualifiedLookup(
+    DeclContext &DC, Expr *baseExpr, DeclBaseName name,
+    SmallVectorImpl<FunctionParams> &candidates) {
+  ConcreteDeclRef ref = nullptr;
+  auto baseTyOpt = getTypeOfCompletionContextExpr(
+      DC.getASTContext(), &DC, CompletionTypeCheckKind::Normal, baseExpr, ref);
+  if (!baseTyOpt)
+    return;
+  auto baseTy = (*baseTyOpt)->getRValueType()->getMetatypeInstanceType();
+  if (!baseTy->mayHaveMembers())
+    return;
+
+  collectPossibleParamListByQualifiedLookup(DC, baseTy, name, candidates);
+}
+
+bool collectPossibleParamListsApply(
+    DeclContext &DC, ApplyExpr *callExpr,
+    SmallVectorImpl<FunctionParams> &candidates) {
+  auto *fnExpr = callExpr->getFn();
+
+  if (auto type = fnExpr->getType()) {
+    if (auto *funcType = type->getAs<AnyFunctionType>())
+      candidates.push_back(funcType->getParams());
+  } else if (auto *DRE = dyn_cast<DeclRefExpr>(fnExpr)) {
+    if (auto *decl = DRE->getDecl()) {
+      auto declType = decl->getInterfaceType();
+      if (auto *funcType = declType->getAs<AnyFunctionType>())
+        candidates.push_back(funcType->getParams());
+    }
+  } else if (auto *OSRE = dyn_cast<OverloadSetRefExpr>(fnExpr)) {
+    for (auto *decl : OSRE->getDecls()) {
+      auto declType = decl->getInterfaceType();
+      if (auto *funcType = declType->getAs<AnyFunctionType>())
+        candidates.push_back(funcType->getParams());
+    }
+  } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(fnExpr)) {
+    collectPossibleParamListByQualifiedLookup(
+        DC, UDE->getBase(), UDE->getName().getBaseName(), candidates);
+  }
+
+  if (candidates.empty()) {
+    ConcreteDeclRef ref = nullptr;
+    auto fnType = getTypeOfCompletionContextExpr(
+        DC.getASTContext(), &DC, CompletionTypeCheckKind::Normal, fnExpr, ref);
+    if (!fnType)
+      return false;
+
+    if (auto *AFT = (*fnType)->getAs<AnyFunctionType>()) {
+      candidates.push_back(AFT->getParams());
+    } else if (auto *AMT = (*fnType)->getAs<AnyMetatypeType>()) {
+      auto baseTy = AMT->getInstanceType();
+      if (baseTy->mayHaveMembers())
+        collectPossibleParamListByQualifiedLookup(
+            DC, baseTy, DeclBaseName::createConstructor(), candidates);
+    }
+  }
+
+  return !candidates.empty();
+}
+
+bool collectPossibleParamListsSubscript(
+    DeclContext &DC, SubscriptExpr *subscriptExpr,
+    SmallVectorImpl<FunctionParams> &candidates) {
+  if (subscriptExpr->hasDecl()) {
+    if (auto SD = dyn_cast<SubscriptDecl>(subscriptExpr->getDecl().getDecl())) {
+      auto declType = SD->getInterfaceType();
+      if (auto *funcType = declType->getAs<AnyFunctionType>())
+        candidates.push_back(funcType->getParams());
+    }
+  } else {
+    collectPossibleParamListByQualifiedLookup(DC, subscriptExpr->getBase(),
+                                              DeclBaseName::createSubscript(),
+                                              candidates);
+  }
+  return !candidates.empty();
+}
+
+bool getPositionInArgs(DeclContext &DC, Expr *Args, Expr *CCExpr,
+                       unsigned &Position, bool &HasName) {
+  if (auto TSE = dyn_cast<TupleShuffleExpr>(Args))
+    Args = TSE->getSubExpr();
+
+  if (isa<ParenExpr>(Args)) {
+    HasName = false;
+    Position = 0;
+    return true;
+  }
+
+  auto *tuple = dyn_cast<TupleExpr>(Args);
+  if (!tuple)
+    return false;
+
+  auto &SM = DC.getASTContext().SourceMgr;
+  for (unsigned i = 0, n = tuple->getNumElements(); i != n; ++i) {
+    if (SM.isBeforeInBuffer(tuple->getElement(i)->getEndLoc(),
+                            CCExpr->getStartLoc()))
+      continue;
+    HasName = tuple->getElementNameLoc(i).isValid();
+    Position = i;
+    return true;
+  }
+  return false;
+}
+
+/// Translate argument index in \p Args to parameter index.
+/// Does nothing unless \p Args is \c TupleShuffleExpr.
+bool translateArgIndexToParamIndex(Expr *Args, unsigned &Position,
+                                   bool &HasName) {
+  auto TSE = dyn_cast<TupleShuffleExpr>(Args);
+  if (!TSE)
+    return true;
+
+  auto mapping = TSE->getElementMapping();
+  for (unsigned destIdx = 0, e = mapping.size(); destIdx != e; ++destIdx) {
+    auto srcIdx = mapping[destIdx];
+    if (srcIdx == (signed)Position) {
+      Position = destIdx;
+      return true;
+    }
+    if (srcIdx == TupleShuffleExpr::Variadic &&
+        llvm::is_contained(TSE->getVariadicArgs(), Position)) {
+      // The arg is a part of variadic args.
+      Position = destIdx;
+      HasName = false;
+      if (auto Args = dyn_cast<TupleExpr>(TSE->getSubExpr())) {
+        // Check if the first variadiac argument has the label.
+        auto firstVarArgIdx = TSE->getVariadicArgs().front();
+        HasName = Args->getElementNameLoc(firstVarArgIdx).isValid();
+      }
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /// Given an expression and its context, the analyzer tries to figure out the
 /// expected type of the expression by analyzing its context.
 class CodeCompletionTypeContextAnalyzer {
@@ -5198,6 +5149,52 @@ class CodeCompletionTypeContextAnalyzer {
   SourceManager &SM;
   ASTContext &Context;
   ExprParentFinder Finder;
+
+  bool collectArgumentExpectation(DeclContext &DC, Expr *E, Expr *CCExpr,
+                                  std::vector<Type> &ExpectedTypes,
+                                  std::vector<StringRef> &ExpectedNames) {
+    // Collect parameter lists for possible func decls.
+    SmallVector<FunctionParams, 4> Candidates;
+    Expr *Arg = nullptr;
+    if (auto *applyExpr = dyn_cast<ApplyExpr>(E)) {
+      if (!collectPossibleParamListsApply(DC, applyExpr, Candidates))
+        return false;
+      Arg = applyExpr->getArg();
+    } else if (auto *subscriptExpr = dyn_cast<SubscriptExpr>(E)) {
+      if (!collectPossibleParamListsSubscript(DC, subscriptExpr, Candidates))
+        return false;
+      Arg = subscriptExpr->getIndex();
+    }
+
+    // Determine the position of code completion token in call argument.
+    unsigned Position;
+    bool HasName;
+    if (!getPositionInArgs(DC, Arg, CCExpr, Position, HasName))
+      return false;
+    if (!translateArgIndexToParamIndex(Arg, Position, HasName))
+      return false;
+
+    // Collect possible types (or labels) at the position.
+    {
+      bool MayNeedName = !HasName && !E->isImplicit() &&
+                         (isa<CallExpr>(E) | isa<SubscriptExpr>(E));
+      SmallPtrSet<TypeBase *, 4> seenTypes;
+      SmallPtrSet<Identifier, 4> seenNames;
+      for (auto Params : Candidates) {
+        if (Position >= Params.size())
+          continue;
+        const auto &Param = Params[Position];
+        if (Param.hasLabel() && MayNeedName) {
+          if (seenNames.insert(Param.getLabel()).second)
+            ExpectedNames.push_back(Param.getLabel().str());
+        } else {
+          if (seenTypes.insert(Param.getOldType().getPointer()).second)
+            ExpectedTypes.push_back(Param.getOldType());
+        }
+      }
+    }
+    return !ExpectedTypes.empty() || !ExpectedNames.empty();
+  }
 
 public:
   CodeCompletionTypeContextAnalyzer(DeclContext *DC, Expr *ParsedExpr) : DC(DC),
@@ -5261,7 +5258,7 @@ public:
       case ExprKind::PrefixUnary: {
         std::vector<Type> PotentialTypes;
         std::vector<StringRef> ExpectedNames;
-        CompletionLookup::collectArgumentExpectation(
+        collectArgumentExpectation(
             *DC, Parent, ParsedExpr, PotentialTypes, ExpectedNames);
         for (Type Ty : PotentialTypes)
           Callback(Ty);
@@ -5292,8 +5289,9 @@ public:
           return;
         unsigned Position = 0;
         bool HasName;
-        if (CompletionLookup::getPositionInArgs(*DC, Parent, ParsedExpr, Position, HasName)) {
-          Callback(Parent->getType()->castTo<TupleType>()->getElementType(Position));
+        if (getPositionInArgs(*DC, Parent, ParsedExpr, Position, HasName)) {
+          Callback(
+              Parent->getType()->castTo<TupleType>()->getElementType(Position));
         }
         break;
       }
@@ -5417,6 +5415,8 @@ public:
     return false;
   }
 };
+
+} // end anonymous namespace
 
 void CodeCompletionCallbacksImpl::doneParsing() {
   CompletionContext.CodeCompletionKind = Kind;


### PR DESCRIPTION
These functions are only used by `CodeCompletionTypeContextAnalyzer`. Move them into it.