### PR TITLE
[Sema][WIP] Redundant Conformance Diagnostic should have an associated fixit

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5069,7 +5069,8 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
                         ? diag::redundant_conformance_conditional
                         : diag::redundant_conformance;
       diagnose(diag.Loc, diagID, dc->getDeclaredInterfaceType(),
-               diag.Protocol->getName());
+               diag.Protocol->getName())
+        .fixItRemove(diag.Loc);
     }
 
     // Special case: explain that 'RawRepresentable' conformance

--- a/test/decl/protocol/conforms/redundant_conformance.swift
+++ b/test/decl/protocol/conforms/redundant_conformance.swift
@@ -19,7 +19,7 @@ extension ConformsToP
   : P2 { // expected-warning{{conformance of 'ConformsToP' to protocol 'P2' was already stated in the protocol's module 'redundant_conformance_B'}}
 }
 
-extension OtherConformsToP : P1 { // expected-error{{redundant conformance of 'OtherConformsToP' to protocol 'P1'}}
+extension OtherConformsToP : P1 { // expected-error{{redundant conformance of 'OtherConformsToP' to protocol 'P1'}}{{27-33=}}
   func f() -> Int { return 0 }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
PR basically adds fixits to redundant conformance diagnostics. @CodaFi helped me getting into this bug. The idea was to add `SourceRange` to `ConformanceDiagnostic` that will let to emit fixit.
As I understand I need to get `SourceLoc` of previous token (":" or ",") and compose `SourceRange` starting ":" or "," ending `ConformanceDiagnostic.Loc`. But I don't know how to get `SourceLoc` of previous token. Help wanted.

```swift
// Test cases:
protocol A {}
protocol B {}
protocol C {}
struct Foo {}

extension Foo: A {}
extension Foo: A {} // after fixit -> extension Foo {}
extension Foo: B {}
extension Foo: C, B {} // after fixit -> extension Foo: C {}
```
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5058](https://bugs.swift.org/browse/SR-5058).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->