### PR TITLE
ClangImporter: make bridging header portable

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1352,7 +1352,12 @@ bool ClangImporter::importBridgingHeader(StringRef header, ModuleDecl *adapter,
     return true;
   }
 
-  llvm::SmallString<128> importLine{"#import \""};
+  llvm::SmallString<128> importLine;
+  if (Impl.SwiftContext.LangOpts.EnableObjCInterop)
+    importLine = "#import \"";
+  else
+    importLine = "#include \"";
+
   importLine += header;
   importLine += "\"\n";
 

--- a/test/ClangImporter/Inputs/app-bridging-header-to-pch.h
+++ b/test/ClangImporter/Inputs/app-bridging-header-to-pch.h
@@ -1,3 +1,10 @@
+
+#ifndef app_bridging_header_to_pch_h
+#define app_bridging_header_to_pch_h
+
 static inline int app_function(int x) {
   return x + 27;
 }
+
+#endif
+

--- a/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h
+++ b/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h
@@ -1,5 +1,12 @@
+
+#ifndef chained_unit_test_bridging_header_to_pch_h
+#define chained_unit_test_bridging_header_to_pch_h
+
 #include "app-bridging-header-to-pch.h"
 
 static inline int unit_test_function(int x) {
   return x + 28;
 }
+
+#endif
+


### PR DESCRIPTION
Using `#import` is confusing when used on Windows targets as it is
treated as a type library import.  Use `#include` instead.  This should
have no impact on other targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
