### PR TITLE
[stdlib/wip] non-mutating UnsafeMutableBufferPointer

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
@@ -375,7 +375,7 @@ extension LoggingMutableCollection: MutableCollection {
    }
    
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     MutableCollectionLog._withUnsafeMutableBufferPointerIfSupported[selfType] += 1
     let result = try base._withUnsafeMutableBufferPointerIfSupported(body)
@@ -578,7 +578,7 @@ extension BufferAccessLoggingMutableCollection: MutableCollection {
   }
 
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     Log._withUnsafeMutableBufferPointerIfSupported[selfType] += 1
     let result = try base._withUnsafeMutableBufferPointerIfSupported(body)

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1273,11 +1273,11 @@ extension Array: RangeReplaceableCollection {
 
   @inlinable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      return try body(&bufferPointer)
+      return try body(bufferPointer)
     }
   }
 

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1067,11 +1067,11 @@ extension ArraySlice: RangeReplaceableCollection {
 
   @inlinable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      return try body(&bufferPointer)
+      return try body(bufferPointer)
     }
   }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SWIFTLIB_ESSENTIAL
   UnicodeScalar.swift # ORDER DEPENDENCY: Must precede Mirrors.swift
   Mirrors.swift.gyb
   Misc.swift
+  MutableBufferPointer.swift
   MutableCollection.swift
   NativeDictionary.swift
   NativeSet.swift

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -320,7 +320,7 @@ extension MutableCollection where Self : BidirectionalCollection {
   ) rethrows -> Index {
     let maybeOffset = try _withUnsafeMutableBufferPointerIfSupported {
       (bufferPointer) -> Int in
-      let unsafeBufferPivot = try bufferPointer._partitionImpl(
+      let unsafeBufferPivot = try bufferPointer.partition(
         by: belongsInSecondPartition)
       return unsafeBufferPivot - bufferPointer.startIndex
     }
@@ -450,6 +450,13 @@ extension MutableCollection where Self : RandomAccessCollection {
   ///   Swift.
   @inlinable
   public mutating func shuffle<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) {
+    _shuffle(using: &generator)
+  }
+
+  @usableFromInline
+  internal mutating func _shuffle<T: RandomNumberGenerator>(
     using generator: inout T
   ) {
     guard count > 1 else { return }

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -915,11 +915,11 @@ extension ContiguousArray: RangeReplaceableCollection {
 
   @inlinable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      return try body(&bufferPointer)
+      return try body(bufferPointer)
     }
   }
 

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -175,6 +175,7 @@
     "Pointer.swift",
     "UnsafePointer.swift",
     "UnsafeRawPointer.swift",
+    "MutableBufferPointer.swift",
     "UnsafeBufferPointer.swift",
     "UnsafeRawBufferPointer.swift"
   ],

--- a/stdlib/public/core/MutableBufferPointer.swift
+++ b/stdlib/public/core/MutableBufferPointer.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public protocol _MutableBufferPointer: MutableCollection
+{
+  override subscript(position: Index) -> Element { get nonmutating set }
+
+  subscript(bounds: Range<Index>) -> Slice<Self> { get nonmutating set }
+  
+  override nonmutating func partition(
+    by belongsInSecondPartition: (Element) throws -> Bool
+  ) rethrows -> Index
+  
+  override nonmutating func swapAt(_ i: Index, _ j: Index)
+
+  nonmutating func _withUnsafeMutableBufferPointerIfSupported<R>(
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R?
+}
+
+extension _MutableBufferPointer
+{
+  @inlinable
+  public nonmutating func _withUnsafeMutableBufferPointerIfSupported<R>(
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    return nil
+  }
+}
+
+/* From CollectionAlgorithms.swift */
+
+extension _MutableBufferPointer
+  where Self: BidirectionalCollection {
+  @inlinable
+  public nonmutating func partition(
+    by belongsInSecondPartition: (Element) throws -> Bool
+  ) rethrows -> Index {
+    var ref = self
+    return try ref._partitionImpl(by: belongsInSecondPartition)
+  }
+}
+
+extension _MutableBufferPointer
+  where Self: RandomAccessCollection {
+  @inlinable
+  public nonmutating func shuffle<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) {
+    var ref = self
+    ref._shuffle(using: &generator)
+  }
+
+  @inlinable
+  public mutating func shuffle() {
+    var g = SystemRandomNumberGenerator()
+    shuffle(using: &g)
+  }
+}
+
+/* From Sort.swift */
+
+extension UnsafeMutableBufferPointer
+  where Element: Comparable {
+   @inlinable
+   public nonmutating func sort() {
+     sort(by: <)
+   }
+}
+
+extension UnsafeMutableBufferPointer {
+  @inlinable
+  public nonmutating func sort(
+    by areInIncreasingOrder: (Element, Element) throws -> Bool
+  ) rethrows {
+    var ref = self
+    try ref._stableSortImpl(by: areInIncreasingOrder)
+  }
+}
+
+extension UnsafeMutableRawBufferPointer {
+  @inlinable
+  public nonmutating func sort() {
+    sort(by: <)
+  }
+
+  @inlinable
+  public nonmutating func sort(
+    by areInIncreasingOrder: (UInt8, UInt8) throws -> Bool
+  ) rethrows {
+    try self.bindMemory(to: UInt8.self).sort(by: areInIncreasingOrder)
+  }
+}
+
+/* From Reverse.swift */
+
+extension _MutableBufferPointer
+  where Self: BidirectionalCollection {
+  @inlinable
+  public nonmutating func reverse() {
+    var ref = self
+    ref._reverse()
+  }
+}
+
+/* From Range.swift */
+
+extension _MutableBufferPointer {
+  public subscript<R: RangeExpression>(r: R) -> Slice<Self>
+    where R.Bound == Index {
+    get {
+      return self[r.relative(to: self)]
+    }
+    nonmutating set {
+      self[r.relative(to: self)] = newValue
+    }
+  }
+
+  public subscript(x: UnboundedRange) -> Slice<Self> {
+    get {
+      return self[startIndex...]
+    }
+    nonmutating set {
+      self[startIndex...] = newValue
+    }
+  }
+}

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -177,7 +177,7 @@ where SubSequence: MutableCollection
   /// same algorithm on `body`\ 's argument lets you trade safety for
   /// speed.
   mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R?
 }
 
@@ -185,7 +185,7 @@ where SubSequence: MutableCollection
 extension MutableCollection {
   @inlinable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return nil
   }

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -24,6 +24,11 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///   collection.
   @inlinable // protocol-only
   public mutating func reverse() {
+    _reverse()
+  }
+
+  @usableFromInline // protocol-only
+  internal mutating func _reverse() {
     if isEmpty { return }
     var f = startIndex
     var l = index(before: endIndex)

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -248,7 +248,7 @@ extension MutableCollection where Self: RandomAccessCollection {
   ) rethrows {
     let didSortUnsafeBuffer = try _withUnsafeMutableBufferPointerIfSupported {
       buffer -> Void? in
-        try buffer._stableSortImpl(by: areInIncreasingOrder)
+        try buffer.sort(by: areInIncreasingOrder)
     }
     if didSortUnsafeBuffer == nil {
       // Fallback since we can't use an unsafe buffer: sort into an outside

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -14,6 +14,7 @@
 % for mutable in (True, False):
 %  Self = 'UnsafeMutableBufferPointer' if mutable else 'UnsafeBufferPointer'
 %  Mutable = 'Mutable' if mutable else ''
+%  BufferMutable = '_MutableBufferPointer, Mutable' if mutable else ''
 /// A nonowning collection interface to a buffer of ${Mutable.lower()}
 /// elements stored contiguously in memory.
 ///
@@ -117,7 +118,7 @@ extension Unsafe${Mutable}BufferPointer: Sequence {
   }
 }
 
-extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessCollection {
+extension Unsafe${Mutable}BufferPointer: ${BufferMutable}Collection, RandomAccessCollection {
   public typealias Index = Int
   public typealias Indices = Range<Int>
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -15,6 +15,7 @@
 % for mutable in (True, False):
 %  Self = 'UnsafeMutableRawBufferPointer' if mutable else 'UnsafeRawBufferPointer'
 %  Mutable = 'Mutable' if mutable else ''
+%  BufferMutable = '_MutableBufferPointer, Mutable' if mutable else ''
 
 /// A ${Mutable.lower()} nonowning collection interface to the bytes in a
 /// region of memory.
@@ -147,7 +148,7 @@ extension Unsafe${Mutable}RawBufferPointer: Sequence {
   }
 }
 
-extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
+extension Unsafe${Mutable}RawBufferPointer: ${BufferMutable}Collection {
   // TODO: Specialize `index` and `formIndex` and
   // `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
   public typealias Element = UInt8

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -272,7 +272,7 @@ UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {
   let uint8Ptr = allocated.initializeMemory(as: UInt8.self, repeating: 1, count: count)
   uint8Ptr[count-1] = UInt8.max
 
-  var buffer = UnsafeMutableRawBufferPointer(start: allocated, count: count - 1)
+  let buffer = UnsafeMutableRawBufferPointer(start: allocated, count: count - 1)
 
   buffer[1] = 0
   expectEqual(1, buffer[0])
@@ -293,6 +293,40 @@ UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {
   expectEqual(1, uint8Ptr[1])
   expectEqual(1, uint8Ptr[2])
   expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  buffer.sort(by: >)
+  expectEqual(1, buffer[0])
+  expectEqual(1, buffer[1])
+  expectEqual(0, buffer[2])
+
+  expectEqual(1, uint8Ptr[0])
+  expectEqual(1, uint8Ptr[1])
+  expectEqual(0, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  let p = buffer.partition(by: { $0%2 == 1 })
+  expectEqual(p, 1)
+  expectEqual(0, buffer[0])
+  expectEqual(1, buffer[1])
+  expectEqual(1, buffer[2])
+
+  expectEqual(0, uint8Ptr[0])
+  expectEqual(1, uint8Ptr[1])
+  expectEqual(1, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  buffer.reverse()
+  expectEqual(1, buffer[0])
+  expectEqual(1, buffer[1])
+  expectEqual(0, buffer[2])
+
+  expectEqual(1, uint8Ptr[0])
+  expectEqual(1, uint8Ptr[1])
+  expectEqual(0, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  buffer[0...1] = buffer[1...]
+  expectEqual(buffer[1], buffer[2])
 }
 
 UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
@@ -302,7 +336,7 @@ UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
   allocated.initialize(repeating: 1.0, count: count)
   allocated[count-1] = -1.0
 
-  var buffer = UnsafeMutableBufferPointer(start: allocated, count: count - 1)
+  let buffer = UnsafeMutableBufferPointer(start: allocated, count: count - 1)
 
   buffer[1] = 0.0
   expectEqual(1.0, buffer[0])
@@ -323,6 +357,40 @@ UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
   expectEqual(1.0, allocated[1])
   expectEqual(1.0, allocated[2])
   expectEqual(-1.0, allocated[count-1])
+
+  buffer.sort(by: >)
+  expectEqual(1.0, buffer[0])
+  expectEqual(1.0, buffer[1])
+  expectEqual(0.0, buffer[2])
+
+  expectEqual(1.0, allocated[0])
+  expectEqual(1.0, allocated[1])
+  expectEqual(0.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+
+  let p = buffer.partition(by: { !$0.isZero })
+  expectEqual(p, 1)
+  expectEqual(0.0, buffer[0])
+  expectEqual(1.0, buffer[1])
+  expectEqual(1.0, buffer[2])
+
+  expectEqual(0.0, allocated[0])
+  expectEqual(1.0, allocated[1])
+  expectEqual(1.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+
+  buffer.reverse()
+  expectEqual(1.0, buffer[0])
+  expectEqual(1.0, buffer[1])
+  expectEqual(0.0, buffer[2])
+
+  expectEqual(1.0, allocated[0])
+  expectEqual(1.0, allocated[1])
+  expectEqual(0.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+
+  buffer[0...1] = buffer[1...]
+  expectEqual(buffer[1], buffer[2])
 }
 
 UnsafeMutableBufferPointerTestSuite.test("_withUnsafeMutableBufferPointerIfSupported") {
@@ -872,11 +940,7 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
   defer { deallocateFor${Raw}Buffer(
       sliceMemory, count: replacementValues.count) }
 
-% if RangeName == 'range':
   let buffer = SubscriptSetTest.create${SelfName}(from: memory)
-% else:
-  var buffer = SubscriptSetTest.create${SelfName}(from: memory)
-% end
 
 %     if IsRaw:
   // A raw buffer pointer has debug bounds checks on indices, and
@@ -987,6 +1051,19 @@ UnsafeMutableBufferPointerTestSuite.test("nonmutating-swapAt-withARC") {
   expectEqual(Array(buffer), ["2", "1", "0"])
 }
 % end
+
+UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("withUMBPIfSupported") {
+% if IsRaw:
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+% else:
+  let buffer = UnsafeMutableBufferPointer<Int>.allocate(capacity: 3)
+% end
+  defer { buffer.deallocate() }
+
+  if let _ = buffer._withUnsafeMutableBufferPointerIfSupported({ _ in expectUnreachable() }) {
+  expectUnreachable()
+  }
+}
 
 % end # SelfName
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
In the review of SE-0237, I suggested giving the UnsafeMutable*BufferPointer types a non-mutating conformance to MutableCollection. Here's one, quickly assembled and tested.
This approach is source-compatible and seems superior to having to declare an UnsafeMutableBufferPointer as `inout` in parameter lists when a buffer is supposed to remain the same. This would allow SE-0237's `withUnsafeMutableBufferPointer` to not have its built-in foot-gun ("the signature says the pointer is mutable, but if you mutate the pointer you'll cause a crash -- as documented").

It's unfortunate that the in-place function already has the ideal name.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->