### PR TITLE
simplify host tools build logic

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2369,7 +2369,7 @@ function(add_swift_host_tool executable)
     ${ARGN})
 
   # Create the executable rule.
-  add_swift_executable(${executable}
+  add_llvm_executable(${executable}
     ${ASHT_UNPARSED_ARGUMENTS})
 
   # And then create the install rule if we are asked to.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2359,8 +2359,7 @@ endmacro()
 
 function(add_swift_host_tool executable)
   set(ADDSWIFTHOSTTOOL_multiple_parameter_options
-        SWIFT_COMPONENT
-        DEPENDS)
+        SWIFT_COMPONENT)
 
   cmake_parse_arguments(
       ADDSWIFTHOSTTOOL # prefix
@@ -2373,7 +2372,6 @@ function(add_swift_host_tool executable)
   add_swift_executable(
     ${executable} 
     ${ADDSWIFTHOSTTOOL_UNPARSED_ARGUMENTS}
-    DEPENDS ${ADDSWIFTHOSTTOOL_DEPENDS}
   )
 
   # And then create the install rule if we are asked to.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2358,31 +2358,27 @@ macro(add_swift_lib_subdirectory name)
 endmacro()
 
 function(add_swift_host_tool executable)
-  set(ADDSWIFTHOSTTOOL_multiple_parameter_options
-        SWIFT_COMPONENT)
+  set(options)
+  set(single_parameter_options SWIFT_COMPONENT)
+  set(multiple_parameter_options)
 
-  cmake_parse_arguments(
-      ADDSWIFTHOSTTOOL # prefix
-      "" # options
-      "" # single-value args
-      "${ADDSWIFTHOSTTOOL_multiple_parameter_options}" # multi-value args
-      ${ARGN})
+  cmake_parse_arguments(ASHT
+    "${options}"
+    "${single_parameter_options}"
+    "${multiple_parameter_options}"
+    ${ARGN})
 
   # Create the executable rule.
-  add_swift_executable(
-    ${executable} 
-    ${ADDSWIFTHOSTTOOL_UNPARSED_ARGUMENTS}
-  )
+  add_swift_executable(${executable}
+    ${ASHT_UNPARSED_ARGUMENTS})
 
   # And then create the install rule if we are asked to.
-  if (ADDSWIFTHOSTTOOL_SWIFT_COMPONENT)
-    swift_install_in_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
+  if (ASHT_SWIFT_COMPONENT)
+    swift_install_in_component(${ASHT_SWIFT_COMPONENT}
       TARGETS ${executable}
       RUNTIME DESTINATION bin)
 
-    swift_is_installing_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
-      is_installing)
-  
+    swift_is_installing_component(${ASHT_SWIFT_COMPONENT} is_installing)
     if(NOT is_installing)
       set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${executable})
     else()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2360,7 +2360,6 @@ endmacro()
 function(add_swift_host_tool executable)
   set(ADDSWIFTHOSTTOOL_multiple_parameter_options
         SWIFT_COMPONENT
-        COMPILE_FLAGS
         DEPENDS)
 
   cmake_parse_arguments(
@@ -2375,7 +2374,6 @@ function(add_swift_host_tool executable)
     ${executable} 
     ${ADDSWIFTHOSTTOOL_UNPARSED_ARGUMENTS}
     DEPENDS ${ADDSWIFTHOSTTOOL_DEPENDS}
-    COMPILE_FLAGS ${ADDSWIFTHOSTTOOL_COMPILE_FLAGS}
   )
 
   # And then create the install rule if we are asked to.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2361,8 +2361,7 @@ function(add_swift_host_tool executable)
   set(ADDSWIFTHOSTTOOL_multiple_parameter_options
         SWIFT_COMPONENT
         COMPILE_FLAGS
-        DEPENDS
-        SWIFT_MODULE_DEPENDS)
+        DEPENDS)
 
   cmake_parse_arguments(
       ADDSWIFTHOSTTOOL # prefix
@@ -2370,15 +2369,6 @@ function(add_swift_host_tool executable)
       "" # single-value args
       "${ADDSWIFTHOSTTOOL_multiple_parameter_options}" # multi-value args
       ${ARGN})
-
-  # Configure variables for this subdirectory.
-  set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
-  set(MODULE_VARIANT_SUFFIX "-swiftmodule${VARIANT_SUFFIX}")
-
-  foreach(mod ${ADDSWIFTHOSTTOOL_SWIFT_MODULE_DEPENDS})
-    list(APPEND ADDSWIFTHOSTTOOL_DEPENDS "swift${mod}${MODULE_VARIANT_SUFFIX}")
-    list(APPEND ADDSWIFTHOSTTOOL_DEPENDS "swift${mod}${VARIANT_SUFFIX}")
-  endforeach()
 
   # Create the executable rule.
   add_swift_executable(

--- a/tools/swift-demangle-fuzzer/CMakeLists.txt
+++ b/tools/swift-demangle-fuzzer/CMakeLists.txt
@@ -1,6 +1,6 @@
+set(LLVM_LINK_COMPONENTS Support)
 add_swift_fuzzer_host_tool(swift-demangle-fuzzer
   swift-demangle-fuzzer.cpp
-  LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT compiler
   )
 target_link_libraries(swift-demangle-fuzzer

--- a/tools/swift-demangle-yamldump/CMakeLists.txt
+++ b/tools/swift-demangle-yamldump/CMakeLists.txt
@@ -1,6 +1,6 @@
+set(LLVM_LINK_COMPONENTS Support)
 add_swift_host_tool(swift-demangle-yamldump
   swift-demangle-yamldump.cpp
-  LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT tools
   )
 target_link_libraries(swift-demangle-yamldump

--- a/tools/swift-demangle/CMakeLists.txt
+++ b/tools/swift-demangle/CMakeLists.txt
@@ -1,6 +1,6 @@
+set(LLVM_LINK_COMPONENTS Support)
 add_swift_host_tool(swift-demangle
   swift-demangle.cpp
-  LLVM_COMPONENT_DEPENDS support
   SWIFT_COMPONENT compiler
   )
 target_link_libraries(swift-demangle

--- a/tools/swift-reflection-dump/CMakeLists.txt
+++ b/tools/swift-reflection-dump/CMakeLists.txt
@@ -1,6 +1,6 @@
+set(LLVM_LINK_COMPONENTS Object Support)
 add_swift_host_tool(swift-reflection-dump
   swift-reflection-dump.cpp
-  LLVM_COMPONENT_DEPENDS object support
   SWIFT_COMPONENT tools
 )
 target_link_libraries(swift-reflection-dump

--- a/tools/swift-syntax-test/CMakeLists.txt
+++ b/tools/swift-syntax-test/CMakeLists.txt
@@ -1,7 +1,6 @@
+set(LLVM_LINK_COMPONENTS Support)
 add_swift_host_tool(swift-syntax-test
   swift-syntax-test.cpp
-  LLVM_COMPONENT_DEPENDS
-    Support
   SWIFT_COMPONENT tools
 )
 target_link_libraries(swift-syntax-test


### PR DESCRIPTION
Reuse the LLVM infrastructure for building toolchain tools.  This greatly simplifies the CMake logic, though most of it is just simply dead code elimination that is now visible thanks to the splitting of the host and target library generation.  Switching to the LLVM component model would remove the need for the last of the argument processing in the host tool code path.