### PR TITLE
[SR-7076] Make ContiguousArray Codable

### DIFF
--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1768,38 +1768,37 @@ extension Array : Decodable where Element : Decodable {
 }
 
 extension ContiguousArray : Encodable where Element : Encodable {
-    /// Encodes the elements of this contiguous array into the given encoder
-    /// in an unkeyed container.
-    ///
-    /// This function throws an error if any values are invalid for the given
-    /// encoder's format.
-    ///
-    /// - Parameter encoder: The encoder to write data to.
-    @inlinable // FIXME(sil-serialize-all)
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.unkeyedContainer()
-        for element in self {
-            try container.encode(element)
-        }
+  /// Encodes the elements of this contiguous array into the given encoder
+  /// in an unkeyed container.
+  ///
+  /// This function throws an error if any values are invalid for the given
+  /// encoder's format.
+  ///
+  /// - Parameter encoder: The encoder to write data to.
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.unkeyedContainer()
+    for element in self {
+      try container.encode(element)
     }
+  }
 }
 
 extension ContiguousArray : Decodable where Element : Decodable {
-    /// Creates a new contiguous array by decoding from the given decoder.
-    ///
-    /// This initializer throws an error if reading from the decoder fails, or
-    /// if the data read is corrupted or otherwise invalid.
-    ///
-    /// - Parameter decoder: The decoder to read data from.
-    @inlinable // FIXME(sil-serialize-all)
-    public init(from decoder: Decoder) throws {
-        self.init()
-        var container = try decoder.unkeyedContainer()
-        while !container.isAtEnd {
-            let element = try container.decode(Element.self)
-            self.append(element)
-        }
+  /// Creates a new contiguous array by decoding from the given decoder.
+  ///
+  /// This initializer throws an error if reading from the decoder fails, or
+  /// if the data read is corrupted or otherwise invalid.
+  ///
+  /// - Parameter decoder: The decoder to read data from.
+  public init(from decoder: Decoder) throws {
+    self.init()
+
+    var container = try decoder.unkeyedContainer()
+    while !container.isAtEnd {
+      let element = try container.decode(Element.self)
+      self.append(element)
     }
+  }
 }
 
 extension Set : Encodable where Element : Encodable {

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1767,6 +1767,41 @@ extension Array : Decodable where Element : Decodable {
   }
 }
 
+extension ContiguousArray : Encodable where Element : Encodable {
+    /// Encodes the elements of this contiguous array into the given encoder
+    /// in an unkeyed container.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
+    @inlinable // FIXME(sil-serialize-all)
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        for element in self {
+            try container.encode(element)
+        }
+    }
+}
+
+extension ContiguousArray : Decodable where Element : Decodable {
+    /// Creates a new contiguous array by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    @inlinable // FIXME(sil-serialize-all)
+    public init(from decoder: Decoder) throws {
+        self.init()
+        var container = try decoder.unkeyedContainer()
+        while !container.isAtEnd {
+            let element = try container.decode(Element.self)
+            self.append(element)
+        }
+    }
+}
+
 extension Set : Encodable where Element : Encodable {
   /// Encodes the elements of this set into the given encoder in an unkeyed
   /// container.


### PR DESCRIPTION

<!-- What's in this pull request? -->
Implements Encodable and Decodable for ContiguousArray.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7076](https://bugs.swift.org/browse/SR-7076).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->