### PR TITLE
stdlib: broaden ucrt module

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -104,12 +104,22 @@ module ucrt [system] {
     }
   }
 
+  module process {
+    header "process.h"
+    export *
+  }
+
   module corecrt {
     header "corecrt.h"
     export *
 
     module io {
       header "corecrt_io.h"
+      export *
+    }
+
+    module math {
+      header "corecrt_math.h"
       export *
     }
   }


### PR DESCRIPTION
Add `process` to the ucrt module as this is used in the Foundation port
for Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
