### PR TITLE
Define mappings for CF types on LLP64

### DIFF
--- a/lib/ClangImporter/MappedTypes.def
+++ b/lib/ClangImporter/MappedTypes.def
@@ -161,6 +161,9 @@ MAP_TYPE("CGFloat", CGFloat, 0, "CoreGraphics", "CGFloat", false, DoNothing)
 
 // CoreFoundation types.
 // Note that we're preserving the typealias for CFIndex.
+MAP_STDLIB_TYPE("CFTypeID", UnsignedWord, 0, "UInt", false, DefineAndUse)
+MAP_STDLIB_TYPE("CFOptionFlags", UnsignedWord, 0, "UInt", false, DefineAndUse)
+MAP_STDLIB_TYPE("CFHashCode", UnsignedWord, 0, "UInt", false, DefineAndUse)
 MAP_STDLIB_TYPE("CFIndex", SignedWord, 0, "Int", false, DefineAndUse)
 
 // Foundation types.

--- a/test/ClangImporter/ctypes_parse_objc.swift
+++ b/test/ClangImporter/ctypes_parse_objc.swift
@@ -70,8 +70,17 @@ func testImportMacTypes() {
 }
 
 func testImportCFTypes() {
-  let t1_unqual: Int = CFIndex_test
-  _ = t1_unqual as CoreFoundation.CFIndex
+  let t1_unqual: UInt = CFTypeID_test
+  _ = t1_unqual as CoreFoundation.CFTypeID
+
+  let t2_unqual: UInt = CFOptionFlags_test
+  _ = t2_unqual as CoreFoundation.CFOptionFlags
+
+  let t3_unqual: UInt = CFHashCode_test
+  _ = t3_unqual as CoreFoundation.CFHashCode
+
+  let t4_unqual: Int = CFIndex_test
+  _ = t4_unqual as CoreFoundation.CFIndex
 }
 
 func testImportSEL() {

--- a/test/Inputs/clang-importer-sdk/usr/include/CoreFoundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/CoreFoundation.h
@@ -18,8 +18,21 @@ typedef struct __attribute__((objc_bridge(NSSet))) __CFSet const *CFSetRef;
 
 typedef CFTypeRef CFAliasForTypeRef;
 
-
+#if __LLP64__
+typedef unsigned long long CFTypeID;
+typedef unsigned long long CFOptionFlags;
+typedef unsigned long long CFHashCode;
+typedef signed long long CFIndex;
+#else
+typedef unsigned long CFTypeID;
+typedef unsigned long CFOptionFlags;
+typedef unsigned long CFHashCode;
 typedef signed long CFIndex;
+#endif
+
+extern CFTypeID CFTypeID_test;
+extern CFOptionFlags CFOptionFlags_test;
+extern CFHashCode CFHashCode_test;
 extern CFIndex CFIndex_test;
 
 #define CF_ENUM(_type, _name) enum _name : _type _name; enum _name : _type


### PR DESCRIPTION
As per https://forums.swift.org/t/llp64-targets-and-integral-types/18253/15, define mappings for `CFTypeID`, `CFOptionFlags`, and `CFHashCode` to `UInt`.

The `DefineAndUse` parameter may be incorrect; it wasn't clear to me what its value should be.

As an alternative solution, CoreFoundation could be updated to typedef these types to e.g. `uintptr_t`, which is already mapped to `UInt` on LLP64.

cc @jckarter and @compnerd