### PR TITLE
[CodeCompletion] Fix call arguments completion in overloaded case

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4971,11 +4971,11 @@ namespace  {
 } // end anonymous namespace
 
 namespace {
-using FunctionParams = ArrayRef<AnyFunctionType::Param>;
+using FunctionTypeAndDecl = std::pair<AnyFunctionType *, ValueDecl *>;
 
-void collectPossibleParamListByQualifiedLookup(
+void collectPossibleCalleesByQualifiedLookup(
     DeclContext &DC, Type baseTy, DeclBaseName name,
-    SmallVectorImpl<FunctionParams> &candidates) {
+    SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
 
   SmallVector<ValueDecl *, 2> decls;
   auto resolver = DC.getASTContext().getLazyResolver();
@@ -5000,14 +5000,14 @@ void collectPossibleParamListByQualifiedLookup(
     if (!fnType || fnType->hasError())
       continue;
     if (auto *AFT = fnType->getAs<AnyFunctionType>()) {
-      candidates.push_back(AFT->getParams());
+      candidates.emplace_back(AFT, VD);
     }
   }
 }
 
-void collectPossibleParamListByQualifiedLookup(
+void collectPossibleCalleesByQualifiedLookup(
     DeclContext &DC, Expr *baseExpr, DeclBaseName name,
-    SmallVectorImpl<FunctionParams> &candidates) {
+    SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
   ConcreteDeclRef ref = nullptr;
   auto baseTyOpt = getTypeOfCompletionContextExpr(
       DC.getASTContext(), &DC, CompletionTypeCheckKind::Normal, baseExpr, ref);
@@ -5017,31 +5017,31 @@ void collectPossibleParamListByQualifiedLookup(
   if (!baseTy->mayHaveMembers())
     return;
 
-  collectPossibleParamListByQualifiedLookup(DC, baseTy, name, candidates);
+  collectPossibleCalleesByQualifiedLookup(DC, baseTy, name, candidates);
 }
 
-bool collectPossibleParamListsApply(
+bool collectPossibleCalleesForApply(
     DeclContext &DC, ApplyExpr *callExpr,
-    SmallVectorImpl<FunctionParams> &candidates) {
+    SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
   auto *fnExpr = callExpr->getFn();
 
   if (auto type = fnExpr->getType()) {
     if (auto *funcType = type->getAs<AnyFunctionType>())
-      candidates.push_back(funcType->getParams());
+      candidates.emplace_back(funcType, fnExpr->getReferencedDecl().getDecl());
   } else if (auto *DRE = dyn_cast<DeclRefExpr>(fnExpr)) {
     if (auto *decl = DRE->getDecl()) {
       auto declType = decl->getInterfaceType();
       if (auto *funcType = declType->getAs<AnyFunctionType>())
-        candidates.push_back(funcType->getParams());
+        candidates.emplace_back(funcType, decl);
     }
   } else if (auto *OSRE = dyn_cast<OverloadSetRefExpr>(fnExpr)) {
     for (auto *decl : OSRE->getDecls()) {
       auto declType = decl->getInterfaceType();
       if (auto *funcType = declType->getAs<AnyFunctionType>())
-        candidates.push_back(funcType->getParams());
+        candidates.emplace_back(funcType, decl);
     }
   } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(fnExpr)) {
-    collectPossibleParamListByQualifiedLookup(
+    collectPossibleCalleesByQualifiedLookup(
         DC, UDE->getBase(), UDE->getName().getBaseName(), candidates);
   }
 
@@ -5053,11 +5053,11 @@ bool collectPossibleParamListsApply(
       return false;
 
     if (auto *AFT = (*fnType)->getAs<AnyFunctionType>()) {
-      candidates.push_back(AFT->getParams());
+      candidates.emplace_back(AFT, ref.getDecl());
     } else if (auto *AMT = (*fnType)->getAs<AnyMetatypeType>()) {
       auto baseTy = AMT->getInstanceType();
       if (baseTy->mayHaveMembers())
-        collectPossibleParamListByQualifiedLookup(
+        collectPossibleCalleesByQualifiedLookup(
             DC, baseTy, DeclBaseName::createConstructor(), candidates);
     }
   }
@@ -5065,19 +5065,19 @@ bool collectPossibleParamListsApply(
   return !candidates.empty();
 }
 
-bool collectPossibleParamListsSubscript(
+bool collectPossibleCalleesForSubscript(
     DeclContext &DC, SubscriptExpr *subscriptExpr,
-    SmallVectorImpl<FunctionParams> &candidates) {
+    SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
   if (subscriptExpr->hasDecl()) {
     if (auto SD = dyn_cast<SubscriptDecl>(subscriptExpr->getDecl().getDecl())) {
       auto declType = SD->getInterfaceType();
       if (auto *funcType = declType->getAs<AnyFunctionType>())
-        candidates.push_back(funcType->getParams());
+        candidates.emplace_back(funcType, SD);
     }
   } else {
-    collectPossibleParamListByQualifiedLookup(DC, subscriptExpr->getBase(),
-                                              DeclBaseName::createSubscript(),
-                                              candidates);
+    collectPossibleCalleesByQualifiedLookup(DC, subscriptExpr->getBase(),
+                                            DeclBaseName::createSubscript(),
+                                            candidates);
   }
   return !candidates.empty();
 }
@@ -5166,14 +5166,14 @@ class CodeCompletionTypeContextAnalyzer {
 
   bool collectArgumentExpectation(DeclContext &DC, Expr *E, Expr *CCExpr) {
     // Collect parameter lists for possible func decls.
-    SmallVector<FunctionParams, 4> Candidates;
+    SmallVector<FunctionTypeAndDecl, 4> Candidates;
     Expr *Arg = nullptr;
     if (auto *applyExpr = dyn_cast<ApplyExpr>(E)) {
-      if (!collectPossibleParamListsApply(DC, applyExpr, Candidates))
+      if (!collectPossibleCalleesForApply(DC, applyExpr, Candidates))
         return false;
       Arg = applyExpr->getArg();
     } else if (auto *subscriptExpr = dyn_cast<SubscriptExpr>(E)) {
-      if (!collectPossibleParamListsSubscript(DC, subscriptExpr, Candidates))
+      if (!collectPossibleCalleesForSubscript(DC, subscriptExpr, Candidates))
         return false;
       Arg = subscriptExpr->getIndex();
     }
@@ -5192,7 +5192,8 @@ class CodeCompletionTypeContextAnalyzer {
                          (isa<CallExpr>(E) | isa<SubscriptExpr>(E));
       SmallPtrSet<TypeBase *, 4> seenTypes;
       SmallPtrSet<Identifier, 4> seenNames;
-      for (auto Params : Candidates) {
+      for (auto &typeAndDecl : Candidates) {
+        auto Params = typeAndDecl.first->getParams();
         if (Position >= Params.size())
           continue;
         const auto &Param = Params[Position];

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4973,6 +4973,7 @@ namespace  {
 namespace {
 using FunctionTypeAndDecl = std::pair<AnyFunctionType *, ValueDecl *>;
 
+/// Collect function (or subscript) members with the given \p name on \p baseTy.
 void collectPossibleCalleesByQualifiedLookup(
     DeclContext &DC, Type baseTy, DeclBaseName name,
     SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
@@ -5005,6 +5006,8 @@ void collectPossibleCalleesByQualifiedLookup(
   }
 }
 
+/// Collect function (or subscript) members with the given \p name on
+/// \p baseExpr expression.
 void collectPossibleCalleesByQualifiedLookup(
     DeclContext &DC, Expr *baseExpr, DeclBaseName name,
     SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
@@ -5020,6 +5023,7 @@ void collectPossibleCalleesByQualifiedLookup(
   collectPossibleCalleesByQualifiedLookup(DC, baseTy, name, candidates);
 }
 
+/// For the given \c callExpr, collect possible callee types and declarations.
 bool collectPossibleCalleesForApply(
     DeclContext &DC, ApplyExpr *callExpr,
     SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
@@ -5065,6 +5069,8 @@ bool collectPossibleCalleesForApply(
   return !candidates.empty();
 }
 
+/// For the given \c subscriptExpr, collect possible callee types and
+/// declarations.
 bool collectPossibleCalleesForSubscript(
     DeclContext &DC, SubscriptExpr *subscriptExpr,
     SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
@@ -5082,6 +5088,9 @@ bool collectPossibleCalleesForSubscript(
   return !candidates.empty();
 }
 
+/// Get index of \p CCExpr in \p Args. \p Args is usually a \c TupleExpr,
+/// \c ParenExpr, or a \c TupleShuffleExpr.
+/// \returns \c true if success, \c false if \p CCExpr is not a part of \p Args.
 bool getPositionInArgs(DeclContext &DC, Expr *Args, Expr *CCExpr,
                        unsigned &Position, bool &HasName) {
   if (auto TSE = dyn_cast<TupleShuffleExpr>(Args))
@@ -5165,6 +5174,7 @@ class CodeCompletionTypeContextAnalyzer {
     PossibleNames.push_back(name);
   }
 
+  /// Collect context information at call argument position.
   bool collectArgumentExpectation(DeclContext &DC, Expr *E, Expr *CCExpr) {
     // Collect parameter lists for possible func decls.
     SmallVector<FunctionTypeAndDecl, 2> Candidates;
@@ -5178,7 +5188,7 @@ class CodeCompletionTypeContextAnalyzer {
         return false;
       Arg = subscriptExpr->getIndex();
     }
-    PossibleCallees.append(Candidates.begin(), Candidates.end());
+    PossibleCallees.assign(Candidates.begin(), Candidates.end());
 
     // Determine the position of code completion token in call argument.
     unsigned Position;

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -11,6 +11,9 @@
 // RUN-FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD2 | %FileCheck %s -check-prefix=OVERLOAD2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD3 | %FileCheck %s -check-prefix=OVERLOAD3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD4 | %FileCheck %s -check-prefix=OVERLOAD4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD5 | %FileCheck %s -check-prefix=OVERLOAD5
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD6 | %FileCheck %s -check-prefix=OVERLOAD6
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD7 | %FileCheck %s -check-prefix=OVERLOAD6
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBER1 | %FileCheck %s -check-prefix=MEMBER1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBER2 | %FileCheck %s -check-prefix=MEMBER2
@@ -215,11 +218,23 @@ class C3 {
   func f2() {
     foo2(C2I, #^OVERLOAD2^#)
   }
-  func f2() {
+  func f3() {
     foo2(C1I, b1: #^OVERLOAD3^#)
   }
-  func f2() {
+  func f4() {
     foo2(C2I, b2: #^OVERLOAD4^#)
+  }
+
+  func f5() {
+    foo2(#^OVERLOAD5^#
+  }
+
+  func overloaded(_ a1: C1, b1: C2) {}
+  func overloaded(a2: C2, b2: C1) {}
+
+  func f6(obj: C3) {
+    overloaded(#^OVERLOAD6^#
+    obj.overloaded(#^OVERLOAD7^#
   }
 }
 
@@ -250,6 +265,20 @@ class C3 {
 
 // FIXME: This should be a negative test case
 // NEGATIVE_OVERLOAD4-NOT: Decl[Class]{{.*}} C2
+
+// OVERLOAD5: Begin completions
+// OVERLOAD5-DAG: Pattern/CurrModule:                 ['(']{#(a): C1#}, {#b1: C2#}[')'][#Void#]; name=a: C1, b1: C2
+// OVERLOAD5-DAG: Pattern/CurrModule:                 ['(']{#(a): C2#}, {#b2: C1#}[')'][#Void#]; name=a: C2, b2: C1
+// OVERLOAD5-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C1I[#C1#]; name=C1I
+// OVERLOAD5-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C2I[#C2#]; name=C2I
+// OVERLOAD5: End completions
+
+// OVERLOAD6: Begin completions
+// OVERLOAD6-DAG: Pattern/CurrModule:                 ['(']{#(a1): C1#}, {#b1: C2#}[')'][#Void#]; name=a1: C1, b1: C2
+// OVERLOAD6-DAG: Pattern/CurrModule:                 ['(']{#a2: C2#}, {#b2: C1#}[')'][#Void#]; name=a2: C2, b2: C1
+// OVERLOAD6-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C1I[#C1#]; name=C1I
+// OVERLOAD6-DAG: Decl[InstanceVar]/CurrNominal:      C2I[#C2#]; name=C2I
+// OVERLOAD6: End completions
 
 class C4 {
   func f1(_ G : Gen) {


### PR DESCRIPTION
In `<expr> '(' <code-completion-token>` case, we usually complete call arguments. However, if `<expr>` isn't typechecked, for example because of overloading, we used to give up arguments completions.

Now, use possible callee informations from `CodeCompletionTypeContextAnalyzer`. This increases the chance to provide arguments completions.

rdar://problem/43703157

(#20703 is a groundwork for this PR)