### PR TITLE
Fix nil KVOChange oldValue/newValue for RawRepresentable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,21 @@ Swift 5.1
 
 ### 2019-09-20 (Xcode 11.0)
 
+* [SR-5872][]:
+
+  When key-value-observing a `RawRepresentable` property using the `KeyPath`-based APIs, the change notification will now have its `oldValue`/`newValue` set correctly (instead of always being nil).
+
+  ```swift
+  @objc enum State: Int { case a, b }
+  class Target: NSObject { @objc dynamic var state: State = .a }
+  let target = Target()
+  target.observe(\.state, options: [.old, .new]) { object, change in
+      change.oldValue // State.a
+      change.newValue // State.b
+  }
+  target.state = .b
+  ```
+
 * [SR-8974][]:
 
   Duplicate tuple element labels are no longer allowed, because it leads
@@ -7862,6 +7877,7 @@ Swift 1.0
 [SR-4248]: <https://bugs.swift.org/browse/SR-4248>
 [SR-5581]: <https://bugs.swift.org/browse/SR-5581>
 [SR-5719]: <https://bugs.swift.org/browse/SR-5719>
+[SR-5872]: <https://bugs.swift.org/browse/SR-5872>
 [SR-6118]: <https://bugs.swift.org/browse/SR-6118>
 [SR-7139]: <https://bugs.swift.org/browse/SR-7139>
 [SR-7251]: <https://bugs.swift.org/browse/SR-7251>

--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -26,6 +26,16 @@ struct Guts {
     }
 }
 
+@objc enum TargetState: Int {
+    case whatTarget = 1
+    case why = 19
+    case deadInside = -42
+}
+
+@objc class OptionalStateHolder : NSObject {
+    @objc dynamic var objcState: TargetState = .whatTarget
+}
+
 class Target : NSObject, NSKeyValueObservingCustomization {
     // This dynamic property is observed by KVO
     @objc dynamic var objcValue: String
@@ -38,6 +48,9 @@ class Target : NSObject, NSKeyValueObservingCustomization {
         }
     }
     @objc dynamic var objcValue3: String
+
+    @objc dynamic var objcState: TargetState
+    @objc dynamic var optionalStateHolder: OptionalStateHolder?
     
     // This Swift-typed property causes vtable usage on this class.
     var swiftValue: Guts
@@ -47,6 +60,8 @@ class Target : NSObject, NSKeyValueObservingCustomization {
         self.objcValue = ""
         self.objcValue2 = ""
         self.objcValue3 = ""
+        self.objcState = .whatTarget
+        self.optionalStateHolder = OptionalStateHolder()
         super.init()
     }
     
@@ -64,28 +79,39 @@ class Target : NSObject, NSKeyValueObservingCustomization {
         }
         return true
     }
-    
-    func print() {
-        Swift.print("swiftValue \(self.swiftValue.value), objcValue \(objcValue)")
-    }
 }
 
 
 class ObserverKVO : NSObject {
     var target: Target?
-    var observation: NSKeyValueObservation? = nil
+    var valueObservation: NSKeyValueObservation? = nil
+    var stateObservation: NSKeyValueObservation? = nil
+    var optionalStateObservation: NSKeyValueObservation? = nil
     
     override init() { target = nil; super.init() }
     
     func observeTarget(_ target: Target) {
         self.target = target
-        observation = target.observe(\.objcValue) { (object, change) in
+        valueObservation = target.observe(\.objcValue) { (object, change) in
             Swift.print("swiftValue \(object.swiftValue.value), objcValue \(object.objcValue)")
+        }
+        stateObservation = target.observe(\.objcState, options: [.old, .new]) { (object, change) in
+            let oldString = change.oldValue.map { String(describing: $0.rawValue) } ?? "nil"
+            let newString = change.newValue.map { String(describing: $0.rawValue) } ?? "nil"
+            Swift.print("state \(object.objcState.rawValue), old \(oldString), new \(newString)")
+        }
+        optionalStateObservation = target.observe(\.optionalStateHolder?.objcState, options: [.old, .new]) { (object, change) in
+            let currentStateString = object.optionalStateHolder.map { String(describing: $0.objcState.rawValue) } ?? "nil"
+            let oldString = change.oldValue?.map { String(describing: $0.rawValue) } ?? "nil"
+            let newString = change.newValue?.map { String(describing: $0.rawValue) } ?? "nil"
+            Swift.print("optionalState \(currentStateString), old \(oldString), new \(newString)")
         }
     }
     
     func removeTarget() {
-        observation!.invalidate()
+        valueObservation!.invalidate()
+        stateObservation!.invalidate()
+        optionalStateObservation!.invalidate()
     }
 }
 
@@ -103,8 +129,14 @@ t2.objcValue = "four"
 t2.swiftValue = Guts(value: 13)
 t2.objcValue2 = "six" //should fire
 t2.objcValue3 = "nothing" //should not fire
+t2.objcState = .why
+t2.objcState = .deadInside
+t2.optionalStateHolder?.objcState = .why
+t2.optionalStateHolder?.objcState = .deadInside
+t2.optionalStateHolder = nil
 o2.removeTarget()
 t2.objcValue = "five" //make sure that we don't crash or keep posting changes if you deallocate an observation after invalidating it
+t2.objcState = .whatTarget
 print("target removed")
 
 // CHECK: registering observer 2
@@ -115,6 +147,11 @@ print("target removed")
 // The next 2 logs are actually a bug and shouldn't happen
 // CHECK-NEXT: swiftValue 13, objcValue four
 // CHECK-NEXT: swiftValue 13, objcValue four
+// CHECK-NEXT: state 19, old 1, new 19
+// CHECK-NEXT: state -42, old 19, new -42
+// CHECK-NEXT: optionalState 19, old 1, new 19
+// CHECK-NEXT: optionalState -42, old 19, new -42
+// CHECK-NEXT: optionalState nil, old -42, new nil
 // CHECK-NEXT: target removed
 
 //===----------------------------------------------------------------------===//
@@ -200,7 +237,8 @@ class TestClassForOptionalKeyPath : NSObject {
     
     // Should not use NSObject? as object type
     @objc dynamic var optionalObject: String?
-    
+
+    @objc dynamic var optionalState: OptionalStateHolder?
 }
 
 let testObjectForOptionalKeyPath = TestClassForOptionalKeyPath()
@@ -214,7 +252,19 @@ let optionalKeyPathObserver = testObjectForOptionalKeyPath.observe(\.optionalObj
 testObjectForOptionalKeyPath.optionalObject = nil
 testObjectForOptionalKeyPath.optionalObject = "foo"
 
+let optionalRawRepresentableKeyPathObserver = testObjectForOptionalKeyPath.observe(\.optionalState?.objcState, options: [.initial, .old, .new]) { (_, change) in
+    Swift.print("[STATE] oldValue = \(change.oldValue.map { $0?.rawValue } as Int??), newValue = \(change.newValue.map { $0?.rawValue } as Int??)")
+}
+
+testObjectForOptionalKeyPath.optionalState = OptionalStateHolder()
+testObjectForOptionalKeyPath.optionalState?.objcState = .why
+testObjectForOptionalKeyPath.optionalState = nil
+
 // CHECK-51-LABEL: observe keyPath with optional value
-// CHECK-51-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
+// CHECK-51-NEXT: oldValue = nil, newValue = Optional(nil)
 // CHECK-51-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
 // CHECK-51-NEXT: oldValue = Optional(nil), newValue = Optional(Optional("foo"))
+// CHECK-51-NEXT: [STATE] oldValue = nil, newValue = Optional(nil)
+// CHECK-51-NEXT: [STATE] oldValue = Optional(nil), newValue = Optional(Optional(1))
+// CHECK-51-NEXT: [STATE] oldValue = Optional(Optional(1)), newValue = Optional(Optional(19))
+// CHECK-51-NEXT: [STATE] oldValue = Optional(Optional(19)), newValue = Optional(nil)


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes the `oldValue` / `newValue` properties of `NSKeyValueObservedChange<Value>` being always `nil` when key-value-observing `RawRepresentable` types (typically enums) like `URLSessionTask.State`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5872](https://bugs.swift.org/browse/SR-5872).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->