### PR TITLE
[WIP][stdlib] Minor Sequence Optimizations

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -901,8 +901,7 @@ extension Sequence {
         ringBuffer.append(element)
       } else {
         ringBuffer[i] = element
-        i += 1
-        i %= maxLength
+        i = (i + 1) % maxLength
       }
     }
 
@@ -978,8 +977,7 @@ extension Sequence {
       } else {
         result.append(ringBuffer[i])
         ringBuffer[i] = element
-        i += 1
-        i %= k
+        i = (i + 1) % k
       }
     }
     return Array(result)

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -889,9 +889,9 @@ extension Sequence {
 
     // FIXME: <rdar://problem/21885650> Create reusable RingBuffer<T>
     // Put incoming elements into a ring buffer to save space. Once all
-    var ringBuffer: [Element] = []
     // elements are consumed, reorder the ring buffer and return it.
     // This saves memory for sequences particularly longer than `maxLength`.
+    var ringBuffer = ContiguousArray<Element>()
     ringBuffer.reserveCapacity(Swift.min(maxLength, underestimatedCount))
 
     var i = 0
@@ -911,7 +911,7 @@ extension Sequence {
       ringBuffer[i..<ringBuffer.endIndex].reverse()
       ringBuffer[0..<ringBuffer.endIndex].reverse()
     }
-    return ringBuffer
+    return Array(ringBuffer)
   }
 
   /// Returns a sequence containing all but the given number of initial
@@ -968,8 +968,8 @@ extension Sequence {
     // holding tank into the result, an `Array`. This saves
     // `k` * sizeof(Element) of memory, because slices keep the entire
     // memory of an `Array` alive.
-    var result: [Element] = []
-    var ringBuffer: [Element] = []
+    var result = ContiguousArray<Element>()
+    var ringBuffer = ContiguousArray<Element>()
     var i = ringBuffer.startIndex
 
     for element in self {
@@ -982,7 +982,7 @@ extension Sequence {
         i %= k
       }
     }
-    return result
+    return Array(result)
   }
 
   /// Returns a sequence by skipping the initial, consecutive elements that
@@ -1064,7 +1064,7 @@ extension Sequence {
   public __consuming func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> [Element] {
-    var result: [Element] = []
+    var result = ContiguousArray<Element>()
 
     for element in self {
       guard try predicate(element) else {
@@ -1072,7 +1072,7 @@ extension Sequence {
       }
       result.append(element)
     }
-    return result
+    return Array(result)
   }
 }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -889,10 +889,9 @@ extension Sequence {
 
     // FIXME: <rdar://problem/21885650> Create reusable RingBuffer<T>
     // Put incoming elements into a ring buffer to save space. Once all
-    // elements are consumed, reorder the ring buffer into an `Array`
-    // and return it. This saves memory for sequences particularly longer
-    // than `maxLength`.
     var ringBuffer: [Element] = []
+    // elements are consumed, reorder the ring buffer and return it.
+    // This saves memory for sequences particularly longer than `maxLength`.
     ringBuffer.reserveCapacity(Swift.min(maxLength, underestimatedCount))
 
     var i = 0
@@ -907,15 +906,12 @@ extension Sequence {
       }
     }
 
-    if i != ringBuffer.startIndex {
-      var rotated: [Element] = []
-      rotated.reserveCapacity(ringBuffer.count)
-      rotated += ringBuffer[i..<ringBuffer.endIndex]
-      rotated += ringBuffer[0..<i]
-      return rotated
-    } else {      
-      return ringBuffer
+    if i != ringBuffer.startIndex { // Rotate the array in-place
+      ringBuffer[0..<i].reverse()
+      ringBuffer[i..<ringBuffer.endIndex].reverse()
+      ringBuffer[0..<ringBuffer.endIndex].reverse()
     }
+    return ringBuffer
   }
 
   /// Returns a sequence containing all but the given number of initial

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -891,7 +891,7 @@ extension Sequence {
     // Put incoming elements into a ring buffer to save space. Once all
     // elements are consumed, reorder the ring buffer and return it.
     // This saves memory for sequences particularly longer than `maxLength`.
-    var ringBuffer = ContiguousArray<Element>()
+    var ringBuffer: [Element] = []
     ringBuffer.reserveCapacity(Swift.min(maxLength, underestimatedCount))
 
     var i = 0
@@ -901,16 +901,20 @@ extension Sequence {
         ringBuffer.append(element)
       } else {
         ringBuffer[i] = element
-        i = (i + 1) % maxLength
+        i += 1
+        i %= maxLength
       }
     }
 
-    if i != ringBuffer.startIndex { // Rotate the array in-place
-      ringBuffer[0..<i].reverse()
-      ringBuffer[i..<ringBuffer.endIndex].reverse()
-      ringBuffer[0..<ringBuffer.endIndex].reverse()
+    if i != ringBuffer.startIndex {
+      var rotated: [Element] = []
+      rotated.reserveCapacity(ringBuffer.count)
+      rotated += ringBuffer[i..<ringBuffer.endIndex]
+      rotated += ringBuffer[0..<i]
+      return rotated
+    } else {
+      return ringBuffer
     }
-    return Array(ringBuffer)
   }
 
   /// Returns a sequence containing all but the given number of initial


### PR DESCRIPTION
Following up on discussion from https://github.com/apple/swift/pull/20221#pullrequestreview-174666315, these are minor tweaks to `Sequence` implementation:
* In-place rotation of `ringBuffer` used in `suffix`, avoiding new array copy.
* Internal use of `ContiguousArray` in `dropLast`, `prefix` and `suffix` (modeled after `map` and `_filter` implementations).