### PR TITLE
IRGen: Force emission of lazy witness table when conformance descriptor is referenced [5.0]

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3539,6 +3539,8 @@ llvm::GlobalValue *IRGenModule::defineAssociatedConformanceDescriptor(
 llvm::Constant *IRGenModule::getAddrOfProtocolConformanceDescriptor(
                                 const RootProtocolConformance *conformance,
                                 ConstantInit definition) {
+  IRGen.addLazyWitnessTable(conformance);
+
   auto entity = LinkEntity::forProtocolConformanceDescriptor(conformance);
   return getAddrOfLLVMVariable(entity, definition,
                                DebugTypeInfo());

--- a/test/IRGen/lazy_conformances.swift
+++ b/test/IRGen/lazy_conformances.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend -parse-as-library -O %s -emit-ir | %FileCheck %s
+
+// CHECK: @"$s17lazy_conformances12MyCollectionVyxGSKAASKRzrlMc" = hidden constant {
+// CHECK: @"$s17lazy_conformances12MyCollectionVyxGSTAAMc" = hidden constant {
+
+struct MyCollection<Base : Collection> : Collection {
+  typealias Index = Base.Index
+  typealias Element = Base.Element
+
+  var startIndex: Index {
+    fatalError()
+  }
+
+  var endIndex: Index {
+    fatalError()
+  }
+
+  func index(after i: Index) -> Index {
+    fatalError()
+  }
+
+  func formIndex(after i: inout Index) {
+    fatalError()
+  }
+
+  subscript(position: Index) -> Element {
+    fatalError()
+  }
+}
+
+extension MyCollection : BidirectionalCollection
+  where Base : BidirectionalCollection
+{
+  func index(before i: Index) -> Index {
+    fatalError()
+  }
+
+  func formIndex(before i: inout Index) {
+    fatalError()
+  }
+}


### PR DESCRIPTION
Otherwise with the new resilient witness table emission pattern, we might miss
conformances for refined protocols, since the witness table itself is never
referenced, only the conformance descriptor is.

Fixes <rdar://problem/46133018>.