### PR TITLE
[stdlib] _HashTable.copyContents: Fix out of bounds access

### DIFF
--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -406,7 +406,7 @@ extension _HashTable {
   @_effects(releasenone)
   internal func copyContents(of other: _HashTable) {
     _internalInvariant(bucketCount == other.bucketCount)
-    self.words.assign(from: other.words, count: bucketCount)
+    self.words.assign(from: other.words, count: wordCount)
   }
 
   /// Insert a new entry with the specified hash value into the table.


### PR DESCRIPTION
There is a distressing typo in `_HashTable` that causes bitmap copy operations to copy up to 64 times more memory than necessary. This sometimes leads to the copy operation overrunning the tail-allocated buffer.

https://bugs.swift.org/browse/SR-9348