### PR TITLE
build: pass `/GR-` when using cl-like drivers

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -265,7 +265,9 @@ function(_add_variant_c_compile_flags)
     # Emulate /GR-.
     # TODO(compnerd) when moving up to VS 2017 15.3 and newer, we can disable
     # RTTI again
-    if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+    if(SWIFT_COMPILER_IS_MSVC_LIKE)
+      list(APPEND result /GR-)
+    else()
       list(APPEND result -frtti)
       list(APPEND result -Xclang;-fno-rtti-data)
     endif()


### PR DESCRIPTION
When building with clang-cl, we should pass /GR- rather than the
gcc-style driver options.  This repairs the build of swift on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
