### PR TITLE
[5.0] [Runtime] Cache and unique based on protocol conformance descriptors, not witness tables

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -527,7 +527,7 @@ swift::swift_getGenericMetadata(MetadataRequest request,
   auto &generics = description->getFullGenericContextHeader();
   size_t numGenericArgs = generics.Base.NumKeyArguments;
 
-  auto key = MetadataCacheKey(arguments, numGenericArgs);
+  auto key = MetadataCacheKey(description, arguments, numGenericArgs);
   auto result =
     getCache(generics).getOrInsert(key, request, description, arguments);
 
@@ -4338,7 +4338,7 @@ static Result performOnMetadataCache(const Metadata *metadata,
     reinterpret_cast<const void * const *>(
                                     description->getGenericArguments(metadata));
   size_t numGenericArgs = generics.Base.NumKeyArguments;
-  auto key = MetadataCacheKey(genericArgs, numGenericArgs);
+  auto key = MetadataCacheKey(description, genericArgs, numGenericArgs);
 
   return std::move(callbacks).forGenericMetadata(metadata, description,
                                                  getCache(generics), key);

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -507,6 +507,12 @@ public:
                              const Metadata *type,
                              const ProtocolConformanceDescriptor *conformance);
 
+  /// Determine whether the given type conforms to the given Swift protocol,
+  /// returning the appropriate protocol conformance descriptor when it does.
+  const ProtocolConformanceDescriptor *
+  _conformsToSwiftProtocol(const Metadata * const type,
+                           const ProtocolDescriptor *protocol);
+
   /// Retrieve an associated type witness from the given witness table.
   ///
   /// \param wtable The witness table.

--- a/test/Runtime/Inputs/synthesized_decl_uniqueness.swift
+++ b/test/Runtime/Inputs/synthesized_decl_uniqueness.swift
@@ -1,4 +1,5 @@
 import CoreLocation
+import Foundation
 
 public func getCLError() -> Any.Type {
   return CLError.self
@@ -6,4 +7,8 @@ public func getCLError() -> Any.Type {
 
 public func getCLErrorCode() -> Any.Type {
   return CLError.Code.self
+}
+
+public func getNotificationNameSet() -> Any.Type {
+  return Set<NSNotification.Name>.self
 }

--- a/test/Runtime/synthesized_decl_uniqueness.swift
+++ b/test/Runtime/synthesized_decl_uniqueness.swift
@@ -17,6 +17,7 @@ var tests = TestSuite("metadata identity for synthesized types")
 tests.test("synthesized type identity across modules") {
   expectEqual(A.getCLError(), B.getCLError())
   expectEqual(A.getCLErrorCode(), B.getCLErrorCode())
+  expectEqual(A.getNotificationNameSet(), B.getNotificationNameSet())
 }
 
 runAllTests()

--- a/validation-test/stdlib/SetAnyHashableExtensions.swift
+++ b/validation-test/stdlib/SetAnyHashableExtensions.swift
@@ -126,7 +126,10 @@ SetTests.test("insert<Hashable>(_:)") {
   expectEqual(expected, s)
 }
 
-SetTests.test("insert<Hashable>(_:)/FormerCastTrap") {
+SetTests.test("insert<Hashable>(_:)/CastTrap")
+  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
+  .crashOutputMatches("to 'main.TestHashableDerivedB'")
+  .code {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
   ]
@@ -138,6 +141,7 @@ SetTests.test("insert<Hashable>(_:)/FormerCastTrap") {
     expectEqual(1, memberAfterInsert.identity)
   }
 
+  expectCrashLater()
   _ = s.insert(TestHashableDerivedB(1010, identity: 3))
 }
 
@@ -177,7 +181,10 @@ SetTests.test("update<Hashable>(with:)") {
   expectEqual(expected, s)
 }
 
-SetTests.test("update<Hashable>(with:)/FormerCastTrap") {
+SetTests.test("update<Hashable>(with:)/CastTrap")
+  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
+  .crashOutputMatches("to 'main.TestHashableDerivedB'")
+  .code {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
   ]
@@ -187,6 +194,7 @@ SetTests.test("update<Hashable>(with:)/FormerCastTrap") {
     expectEqual(1, old.identity)
   }
 
+  expectCrashLater()
   s.update(with: TestHashableDerivedB(1010, identity: 3))
 }
 
@@ -220,7 +228,10 @@ SetTests.test("remove<Hashable>(_:)") {
   }
 }
 
-SetTests.test("remove<Hashable>(_:)/FormerCastTrap") {
+SetTests.test("remove<Hashable>(_:)/CastTrap")
+  .crashOutputMatches("Could not cast value of type 'main.TestHashableDerivedA'")
+  .crashOutputMatches("to 'main.TestHashableDerivedB'")
+  .code {
   var s: Set<AnyHashable> = [
     AnyHashable(TestHashableDerivedA(1010, identity: 1)),
     AnyHashable(TestHashableDerivedA(2020, identity: 1)),
@@ -232,6 +243,7 @@ SetTests.test("remove<Hashable>(_:)/FormerCastTrap") {
     expectEqual(1, old.identity)
   }
 
+  expectCrashLater()
   s.remove(TestHashableDerivedB(2020, identity: 2))
 }
 


### PR DESCRIPTION
The conformance cache was caching the witness table for a conformance
`T: P`, where `T` is a concrete type and `P` is a protocol. However, it
essentially picked one of potentially many witness tables for that
conformance, because retroactive conformances might produce different results
from different modules.

Make the conformance cache what is says it is: a cache of the conformance
descriptor for a given `T: P`. Clients of the conformance cache can choose how to interpret
the protocol conformance descriptor, e.g., by instantiating a witness table with a
particular set of arguments.

Moreover, unique metadata entries based on conformance descriptors, rather than witness tables.
This is both a correctness fix (when there are multiple, synthesized conformances in multiple modules)
and enables future optimizations (e.g., the use of pre-specialized witness tables).