### PR TITLE
[Mangle] Include generic arguments of extensions for the Objective-C runtime

### DIFF
--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1894,6 +1894,11 @@ void Remangler::mangleGenericArgs(Node *node, EntityContext &ctx) {
     break;
   }
 
+  case Node::Kind::Extension: {
+    mangleGenericArgs(node->getChild(1), ctx);
+    break;
+  }
+
   default:
     break;
   }

--- a/test/Demangle/remangle.swift
+++ b/test/Demangle/remangle.swift
@@ -9,3 +9,6 @@ RUN: diff %t.input %t.output
 // CHECK: Swift.(Mystruct in _7B40D7ED6632C2BEA2CA3BFFD57E3435)
 RUN: swift-demangle -remangle-objc-rt '$ss8Mystruct33_7B40D7ED6632C2BEA2CA3BFFD57E3435LLV' | %FileCheck %s
 
+// CHECK-GENERICEXT: Swift._ContiguousArrayStorage<(extension in Swift):Swift.FlattenSequence<StdlibCollectionUnittest.MinimalBidirectionalCollection<StdlibCollectionUnittest.MinimalBidirectionalCollection<Swift.Int>>>.Index>
+RUN: swift-demangle -remangle-objc-rt '$ss23_ContiguousArrayStorageCys15FlattenSequenceVsE5IndexVy24StdlibCollectionUnittest020MinimalBidirectionalH0VyAIySiGG_GGD' | %FileCheck -check-prefix CHECK-GENERICEXT %s
+

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -1251,36 +1251,32 @@ do {
   % for Traversal in 'Forward', 'Bidirectional':
   %   TraversalCollection = collectionForTraversal(Traversal)
 
-    // re-enable commented out test case below as well when this is fixed 
-    // (find FIXME: rdar45956357)
-    if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-      tests.test("FlattenCollection/${Traversal}/\(data)") {
-        let base = Minimal${TraversalCollection}(
-          elements: data.map { Minimal${TraversalCollection}(elements: $0) })
+    tests.test("FlattenCollection/${Traversal}/\(data)") {
+      let base = Minimal${TraversalCollection}(
+        elements: data.map { Minimal${TraversalCollection}(elements: $0) })
 
-        let flattened = base.joined()
-        check${Traversal}Collection(expected, flattened, resiliencyChecks: .none)
+      let flattened = base.joined()
+      check${Traversal}Collection(expected, flattened, resiliencyChecks: .none)
 
-        // Checking that flatten doesn't introduce laziness
-        var calls = 0
-        _ = flattened.map { _ in calls += 1 }
-        expectLE(
-          expected.count, calls,
-          "unexpected laziness in \(type(of: flattened))")
-      }
+      // Checking that flatten doesn't introduce laziness
+      var calls = 0
+      _ = flattened.map { _ in calls += 1 }
+      expectLE(
+        expected.count, calls,
+        "unexpected laziness in \(type(of: flattened))")
+    }
 
-      tests.test("FlattenCollection/${Traversal}/Lazy\(data)") {
-        // Checking that flatten doesn't remove laziness
-        let base = Minimal${TraversalCollection}(
-          elements: data.map { Minimal${TraversalCollection}(elements: $0) }
-        ).lazy.map { $0 }
+    tests.test("FlattenCollection/${Traversal}/Lazy\(data)") {
+      // Checking that flatten doesn't remove laziness
+      let base = Minimal${TraversalCollection}(
+        elements: data.map { Minimal${TraversalCollection}(elements: $0) }
+      ).lazy.map { $0 }
 
-        let flattened = base.joined()
+      let flattened = base.joined()
 
-        var calls = 0
-        _ = flattened.map { _ in calls += 1 }
-        expectEqual(0, calls, "unexpected eagerness in \(type(of: flattened))")
-      }
+      var calls = 0
+      _ = flattened.map { _ in calls += 1 }
+      expectEqual(0, calls, "unexpected eagerness in \(type(of: flattened))")
     }
   % end
   }
@@ -1295,38 +1291,20 @@ struct TryFlattenIndex<C: Collection> where C.Element: Collection {
 
 let prefixDropWhileTests: [(data: [Int], value: Int, pivot: Int)]
 
-// FIXME: rdar45956357
-if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-  prefixDropWhileTests = [
-    ([],                       0,     0),
-    ([0],                      0,     0),
-    ([0],                     99,     1),
-    ([0, 10],                  0,     0),
-    ([0, 10],                 10,     1),
-    ([0, 10],                 99,     2),
-    ([0, 10, 20, 30, 40],      0,     0),
-    ([0, 10, 20, 30, 40],     10,     1),
-    ([0, 10, 20, 30, 40],     20,     2),
-    ([0, 10, 20, 30, 40],     30,     3),
-    ([0, 10, 20, 30, 40],     40,     4),
-    ([0, 10, 20, 30, 40],     99,     5) 
-  ]
-} else {
-  prefixDropWhileTests = [
-    ([],                       0,     0),
-    ([0],                      0,     0),
-    // ([0],                     99,     1),
-    ([0, 10],                  0,     0),
-    // ([0, 10],                 10,     1),
-    // ([0, 10],                 99,     2),
-    // ([0, 10, 20, 30, 40],      0,     0),
-    // ([0, 10, 20, 30, 40],     10,     1),
-    // ([0, 10, 20, 30, 40],     20,     2),
-    // ([0, 10, 20, 30, 40],     30,     3),
-    // ([0, 10, 20, 30, 40],     40,     4),
-    // ([0, 10, 20, 30, 40],     99,     5)
-  ]
-}
+prefixDropWhileTests = [
+  ([],                       0,     0),
+  ([0],                      0,     0),
+  ([0],                     99,     1),
+  ([0, 10],                  0,     0),
+  ([0, 10],                 10,     1),
+  ([0, 10],                 99,     2),
+  ([0, 10, 20, 30, 40],      0,     0),
+  ([0, 10, 20, 30, 40],     10,     1),
+  ([0, 10, 20, 30, 40],     20,     2),
+  ([0, 10, 20, 30, 40],     30,     3),
+  ([0, 10, 20, 30, 40],     40,     4),
+  ([0, 10, 20, 30, 40],     99,     5) 
+]
 
 % for Kind in 'Sequence', 'Forward', 'Bidirectional':
 %   Self = 'Sequence' if Kind == 'Sequence' else collectionForTraversal(Kind)


### PR DESCRIPTION
The remangler for the Objective-C runtime was dropping generic arguments
of extension contexts, leading to collisions with @objc class names.
Include the generic arguments of extensions.

Fixes rdar://problem/45956357.
