### PR TITLE
rename [reverse_differentiable] -> [differentiable]; add jvp and vjp

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1318,9 +1318,8 @@ public:
 /// Note: 'primal' and 'adjoint' are legacy functions that we will keep around
 /// until we have fully switched to 'jvp' and 'vjp'.
 ///
-/// Note: 'jvp' and 'vjp' are not fully supported yet. In particular, they do
-/// not get lowered to the sil differentiable attribute, and the core AD pass
-/// does not use them. We are incrementally adding support for them.
+/// Note: 'jvp' and 'vjp' are not fully supported yet. In particular, the core
+/// AD pass does not use them. We are incrementally adding support for them.
 ///
 /// For example:
 ///   @differentiable(reverse, adjoint: foo(_:_:seed:) where T : FloatingPoint)

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -365,7 +365,7 @@ ERROR(pound_assert_failure,none,
 ERROR(autodiff_internal_swift_not_imported,none,
       "AD internal error: the Swift module is not imported", ())
 ERROR(autodiff_incomplete_differentiable_attr,none,
-      "incomplete `reverse_differentiable` attribute; it should specify either "
+      "incomplete `differentiable` attribute; it should specify either "
       "both primal and adjoint or nothing", ())
 ERROR(autodiff_opaque_function_unsupported,none,
       "differentiating an opaque function is not supported yet", ())

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 456; // Last change: add jvp and vjp to @differentiable
+const uint16_t VERSION_MINOR = 457; // Last change: add jvp and vjp to sil differentiable attribute
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -57,25 +57,30 @@ void SILFunction::addSpecializeAttr(SILSpecializeAttr *Attr) {
 }
 
 /// SWIFT_ENABLE_TENSORFLOW
-SILReverseDifferentiableAttr::
-SILReverseDifferentiableAttr(const SILAutoDiffIndices &indices,
-                             StringRef primalName,
-                             StringRef adjointName,
-                             bool adjointIsPrimitive)
+SILDifferentiableAttr::
+SILDifferentiableAttr(const SILAutoDiffIndices &indices,
+                      StringRef primalName,
+                      StringRef adjointName,
+                      bool adjointIsPrimitive,
+                      StringRef jvpName,
+                      StringRef vjpName)
   : indices(indices), PrimalName(primalName), AdjointName(adjointName),
-    AdjointIsPrimitive(adjointIsPrimitive) {}
+    AdjointIsPrimitive(adjointIsPrimitive), JVPName(jvpName), VJPName(vjpName)
+    {}
 
-SILReverseDifferentiableAttr *
-SILReverseDifferentiableAttr::create(SILModule &M,
-                                     const SILAutoDiffIndices &indices,
-                                     StringRef primalName,
-                                     StringRef adjointName,
-                                     bool adjointIsPrimitive) {
-  void *mem = M.allocate(sizeof(SILReverseDifferentiableAttr),
-                         alignof(SILReverseDifferentiableAttr));
+SILDifferentiableAttr *
+SILDifferentiableAttr::create(SILModule &M,
+                              const SILAutoDiffIndices &indices,
+                              StringRef primalName,
+                              StringRef adjointName,
+                              bool adjointIsPrimitive,
+                              StringRef jvpName,
+                              StringRef vjpName) {
+  void *mem = M.allocate(sizeof(SILDifferentiableAttr),
+                         alignof(SILDifferentiableAttr));
   return ::new (mem)
-      SILReverseDifferentiableAttr(indices, primalName, adjointName,
-                                   adjointIsPrimitive);
+      SILDifferentiableAttr(indices, primalName, adjointName,
+                            adjointIsPrimitive, jvpName, vjpName);
 }
 
 SILFunction *SILFunction::create(

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2502,8 +2502,8 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  for (auto *Attr : getReverseDifferentiableAttrs()) {
-    OS << "[reverse_differentiable "; Attr->print(OS); OS << "] ";
+  for (auto *Attr : getDifferentiableAttrs()) {
+    OS << "[differentiable "; Attr->print(OS); OS << "] ";
   }
 
   // TODO: Handle clang node owners which don't have a name.
@@ -3187,7 +3187,7 @@ void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {
 }
 
 /// SWIFT_ENABLE_TENSORFLOW
-void SILReverseDifferentiableAttr::print(llvm::raw_ostream &OS) const {
+void SILDifferentiableAttr::print(llvm::raw_ostream &OS) const {
   auto &indices = getIndices();
   OS << "source " << indices.source << " wrt ";
   interleave(indices.parameters.set_bits(),
@@ -3200,6 +3200,12 @@ void SILReverseDifferentiableAttr::print(llvm::raw_ostream &OS) const {
     OS << " adjoint @" << AdjointName;
   }
   if (AdjointIsPrimitive) OS << " primitive";
+  if (!JVPName.empty()) {
+    OS << " jvp @" << JVPName;
+  }
+  if (!VJPName.empty()) {
+    OS << " vjp @" << VJPName;
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4577,9 +4577,9 @@ public:
   }
 
   /// SWIFT_ENABLE_TENSORFLOW
-  /// Verify the [reverse_differentiable] attribute.
-  void verifyReverseDifferentiableAttr(SILFunction *F,
-                                       SILReverseDifferentiableAttr &Attr) {
+  /// Verify the [differentiable] attribute.
+  void verifyDifferentiableAttr(SILFunction *F,
+                                       SILDifferentiableAttr &Attr) {
     // Parameter indices must be specified.
     require(!Attr.getIndices().parameters.empty(),
             "Parameter indices cannot be empty");
@@ -4957,8 +4957,8 @@ public:
     verifySILFunctionType(FTy);
 
     // SWIFT_ENABLE_TENSORFLOW
-    for (auto *RDiffAttr : F->getReverseDifferentiableAttrs())
-      verifyReverseDifferentiableAttr(F, *RDiffAttr);
+    for (auto *RDiffAttr : F->getDifferentiableAttrs())
+      verifyDifferentiableAttr(F, *RDiffAttr);
 
     if (F->isExternalDeclaration()) {
       if (F->hasForeignBody())

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -717,15 +717,15 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  // [reverse_differentiable] attributes only make sense on functions with
-  // bodies, because [reverse_differentiable] attributes declare actual primals
+  // [differentiable] attributes only make sense on functions with
+  // bodies, because [differentiable] attributes declare actual primals
   // and adjoints corresponding to the function body.
   if (!AFD->hasBody())
     return;
 
   // If the declaration has a @differentiable(reverse) attribute, turn it into a
-  // SIL [reverse_differentiable] attribute with lowered primal and adjoint
-  // function names and lowered differentiation parameter indices.
+  // SIL [differentiable] attribute with lowered associated function names and
+  // lowered differentiation parameter indices.
   //
   // FIXME: Handle multiple @differentiable attributes.
   if (auto *diffAttr = cast_or_null<DifferentiableAttr>(
@@ -739,7 +739,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
       auto silOriginalFn = getFunction(SILDeclRef(AFD), ForDefinition);
       // Either only adjoint is specified, or both primal and adjoint are
       // spcified.
-      StringRef primName, adjName;
+      StringRef primName, adjName, jvpName, vjpName;
       bool hasPrimitiveAdjoint = false;
       if (auto *primFn = diffAttr->getPrimalFunction())
         primName = getFunction(SILDeclRef(primFn), ForDefinition)->getName();
@@ -755,14 +755,18 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
         assert(primName.empty() &&
                "Primal cannot be present if adjoint is not");
       }
+      if (auto *jvpFn = diffAttr->getJVPFunction())
+        jvpName = getFunction(SILDeclRef(jvpFn), ForDefinition)->getName();
+      if (auto *vjpFn = diffAttr->getVJPFunction())
+        vjpName = getFunction(SILDeclRef(vjpFn), ForDefinition)->getName();
       // Get lowered argument indices.
       auto paramIndices = diffAttr->getCheckedParameterIndices()->getLowered(
           AFD->getInterfaceType()->castTo<AnyFunctionType>());
       SILAutoDiffIndices indices(/*source*/ 0, paramIndices);
-      silOriginalFn->addReverseDifferentiableAttr(
-          SILReverseDifferentiableAttr::create(
+      silOriginalFn->addDifferentiableAttr(
+          SILDifferentiableAttr::create(
             M, indices, primName, adjName,
-            /*primitive*/ hasPrimitiveAdjoint));
+            /*primitive*/ hasPrimitiveAdjoint, jvpName, vjpName));
       break;
     }
     }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -467,14 +467,14 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
   unsigned rawLinkage, isTransparent, isSerialized, isThunk,
       isWithoutactuallyEscapingThunk, isGlobal, inlineStrategy,
       // SWIFT_ENABLE_TENSORFLOW
-      optimizationMode, effect, numSpecAttrs, numReverseDifferentiableAttrs,
+      optimizationMode, effect, numSpecAttrs, numDifferentiableAttrs,
       hasQualifiedOwnership, isWeakLinked;
   ArrayRef<uint64_t> SemanticsIDs;
   SILFunctionLayout::readRecord(
       scratch, rawLinkage, isTransparent, isSerialized, isThunk,
       isWithoutactuallyEscapingThunk, isGlobal, inlineStrategy,
       // SWIFT_ENABLE_TENSORFLOW
-      optimizationMode, effect, numSpecAttrs, numReverseDifferentiableAttrs,
+      optimizationMode, effect, numSpecAttrs, numDifferentiableAttrs,
       hasQualifiedOwnership, isWeakLinked, funcTyID, genericEnvID,
       clangNodeOwnerID, SemanticsIDs);
 
@@ -617,7 +617,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
   // SWIFT_ENABLE_TENSORFLOW
   // Read and instantiate the differentiable attributes.
-  while (numReverseDifferentiableAttrs--) {
+  while (numDifferentiableAttrs--) {
     auto next = SILCursor.advance(AF_DontPopBlockAtEnd);
     assert(next.Kind == llvm::BitstreamEntry::Record);
 
@@ -629,24 +629,28 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     uint64_t primalNameId;
     uint64_t adjointNameId;
     bool adjointIsPrimitive;
+    uint64_t jvpNameId;
+    uint64_t vjpNameId;
     uint64_t source;
     ArrayRef<uint64_t> parameters;
-    SILReverseDifferentiableAttrLayout::readRecord(scratch, primalNameId,
-                                                   adjointNameId,
-                                                   adjointIsPrimitive,
-                                                   source, parameters);
+    SILDifferentiableAttrLayout::readRecord(scratch, primalNameId,
+                                            adjointNameId, adjointIsPrimitive,
+                                            jvpNameId, vjpNameId, source,
+                                            parameters);
 
     StringRef primalName = MF->getIdentifier(primalNameId).str();
     StringRef adjointName = MF->getIdentifier(adjointNameId).str();
     llvm::SmallBitVector parametersBitVector(parameters.size());
+    StringRef jvpName = MF->getIdentifier(jvpNameId).str();
+    StringRef vjpName = MF->getIdentifier(vjpNameId).str();
     for (unsigned i = 0; i < parameters.size(); i++)
       parametersBitVector[i] = parameters[i];
     SILAutoDiffIndices indices(source, parametersBitVector);
 
-    auto *attr = SILReverseDifferentiableAttr::create(SILMod, indices,
-                                                      primalName, adjointName,
-                                                      adjointIsPrimitive);
-    fn->addReverseDifferentiableAttr(attr);
+    auto *attr = SILDifferentiableAttr::create(SILMod, indices, primalName,
+                                               adjointName, adjointIsPrimitive,
+                                               jvpName, vjpName);
+    fn->addDifferentiableAttr(attr);
   }
 
   GenericEnvironment *genericEnv = nullptr;
@@ -2574,7 +2578,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
   unsigned rawLinkage, isTransparent, isSerialized, isThunk,
       isWithoutactuallyEscapingThunk, isGlobal, inlineStrategy,
       // SWIFT_ENABLE_TENSORFLOW
-      optimizationMode, effect, numSpecAttrs, numReverseDifferentiableAttrs,
+      optimizationMode, effect, numSpecAttrs, numDifferentiableAttrs,
       hasQualifiedOwnership, isWeakLinked;
   ArrayRef<uint64_t> SemanticsIDs;
   SILFunctionLayout::readRecord(
@@ -2582,7 +2586,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
       isWithoutactuallyEscapingThunk, isGlobal, inlineStrategy,
       optimizationMode, effect, numSpecAttrs,
       // SWIFT_ENABLE_TENSORFLOW
-      numReverseDifferentiableAttrs, hasQualifiedOwnership, isWeakLinked,
+      numDifferentiableAttrs, hasQualifiedOwnership, isWeakLinked,
       funcTyID, genericEnvID, clangOwnerID, SemanticsIDs);
   auto linkage = fromStableSILLinkage(rawLinkage);
   if (!linkage) {

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -313,11 +313,13 @@ namespace sil_block {
                      >;
 
   // SWIFT_ENABLE_TENSORFLOW
-  using SILReverseDifferentiableAttrLayout = BCRecordLayout<
+  using SILDifferentiableAttrLayout = BCRecordLayout<
     SIL_REVERSE_DIFFERENTIABLE_ATTR,
     IdentifierIDField,  // Primal name.
     IdentifierIDField,  // Adjoint name.
     BCFixed<1>,         // Adjoint is primitive.
+    IdentifierIDField,  // JVP name.
+    IdentifierIDField,  // VJP name.
     BCFixed<32>,        // Indices' source.
     BCArray<BCFixed<1>> // Indices' parameters bitvector.
   >;

--- a/test/AutoDiff/autodiff_basic.sil
+++ b/test/AutoDiff/autodiff_basic.sil
@@ -10,7 +10,7 @@ bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float):
   return %2 : $Float
 }
 
-sil hidden [reverse_differentiable source 0 wrt 0 primal @foo adjoint @foo_adj primitive] @foo : $@convention(thin) (Float) -> Float {
+sil hidden [differentiable source 0 wrt 0 primal @foo adjoint @foo_adj primitive] @foo : $@convention(thin) (Float) -> Float {
 bb0(%0 : @trivial $Float):
   return %0 : $Float
 }

--- a/test/AutoDiff/autodiff_function_inst.sil
+++ b/test/AutoDiff/autodiff_function_inst.sil
@@ -16,7 +16,7 @@ bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float):
 }
 
 // The original function with an attribute that specifies the compiler-emitted pullback.
-sil hidden [reverse_differentiable source 0 wrt 0 primal @foo adjoint @foo_adj primitive] @foo : $@convention(thin) (Float) -> Float {
+sil hidden [differentiable source 0 wrt 0 primal @foo adjoint @foo_adj primitive] @foo : $@convention(thin) (Float) -> Float {
 bb0(%0 : @trivial $Float):
   return %0 : $Float
 }

--- a/test/AutoDiff/builtin_math.sil
+++ b/test/AutoDiff/builtin_math.sil
@@ -91,10 +91,10 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK:   @sil_stored var v_1: Builtin.FPIEEE32
 // CHECK: }
 
-// CHECK-LABEL: [reverse_differentiable source 0 wrt 0, 1 primal @AD__simple_mul__primal_src_0_wrt_0_1 adjoint @AD__simple_mul__adjoint_src_0_wrt_0_1] @simple_mul
-// CHECK-LABEL: [reverse_differentiable source 0 wrt 0, 1 primal @AD__chain_rule__primal_src_0_wrt_0_1 adjoint @AD__chain_rule__adjoint_src_0_wrt_0_1] @chain_rule
-// CHECK-LABEL: [reverse_differentiable source 0 wrt 0, 1 primal @AD__add_literals__primal_src_0_wrt_0_1 adjoint @AD__add_literals__adjoint_src_0_wrt_0_1] @add_literals
-// CHECK-LABEL [reverse_differentiable source 0 wrt 0, 1 primal @AD__fanout__primal_src_0_wrt_0_1 adjoint @AD__fanout__adjoint_src_0_wrt_0_1] @fanout
+// CHECK-LABEL: [differentiable source 0 wrt 0, 1 primal @AD__simple_mul__primal_src_0_wrt_0_1 adjoint @AD__simple_mul__adjoint_src_0_wrt_0_1] @simple_mul
+// CHECK-LABEL: [differentiable source 0 wrt 0, 1 primal @AD__chain_rule__primal_src_0_wrt_0_1 adjoint @AD__chain_rule__adjoint_src_0_wrt_0_1] @chain_rule
+// CHECK-LABEL: [differentiable source 0 wrt 0, 1 primal @AD__add_literals__primal_src_0_wrt_0_1 adjoint @AD__add_literals__adjoint_src_0_wrt_0_1] @add_literals
+// CHECK-LABEL [differentiable source 0 wrt 0, 1 primal @AD__fanout__primal_src_0_wrt_0_1 adjoint @AD__fanout__adjoint_src_0_wrt_0_1] @fanout
 
 // CHECK-LABEL: @AD__simple_mul__primal_src_0_wrt_0_1
 // CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -10,7 +10,7 @@ public func foo(_ x: Float, _ y: Float) -> Float {
   return 1
 }
 
-// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1 primal @foo adjoint @dfoo primitive] @foo
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 primal @foo adjoint @dfoo primitive] @foo
 
 @_silgen_name("dfoo")
 public func dfoo(_ x: Float, _ y: Float, partial: Float, seed: Float) -> (Float, Float) {
@@ -29,7 +29,7 @@ public func foo_indir_ret<T>(_ x: Float, _ y: T) -> T {
   return y
 }
 
-// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1 primal @foo_indir_ret adjoint @dfoo_indir_ret primitive] @foo_indir_ret : $@convention(thin) <T> (Float, @in_guaranteed T) -> @out T {
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 primal @foo_indir_ret adjoint @dfoo_indir_ret primitive] @foo_indir_ret : $@convention(thin) <T> (Float, @in_guaranteed T) -> @out T {
 // CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $Float, %2 : @trivial $*T):
 
 @_silgen_name("dfoo_indir_ret")
@@ -50,7 +50,7 @@ public func foo_tuple(_ x: ((Float, (Float, Float)), Float, ((Float))), _ y: Flo
   return 1
 }
 
-// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1, 2, 3, 4, 5 primal @foo_tuple adjoint @dfoo_tuple primitive] @foo_tuple : $@convention(thin) (Float, Float, Float, Float, Float, Float) -> Float
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1, 2, 3, 4, 5 primal @foo_tuple adjoint @dfoo_tuple primitive] @foo_tuple : $@convention(thin) (Float, Float, Float, Float, Float, Float) -> Float
 
 @_silgen_name("dfoo_tuple")
 public func dfoo_tuple(_ x: ((Float, (Float, Float)), Float, ((Float))), _ y: Float, partial: Float, seed: Float) -> (((Float, (Float, Float)), Float, ((Float))), Float) {
@@ -65,4 +65,42 @@ public func no_prim_or_adj(_ x: Float) -> Float {
   return x * x
 }
 
-// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0] @no_prim_or_adj : $@convention(thin) (Float) -> Float
+// CHECK-LABEL: sil [differentiable source 0 wrt 0] @no_prim_or_adj : $@convention(thin) (Float) -> Float
+
+//===----------------------------------------------------------------------===//
+// JVP
+//===----------------------------------------------------------------------===//
+
+@_silgen_name("hasjvp")
+@differentiable(reverse, jvp: dhasjvp)
+public func hasjvp(_ x: Float, _ y: Float) -> Float {
+  return 1
+}
+
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 jvp @dhasjvp] @hasjvp
+
+@_silgen_name("dhasjvp")
+public func dhasjvp(_ x: Float, _ y: Float) -> (Float, (Float, Float) -> Float) {
+  return (1, { _, _ in 1 })
+}
+
+// CHECK-LABEL: sil @dhasjvp
+
+//===----------------------------------------------------------------------===//
+// VJP
+//===----------------------------------------------------------------------===//
+
+@_silgen_name("hasvjp")
+@differentiable(reverse, vjp: dhasvjp)
+public func hasvjp(_ x: Float, _ y: Float) -> Float {
+  return 1
+}
+
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 vjp @dhasvjp] @hasvjp
+
+@_silgen_name("dhasvjp")
+public func dhasvjp(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float, Float)) {
+  return (1, { _ in (1, 1) })
+}
+
+// CHECK-LABEL: sil @dhasvjp

--- a/test/AutoDiff/differentiable_sil_attr.swift
+++ b/test/AutoDiff/differentiable_sil_attr.swift
@@ -11,14 +11,14 @@ entry(%0: $Float, %1: $Float, %2: $Float, %3: $Float):
   return %ret: $(Float, Float)
 }
 
-// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1 adjoint @bar_adj] @bar_just_adj
-sil public [reverse_differentiable source 0 wrt 0, 1 adjoint @bar_adj] @bar_just_adj : $@convention(thin) (Float, Float) -> Float {
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 adjoint @bar_adj] @bar_just_adj
+sil public [differentiable source 0 wrt 0, 1 adjoint @bar_adj] @bar_just_adj : $@convention(thin) (Float, Float) -> Float {
 entry(%0: $Float, %1: $Float):
   return %0: $Float
 }
 
-// CHECK-LABEL: sil [reverse_differentiable source 0 wrt 0, 1 primal @bar adjoint @bar_adj] @bar_prim_adj
-sil public [reverse_differentiable source 0 wrt 0, 1 primal @bar adjoint @bar_adj] @bar_prim_adj : $@convention(thin) (Float, Float) -> Float {
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 primal @bar adjoint @bar_adj] @bar_prim_adj
+sil public [differentiable source 0 wrt 0, 1 primal @bar adjoint @bar_adj] @bar_prim_adj : $@convention(thin) (Float, Float) -> Float {
 entry(%0: $Float, %1: $Float):
   return %0: $Float
 }

--- a/test/AutoDiff/nested_calls.sil
+++ b/test/AutoDiff/nested_calls.sil
@@ -16,7 +16,7 @@ bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float, %3 : @triv
   return %3 : $Float
 }
 
-sil [reverse_differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
+sil [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
 bb0(%0 : @trivial $Float):
   return %0 : $Float
 }
@@ -30,7 +30,7 @@ bb0(%0 : @trivial $Float):
 }
 
 // Main function to differentiate.
-sil [reverse_differentiable source 0 wrt 0] @func_to_diff : $@convention(thin) (Float) -> Float {
+sil [differentiable source 0 wrt 0] @func_to_diff : $@convention(thin) (Float) -> Float {
 bb0(%0 : @trivial $Float):
   %1 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
   %2 = apply %1(%0) : $@convention(thin) (Float) -> Float
@@ -62,17 +62,17 @@ bb0(%0 : @trivial $Float):
 // CHECK:   return %3 : $Float
 // CHECK: }
 
-// CHECK-LABEL: [reverse_differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
+// CHECK-LABEL: [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
 // CHECK: bb0(%0 : $Float):
 // CHECK:   return %0 : $Float
 // CHECK: }
 
-// CHECK-LABEL: [reverse_differentiable source 0 wrt 0 primal @AD__nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {
+// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {
 // CHECK: bb0(%0 : $Float):
 // CHECK:   return %0 : $Float
 // CHECK: }
 
-// CHECK-LABEL: [reverse_differentiable source 0 wrt 0 primal @AD__func_to_diff__primal_src_0_wrt_0 adjoint @AD__func_to_diff__adjoint_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float {
+// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__func_to_diff__primal_src_0_wrt_0 adjoint @AD__func_to_diff__adjoint_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float {
 // CHECK: bb0(%0 : $Float):
 // CHECK:   return %0 : $Float
 // CHECK: }

--- a/test/SIL/Serialization/differentiableattr.sil
+++ b/test/SIL/Serialization/differentiableattr.sil
@@ -1,0 +1,17 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-sil -assume-parsing-unqualified-ownership-sil -emit-sib -parse-as-library -parse-stdlib -module-name DifferentiableAttr -o %t/DifferentiableAttr.sib %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %t/DifferentiableAttr.sib -o - -emit-sorted-sil | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK: [differentiable source 0 wrt 0 primal @function1primal adjoint @function1adjoint jvp @function1jvp vjp @function1vjp]
+sil hidden [differentiable source 0 wrt 0 primal @function1primal adjoint @function1adjoint jvp @function1jvp vjp @function1vjp] @function1 : $@convention(thin) (Float) -> Float {
+bb0(%0 : $Float):
+  %2 = float_literal $Builtin.FPIEEE32, 0x3F800000 // 1
+  %3 = struct $Float (%2 : $Builtin.FPIEEE32)
+  return %3 : $Float
+}


### PR DESCRIPTION
Plumbs JVP and VJP a bit farther along into the compiler. Specifically,
* Renames [reverse_differentiable] -> [differentiable]. Also renames corresponding C++ types, function names, and variable names.
* Adds JVP and VJP to the [differentiable] SIL attribute.