### PR TITLE
Re-enable a test that had been disabled at one point.

### DIFF
--- a/test/Constraints/warn_long_compile.swift
+++ b/test/Constraints/warn_long_compile.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -warn-long-function-bodies=1 %s
-// REQUIRES: rdar44305428
+
 @_silgen_name("generic_foo")
 func foo<T>(_ x: T) -> T
 

--- a/test/Constraints/warn_long_compile.swift
+++ b/test/Constraints/warn_long_compile.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -warn-long-function-bodies=1 %s
+// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -warn-long-function-bodies=1
 
 @_silgen_name("generic_foo")
 func foo<T>(_ x: T) -> T


### PR DESCRIPTION
We saw a failure of this test on Linux at some point, and disabled
it. It looks like it may have been due to the fact that the
`%target-typecheck-verify-swift` provides the filename, but we
explicitly provide the filename in the test invocation here as well.

I'm going to re-enable and see if we can get through tests on all
supported platforms.

Fixes: rdar://problem/44305428