### PR TITLE
[AutoDiff] Fix SR-9345: Checkpointing after release

### DIFF
--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -71,4 +71,20 @@ TensorADTests.testAllBackends("negate") {
   expectTrue([-1] == grad([10]))
 }
 
+TensorADTests.testAllBackends("SR-9345: OwnedCheckpoints") {
+  @differentiable(reverse, adjoint: adjointFoo)
+  func foo(_ x: Tensor<Float>) -> Tensor<Float> {
+      return Raw.identity(x)
+  }
+  func adjointFoo(_ x: Tensor<Float>, originalValue: Tensor<Float>, 
+                  seed: Tensor<Float>) -> Tensor<Float> {
+    return seed
+  }
+  func body(_ x: Tensor<Float>) -> Tensor<Float> {
+    return foo(foo(x))
+  }
+  let res = #gradient(body)(Tensor(Float(10)))
+  expectEqual(Tensor(1.0), res)
+}
+
 runAllTests()


### PR DESCRIPTION
* Fixes a segfault where a checkpoints struct is formed after `release_value`.

    ```swift
      %3 = apply %2(%0) : $@convention(thin) (@guaranteed Tensor<Float>) -> @owned Tensor<Float> // users: %7, %6, %5
      ...
      release_value %3 : $Tensor<Float>               // id: %6
      %7 = struct $AD__$s4test3fooy10TensorFlow0C0VySfGAFF__Type__src_0_wrt_0 (%3 : $Tensor<Float>, %5 : $Tensor<Float>)
    ```

  When a primal value is also a checkpoint, primal synthesis should not clone the `release_value` instruction over to the primal function. This was not tested in `test/AutoDiff/` beacuse we didn't encounter non-trivial types like `Tensor` - `release_value` on trivial types is a no-op.

* When there are no nested primal values, PrimalGen produced `$()` checkpoints. This patch also eliminates `$()` checkpoints because they are useless.

Resolves [SR-9345](https://bugs.swift.org/browse/SR-9345).