### PR TITLE
Class metadata fix for Windows [5.0, ABI]

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1059,8 +1059,9 @@ private:
   ConstTargetMetadataPointer<Runtime, TargetClassDescriptor> Description;
 
 public:
-  /// A function for destroying instance variables, used to clean up
-  /// after an early return from a constructor.
+  /// A function for destroying instance variables, used to clean up after an
+  /// early return from a constructor. If null, no clean up will be performed
+  /// and all ivars must be trivial.
   TargetPointer<Runtime, ClassIVarDestroyer> IVarDestroyer;
 
   // After this come the class members, laid out as follows:
@@ -3110,7 +3111,8 @@ struct TargetGenericClassMetadataPattern final :
   TargetRelativeDirectPointer<Runtime, HeapObjectDestroyer> Destroy;
 
   /// The ivar-destructor function.
-  TargetRelativeDirectPointer<Runtime, ClassIVarDestroyer> IVarDestroyer;
+  TargetRelativeDirectPointer<Runtime, ClassIVarDestroyer, /*nullable*/ true>
+    IVarDestroyer;
 
   /// The class flags.
   ClassFlags Flags;
@@ -3353,7 +3355,8 @@ struct TargetResilientClassMetadataPattern {
   TargetRelativeDirectPointer<Runtime, HeapObjectDestroyer> Destroy;
 
   /// The ivar-destructor function.
-  TargetRelativeDirectPointer<Runtime, ClassIVarDestroyer> IVarDestroyer;
+  TargetRelativeDirectPointer<Runtime, ClassIVarDestroyer, /*nullable*/ true>
+    IVarDestroyer;
 
   /// The class flags.
   ClassFlags Flags;

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -610,8 +610,8 @@ void swift_initStructMetadata(StructMetadata *self,
 /// swift_initClassMetadata().
 SWIFT_RUNTIME_EXPORT
 ClassMetadata *
-swift_relocateClassMetadata(ClassDescriptor *descriptor,
-                            ResilientClassMetadataPattern *pattern);
+swift_relocateClassMetadata(const ClassDescriptor *descriptor,
+                            const ResilientClassMetadataPattern *pattern);
 
 /// Initialize various fields of the class metadata.
 ///
@@ -667,9 +667,9 @@ void swift_updateClassMetadata(ClassMetadata *self,
 /// the same class or a subclass of the descriptor.
 SWIFT_RUNTIME_EXPORT
 void *
-swift_lookUpClassMethod(ClassMetadata *metadata,
-                        MethodDescriptor *method,
-                        ClassDescriptor *description);
+swift_lookUpClassMethod(const ClassMetadata *metadata,
+                        const MethodDescriptor *method,
+                        const ClassDescriptor *description);
 
 /// \brief Fetch a uniqued metadata for a metatype type.
 SWIFT_RUNTIME_EXPORT

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2478,17 +2478,6 @@ namespace {
       B.add(metadata);
     }
 
-    /// The runtime provides a value witness table for Builtin.NativeObject.
-    void addValueWitnessTable() {
-      ClassDecl *cls = Target;
-      
-      auto type = (cls->checkObjCAncestry() != ObjCClassKind::NonObjC
-                   ? IGM.Context.TheUnknownObjectType
-                   : IGM.Context.TheNativeObjectType);
-      auto wtable = IGM.getAddrOfValueWitnessTable(type);
-      B.add(wtable);
-    }
-
     void addDestructorFunction() {
       if (auto ptr = getAddrOfDestructorFunction(IGM, Target)) {
         B.add(*ptr);
@@ -2658,6 +2647,14 @@ namespace {
       B.addInt(IGM.SizeTy, getClassFieldOffset(IGM, baseType, var).getValue());
     }
 
+    void addValueWitnessTable() {
+      auto type = (Target->checkObjCAncestry() != ObjCClassKind::NonObjC
+                   ? IGM.Context.TheUnknownObjectType
+                   : IGM.Context.TheNativeObjectType);
+      auto wtable = IGM.getAddrOfValueWitnessTable(type);
+      B.add(wtable);
+    }
+
     void addFieldOffsetPlaceholders(MissingMemberDecl *placeholder) {
       llvm_unreachable("Fixed class metadata cannot have missing members");
     }
@@ -2689,6 +2686,11 @@ namespace {
       // Field offsets are either copied from the superclass or calculated
       // at runtime.
       B.addInt(IGM.SizeTy, 0);
+    }
+
+    void addValueWitnessTable() {
+      // The runtime fills in the value witness table for us.
+      B.add(llvm::ConstantPointerNull::get(IGM.WitnessTablePtrTy));
     }
 
     void addFieldOffsetPlaceholders(MissingMemberDecl *placeholder) {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2024,8 +2024,8 @@ static MetadataAllocator &getResilientMetadataAllocator() {
 }
 
 ClassMetadata *
-swift::swift_relocateClassMetadata(ClassDescriptor *description,
-                                   ResilientClassMetadataPattern *pattern) {
+swift::swift_relocateClassMetadata(const ClassDescriptor *description,
+                                   const ResilientClassMetadataPattern *pattern) {
   auto bounds = description->getMetadataBounds();
 
   auto metadata = reinterpret_cast<ClassMetadata *>(
@@ -2695,7 +2695,7 @@ swift::swift_updateClassMetadata(ClassMetadata *self,
 
 #ifndef NDEBUG
 static bool isAncestorOf(const ClassMetadata *metadata,
-                         ClassDescriptor *description) {
+                         const ClassDescriptor *description) {
   auto ancestor = metadata;
   while (ancestor && ancestor->isTypeMetadata()) {
     if (ancestor->getDescription() == description)
@@ -2707,9 +2707,9 @@ static bool isAncestorOf(const ClassMetadata *metadata,
 #endif
 
 void *
-swift::swift_lookUpClassMethod(ClassMetadata *metadata,
-                               MethodDescriptor *method,
-                               ClassDescriptor *description) {
+swift::swift_lookUpClassMethod(const ClassMetadata *metadata,
+                               const MethodDescriptor *method,
+                               const ClassDescriptor *description) {
   assert(metadata->isTypeMetadata());
 
   assert(isAncestorOf(metadata, description));
@@ -2722,7 +2722,7 @@ swift::swift_lookUpClassMethod(ClassMetadata *metadata,
   assert(index < methods.size());
 
   auto vtableOffset = vtable->getVTableOffset(description) + index;
-  auto *words = reinterpret_cast<void **>(metadata);
+  auto *words = reinterpret_cast<void * const *>(metadata);
 
   return *(words + vtableOffset);
 }

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -83,7 +83,7 @@
 
 // CHECK: @"$s16class_resilience14ResilientChildCMP" = internal constant <{{.*}}> <{
 // --       instantiation function:
-// CHECK-SAME:   @"$s16class_resilience14ResilientChildCMi"
+// CHECK-SAME:   i32 0,
 // --       destructor:
 // CHECK-SAME:   @"$s16class_resilience14ResilientChildCfD"
 // --       ivar destroyer:
@@ -525,28 +525,12 @@ extension ResilientGenericOutsideParent {
 // CHECK-NEXT: ret void
 
 
-// ResilientChild metadata relocation function
-
-// CHECK-LABEL: define internal %swift.type* @"$s16class_resilience14ResilientChildCMi"(%swift.type_descriptor*, i8*)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: [[METADATA:%.*]] = call %swift.type* @swift_relocateClassMetadata(%swift.type_descriptor* %0, i8* %1)
-// CHECK-NEXT: ret %swift.type* [[METADATA]]
-
-
 // FixedLayoutChild metadata initialization function
 
 // CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s16class_resilience16FixedLayoutChildCMr"(%swift.type*, i8*, i8**)
 
 // Initialize the superclass field...
 // CHECK:      call void @swift_initClassMetadata(%swift.type* %0, [[INT]] 0, [[INT]] 1, i8*** {{%.*}}, [[INT]]* {{%.*}})
-
-
-// FixedLayoutChild metadata relocation function
-
-// CHECK-LABEL: define internal %swift.type* @"$s16class_resilience16FixedLayoutChildCMi"(%swift.type_descriptor*, i8*)
-// CHECK-NEXT: entry:
-// CHECK-NEXT: [[METADATA:%.*]] = call %swift.type* @swift_relocateClassMetadata(%swift.type_descriptor* %0, i8* %1)
-// CHECK-NEXT: ret %swift.type* [[METADATA]]
 
 
 // ResilientGenericChild metadata initialization function

--- a/test/IRGen/dllimport.swift
+++ b/test/IRGen/dllimport.swift
@@ -42,14 +42,12 @@ public func g() {
 // CHECK-NO-OPT-DAG: declare dllimport %swift.refcounted* @swift_retain(%swift.refcounted* returned)
 // CHECK-NO-OPT-DAG: @"$s9dllexport1pMp" = external dllimport global %swift.protocol
 // CHECK-NO-OPT-DAG: @"$sytN" = external dllimport global %swift.full_type
-// CHECK-NO-OPT-DAG: @"$sBoWV" = external dllimport global i8*
 // CHECK-NO-OPT-DAG: declare dllimport swiftcc i8* @"$s9dllexport2ciAA1cCvau"()
 // CHECK-NO-OPT-DAG: declare dllimport swiftcc %swift.refcounted* @"$s9dllexport1cCfd"(%T9dllexport1cC* swiftself)
 // CHECK-NO-OPT-DAG: declare dllimport swiftcc %swift.metadata_response @"$s9dllexport1cCMa"(i32)
 // CHECK-NO-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
 
 // CHECK-OPT-DAG: declare dllimport %swift.refcounted* @swift_retain(%swift.refcounted* returned) local_unnamed_addr
-// CHECK-OPT-DAG: @"$sBoWV" = external dllimport global i8*
 // CHECK-OPT-DAG: @"__imp_$s9dllexport1pMp" = external externally_initialized constant %swift.protocol*
 // CHECK-OPT-DAG: declare dllimport swiftcc i8* @"$s9dllexport2ciAA1cCvau"()
 // CHECK-OPT-DAG: declare dllimport swiftcc %swift.metadata_response @"$s9dllexport1cCMa"(i32)

--- a/test/IRGen/generic_vtable.swift
+++ b/test/IRGen/generic_vtable.swift
@@ -38,6 +38,10 @@ public class Concrete : Derived<Int> {
 //// Type metadata for 'Base' has a static vtable.
 
 // CHECK-LABEL: @"$s14generic_vtable4BaseCMf" = internal global
+// -- destructor
+// CHECK-SAME: void (%T14generic_vtable4BaseC*)* @"$s14generic_vtable4BaseCfD"
+// -- value witness table
+// CHECK-SAME: i8** @"$sBoWV"
 // -- vtable entry for 'm1()'
 // CHECK-SAME: void (%T14generic_vtable4BaseC*)* @"$s14generic_vtable4BaseC2m1yyF"
 // -- vtable entry for 'm2()'
@@ -110,6 +114,10 @@ public class Concrete : Derived<Int> {
 //// Type metadata for 'Concrete' has a static vtable.
 
 // CHECK-LABEL: @"$s14generic_vtable8ConcreteCMf" = internal global <{{.*}}> <{
+// -- destructor
+// CHECK-SAME: void (%T14generic_vtable8ConcreteC*)* @"$s14generic_vtable8ConcreteCfD",
+// -- value witness table is filled in at runtime
+// CHECK-SAME: i8** null,
 // -- nominal type descriptor
 // CHECK-SAME: @"$s14generic_vtable8ConcreteCMn",
 // -- vtable entry for 'm1()'


### PR DESCRIPTION
On Windows we can't reference the runtime's Builtin.NativeObject value witness table directly from class metadata. Instead fill it in at runtime for singleton metadata initialization.

Do this on all platforms, even though its not needed on Linux or Darwin, for simplicity. A subsequent Windows-specific change will *force* the use of singleton metadata initialization for all classes, even when the class is otherwise fixed.