### PR TITLE
Mark lazy properties as having mutating getters immediately.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -189,12 +189,6 @@ static AccessorDecl *createGetterPrototype(TypeChecker &TC,
   ParamDecl *selfDecl = nullptr;
   if (storage->getDeclContext()->isTypeContext()) {
     if (storage->getAttrs().hasAttribute<LazyAttr>()) {
-      // The getter is considered mutating if it's on a value type.
-      if (!storage->getDeclContext()->getSelfClassDecl() &&
-          !storage->isStatic()) {
-        storage->setIsGetterMutating(true);
-      }
-
       // For lazy properties, steal the 'self' from the initializer context.
       auto *varDecl = cast<VarDecl>(storage);
       auto *bindingDecl = varDecl->getParentPatternBinding();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2280,6 +2280,15 @@ static bool validateAccessorIsMutating(TypeChecker &TC, FuncDecl *accessor) {
 
 static bool computeIsGetterMutating(TypeChecker &TC,
                                     AbstractStorageDecl *storage) {
+  // 'lazy' overrides the normal accessor-based rules and heavily
+  // restricts what accessors can be used.  The getter is considered
+  // mutating if this is instance storage on a value type.
+  if (storage->getAttrs().hasAttribute<LazyAttr>()) {
+    return storage->getDeclContext()->isTypeContext() &&
+           !storage->getDeclContext()->getSelfClassDecl() &&
+           !storage->isStatic();
+  }
+
   switch (storage->getReadImpl()) {
   case ReadImplKind::Stored:
     return false;

--- a/test/multifile/Inputs/external_lazy_property.swift
+++ b/test/multifile/Inputs/external_lazy_property.swift
@@ -1,0 +1,3 @@
+public struct Test1 {
+    lazy var property: String = "help"
+}

--- a/test/multifile/lazy.swift
+++ b/test/multifile/lazy.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -emit-sil -verify -primary-file %s %S/Inputs/external_lazy_property.swift
+
+// rdar://45712204
+func test1(s: Test1) {
+  s.property // expected-error {{cannot use mutating getter on immutable value: 's' is a 'let' constant}}
+}


### PR DESCRIPTION
We were trying to do this when synthesizing the getter prototype, but we don't do that immediately when we're just type-checking a reference to the storage, which could lead to the reference thinking that the getter was non-mutating.

Fixes rdar://45712204.

This is the 5.0 branch version of #20779.

This is not ABI-affecting; it's just a bug-fix when type-checking multiple files.  Probably not important for convergence because it's a crash-on-invalid.