### PR TITLE
[TypeChecker] Fix a problem with rethrows classification.

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -710,7 +710,10 @@ private:
 
     // If it doesn't have function type, we must have invalid code.
     Type argType = fn.getType();
-    auto argFnType = (argType ? argType->getAs<AnyFunctionType>() : nullptr);
+    if (!argType) return Classification::forInvalidCode();
+
+    auto argFnType =
+        argType->lookThroughAllOptionalTypes()->getAs<AnyFunctionType>();
     if (!argFnType) return Classification::forInvalidCode();
 
     // If it doesn't throw, this argument does not cause the call to throw.

--- a/test/Constraints/rdar45615204.swift
+++ b/test/Constraints/rdar45615204.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+func test(_ a: [Int], _ f: ((Int) -> Bool)?) {
+  _ = a.filter(f!)
+}


### PR DESCRIPTION
We failed to properly classify arguments that are of optional function
type, in this case leading to a verification failure due to the throws
attribute on the apply expression not being set to some value.

Fixes: rdar://problem/45615204