### PR TITLE
[5.0] stdlib: Make ArrayBufferProtocol.init inlinable to facilitate specialization

### DIFF
--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -128,7 +128,8 @@ extension _ArrayBufferProtocol where Indices == Range<Int>{
 
   // Make sure the compiler does not inline _copyBuffer to reduce code size.
   @inline(never)
-  @usableFromInline
+  @inlinable // This code should be specializable such that copying an array is
+             // fast and does not end up in an unspecialized entry point.
   internal init(copying buffer: Self) {
     let newBuffer = _ContiguousArrayBuffer<Element>(
       _uninitializedCount: buffer.count, minimumCapacity: buffer.count)


### PR DESCRIPTION
Change the attribute of init(copying:) from @usableFromInline to
@inlinable to enable generic specialization. Resulting in a 2x speedup
of array copying.

This is not ABI affecting because both @usableFromInline and @inlinable
cause emission of the symbol in the standard library dylib.

This is a fix for a performance regression from a previously shipped
swift and it is not a correctness fix.

SR-9284
rdar://46277030