### PR TITLE
[5.0] [CMake] Disable generation of .swiftinterface files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,10 @@ option(SWIFT_FORCE_OPTIMIZED_TYPECHECKER "Override the optimization setting of
   the type checker so that it always compiles with optimization. This eases
   debugging after type checking occurs by speeding up type checking" FALSE)
 
+option(SWIFT_ENABLE_PARSEABLE_MODULE_INTERFACES
+       "Generate .swiftinterface files alongside .swiftmodule files"
+       FALSE)
+
 #
 # User-configurable Android specific options.
 #

--- a/validation-test/ParseableInterface/verify_all_overlays.swift
+++ b/validation-test/ParseableInterface/verify_all_overlays.swift
@@ -1,6 +1,9 @@
+// Note that this test should still "pass" when no swiftinterfaces have been
+// generated.
+
 // RUN: %empty-directory(%t)
-// RUN: for x in %platform-sdk-overlay-dir/*.swiftinterface; do [[ $(basename "$x") = Swift.swiftinterface || $(basename "$x") = simd.swiftinterface || $(basename "$x") = SwiftLang.swiftinterface ]] && continue; %target-swift-frontend "$x" -emit-module -o %t/$(basename "$x" .swiftinterface).swiftmodule -disable-objc-attr-requires-foundation-module -enable-resilience -Fsystem %sdk/System/Library/PrivateFrameworks/ -swift-version 4 || echo '%target-os:' $(basename "$x") >> %t/failures.txt; done
-// RUN: diff <(grep '%target-os:' %s) <(sort -f %t/failures.txt)
+// RUN: for x in %platform-sdk-overlay-dir/*.swiftinterface; do [[ $(basename "$x") = Swift.swiftinterface || $(basename "$x") = simd.swiftinterface || $(basename "$x") = SwiftLang.swiftinterface || $(basename "$x") = '*.swiftinterface' ]] && continue; %target-swift-frontend "$x" -emit-module -o %t/$(basename "$x" .swiftinterface).swiftmodule -disable-objc-attr-requires-foundation-module -enable-resilience -Fsystem %sdk/System/Library/PrivateFrameworks/ -swift-version 4 || echo '%target-os:' $(basename "$x") >> %t/failures.txt; done
+// RUN: test ! -e %t/failures.txt || diff <(grep '%target-os:' %s) <(sort -f %t/failures.txt)
 
 // REQUIRES: nonexecutable_test
 

--- a/validation-test/ParseableInterface/verify_all_overlays_O.swift
+++ b/validation-test/ParseableInterface/verify_all_overlays_O.swift
@@ -1,6 +1,9 @@
+// Note that this test should still "pass" when no swiftinterfaces have been
+// generated.
+
 // RUN: %empty-directory(%t)
-// RUN: for x in %platform-sdk-overlay-dir/*.swiftinterface; do [[ $(basename "$x") = Swift.swiftinterface || $(basename "$x") = simd.swiftinterface || $(basename "$x") = SwiftLang.swiftinterface ]] && continue; %target-swift-frontend "$x" -emit-module -o %t/$(basename "$x" .swiftinterface).swiftmodule -disable-objc-attr-requires-foundation-module -enable-resilience -Fsystem %sdk/System/Library/PrivateFrameworks/ -swift-version 4 -O || echo '%target-os:' $(basename "$x") >> %t/failures.txt; done
-// RUN: diff <(grep '%target-os:' %s) <(sort -f %t/failures.txt)
+// RUN: for x in %platform-sdk-overlay-dir/*.swiftinterface; do [[ $(basename "$x") = Swift.swiftinterface || $(basename "$x") = simd.swiftinterface || $(basename "$x") = SwiftLang.swiftinterface || $(basename "$x") = '*.swiftinterface' ]] && continue; %target-swift-frontend "$x" -emit-module -o %t/$(basename "$x" .swiftinterface).swiftmodule -disable-objc-attr-requires-foundation-module -enable-resilience -Fsystem %sdk/System/Library/PrivateFrameworks/ -swift-version 4 -O || echo '%target-os:' $(basename "$x") >> %t/failures.txt; done
+// RUN: test ! -e %t/failures.txt || diff <(grep '%target-os:' %s) <(sort -f %t/failures.txt)
 
 // REQUIRES: nonexecutable_test
 

--- a/validation-test/ParseableInterface/verify_simd.swift
+++ b/validation-test/ParseableInterface/verify_simd.swift
@@ -1,6 +1,9 @@
+// Note that this test should still "pass" when simd.swiftinterface has not been
+// generated.
+
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %platform-sdk-overlay-dir/simd.swiftinterface -emit-module -o %t/simd.swiftmodule -enable-resilience -parse-stdlib -import-module Swift -swift-version 4
-// RUN: %target-swift-frontend %platform-sdk-overlay-dir/simd.swiftinterface -emit-module -o %t/simd.swiftmodule -enable-resilience -parse-stdlib -import-module Swift -swift-version 4 -O
+// RUN: test ! -e %platform-sdk-overlay-dir/simd.swiftinterface || %target-swift-frontend %platform-sdk-overlay-dir/simd.swiftinterface -emit-module -o %t/simd.swiftmodule -enable-resilience -parse-stdlib -import-module Swift -swift-version 4
+// RUN: test ! -e %platform-sdk-overlay-dir/simd.swiftinterface || %target-swift-frontend %platform-sdk-overlay-dir/simd.swiftinterface -emit-module -o %t/simd.swiftmodule -enable-resilience -parse-stdlib -import-module Swift -swift-version 4 -O
 
 // REQUIRES: nonexecutable_test
 // REQUIRES: objc_interop


### PR DESCRIPTION
- **Explanation**: Places the generation of swiftinterface files for the standard library and overlays behind a flag, which is off by default. We haven't finished implementing this feature, so we shouldn't ship it in toolchains.

- **Scope**: CMake changes only. Nothing was using these files except tests.

- **Issue**: rdar://problem/44942414

- **Risk**: None

- **Testing**: Checked that regression tests using these files are properly ignored when they are not present.

- **Reviewed by**: @Rostepher, @compnerd 
