### PR TITLE
test: fix typo in windows test configuration

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -846,7 +846,7 @@ elif run_os in ['windows-msvc']:
     config.target_swift_ide_test =                                               \
             ('%r -target %s %s %s %s' % (config.swift_ide_test,                  \
                                          config.variant_triple,                  \
-                                         resource_dir_opt, pcp_opt, ccp_opt))
+                                         resource_dir_opt, mcp_opt, ccp_opt))
 
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ''


### PR DESCRIPTION
Fix a silly typo that I missed during the last synchronisation across Windows to
Linux.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
