### PR TITLE
[benchmark] fixes index(of:) deprecation warnings in ArgParse

### DIFF
--- a/benchmark/utils/ArgParse.swift
+++ b/benchmark/utils/ArgParse.swift
@@ -46,7 +46,7 @@ func checked<T>(
   if let t = try parse(value)  { return t }
   var type = "\(T.self)"
   if type.starts(with: "Optional<") {
-      let s = type.index(after: type.index(of:"<")!)
+      let s = type.index(after: type.firstIndex(of: "<")!)
       let e = type.index(before: type.endIndex) // ">"
       type = String(type[s ..< e]) // strip Optional< >
   }
@@ -66,7 +66,7 @@ class ArgumentParser<U> {
     private let programName: String = {
       // Strip full path from the program name.
       let r = CommandLine.arguments[0].reversed()
-      let ss = r[r.startIndex ..< (r.index(of:"/") ?? r.endIndex)]
+      let ss = r[r.startIndex ..< (r.firstIndex(of: "/") ?? r.endIndex)]
       return String(ss.reversed())
     }()
     private var positionalArgs = [String]()


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes two deprecation warnings in ArgParse.swift in benchmark when building Swift from scratch on macOS 10.14.1 with the toolchain from Xcode 10.1 (10B61).

Running
`$ ninja swift-benchmark-macosx-x86_64`

Produced the following output:
```
<path>/swift-source/swift/benchmark/utils/ArgParse.swift:69:38: warning: 'index(of:)' is deprecated: renamed to 'firstIndex(of:)'
      let ss = r[r.startIndex ..< (r.index(of:"/") ?? r.endIndex)]
                                     ^
<path>/swift-source/swift/benchmark/utils/ArgParse.swift:69:38: note: use 'firstIndex(of:)' instead
      let ss = r[r.startIndex ..< (r.index(of:"/") ?? r.endIndex)]
                                     ^~~~~
                                     firstIndex
<path>/swift-source/swift/benchmark/utils/ArgParse.swift:69:38: warning: 'index(of:)' is deprecated: renamed to 'firstIndex(of:)'
      let ss = r[r.startIndex ..< (r.index(of:"/") ?? r.endIndex)]
                                     ^
<path>/swift-source/swift/benchmark/utils/ArgParse.swift:69:38: note: use 'firstIndex(of:)' instead
      let ss = r[r.startIndex ..< (r.index(of:"/") ?? r.endIndex)]
                                     ^~~~~
                                     firstIndex
<path>/swift-source/swift/benchmark/utils/ArgParse.swift:49:38: warning: 'index(of:)' is deprecated: renamed to 'firstIndex(of:)'
      let s = type.index(after: type.index(of:"<")!)
                                     ^
<path>/swift-source/swift/benchmark/utils/ArgParse.swift:49:38: note: use 'firstIndex(of:)' instead
      let s = type.index(after: type.index(of:"<")!)
                                     ^~~~~
                                     firstIndex
```

This PR just applies the suggested fixes.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->