### PR TITLE
[5.0][GSB] When adding same-type requirements pick representative based ...

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4889,15 +4889,12 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenTypeParameters(
   auto T1 = OrigT1->getRepresentative();
   auto T2 = OrigT2->getRepresentative();
 
-  // Decide which potential archetype is to be considered the representative.
-  // We prefer potential archetypes with lower nesting depths, because it
-  // prevents us from unnecessarily building deeply nested potential archetypes.
-  unsigned nestingDepth1 = T1->getNestingDepth();
-  unsigned nestingDepth2 = T2->getNestingDepth();
-  if (nestingDepth2 < nestingDepth1) {
+  // Pick representative based on the canonical ordering of the type parameters.
+  if (compareDependentTypes(depType2, depType1) < 0) {
     std::swap(T1, T2);
     std::swap(OrigT1, OrigT2);
     std::swap(equivClass, equivClass2);
+    std::swap(depType1, depType2);
   }
 
   // T1 must have an equivalence class; create one if we don't already have

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -34,6 +34,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Statistic.h"
 #include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
@@ -4894,7 +4895,6 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenTypeParameters(
     std::swap(T1, T2);
     std::swap(OrigT1, OrigT2);
     std::swap(equivClass, equivClass2);
-    std::swap(depType1, depType2);
   }
 
   // T1 must have an equivalence class; create one if we don't already have
@@ -4903,6 +4903,8 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenTypeParameters(
     equivClass = T1->getOrCreateEquivalenceClass(*this);
 
   // Record this same-type constraint.
+  // Let's keep type order in the new constraint the same as it's written
+  // in source, which makes it much easier to diagnose later.
   equivClass->sameTypeConstraints.push_back({depType1, depType2, source});
 
   // Determine the anchor types of the two equivalence classes.
@@ -6905,34 +6907,121 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
   // connect all of the components, or else we wouldn't have an equivalence
   // class.
   if (intercomponentEdges.size() > numComponents - 1) {
-    std::vector<bool> connected(numComponents, false);
-    const auto &firstEdge = intercomponentEdges.front();
-    for (const auto &edge : intercomponentEdges) {
-      // If both the source and target are already connected, this edge is
-      // not part of the spanning tree.
-      if (connected[edge.source] && connected[edge.target]) {
-        if (edge.constraint.source->shouldDiagnoseRedundancy(true) &&
-            firstEdge.constraint.source->shouldDiagnoseRedundancy(false)) {
-          Diags.diagnose(edge.constraint.source->getLoc(),
-                         diag::redundant_same_type_constraint,
-                         edge.constraint.getSubjectDependentType(
-                                                          genericParams),
-                         edge.constraint.value);
+    auto &sourceMgr = getASTContext().SourceMgr;
 
-          Diags.diagnose(firstEdge.constraint.source->getLoc(),
-                         diag::previous_same_type_constraint,
-                         firstEdge.constraint.source->classifyDiagKind(),
-                         firstEdge.constraint.getSubjectDependentType(
-                                                          genericParams),
-                         firstEdge.constraint.value);
+    // First let's order all of the intercomponent edges
+    // as written in source, this helps us to diagnose
+    // all of the duplicate constraints in correct order.
+    std::vector<unsigned> sourceOrderedEdges;
+    for (unsigned i : indices(intercomponentEdges))
+      sourceOrderedEdges.push_back(i);
+
+    std::sort(sourceOrderedEdges.begin(), sourceOrderedEdges.end(),
+              [&sourceMgr, &intercomponentEdges](
+                  const unsigned &indexA, const unsigned &indexB) -> bool {
+                auto &a = intercomponentEdges[indexA];
+                auto &b = intercomponentEdges[indexB];
+
+                auto locA = a.constraint.source->getLoc();
+                auto locB = b.constraint.source->getLoc();
+
+                auto bufferA = sourceMgr.findBufferContainingLoc(locA);
+                auto bufferB = sourceMgr.findBufferContainingLoc(locB);
+
+                if (bufferA != bufferB)
+                  return bufferA < bufferB;
+
+                auto offsetA = sourceMgr.getLocOffsetInBuffer(locA, bufferA);
+                auto offsetB = sourceMgr.getLocOffsetInBuffer(locB, bufferB);
+
+                return offsetA < offsetB;
+              });
+
+    auto isDiagnosable = [](const IntercomponentEdge &edge, bool isPrimary) {
+      return edge.constraint.source->shouldDiagnoseRedundancy(isPrimary);
+    };
+
+    using EquivClass = llvm::DenseMap<Type, unsigned>;
+    llvm::DenseMap<Type, EquivClass> equivalences;
+    // The idea here is to form an equivalence class per representative
+    // (picked from each edge constraint in type parameter order) and
+    // propagate all new equivalent types up the chain until duplicate
+    // entry is found, that entry is going to point to previous
+    // declaration and is going to mark current edge as a duplicate of
+    // such entry.
+    for (const unsigned edgeIdx : sourceOrderedEdges) {
+      const auto &edge = intercomponentEdges[edgeIdx];
+
+      Type lhs = edge.constraint.getSubjectDependentType(genericParams);
+      Type rhs = edge.constraint.value;
+
+      // Make sure that representative for equivalence class is picked
+      // in canonical type parameter order.
+      if (compareDependentTypes(rhs, lhs) < 0)
+        std::swap(lhs, rhs);
+
+      // Index of the previous declaration of the same-type constraint
+      // which current edge might be a duplicate of.
+      Optional<unsigned> previousIndex;
+
+      bool isDuplicate = false;
+      auto &representative = equivalences[lhs];
+      if (representative.insert({rhs, edgeIdx}).second) {
+        // Since this is a new equivalence, and right-hand side might
+        // be a representative of some other equivalence class,
+        // its existing members have to be merged up.
+        auto RHSEquivClass = equivalences.find(rhs);
+        if (RHSEquivClass != equivalences.end()) {
+          auto &equivClass = RHSEquivClass->getSecond();
+          representative.insert(equivClass.begin(), equivClass.end());
         }
 
-        continue;
+        // If left-hand side is involved in any other equivalences
+        // let's propagate new information up the chain.
+        for (auto &e : equivalences) {
+          auto &repr = e.first;
+          auto &equivClass = e.second;
+
+          if (repr->isEqual(lhs) || !equivClass.count(lhs))
+            continue;
+
+          if (!equivClass.insert({rhs, edgeIdx}).second) {
+            // Even if "previous" edge is not diagnosable we
+            // still need to produce diagnostic about main duplicate.
+            isDuplicate = true;
+
+            auto prevIdx = equivClass[rhs];
+            if (!isDiagnosable(intercomponentEdges[prevIdx],
+                               /*isPrimary=*/false))
+              continue;
+
+            // If there is a diagnosable duplicate equivalence,
+            // it means that we've found our previous declaration.
+            previousIndex = prevIdx;
+            break;
+          }
+        }
+      } else {
+        // Looks like this is a situation like T.A == T.B, ..., T.B == T.A
+        previousIndex = representative[rhs];
+        isDuplicate = true;
       }
 
-      // Put the source and target into the spanning tree.
-      connected[edge.source] = true;
-      connected[edge.target] = true;
+      if (!isDuplicate || !isDiagnosable(edge, /*isPrimary=*/true))
+        continue;
+
+      Diags.diagnose(edge.constraint.source->getLoc(),
+                     diag::redundant_same_type_constraint,
+                     edge.constraint.getSubjectDependentType(genericParams),
+                     edge.constraint.value);
+
+      if (previousIndex) {
+        auto &prevEquiv = intercomponentEdges[*previousIndex].constraint;
+        Diags.diagnose(
+            prevEquiv.source->getLoc(), diag::previous_same_type_constraint,
+            prevEquiv.source->classifyDiagKind(),
+            prevEquiv.getSubjectDependentType(genericParams), prevEquiv.value);
+      }
     }
   }
 

--- a/test/Generics/rdar45957015.swift
+++ b/test/Generics/rdar45957015.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol C {
+  associatedtype T : Collection where T.Element == Self
+}
+
+protocol V : C, RawRepresentable where RawValue == String {}
+
+protocol P {
+  associatedtype A: V
+}
+
+extension P {
+  func foo<U: Collection>(_ args: U) -> String where U.Element == A {
+    return args.reduce("", { $1.rawValue }) // Ok
+  }
+}

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -351,11 +351,11 @@ func intercomponentSameComponents<T: P10>(_: T)
         T.B == T.A { } // expected-note{{previous same-type constraint 'T.B' == 'T.A' written here}}
 
 func intercomponentMoreThanSpanningTree<T: P10>(_: T)
-  where T.A == T.B,
+  where T.A == T.B, // expected-note {{previous same-type constraint 'T.A' == 'T.B' written here}}
         T.B == T.C,
-        T.D == T.E, // expected-note{{previous same-type constraint 'T.D' == 'T.E' written here}}
+        T.D == T.E, // expected-warning {{redundant same-type constraint 'T.D' == 'T.E'}}
         T.D == T.B,
-        T.E == T.B  // expected-warning{{redundant same-type constraint 'T.E' == 'T.B'}}
+        T.E == T.B
         { }
 
 func trivialRedundancy<T: P10>(_: T) where T.A == T.A { } // expected-warning{{redundant same-type constraint 'T.A' == 'T.A'}}

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -351,11 +351,11 @@ func intercomponentSameComponents<T: P10>(_: T)
         T.B == T.A { } // expected-note{{previous same-type constraint 'T.B' == 'T.A' written here}}
 
 func intercomponentMoreThanSpanningTree<T: P10>(_: T)
-  where T.A == T.B, // expected-note {{previous same-type constraint 'T.A' == 'T.B' written here}}
+  where T.A == T.B,
         T.B == T.C,
-        T.D == T.E, // expected-warning {{redundant same-type constraint 'T.D' == 'T.E'}}
+        T.D == T.E, // expected-note {{previous same-type constraint 'T.D' == 'T.E' written here}}
         T.D == T.B,
-        T.E == T.B
+        T.E == T.B  // expected-warning {{redundant same-type constraint 'T.E' == 'T.B'}}
         { }
 
 func trivialRedundancy<T: P10>(_: T) where T.A == T.A { } // expected-warning{{redundant same-type constraint 'T.A' == 'T.A'}}

--- a/test/decl/protocol/req/associated_type_ambiguity.swift
+++ b/test/decl/protocol/req/associated_type_ambiguity.swift
@@ -15,7 +15,7 @@ protocol P1 {
 }
 
 protocol P2 {
-  associatedtype T // expected-note {{found this candidate}}
+  associatedtype T // expected-note 2 {{found this candidate}}
 }
 
 // FIXME: This extension's generic signature is still minimized differently from
@@ -36,7 +36,7 @@ extension P1 where Self : P2 {
 // Same as above, but now we have two visible associated types with the same
 // name.
 protocol P3 {
-  associatedtype T
+  associatedtype T // expected-note {{found this candidate}}
 }
 
 // FIXME: This extension's generic signature is still minimized differently from
@@ -48,7 +48,7 @@ extension P2 where Self : P3, T == Int {
 }
 
 extension P2 where Self : P3 {
-  func takeT1(_: T) {}
+  func takeT1(_: T) {} // expected-error {{'T' is ambiguous for type lookup in this context}}
   func takeT2(_: Self.T) {}
 }
 


### PR DESCRIPTION
... on canonical order

Instead of trying to order based on the "nested depth", let's
always prefer canonical ordering of type parameters when it comes
to picking representative equivalence class.

Resolves: rdar://problem/45957015

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
