### PR TITLE
[String] Expunge _StringGutsSlice from ABI

### DIFF
--- a/stdlib/public/core/StringGutsSlice.swift
+++ b/stdlib/public/core/StringGutsSlice.swift
@@ -16,22 +16,18 @@
 
 // A sliced _StringGuts, convenient for unifying String/Substring comparison,
 // hashing, and RRC.
-@_fixed_layout
-@usableFromInline
 internal struct _StringGutsSlice {
-  @usableFromInline
   internal var _guts: _StringGuts
 
-  @usableFromInline
   internal var _offsetRange: Range<Int>
 
-  @inlinable @inline(__always)
+  @inline(__always)
   internal init(_ guts: _StringGuts) {
     self._guts = guts
     self._offsetRange = 0..<self._guts.count
   }
 
-  @inlinable @inline(__always)
+  @inline(__always)
   internal init(_ guts: _StringGuts, _ offsetRange: Range<Int>) {
     self._guts = guts
     self._offsetRange = offsetRange
@@ -83,7 +79,7 @@ internal struct _StringGutsSlice {
     }
   }
 
-  @inlinable @inline(__always)
+  @inline(__always)
   internal func withFastUTF8<R>(
     _ f: (UnsafeBufferPointer<UInt8>) throws -> R
   ) rethrows -> R {

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -45,7 +45,6 @@ extension StringProtocol {
 }
 
 extension _StringGutsSlice {
-  @usableFromInline // @opaque
   @inline(never) // slow-path
   internal func _normalizedHash(into hasher: inout Hasher) {
     if self.isNFCFastUTF8 {

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -132,7 +132,6 @@ extension StringProtocol {
     get { return String(self) }
   }
 
-  @inlinable // Eliminate for String, Substring
   internal var _gutsSlice: _StringGutsSlice {
     @_specialize(where Self == String)
     @_specialize(where Self == Substring)
@@ -152,7 +151,8 @@ extension StringProtocol {
     @inline(__always) get {
       let start = startIndex
       let end = endIndex
-      _internalInvariant(start.transcodedOffset == 0 && end.transcodedOffset == 0)
+      _internalInvariant(
+        start.transcodedOffset == 0 && end.transcodedOffset == 0)
       return Range(uncheckedBounds: (start.encodedOffset, end.encodedOffset))
     }
   }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -483,6 +483,23 @@ Protocol _NSEnumerator has been removed
 Protocol _NSFastEnumeration has been removed
 Protocol _ShadowProtocol has been removed
 
+Constructor _StringGutsSlice.init(_:) has been removed
+Constructor _StringGutsSlice.init(_:_:) has been removed
+Func _StringGutsSlice._normalizedHash(into:) has been removed
+Func _StringGutsSlice.compare(with:expecting:) has been removed
+Func _StringGutsSlice.withFastUTF8(_:) has been removed
+Struct _StringGutsSlice is now without @_fixed_layout
+Var StringProtocol._gutsSlice has been removed
+Var _StringGutsSlice._guts has been removed
+Var _StringGutsSlice._offsetRange has been removed
+Var _StringGutsSlice.count has been removed
+Var _StringGutsSlice.end has been removed
+Var _StringGutsSlice.isASCII has been removed
+Var _StringGutsSlice.isFastUTF8 has been removed
+Var _StringGutsSlice.isNFCFastUTF8 has been removed
+Var _StringGutsSlice.range has been removed
+Var _StringGutsSlice.start has been removed
+
 Func ManagedBufferPointer._sanityCheckValidBufferClass(_:creating:) has been removed
 Func _sanityCheck(_:_:file:line:) has been removed
 Func _sanityCheckFailure(_:file:line:) has been removed


### PR DESCRIPTION
_StringGutsSlice is an implementation helper that's no longer needed
from inlinable code. Internalize it.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
