### PR TITLE
Remove DebugTypeInfo::isImplicitlyIndirect().

### DIFF
--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -88,14 +88,6 @@ public:
     return Type->getWithoutSpecifierType()->is<ArchetypeType>();
   }
 
-  /// LValues, inout args, and Archetypes are implicitly indirect by
-  /// virtue of their DWARF type.
-  //
-  // FIXME: There exists an inverse workaround in LLDB. Both should be removed.
-  bool isImplicitlyIndirect() const {
-    return isArchetype();
-  }
-
   bool isNull() const { return Type == nullptr; }
   bool operator==(DebugTypeInfo T) const;
   bool operator!=(DebugTypeInfo T) const;

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3727,8 +3727,7 @@ void IRGenSILFunction::visitDebugValueAddrInst(DebugValueAddrInst *i) {
       emitShadowCopyIfNeeded(Addr, i->getDebugScope(), Name, VarInfo->ArgNo,
                              IsAnonymous),
       DbgTy, SILType(), i->getDebugScope(), Decl, Name, VarInfo->ArgNo,
-      (IsLoadablyByAddress || DbgTy.isImplicitlyIndirect()) ? DirectValue
-                                                            : IndirectValue);
+      (IsLoadablyByAddress) ? DirectValue : IndirectValue);
 }
 
 void IRGenSILFunction::visitFixLifetimeInst(swift::FixLifetimeInst *i) {
@@ -3995,10 +3994,6 @@ void IRGenSILFunction::emitDebugInfoForAllocStack(AllocStackInst *i,
   auto DbgTy = DebugTypeInfo::getLocalVariable(
       CurSILFn->getDeclContext(), CurSILFn->getGenericEnvironment(), Decl,
       RealType, type);
-
-  // FIXME: This is working around the inverse special case in LLDB.
-  if (DbgTy.isImplicitlyIndirect())
-    Indirection = DirectValue;
 
   bindArchetypes(DbgTy.getType());
   if (IGM.DebugInfo)

--- a/test/DebugInfo/generic_arg.swift
+++ b/test/DebugInfo/generic_arg.swift
@@ -7,7 +7,7 @@ func foo<T>(_ x: T) -> () {
   // CHECK-SAME:               metadata ![[T1:.*]], metadata !DIExpression())
   // CHECK: %[[X:.*]] = alloca %swift.opaque*
   // CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %[[X]],
-  // CHECK-SAME:               metadata ![[X1:.*]], metadata !DIExpression())
+  // CHECK-SAME: metadata ![[X1:.*]], metadata !DIExpression(DW_OP_deref))
   // CHECK: store %swift.type* %T, %swift.type** %[[T]],
   // CHECK: store %swift.opaque* %0, %swift.opaque** %[[X]],
   // CHECK: ![[T1]] = !DILocalVariable(name: "$\CF\84_0_0",

--- a/test/DebugInfo/generic_arg2.swift
+++ b/test/DebugInfo/generic_arg2.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
 
 // CHECK: define hidden swiftcc void @"$s12generic_arg25ClassC3foo{{.*}}, %swift.type* %U
-// CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %y.debug, metadata ![[U:.*]], metadata !DIExpression())
+// CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %y.debug, metadata ![[U:.*]], metadata !DIExpression(DW_OP_deref))
 // Make sure there is no conflicting dbg.value for this variable.x
 // CHECK-NOT: dbg.value{{.*}}metadata ![[U]]
 class Class <T> {

--- a/test/DebugInfo/generic_arg3.swift
+++ b/test/DebugInfo/generic_arg3.swift
@@ -6,7 +6,7 @@ public func f<Type>(_ value : Type)
 {
   // CHECK: define {{.*}}$s12generic_arg31fyyxlFxxXEfU_
   // CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %[[ALLOCA:[^,]+]],
-  // CHECK-SAME:       metadata ![[ARG:.*]], metadata !DIExpression())
+  // CHECK-SAME: metadata ![[ARG:.*]], metadata !DIExpression(DW_OP_deref))
   // CHECK: store %swift.opaque* %1, %swift.opaque** %[[ALLOCA]], align
   // No deref here.
   // CHECK: ![[TY:.*]] = !DICompositeType({{.*}}identifier: "$sxD"


### PR DESCRIPTION
I found the corresponding code in LLDB that depended on this hack and
am now removing both. This makes it possible to share the same code
path for top-level archetypes and member types.

rdar://problem/45462765
