### PR TITLE
[ParseableInterface] Ensure module-link-name is serialized and used

### DIFF
--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -344,10 +344,12 @@ static bool buildSwiftModuleFromSwiftInterface(
     }
 
     LLVM_DEBUG(llvm::dbgs() << "Serializing " << OutPath << "\n");
+    FrontendOptions &FEOpts = SubInvocation.getFrontendOptions();
     SerializationOptions SerializationOpts;
     std::string OutPathStr = OutPath;
     SerializationOpts.OutputPath = OutPathStr.c_str();
     SerializationOpts.SerializeAllSIL = true;
+    SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
     SmallVector<FileDependency, 16> Deps;
     if (collectDepsForSerialization(FS, SubInstance, InPath, ModuleCachePath,
                                     Deps, Diags, OuterTracker)) {

--- a/test/ParseableInterface/Inputs/TestModule.swift
+++ b/test/ParseableInterface/Inputs/TestModule.swift
@@ -1,0 +1,3 @@
+public struct TestStruct {
+  public init() {}
+}

--- a/test/ParseableInterface/linking-to-module.swift
+++ b/test/ParseableInterface/linking-to-module.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name coreTestModuleKitUtilsTool %S/Inputs/TestModule.swift -emit-parseable-module-interface -o %t/libcoreTestModuleKitUtilsTool.%target-dylib-extension
+// RUN: %target-swift-frontend -emit-ir -I %t -L %t -enable-parseable-module-interface %s | %FileCheck %s
+
+import TestModule
+
+_ = TestStruct()
+
+// CHECK: -lcoreTestModuleKitUtilsTool


### PR DESCRIPTION
Previously, when trying to run the tests with a stdlib compiled from a `.swiftinterface`, we would see a ton of linker errors because `-module-link-name swiftCore` was not being serialized in the binary module.