### PR TITLE
[ownership] Ban ValueOwnershipKind::Any in preparation for eliminated ValueOwnershipKind::Trivial

### DIFF
--- a/include/swift/SIL/SILUndef.h
+++ b/include/swift/SIL/SILUndef.h
@@ -23,8 +23,9 @@ class SILInstruction;
 class SILModule;
 
 class SILUndef : public ValueBase {
-  SILUndef(SILType Ty)
-      : ValueBase(ValueKind::SILUndef, Ty, IsRepresentative::Yes) {}
+  ValueOwnershipKind ownershipKind;
+
+  SILUndef(SILType type, SILModule &m);
 
 public:
   void operator=(const SILArgument &) = delete;
@@ -33,8 +34,12 @@ public:
   static SILUndef *get(SILType ty, SILModule &m);
   static SILUndef *get(SILType ty, SILModule *m) { return get(ty, *m); }
 
-  template<class OwnerTy>
-  static SILUndef *getSentinelValue(SILType Ty, OwnerTy Owner) { return new (*Owner) SILUndef(Ty); }
+  template <class OwnerTy>
+  static SILUndef *getSentinelValue(SILType type, SILModule &m, OwnerTy owner) {
+    return new (*owner) SILUndef(type, m);
+  }
+
+  ValueOwnershipKind getOwnershipKind() const { return ownershipKind; }
 
   static bool classof(const SILArgument *) = delete;
   static bool classof(const SILInstruction *) = delete;

--- a/include/swift/SIL/SILUndef.h
+++ b/include/swift/SIL/SILUndef.h
@@ -17,6 +17,7 @@
 #include "swift/SIL/SILValue.h"
 
 namespace swift {
+
 class SILArgument;
 class SILInstruction;
 class SILModule;
@@ -29,8 +30,8 @@ public:
   void operator=(const SILArgument &) = delete;
   void operator delete(void *, size_t) SWIFT_DELETE_OPERATOR_DELETED;
 
-  static SILUndef *get(SILType Ty, SILModule *M);
-  static SILUndef *get(SILType Ty, SILModule &M) { return get(Ty, &M); }
+  static SILUndef *get(SILType ty, SILModule &m);
+  static SILUndef *get(SILType ty, SILModule *m) { return get(ty, *m); }
 
   template<class OwnerTy>
   static SILUndef *getSentinelValue(SILType Ty, OwnerTy Owner) { return new (*Owner) SILUndef(Ty); }

--- a/include/swift/SIL/SILUndef.h
+++ b/include/swift/SIL/SILUndef.h
@@ -22,14 +22,12 @@ class SILInstruction;
 class SILModule;
 
 class SILUndef : public ValueBase {
-  void operator=(const SILArgument &) = delete;
-
-  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED;
-
   SILUndef(SILType Ty)
       : ValueBase(ValueKind::SILUndef, Ty, IsRepresentative::Yes) {}
 
 public:
+  void operator=(const SILArgument &) = delete;
+  void operator delete(void *, size_t) SWIFT_DELETE_OPERATOR_DELETED;
 
   static SILUndef *get(SILType Ty, SILModule *M);
   static SILUndef *get(SILType Ty, SILModule &M) { return get(Ty, &M); }

--- a/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
+++ b/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
@@ -51,12 +51,15 @@ class SILSSAUpdater {
   // If not null updated with inserted 'phi' nodes (SILArgument).
   SmallVectorImpl<SILPhiArgument *> *InsertedPHIs;
 
+  SILModule &M;
+
   // Not copyable.
   void operator=(const SILSSAUpdater &) = delete;
   SILSSAUpdater(const SILSSAUpdater &) = delete;
 
 public:
   explicit SILSSAUpdater(
+      SILModule &M,
       SmallVectorImpl<SILPhiArgument *> *InsertedPHIs = nullptr);
   ~SILSSAUpdater();
 

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -37,6 +37,7 @@ add_swift_host_library(swiftSIL STATIC
   SILProfiler.cpp
   SILSuccessor.cpp
   SILType.cpp
+  SILUndef.cpp
   SILValue.cpp
   SILVerifier.cpp
   SILOwnershipVerifier.cpp

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -30,12 +30,12 @@
 
 using namespace swift;
 
-SILUndef *SILUndef::get(SILType Ty, SILModule *M) {
+SILUndef *SILUndef::get(SILType ty, SILModule &m) {
   // Unique these.
-  SILUndef *&Entry = M->UndefValues[Ty];
-  if (Entry == nullptr)
-    Entry = new (*M) SILUndef(Ty);
-  return Entry;
+  SILUndef *&entry = m.UndefValues[ty];
+  if (entry == nullptr)
+    entry = new (m) SILUndef(ty);
+  return entry;
 }
 
 FormalLinkage swift::getDeclLinkage(const ValueDecl *D) {

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -30,14 +30,6 @@
 
 using namespace swift;
 
-SILUndef *SILUndef::get(SILType ty, SILModule &m) {
-  // Unique these.
-  SILUndef *&entry = m.UndefValues[ty];
-  if (entry == nullptr)
-    entry = new (m) SILUndef(ty);
-  return entry;
-}
-
 FormalLinkage swift::getDeclLinkage(const ValueDecl *D) {
   const DeclContext *fileContext = D->getDeclContext()->getModuleScopeContext();
 

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -709,6 +709,8 @@ void SILValue::verifyOwnership(SILModule &mod,
   if (!f->hasQualifiedOwnership() || !f->shouldVerifyOwnership())
     return;
 
+  assert(getOwnershipKind() != ValueOwnershipKind::Any &&
+         "No values should have any ownership anymore");
   ErrorBehaviorKind errorBehavior;
   if (IsSILOwnershipVerifierTestingEnabled) {
     errorBehavior = ErrorBehaviorKind::PrintMessageAndReturnFalse;

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -669,9 +669,6 @@ void SILInstruction::verifyOperandOwnership() const {
       continue;
     SILValue opValue = op.get();
 
-    // Skip any SILUndef that we see.
-    if (isa<SILUndef>(opValue))
-      continue;
     auto operandOwnershipKindMap = op.getOwnershipKindMap();
     auto valueOwnershipKind = opValue.getOwnershipKind();
     if (operandOwnershipKindMap.canAcceptKind(valueOwnershipKind))
@@ -700,11 +697,6 @@ void SILValue::verifyOwnership(SILModule &mod,
                                DeadEndBlocks *deadEndBlocks) const {
 #ifndef NDEBUG
   if (DisableOwnershipVerification)
-    return;
-
-  // If we are SILUndef, just bail. SILUndef can pair with anything. Any uses of
-  // the SILUndef will make sure that the matching checks out.
-  if (isa<SILUndef>(*this))
     return;
 
   // Since we do not have SILUndef, we now know that getFunction() should return
@@ -742,11 +734,6 @@ bool OwnershipChecker::checkValue(SILValue value) {
   regularUsers.clear();
   lifetimeEndingUsers.clear();
   liveBlocks.clear();
-
-  // If we are SILUndef, just bail. SILUndef can pair with anything. Any uses of
-  // the SILUndef will make sure that the matching checks out.
-  if (isa<SILUndef>(value))
-    return false;
 
   // Since we do not have SILUndef, we now know that getFunction() should return
   // a real function. Assert in case this assumption is no longer true.

--- a/lib/SIL/SILUndef.cpp
+++ b/lib/SIL/SILUndef.cpp
@@ -1,0 +1,34 @@
+//===--- SILUndef.cpp -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILUndef.h"
+#include "swift/SIL/SILModule.h"
+
+using namespace swift;
+
+static ValueOwnershipKind getOwnershipKindForUndef(SILType type, SILModule &m) {
+  if (type.isTrivial(m))
+    return ValueOwnershipKind::Trivial;
+  return ValueOwnershipKind::Owned;
+}
+
+SILUndef::SILUndef(SILType type, SILModule &m)
+    : ValueBase(ValueKind::SILUndef, type, IsRepresentative::Yes),
+      ownershipKind(getOwnershipKindForUndef(type, m)) {}
+
+SILUndef *SILUndef::get(SILType ty, SILModule &m) {
+  // Unique these.
+  SILUndef *&entry = m.UndefValues[ty];
+  if (entry == nullptr)
+    entry = new (m) SILUndef(ty, m);
+  return entry;
+}

--- a/lib/SIL/ValueOwnership.cpp
+++ b/lib/SIL/ValueOwnership.cpp
@@ -280,8 +280,8 @@ ValueOwnershipKindClassifier::visitUncheckedOwnershipConversionInst(
   return I->getConversionOwnershipKind();
 }
 
-ValueOwnershipKind ValueOwnershipKindClassifier::visitSILUndef(SILUndef *Arg) {
-  return ValueOwnershipKind::Any;
+ValueOwnershipKind ValueOwnershipKindClassifier::visitSILUndef(SILUndef *arg) {
+  return arg->getOwnershipKind();
 }
 
 ValueOwnershipKind

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1619,7 +1619,7 @@ protected:
   }
 
   void updateSSAForm() {
-    SILSSAUpdater SSAUp;
+    SILSSAUpdater SSAUp(StartBB->getParent()->getModule());
     for (auto *origBB : originalPreorderBlocks()) {
       // Update outside used phi values.
       for (auto *arg : origBB->getArguments())

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -174,7 +174,7 @@ rewriteNewLoopEntryCheckBlock(SILBasicBlock *Header,
                               SILBasicBlock *EntryCheckBlock,
                         const llvm::DenseMap<ValueBase *, SILValue> &ValueMap) {
   SmallVector<SILPhiArgument *, 4> InsertedPHIs;
-  SILSSAUpdater Updater(&InsertedPHIs);
+  SILSSAUpdater Updater(Header->getParent()->getModule(), &InsertedPHIs);
 
   // Fix PHIs (incoming arguments).
   for (auto *Arg : Header->getArguments())

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -305,9 +305,9 @@ void LoopCloner::collectLoopLiveOutValues(
 }
 
 static void
-updateSSA(SILLoop *Loop,
+updateSSA(SILModule &M, SILLoop *Loop,
           DenseMap<SILValue, SmallVector<SILValue, 8>> &LoopLiveOutValues) {
-  SILSSAUpdater SSAUp;
+  SILSSAUpdater SSAUp(M);
   for (auto &MapEntry : LoopLiveOutValues) {
     // Collect out of loop uses of this value.
     auto OrigValue = MapEntry.first;
@@ -335,6 +335,7 @@ static bool tryToUnrollLoop(SILLoop *Loop) {
   auto *Preheader = Loop->getLoopPreheader();
   if (!Preheader)
     return false;
+  SILModule &M = Preheader->getParent()->getModule();
 
   auto *Latch = Loop->getLoopLatch();
   if (!Latch)
@@ -409,7 +410,7 @@ static bool tryToUnrollLoop(SILLoop *Loop) {
   }
 
   // Fixup SSA form for loop values used outside the loop.
-  updateSSA(Loop, LoopLiveOutValues);
+  updateSSA(M, Loop, LoopLiveOutValues);
   return true;
 }
 

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -537,7 +537,7 @@ SILValue AvailableValueAggregator::handlePrimitiveValue(SILType LoadTy,
 
   // If we have an available value, then we want to extract the subelement from
   // the borrowed aggregate before each insertion point.
-  SILSSAUpdater Updater;
+  SILSSAUpdater Updater(B.getModule());
   Updater.Initialize(LoadTy);
   for (auto *I : Val.getInsertionPoints()) {
     // Use the scope and location of the store at the insertion point.

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -595,7 +595,7 @@ static bool removeAndReleaseArray(SingleValueInstruction *NewArrayValue,
       return false;
   }
   // For each store location, insert releases.
-  SILSSAUpdater SSAUp;
+  SILSSAUpdater SSAUp(ArrayDef->getModule());
   ValueLifetimeAnalysis::Frontier ArrayFrontier;
   if (!VLA.computeFrontier(ArrayFrontier,
                            ValueLifetimeAnalysis::UsersMustPostDomDef,

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -1191,7 +1191,7 @@ void BlockState::dump(RLEContext &Ctx) {
 RLEContext::RLEContext(SILFunction *F, SILPassManager *PM, AliasAnalysis *AA,
                        TypeExpansionAnalysis *TE, PostOrderFunctionInfo *PO,
                        EpilogueARCFunctionInfo *EAFI, bool disableArrayLoads)
-    : Fn(F), PM(PM), AA(AA), TE(TE), PO(PO), EAFI(EAFI),
+    : Fn(F), PM(PM), AA(AA), TE(TE), Updater(F->getModule()), PO(PO), EAFI(EAFI),
       ArrayType(disableArrayLoads ?
                 F->getModule().getASTContext().getArrayDecl() : nullptr)
 #ifndef NDEBUG

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -207,7 +207,7 @@ static bool isUsedOutsideOfBlock(SILValue V, SILBasicBlock *BB) {
 /// Helper function to perform SSA updates in case of jump threading.
 void swift::updateSSAAfterCloning(BasicBlockCloner &Cloner,
                                   SILBasicBlock *SrcBB, SILBasicBlock *DestBB) {
-  SILSSAUpdater SSAUp;
+  SILSSAUpdater SSAUp(SrcBB->getParent()->getModule());
   for (auto AvailValPair : Cloner.AvailVals) {
     ValueBase *Inst = AvailValPair.first;
     if (Inst->use_empty())

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -34,9 +34,9 @@ void SILSSAUpdater::deallocateSentinel(SILUndef *D) {
   AlignedFree(D);
 }
 
-SILSSAUpdater::SILSSAUpdater(SmallVectorImpl<SILPhiArgument *> *PHIs)
+SILSSAUpdater::SILSSAUpdater(SILModule &M, SmallVectorImpl<SILPhiArgument *> *PHIs)
     : AV(nullptr), PHISentinel(nullptr, deallocateSentinel),
-      InsertedPHIs(PHIs) {}
+      InsertedPHIs(PHIs), M(M) {}
 
 SILSSAUpdater::~SILSSAUpdater() = default;
 
@@ -44,7 +44,7 @@ void SILSSAUpdater::Initialize(SILType Ty) {
   ValType = Ty;
 
   PHISentinel = std::unique_ptr<SILUndef, void (*)(SILUndef *)>(
-      SILUndef::getSentinelValue(Ty, this), SILSSAUpdater::deallocateSentinel);
+      SILUndef::getSentinelValue(Ty, M, this), SILSSAUpdater::deallocateSentinel);
 
   if (!AV)
     AV.reset(new AvailableValsTy());

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -1050,6 +1050,7 @@ sil @class_method_undef_test : $@convention(thin) () -> () {
 bb0:
   %0 = unchecked_ref_cast undef : $Builtin.NativeObject to $SuperKlass
   %1 = class_method %0 : $SuperKlass, #SuperKlass.d!1 : (SuperKlass) -> () -> (), $@convention(method) (@guaranteed SuperKlass) -> ()
+  destroy_value %0 : $SuperKlass
   %9999 = tuple()
   return %9999 : $()
 }
@@ -1058,6 +1059,7 @@ sil @forwarding_instruction_undef_test : $@convention(thin) () -> () {
 bb0:
   %0 = unchecked_ref_cast undef : $Builtin.NativeObject to $SuperKlass
   %1 = unchecked_ref_cast %0 : $SuperKlass to $Builtin.NativeObject
+  destroy_value %1 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
This PR eliminates our usage of ValueOwnershipKind::Any's old undef like semantics and temporarily bans ValueOwnershipKind::Any when ownership verification is enabled. This involves:

1. Changing SILUndef to produce owned ownership if it has a non-trivial type and trivial ownership if it has a trivial type. This involved storing in SILUndef said ValueOwnershipKind since we do not have access to a SILModule when computing the ValueOwnershipKind of a SILValue.

2. Adding an assert that bans ValueOwnershipKind::Any for /all/ values.

After this commit, I should be able to just do a sed-ish replace of all references to ValueOwnershipKind::Trivial to ValueOwnershipKind::Any and start debriding.

rdar://46294760