### PR TITLE
IRGen: weak linkage is not supported on COFF, avoid it

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -43,6 +43,7 @@ class UniversalLinkageInfo {
 public:
   bool IsELFObject;
   bool UseDLLStorage;
+  bool SupportsWeakLinkage;
 
   /// True iff are multiple llvm modules.
   bool HasMultipleIGMs;
@@ -1001,7 +1002,7 @@ public:
   }
 
   /// Determine whether this entity will be weak-imported.
-  bool isWeakImported(ModuleDecl *module) const;
+  bool isWeakImported(ModuleDecl *module, const UniversalLinkageInfo &LI) const;
   
   /// Return the source file whose codegen should trigger emission of this
   /// link entity, if one can be identified.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1509,8 +1509,8 @@ void irgen::updateLinkageForDefinition(IRGenModule &IGM,
   // entire linkage computation.
   UniversalLinkageInfo linkInfo(IGM);
   auto IRL =
-      getIRLinkage(linkInfo, entity.getLinkage(ForDefinition),
-                   ForDefinition, entity.isWeakImported(IGM.getSwiftModule()));
+      getIRLinkage(linkInfo, entity.getLinkage(ForDefinition), ForDefinition,
+                   entity.isWeakImported(IGM.getSwiftModule(), linkInfo));
   ApplyIRLinkage(IRL).to(global);
 
   // Everything externally visible is considered used in Swift.
@@ -1545,8 +1545,9 @@ LinkInfo LinkInfo::get(const UniversalLinkageInfo &linkInfo,
       ForDefinition_t(swiftModule->isStdlibModule() || isDefinition);
 
   entity.mangle(result.Name);
-  result.IRL = getIRLinkage(linkInfo, entity.getLinkage(isStdlibOrDefinition),
-                            isDefinition, entity.isWeakImported(swiftModule));
+  result.IRL =
+      getIRLinkage(linkInfo, entity.getLinkage(isStdlibOrDefinition),
+                   isDefinition, entity.isWeakImported(swiftModule, linkInfo));
   result.ForDefinition = isDefinition;
   return result;
 }


### PR DESCRIPTION
Disable weak linkage on COFF as it is not supported.  Everything must be
fully resolved at link time.  This disables the use of weak linkage if
that file format is in use.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
