### PR TITLE
AST: simplify `AKAFormatString`

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -289,7 +289,7 @@ namespace swift {
 
     DiagnosticFormatOptions()
         : OpeningQuotationMark("'"), ClosingQuotationMark("'"),
-          AKAFormatString("'%1$s' (aka '%2$s')") {}
+          AKAFormatString("'%s' (aka '%s')") {}
   };
   
   /// Diagnostic - This is a specific instance of a diagnostic along with all of


### PR DESCRIPTION
Remove the unnecessary use of the positional arguments in the diagnostic
formatting.  This is not portable as it is a SUS extension and the Microsoft C
runtime does not support this extension.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
