### PR TITLE
[BugFix] Avoid cloning a block multiple times during SESE canonicalization.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -385,15 +385,10 @@ static SILValue createTFIntegerConst(GraphFunctionDeviceInfo &deviceInfo,
 namespace {
 
 class BasicBlockCloner : public SILClonerWithScopes<BasicBlockCloner> {
-private:
-  /// The flag to track if  this cloner was used to clone any blocks.
-  bool cloned;
-
 public:
-  BasicBlockCloner(SILFunction &F)
-      : SILClonerWithScopes(F), cloned(false) {}
+  BasicBlockCloner(SILFunction &F) : SILClonerWithScopes(F) {}
 
-  bool hasCloned() const { return cloned; }
+  bool hasCloned() const { return !BBMap.empty(); }
 
   SILBasicBlock *cloneBlock(SILBasicBlock *bb) {
     auto bbIt = BBMap.find(bb);
@@ -526,8 +521,6 @@ private:
     auto bbIt = BBMap.find(bb);
     if (bbIt != BBMap.end())
       return bbIt->second;
-
-    cloned = true;
 
     SILFunction &F = getBuilder().getFunction();
     SILBasicBlock *newBB = F.createBasicBlock();

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -395,43 +395,13 @@ public:
 
   bool hasCloned() const { return cloned; }
 
-  /// Create a block and clone the arguments alone.
-  SILBasicBlock *initBlock(SILBasicBlock *bb) {
-    auto bbIt = BBMap.find(bb);
-    if (bbIt != BBMap.end())
-      return bbIt->second;
-
-    cloned = true;
-
-    SILFunction &F = getBuilder().getFunction();
-    SILBasicBlock *newBB = F.createBasicBlock();
-    getBuilder().setInsertionPoint(newBB);
-    BBMap[bb] = newBB;
-    // If the basic block has arguments, clone them as well.
-    for (auto *arg : bb->getArguments()) {
-      // Create a new argument and copy it into the ValueMap so future
-      // references use it.
-      ValueMap[arg] = newBB->createPhiArgument(
-          arg->getType(), arg->getOwnershipKind(), arg->getDecl());
-    }
-    return newBB;
-  }
-
-  // Clone all the instructions and return the cloned block.
   SILBasicBlock *cloneBlock(SILBasicBlock *bb) {
     auto bbIt = BBMap.find(bb);
-    assert (bbIt != BBMap.end() && "Block is not initialied before cloning.");
-    SILBasicBlock *newBB = bbIt->second;
-    getBuilder().setInsertionPoint(newBB);
-    for (auto &inst : *bb) {
-      visit(&inst);
+    if (bbIt != BBMap.end()) {
+      return bbIt->second;
     }
-    return newBB;
-  }
-
-  SILBasicBlock *initAndCloneBlock(SILBasicBlock *bb) {
     initBlock(bb);
-    return cloneBlock(bb);
+    return cloneInstructions(bb);
   }
 
   /// Handle references to basic blocks when cloning.
@@ -539,7 +509,7 @@ public:
       }
     }
     for (SILBasicBlock *bb : initializedBlocks) {
-      SILBasicBlock *clonedBlock = cloneBlock(bb);
+      SILBasicBlock *clonedBlock = cloneInstructions(bb);
       if (SILLoop *loopClone = loopClones[LI->getLoopFor(bb)]) {
         loopClone->addBasicBlockToLoop(clonedBlock, LI->getBase());
         if (LI->getLoopFor(bb)->getHeader() == bb) {
@@ -549,6 +519,42 @@ public:
     }
     return loopClones[loop];
   }
+
+private:
+  /// Create a block and clone the arguments alone.
+  SILBasicBlock *initBlock(SILBasicBlock *bb) {
+    auto bbIt = BBMap.find(bb);
+    if (bbIt != BBMap.end())
+      return bbIt->second;
+
+    cloned = true;
+
+    SILFunction &F = getBuilder().getFunction();
+    SILBasicBlock *newBB = F.createBasicBlock();
+    getBuilder().setInsertionPoint(newBB);
+    BBMap[bb] = newBB;
+    // If the basic block has arguments, clone them as well.
+    for (auto *arg : bb->getArguments()) {
+      // Create a new argument and copy it into the ValueMap so future
+      // references use it.
+      ValueMap[arg] = newBB->createPhiArgument(
+          arg->getType(), arg->getOwnershipKind(), arg->getDecl());
+    }
+    return newBB;
+  }
+
+  // Clone all the instructions and return the cloned block.
+  SILBasicBlock *cloneInstructions(SILBasicBlock *bb) {
+    auto bbIt = BBMap.find(bb);
+    assert (bbIt != BBMap.end() && "Block is not initialied before cloning.");
+    SILBasicBlock *newBB = bbIt->second;
+    getBuilder().setInsertionPoint(newBB);
+    for (auto &inst : *bb) {
+      visit(&inst);
+    }
+    return newBB;
+  }
+
 };
 
 }  // namespace
@@ -843,7 +849,7 @@ void SingleExitLoopTransformer::ensureSingleExitBlock() {
         if (DI->properlyDominates(succ, header)) continue;
 
         // Clone the block and rewire the edge.
-        SILBasicBlock *clonedSucc = cloner.initAndCloneBlock(succ);
+        SILBasicBlock *clonedSucc = cloner.cloneBlock(succ);
         // If `succ` is a preheader of an unrelated loop, we will have to clone
         // the entire loop now so that we can also incrementally update LoopInfo.
         if (succBlockLoop) {

--- a/test/TensorFlow/sese_loop_canonicalization.sil
+++ b/test/TensorFlow/sese_loop_canonicalization.sil
@@ -262,7 +262,7 @@ bb1(%4: $Builtin.Int32):
   %5 = builtin "sadd_with_overflow_Int32"(%4 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int32
   %6 = builtin "cmp_eq_Int32"(%5 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int1
   cond_br %6, bb2, bb3(%5 : $Builtin.Int32)
-	
+
 bb2:
   %7 = builtin "sadd_with_overflow_Int32"(%5 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int32
   %8 = builtin "cmp_slt_Int32"(%7 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1
@@ -374,6 +374,98 @@ bb8:
 bb9(%18 : $Builtin.Int32):
   return %18 : $Builtin.Int32
 }
+
+// The following example is similar to loopThatRequiresNodecloning, except that we
+// will attempt to clone block [9] multiple times as it is reachable from [8] and
+// [3]. This test makes sure we don't clone it twice.
+//
+// The CFG is shown below:
+//
+// [0]-------+
+//  |         \
+// [1]       [2]
+//  |         |
+//  |   +--->[4]
+//  |  [7]   /  \
+//  |   |  [6]  [5]
+//  V   +-+ \    |
+// [3]<-----[8]  |
+//  |      /     |
+//  +-->[9]      |
+//       |       |
+//      [10]-----+
+//
+// CHECK-LABEL: --- XLA CFG Canonicalize: $loopThatRequiresNodeCloningMultipleTimes
+// CHECK: [sequence
+// CHECK:   {condition Header: {{bb[0-9]+}}
+// CHECK:     block {{bb[0-9]+}}
+// CHECK:     [sequence
+// CHECK:       <while Preheader: {{bb[0-9]+}}, Header: {{bb[0-9]+}}, exit: {{bb[0-9]+}}
+// CHECK:         [sequence
+// CHECK:           {condition Header: {{bb[0-9]+}}
+// CHECK:             block {{bb[0-9]+}}
+// CHECK:             {condition Header: {{bb[0-9]+}}
+// CHECK:               [sequence
+// CHECK:                 {condition Header: {{bb[0-9]+}}
+// CHECK:                   block {{bb[0-9]+}}
+// CHECK:                   block {{bb[0-9]+}}}
+// CHECK:                 block {{bb[0-9]+}}]
+// CHECK:               block {{bb[0-9]+}}}}
+// CHECK:           block {{bb[0-9]+}}]>
+// CHECK:       block {{bb[0-9]+}}]}
+// CHECK:   block {{bb[0-9]+}}]
+// CHECK: --- XLA CFG Canonicalize end
+//
+sil @$loopThatRequiresNodeCloningMultipleTimes : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32 {
+bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
+  %2 = integer_literal $Builtin.Int32, 1
+  %3 = integer_literal $Builtin.Int32, 100
+  %4 = builtin "sadd_with_overflow_Int32"(%0 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int32
+  %5 = builtin "cmp_slt_Int32"(%4 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1
+	cond_br %5, bb1, bb2
+
+bb1:
+  // First arg is sum, the second arg is loop counter.
+  br bb3(%4 : $Builtin.Int32, %0 : $Builtin.Int32)
+
+bb2:
+  br bb4(%4 : $Builtin.Int32, %0 : $Builtin.Int32)
+
+bb3(%6 : $Builtin.Int32, %7 : $Builtin.Int32):
+  %8 = builtin "ssub_with_overflow_Int32"(%6 : $Builtin.Int32, %7 : $Builtin.Int32) : $Builtin.Int32
+  br bb9(%8 : $Builtin.Int32)
+
+bb4(%9 : $Builtin.Int32, %10 : $Builtin.Int32):
+  %11 = builtin "sadd_with_overflow_Int32"(%10 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int32
+  %12 = builtin "sadd_with_overflow_Int32"(%9 : $Builtin.Int32, %10 : $Builtin.Int32) : $Builtin.Int32
+  %13 = builtin "cmp_slt_Int32"(%11 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %13, bb5, bb6
+
+bb5:
+  br bb10(%12 : $Builtin.Int32)
+
+bb6:
+  %14 = builtin "sadd_with_overflow_Int32"(%11 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int32
+  %15 = builtin "sadd_with_overflow_Int32"(%12 : $Builtin.Int32, %14 : $Builtin.Int32) : $Builtin.Int32
+  %16 = builtin "cmp_slt_Int32"(%14 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %16, bb8, bb7
+
+bb7:
+  br bb4(%15 : $Builtin.Int32, %14 : $Builtin.Int32)
+
+bb8:
+  %18 = builtin "sadd_with_overflow_Int32"(%11 : $Builtin.Int32, %12 : $Builtin.Int32) : $Builtin.Int32
+  %19 = builtin "cmp_slt_Int32"(%18 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %19, bb3(%11: $Builtin.Int32, %12: $Builtin.Int32), bb9(%18: $Builtin.Int32)
+
+bb9(%20 : $Builtin.Int32):
+  %21 = builtin "sadd_with_overflow_Int32"(%20 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int32
+	br bb10(%21: $Builtin.Int32)
+
+bb10(%22: $Builtin.Int32):
+  return %22 : $Builtin.Int32
+}
+
 
 // The following example is similar to loopThatRequiresNodeCloning, where the
 // nodes that lead to the common post dominator of all exit nodes is also


### PR DESCRIPTION
This PR fixes a bug in BasicBlock cloning logic in SESE canonicalization. Consider the CFG below:
```
 [0]-------+
  |         \
 [1]       [2]
  |         |
  |   +--->[4]
  |  [7]   /  \
  |   |  [6]  [5]
  V   +-+ \    |
 [3]<-----[8]  |
  |      /     |
  +-->[9]      |
       |       |
      [10]-----+
```

In this example, we will attempt to clone block [9] multiple times as it is reachable from [8] and
 [3]. On the second attempt to clone, we should return the already cloned block instead of cloning it again. This PR fixes the bug.  

Even though the PR is big, it is mostly restructuring some of the functions into private to avoid such bugs in future. The relevant bugfix  is in the `cloneBlock` function. 