### PR TITLE
[5.0][CSSimplify] Delay binding metatype instance types if one side is typ…

### DIFF
--- a/test/Constraints/rdar44816848.swift
+++ b/test/Constraints/rdar44816848.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift
+
+class A {}
+class B: A {}
+class C: A {}
+
+struct S {
+  func foo<T: A>(types: [T.Type]) {}
+}
+
+func bar(_ s: S, _ forced_s: S!) {
+  s.foo(types: [A.self, B.self]) // ok
+  s.foo(types: [B.self, A.self]) // ok
+  forced_s.foo(types: [A.self, B.self]) // ok
+  forced_s.foo(types: [B.self, A.self]) // ok
+}


### PR DESCRIPTION
…e variable

- **Explanation**:  While matching two metatypes where one side is a class (which could have
supertypes) and another is a type variable use `subtype` constraint to
delay binding types together because there is a real possibility that
there exists a superclass associated with yet free type variable which
would be a better match when attempted.

- **Issue**: rdar://problem/44816848

- **Scope**: TypeChecker

- **Risk**: Low, very narrow case when bindings are picked in particular order which results in having type variable on the right-side of the type relation.

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @rudkx

Resolves: rdar://problem/44816848
(cherry picked from commit 28a66a23eb237fdd6ad98cc91b96f1afba9bdd1a)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
