### PR TITLE
Adding support for [T]() array construction into TFConstExpr.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -55,6 +55,8 @@ enum class WellKnownFunction {
   AssertionFailure,
   // Array._allocateUninitializedArray
   AllocateUninitializedArray,
+  // Array.init()
+  ArrayInitEmpty,
 };
 
 static WellKnownFunction classifyFunction(SILFunction *fn) {
@@ -64,6 +66,8 @@ static WellKnownFunction classifyFunction(SILFunction *fn) {
   StringRef mangledName = fn->getName();
   if (mangledName == "$sS2SycfC")
     return WellKnownFunction::StringInitEmpty;
+  if (mangledName == "$sS2ayxGycfC")
+    return WellKnownFunction::ArrayInitEmpty;
 
   if (mangledName.contains("_assertionFailure"))
     return WellKnownFunction::AssertionFailure;
@@ -827,6 +831,23 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
         byteCount.getIntegerValue().getLimitedValue() != literalVal.size())
       break;
     setValue(apply, literal);
+    return None;
+  }
+  case WellKnownFunction::ArrayInitEmpty: { // Array.init()
+    assert(conventions.getNumDirectSILResults() == 1 &&
+           conventions.getNumIndirectSILResults() == 0 &&
+           "unexpected Array.init() signature");
+
+    auto literal = getConstantValue(apply->getOperand(1));
+    if (literal.getKind() != SymbolicValue::Metatype)
+      break;
+
+    auto literalType = literal.getMetatypeValue();
+
+    auto arrayVal = SymbolicValue::getArray(
+        {}, getArrayElementType(literalType)->getCanonicalType(),
+        evaluator.getAllocator());
+    setValue(apply, arrayVal);
     return None;
   }
   case WellKnownFunction::AllocateUninitializedArray: {

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -3,6 +3,13 @@ import TensorFlow
 
 // FIXME: This should not build with -O.
 
+// CHECK-LABEL: --- TFDeabstraction Result: {{.*}}reproduceSR9365{{.*}}
+// CHECK: graph_op "Reproduce SR-9365"() {test: [$String: ], 
+@TensorFlowGraph
+func reproduceSR9365() {
+   let _: () = #tfop("Reproduce SR-9365", test: Array<String>())
+}
+
 public func trivialAdd(a: Tensor<Float>) -> Tensor<Float> {
   let b = a.toAccelerator()
   return b+b


### PR DESCRIPTION
This improves usability for ops like "ParseSingleExample" which users may
pass trivially constructed empty arrays into.