### PR TITLE
Add test for Metal APIs new in iOS 12

### DIFF
--- a/test/stdlib/Metal.swift
+++ b/test/stdlib/Metal.swift
@@ -259,10 +259,12 @@ if #available(OSX 10.14, iOS 12.0, tvOS 12.0, *){
       let encoder = cmdBuf.makeRenderCommandEncoder(descriptor: rpDesc)!
       encoder.useResources([buf], usage: MTLResourceUsage.read)
       encoder.useHeaps([heap])
-      #if os(macOS)
+#if os(macOS) || os(iOS)
+      if #available(iOS 12.0, macOS 10.13, *) {
         encoder.setViewports([MTLViewport()])
         encoder.setScissorRects([MTLScissorRect(x:0, y:0, width:1, height:1)])
-      #endif
+      }
+#endif
       encoder.setVertexBuffers([buf], offsets: [0], range: 0..<1)
       encoder.setVertexTextures([tex], range: 0..<1)
       encoder.setVertexSamplerStates([smplr], range: 0..<1)


### PR DESCRIPTION
These APIs were used in the test for macOS only, but now with the iOS 12
they can also be called on iOS, so let's test them.