### PR TITLE
[stdlib] adds nullability type specifier to NSStringGetCStringTrampoline

### DIFF
--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -134,7 +134,7 @@ _swift_stdlib_NSStringCStringUsingEncodingTrampoline(id _Nonnull obj,
 SWIFT_RUNTIME_STDLIB_API
 __swift_uint8_t
 _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
-                                         _swift_shims_UInt8 *buffer,
+                                         _swift_shims_UInt8 *_Nonnull buffer,
                                          _swift_shims_CFIndex maxLength,
                                          unsigned long encoding);
   


### PR DESCRIPTION
Adds missing nullability specifier to the buffer passed to `_swift_stdlib_NSStringGetCStringTrampoline`.

Output from building from scratch on macOS 10.14.1 with the toolchain from Xcode 10.1 (10B61).

```
[108/1619] Building CXX object stdlib/...cosx-x86_64.dir/FoundationHelpers.mm.o
In file included from <path>swift/stdlib/public/stubs/FoundationHelpers.mm:23:
<path>swift/stdlib/public/stubs/../SwiftShims/CoreFoundationShims.h:137:61: warning: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Wnullability-completeness]
                                         _swift_shims_UInt8 *buffer,
                                                            ^
<path>swift/stdlib/public/stubs/../SwiftShims/CoreFoundationShims.h:137:61: note: insert '_Nullable' if the pointer may be null
                                         _swift_shims_UInt8 *buffer,
                                                            ^
                                                              _Nullable 
<path>swift/stdlib/public/stubs/../SwiftShims/CoreFoundationShims.h:137:61: note: insert '_Nonnull' if the pointer should never be null
                                         _swift_shims_UInt8 *buffer,
                                                            ^
                                                              _Nonnull 
1 warning generated.
```

According to documentation and auto-completion in Xcode this pointer should be `_Nonnull`:

`[@"" getCString:(nonnull char *) maxLength:(NSUInteger) encoding:(NSStringEncoding)];`