### PR TITLE
[Runtime] Fix leak when casting to AnyHashable.

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1922,6 +1922,9 @@ static bool tryDynamicCastBoxedSwiftValue(OpaqueValue *dest,
   
 #if !SWIFT_OBJC_INTEROP // __SwiftValue is a native class:
   if (swift_unboxFromSwiftValueWithType(src, dest, targetType)) {
+    // Release the source if we need to.
+    if (flags & DynamicCastFlags::TakeOnSuccess)
+      srcType->vw_destroy(src);
     return true;
   }
 #endif

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -635,23 +635,13 @@ static bool _dynamicCastToAnyHashable(OpaqueValue *destination,
 
   // If we do find one, the cast succeeds.
 
-  // The intrinsic wants the value at +1, so we have to copy it into
-  // a temporary.
-  ValueBuffer buffer;
-  bool mustDeallocBuffer = false;
-  if (!(flags & DynamicCastFlags::TakeOnSuccess)) {
-    auto *valueAddr = sourceType->allocateBufferIn(&buffer);
-    source = sourceType->vw_initializeWithCopy(valueAddr, source);
-    mustDeallocBuffer = true;
-  }
-
   // Initialize the destination.
   _swift_convertToAnyHashableIndirect(source, destination,
                                       sourceType, hashableConformance);
 
-  // Deallocate the buffer if we used it.
-  if (mustDeallocBuffer) {
-    sourceType->deallocateBufferIn(&buffer);
+  // Destroy the value if requested.
+  if (flags & DynamicCastFlags::TakeOnSuccess) {
+    sourceType->vw_destroy(source);
   }
 
   // The cast succeeded.

--- a/test/stdlib/AnyHashableCasts.swift.gyb
+++ b/test/stdlib/AnyHashableCasts.swift.gyb
@@ -118,6 +118,16 @@ AnyHashableCasts.test("${valueExpr} as ${coercedType} as? ${castType}") {
 }
 % end
 
+AnyHashableCasts.test("Casting to AnyHashable doesn't leak") {
+  do {
+    let tracked = LifetimeTracked(42)
+    let anyHashable = AnyHashable(tracked)
+    let anyObject = anyHashable as AnyObject
+    _ = anyObject as? AnyHashable
+  }
+  expectEqual(LifetimeTracked.instances, 0)
+}
+
 #if _runtime(_ObjC)
 // A wrapper type around Int that bridges to NSNumber.
 struct IntWrapper1: _SwiftNewtypeWrapper, Hashable, _ObjectiveCBridgeable {


### PR DESCRIPTION
`_dynamicCastToAnyHashable` assumed that `_swift_convertToAnyHashableIndirect` takes its argument at +1, but that is no longer the case.

rdar://problem/44686587