### PR TITLE
[5.0][api-digester] Don't report as API breaking when an ObjC protocol gets a new optional method

### DIFF
--- a/test/api-digester/Inputs/Foo-new-version/foo.h
+++ b/test/api-digester/Inputs/Foo-new-version/foo.h
@@ -1,0 +1,14 @@
+#import <Foundation.h>
+
+@protocol ObjcProt
+  -(void) someFunctionFromProt;
+
+  -(void) someFunctionFromProt2;
+
+@optional
+  -(void) someOptionalFunctionFromProt;
+@end
+
+@interface ClangInterface: NSObject <ObjcProt>
+- (void)someFunction;
+@end

--- a/test/api-digester/Inputs/Foo-new-version/module.modulemap
+++ b/test/api-digester/Inputs/Foo-new-version/module.modulemap
@@ -1,0 +1,3 @@
+module Foo {
+  header "foo.h"
+}

--- a/test/api-digester/Outputs/Foo-diff.txt
+++ b/test/api-digester/Outputs/Foo-diff.txt
@@ -1,0 +1,1 @@
+Foo: Func ObjcProt.someFunctionFromProt2() has been added as a protocol requirement

--- a/test/api-digester/compare-clang-dump.swift
+++ b/test/api-digester/compare-clang-dump.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t.module-cache)
+// RUN: %api-digester -dump-sdk -module Foo -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/Foo -avoid-location
+// RUN: %api-digester -dump-sdk -module Foo -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/Foo-new-version -avoid-location
+// RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result
+
+// RUN: %clang -E -P -x c %S/Outputs/Foo-diff.txt -o - | sed '/^\s*$/d' > %t.expected
+// RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
+// RUN: diff -u %t.expected %t.result.tmp

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -393,6 +393,10 @@ StringRef SDKNodeDecl::getFullyQualifiedName() const {
   return getSDKContext().buffer(OS.str());
 }
 
+bool SDKNodeDecl::isNonOptionalProtocolRequirement() const {
+  return isProtocolRequirement() && !hasDeclAttribute(DAK_Optional);
+}
+
 bool SDKNodeDecl::hasDeclAttribute(DeclAttrKind DAKind) const {
   return std::find(DeclAttributes.begin(), DeclAttributes.end(), DAKind) !=
     DeclAttributes.end();

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -322,6 +322,7 @@ public:
   StringRef getFullyQualifiedName() const;
   bool isDeprecated() const { return IsDeprecated; };
   bool isProtocolRequirement() const { return IsProtocolReq; }
+  bool isNonOptionalProtocolRequirement() const;
   bool hasDeclAttribute(DeclAttrKind DAKind) const;
   bool isImplicit() const { return IsImplicit; };
   bool isStatic() const { return IsStatic; };

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -978,7 +978,7 @@ public:
       }
       // Complain about added protocol requirements
       if (auto *D = dyn_cast<SDKNodeDecl>(Right)) {
-        if (D->isProtocolRequirement()) {
+        if (D->isNonOptionalProtocolRequirement()) {
           bool ShouldComplain = !D->isOverriding();
           // We should allow added associated types with default.
           if (auto ATD = dyn_cast<SDKNodeDeclAssociatedType>(D)) {


### PR DESCRIPTION
master: https://github.com/apple/swift/pull/20833