### PR TITLE
[stdlib][ABI] Make reduce(into:_) take its initial value owned

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -723,7 +723,7 @@ extension Sequence {
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
   public func reduce<Result>(
-    into initialResult: Result,
+    into initialResult: __owned Result,
     _ updateAccumulatingResult:
       (_ partialResult: inout Result, Element) throws -> ()
   ) rethrows -> Result {

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -528,3 +528,5 @@ Class _StringStorage has changed its super class from _AbstractStringStorage to 
 Constructor _AbstractStringStorage.init() has been removed
 Func _AbstractStringStorage.copy(with:) has been removed
 Func _AbstractStringStorage.getOrComputeBreadcrumbs() has been removed
+
+Func Sequence.reduce(into:_:) has parameter 0 changing from Default to Owned

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -210,3 +210,5 @@ Func LazyCollectionProtocol.map(_:) has been removed
 Func LazyCollectionProtocol.prefix(while:) has been removed
 Func LazyCollectionProtocol.reversed() has been removed
 Var LazyCollectionProtocol.lazy has declared type change from LazyCollection<Self.Elements> to LazySequence<Self.Elements>
+
+Func Sequence.reduce(into:_:) has parameter 0 changing from Default to Owned


### PR DESCRIPTION
Given the goal of this method is to mutate the initial parameter, it should take it owned since the most common usage is to give up an initial value (like `[]`) to it.