### PR TITLE
Revert "Re-enable a test that had been disabled at one point."

### DIFF
--- a/test/Constraints/warn_long_compile.swift
+++ b/test/Constraints/warn_long_compile.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -warn-long-function-bodies=1
-
+// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -warn-long-function-bodies=1 %s
+// REQUIRES: rdar44305428
 @_silgen_name("generic_foo")
 func foo<T>(_ x: T) -> T
 


### PR DESCRIPTION
Reverts apple/swift#20778

We're still seeing a failure on Linux when this test is enabled. We'll need to debug it there.