### PR TITLE
[api-digester] Add '-protocol-requirement-white-list' option to the digester for when diagnosing API breakage in SDKs

### DIFF
--- a/test/api-digester/Inputs/Foo-new-version/foo.h
+++ b/test/api-digester/Inputs/Foo-new-version/foo.h
@@ -9,6 +9,11 @@
   -(void) someOptionalFunctionFromProt;
 @end
 
+@protocol AnotherObjcProt
+  -(void) anotherFunctionFromProt;
+  -(void) anotherFunctionFromProt2;
+@end
+
 @interface ClangInterface: NSObject <ObjcProt>
 - (void)someFunction;
 @end

--- a/test/api-digester/Inputs/Foo-prot-whitelist.txt
+++ b/test/api-digester/Inputs/Foo-prot-whitelist.txt
@@ -1,0 +1,1 @@
+AnotherObjcProt

--- a/test/api-digester/Inputs/Foo/foo.h
+++ b/test/api-digester/Inputs/Foo/foo.h
@@ -4,6 +4,10 @@
   -(void) someFunctionFromProt;
 @end
 
+@protocol AnotherObjcProt
+  -(void) anotherFunctionFromProt;
+@end
+
 @interface ClangInterface: NSObject <ObjcProt>
 - (void)someFunction;
 @end

--- a/test/api-digester/Outputs/clang-module-dump.txt
+++ b/test/api-digester/Outputs/clang-module-dump.txt
@@ -5,6 +5,47 @@
   "children": [
     {
       "kind": "TypeDecl",
+      "name": "AnotherObjcProt",
+      "printedName": "AnotherObjcProt",
+      "children": [
+        {
+          "kind": "Function",
+          "name": "anotherFunctionFromProt",
+          "printedName": "anotherFunctionFromProt()",
+          "children": [
+            {
+              "kind": "TypeNameAlias",
+              "name": "Void",
+              "printedName": "Void",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "c:objc(pl)AnotherObjcProt(im)anotherFunctionFromProt",
+          "moduleName": "Foo",
+          "genericSig": "<Self where Self : AnotherObjcProt>",
+          "protocolReq": true,
+          "declAttributes": [
+            "ObjC"
+          ],
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Protocol",
+      "usr": "c:objc(pl)AnotherObjcProt",
+      "moduleName": "Foo",
+      "declAttributes": [
+        "ObjC"
+      ]
+    },
+    {
+      "kind": "TypeDecl",
       "name": "ClangInterface",
       "printedName": "ClangInterface",
       "children": [

--- a/test/api-digester/compare-clang-dump.swift
+++ b/test/api-digester/compare-clang-dump.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t.module-cache)
 // RUN: %api-digester -dump-sdk -module Foo -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/Foo -avoid-location
 // RUN: %api-digester -dump-sdk -module Foo -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/Foo-new-version -avoid-location
-// RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result
+// RUN: %api-digester -diagnose-sdk -protocol-requirement-white-list %S/Inputs/Foo-prot-whitelist.txt -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result
 
 // RUN: %clang -E -P -x c %S/Outputs/Foo-diff.txt -o - | sed '/^\s*$/d' > %t.expected
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp


### PR DESCRIPTION
This option access a file that lists protocol names that are 'whitelisted' for getting new protocol requirements.
This allows the SDK checker to avoid flagging protocol method additions for protocols that we know are not intended
for user classes to conform to.