### PR TITLE
[5.0] Change Default Linker to Gold for AArch64

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -103,6 +103,7 @@ ToolChain::InvocationInfo toolchains::GenericUnix::constructInvocation(
 std::string toolchains::GenericUnix::getDefaultLinker() const {
   switch (getTriple().getArch()) {
   case llvm::Triple::arm:
+  case llvm::Triple::aarch64:
   case llvm::Triple::armeb:
   case llvm::Triple::thumb:
   case llvm::Triple::thumbeb:


### PR DESCRIPTION
<!-- What's in this pull request? -->
Cherry-pick of: https://github.com/apple/swift/pull/20845
For all the same reasons outlined in PR https://github.com/apple/swift/pull/19875
AArch64 also needs to default to the "Gold" linker.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
