### PR TITLE
Use @_borrowed on a few declarations in the stdlib and overlays

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -261,8 +261,12 @@ bool SILPerformanceInliner::isProfitableToInline(
   int BaseBenefit = RemovedCallBenefit;
 
   // Osize heuristic.
+  //
+  // As a hack, don't apply this at all to coroutine inlining; avoiding
+  // coroutine allocation overheads is extremely valuable.  There might be
+  // more principled ways of getting this effect.
   bool isClassMethodAtOsize = false;
-  if (OptMode == OptimizationMode::ForSize) {
+  if (OptMode == OptimizationMode::ForSize && !isa<BeginApplyInst>(AI)) {
     // Don't inline into thunks.
     if (AI.getFunction()->isThunk())
       return false;

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -151,16 +151,17 @@ extension UnsafeMutableAudioBufferListPointer
   }
 
   /// Access an indexed `AudioBuffer` (`mBuffers[i]`).
+  @_borrowed
   public subscript(index: Index) -> Element {
-    get {
+    _read {
       precondition(index >= 0 && index < self.count,
         "subscript index out of range")
-      return (_audioBuffersPointer + index).pointee
+      yield ((_audioBuffersPointer + index).pointee)
     }
-    nonmutating set(newValue) {
+    nonmutating _modify {
       precondition(index >= 0 && index < self.count,
         "subscript index out of range")
-      (_audioBuffersPointer + index).pointee = newValue
+      yield (&(_audioBuffersPointer + index).pointee)
     }
   }
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -414,6 +414,7 @@ public protocol Collection: Sequence {
   ///   `endIndex` property.
   ///
   /// - Complexity: O(1)
+  @_borrowed
   subscript(position: Index) -> Element { get }
 
   /// Accesses a contiguous subrange of the collection's elements.

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -85,6 +85,7 @@ where SubSequence: MutableCollection
   ///   `endIndex` property.
   ///
   /// - Complexity: O(1)
+  @_borrowed
   override subscript(position: Index) -> Element { get set }
 
   /// Accesses a contiguous subrange of the collection's elements.


### PR DESCRIPTION
This is the 5.0 version of #20415.

It is ABI-affecting.  I would call it important for convergence because it affects the compilation of basically all code that is generic over collections.