### PR TITLE
remote-run: execute with python

### DIFF
--- a/test/remote-run/lit.local.cfg
+++ b/test/remote-run/lit.local.cfg
@@ -2,4 +2,4 @@
 config.substitutions = list(config.substitutions)
 
 config.substitutions.insert(0, ('%debug-remote-run',
-  '%utils/remote-run --debug-as-local %sftp-server --remote-dir %t-REMOTE') )
+                                '%r %utils/remote-run --debug-as-local %sftp-server --remote-dir %t-REMOTE' % (sys.executable,)))


### PR DESCRIPTION
This is needed for Windows, where the shebang does not suffice for
setting an interpreter.  Explicitly run the interpreter.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
