### PR TITLE
rearrange adjoint parameter order

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4127,9 +4127,9 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
   // Compute the adjoint parameters.
   SmallVector<AnyFunctionType::Param, 8> adjointParams;
 
-  // The first parameters are the same as those of the original function.
-  for (auto &param : unwrapped->getParams())
-    adjointParams.push_back(param);
+  // The first parameter is the seed, which has the same type as the original
+  // return type.
+  adjointParams.push_back(AnyFunctionType::Param(unwrapped->getResult()));
 
   // If the primal exists, the checkpoints type is the primal result type.
   if (primalResultTy) {
@@ -4137,9 +4137,12 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
     adjointParams.push_back(AnyFunctionType::Param(checkpointsTy));
   }
 
-  // The original result and the seed have the same type as the original
-  // return type.
-  adjointParams.append(2, AnyFunctionType::Param(unwrapped->getResult()));
+  // The original result has the same type as the original return type.
+  adjointParams.push_back(AnyFunctionType::Param(unwrapped->getResult()));
+
+  // The last parameters are the parameters of the original function.
+  for (auto &param : unwrapped->getParams())
+    adjointParams.push_back(param);
 
   // Build the adjoint type.
   AnyFunctionType *adjoint = makeFunctionType(unwrapped, adjointParams, retTy);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2180,6 +2180,9 @@ static FuncDecl *resolveAutoDiffAssociatedFunction(
       overloadDiagnostic, ambiguousDiagnostic, notFunctionDiagnostic,
       lookupOptions, hasValidTypeContext, invalidTypeContextDiagnostic);
 
+  if (!candidate)
+    return nullptr;
+
   if (checkAccessControl(candidate))
     return nullptr;
 

--- a/stdlib/public/TensorFlow/CompositeMath.swift
+++ b/stdlib/public/TensorFlow/CompositeMath.swift
@@ -26,7 +26,7 @@ public func sigmoid<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
 /// Computes `relu` of the specified tensor element-wise.
 /// Specifically, computes `max(0, x)`.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointRelu(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointRelu(_:_:_:))
 public func relu<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return max(0, x)
 }

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -52,7 +52,7 @@
 extension Tensor where Scalar : Numeric {
   @inlinable
   static func _adjointAdd(
-    _ x: Tensor, _ y: Tensor, originalValue: Tensor, seed: Tensor
+    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor, _ y: Tensor
   ) -> (Tensor, Tensor) {
     let seed = seed.broadcast(like: originalValue)
     return (seed.unbroadcast(like: x), seed.unbroadcast(like: y))
@@ -60,7 +60,7 @@ extension Tensor where Scalar : Numeric {
 
   @inlinable
   static func _adjointSubtract(
-    _ x: Tensor, _ y: Tensor, originalValue: Tensor, seed: Tensor
+    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor, _ y: Tensor
   ) -> (Tensor, Tensor) {
     let seed = seed.broadcast(like: originalValue)
     return (seed.unbroadcast(like: x), 0 - seed.unbroadcast(like: y))
@@ -68,7 +68,7 @@ extension Tensor where Scalar : Numeric {
 
   @inlinable
   static func _adjointMultiply(
-    _ x: Tensor, _ y: Tensor, originalValue: Tensor, seed: Tensor
+    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor, _ y: Tensor
   ) -> (Tensor, Tensor) {
     return ((y * seed).unbroadcast(like: x),
             (x * seed).unbroadcast(like: y))
@@ -76,7 +76,7 @@ extension Tensor where Scalar : Numeric {
 
   @inlinable
   static func _adjointDivide(
-    _ x: Tensor, _ y: Tensor, originalValue: Tensor, seed: Tensor
+    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor, _ y: Tensor
   ) -> (Tensor, Tensor) {
     return ((seed / y).unbroadcast(like: x),
             ((0 - x) / y.squared() * seed).unbroadcast(like: y))
@@ -85,7 +85,7 @@ extension Tensor where Scalar : Numeric {
 
 @inlinable
 func _adjointMinMax<T : Numeric & Comparable>(
-  _ x: Tensor<T>, _ y: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>, _ y: Tensor<T>
 ) -> (Tensor<T>, Tensor<T>) {
   let denom = 1 + Tensor<T>(x.elementsEqual(y))
   let dfdx = seed * Tensor<T>(x.elementsEqual(originalValue)) / denom
@@ -95,7 +95,7 @@ func _adjointMinMax<T : Numeric & Comparable>(
 
 @inlinable
 func _adjointPow<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, _ y: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>, _ y: Tensor<T>
 ) -> (Tensor<T>, Tensor<T>) {
   return ((seed * y * pow(x, y-1)).unbroadcast(like: x),
           (seed * log(x) * originalValue).unbroadcast(like: y))
@@ -108,7 +108,7 @@ func _adjointPow<T : BinaryFloatingPoint>(
 extension Tensor where Scalar : SignedNumeric {
   @inlinable
   static func _adjointNegate(
-    _ x: Tensor, originalValue: Tensor, seed: Tensor
+    _ seed: Tensor, _ originalValue: Tensor, _ x: Tensor
   ) -> Tensor {
     return -seed.broadcast(like: originalValue)
   }
@@ -116,90 +116,90 @@ extension Tensor where Scalar : SignedNumeric {
 
 @inlinable
 func _adjointLog<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed / x
 }
 
 @inlinable
 func _adjointSin<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * cos(x)
 }
 
 @inlinable
 func _adjointCos<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return -seed * sin(x)
 }
 
 @inlinable
 func _adjointTan<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * (1 + originalValue.squared())
 }
 
 @inlinable
 func _adjointSinh<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * cosh(x)
 }
 
 @inlinable
 func _adjointCosh<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * sinh(x)
 }
 
 @inlinable
 func _adjointTanh<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed * (1 - originalValue.squared())
 }
 
 @inlinable
 func _adjointExp<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return originalValue * seed
 }
 
 @inlinable
 func _adjointCeil<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return Tensor(0).broadcast(like: x)
 }
 
 @inlinable
 func _adjointFloor<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return Tensor(0).broadcast(like: x)
 }
 
 @inlinable
 func _adjointSqrt<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return seed / (2 * originalValue)
 }
 
 @inlinable
 func _adjointRsqrt<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return -seed / 2 * pow(originalValue, 3)
 }
 
 func _adjointSquared<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return 2 * x * seed
 }
@@ -210,8 +210,8 @@ func _adjointSquared<T : BinaryFloatingPoint>(
 
 @inlinable
 func _adjointMatmul<Scalar : Numeric>(
-  _ left: Tensor<Scalar>, _ right: Tensor<Scalar>,
-  originalValue: Tensor<Scalar>, seed: Tensor<Scalar>
+  _ seed: Tensor<Scalar>, _ originalValue: Tensor<Scalar>,
+  _ left: Tensor<Scalar>, _ right: Tensor<Scalar>
 ) -> (Tensor<Scalar>, Tensor<Scalar>) {
   let bcSeed = seed.broadcast(like: originalValue)
   return (matmul(bcSeed, right.transposed()), matmul(left.transposed(), bcSeed))
@@ -222,17 +222,17 @@ func _adjointMatmul<Scalar : Numeric>(
 // remove the custom adjoint.
 extension Tensor where Scalar : Numeric {
   @inlinable
-  static func _adjointMatmulOperator(lhs: Tensor, rhs: Tensor,
-                                     originalValue: Tensor, seed: Tensor)
+  static func _adjointMatmulOperator(seed: Tensor, originalValue: Tensor,
+                                     lhs: Tensor, rhs: Tensor)
       -> (Tensor, Tensor) {
-    return _adjointMatmul(lhs, rhs, originalValue: originalValue, seed: seed)
+    return _adjointMatmul(seed, originalValue, lhs, rhs)
   }
 }
 
 extension Tensor {
   @inlinable
   func _adjointTransposed(
-    _ permutations: Tensor<Int32>, originalValue: Tensor, seed: Tensor
+    _ seed: Tensor, _ originalValue: Tensor, _ permutations: Tensor<Int32>
   ) -> Tensor {
     let seed = seed.broadcast(like: originalValue)
     return seed.transposed(withPermutations: permutations)
@@ -246,7 +246,7 @@ extension Tensor {
 extension Tensor {
   @inlinable
   func _adjointReshaped(
-    toShape newShape: Tensor<Int32>, originalValue: Tensor, seed: Tensor
+    seed: Tensor, originalValue: Tensor, toShape newShape: Tensor<Int32>
   ) -> Tensor {
     let seed = seed.broadcast(like: originalValue)
     return seed.reshaped(toShape: shapeTensor)
@@ -254,7 +254,7 @@ extension Tensor {
 
   @inlinable
   func _adjointExpandingShape(
-    at shapeIndex: Int32, originalValue: Tensor, seed: Tensor
+    seed: Tensor, originalValue: Tensor, at shapeIndex: Int32
   ) -> Tensor {
     let seed = seed.broadcast(like: originalValue)
     return seed.squeezingShape(at: shapeIndex)
@@ -269,12 +269,12 @@ extension Tensor where Scalar : BinaryFloatingPoint {
   // TODO: Verify that these calculations are correct.
   @inlinable
   func _adjointBatchNormalized(
+    seed: Tensor,
+    originalValue: Tensor,
     alongAxis axis: Int32,
     offset: Scalar,
     scale: Scalar,
-    epsilon: Scalar,
-    originalValue: Tensor,
-    seed: Tensor
+    epsilon: Scalar
   ) -> (Tensor, Scalar, Scalar) {
     let mean = self.mean(alongAxes: axis)
     let squaredDiff: Tensor = Raw.squaredDifference(self, mean)
@@ -347,13 +347,13 @@ extension Tensor where Scalar : BinaryFloatingPoint {
 
   @inlinable
   func _adjointTFConv2DBackpropInput(
+    _ seed: Tensor,
+    _ originalValue: Tensor,
     _ shape: Tensor<Int32>,
     _ filter: Tensor,
     _ backpropOutput: Tensor,
     _ strides: (Int32, Int32, Int32, Int32),
-    _ padding: Padding,
-    _ originalValue: Tensor,
-    _ seed: Tensor
+    _ padding: Padding
   ) -> (Tensor, Tensor) {
     return (
       _TFConv2DBackpropFilter(input: seed, filterSizes: shape,
@@ -365,13 +365,13 @@ extension Tensor where Scalar : BinaryFloatingPoint {
 
   @inlinable
   func _adjointTFConv2DBackpropFilter(
+    _ seed: Tensor,
+    _ originalValue: Tensor,
     _ input: Tensor,
     _ filterSizes: Tensor<Int32>,
     _ backpropOutput: Tensor,
     _ strides: (Int32, Int32, Int32, Int32),
-    _ padding: Padding,
-    _ originalValue: Tensor,
-    _ seed: Tensor
+    _ padding: Padding
   ) -> (Tensor, Tensor) {
     return (
       _TFConv2DBackpropInput(shape: filterSizes, filter: seed,
@@ -383,11 +383,11 @@ extension Tensor where Scalar : BinaryFloatingPoint {
 
   @inlinable
   func _adjointConvolved2D(
+    seed: Tensor,
+    originalValue: Tensor,
     filter: Tensor,
     strides: (Int32, Int32, Int32, Int32),
-    padding: Padding,
-    originalValue: Tensor,
-    seed: Tensor
+    padding: Padding
   ) -> (Tensor, Tensor) {
     return (
       _TFConv2DBackpropInput(
@@ -403,11 +403,11 @@ extension Tensor where Scalar : BinaryFloatingPoint {
 
   @inlinable
   func _adjointMaxPooled(
+    seed: Tensor,
+    originalValue: Tensor,
     kernelSize: (Int32, Int32, Int32, Int32),
     strides: (Int32, Int32, Int32, Int32),
-    padding: Padding,
-    originalValue: Tensor,
-    seed: Tensor
+    padding: Padding
   ) -> Tensor {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
@@ -423,11 +423,11 @@ extension Tensor where Scalar : BinaryFloatingPoint {
 
   @inlinable
   func _adjointAveragePooled(
+    seed: Tensor,
+    originalValue: Tensor,
     kernelSize: (Int32, Int32, Int32, Int32),
     strides: (Int32, Int32, Int32, Int32),
-    padding: Padding,
-    originalValue: Tensor,
-    seed: Tensor
+    padding: Padding
   ) -> Tensor {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
@@ -447,7 +447,7 @@ extension Tensor where Scalar : BinaryFloatingPoint {
 
 @inlinable
 func _adjointRelu<T : BinaryFloatingPoint>(
-  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+  _ seed: Tensor<T>, _ originalValue: Tensor<T>, _ x: Tensor<T>
 ) -> Tensor<T> {
   return Tensor(x.elementsGreater(0)) * seed
 }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -72,7 +72,7 @@ extension Tensor : AdditiveArithmetic where Scalar : Numeric {
   /// Adds two tensors and produces their sum.
   /// - Note: `+` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointAdd(_:_:originalValue:seed:))
+  @differentiable(reverse, adjoint: _adjointAdd(_:_:_:_:))
   public static func + (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.add(lhs, rhs)
   }
@@ -80,7 +80,7 @@ extension Tensor : AdditiveArithmetic where Scalar : Numeric {
   /// Subtracts one tensor from another and produces their difference.
   /// - Note: `-` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointSubtract(_:_:originalValue:seed:))
+  @differentiable(reverse, adjoint: _adjointSubtract(_:_:_:_:))
   public static func - (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.sub(lhs, rhs)
   }
@@ -167,7 +167,7 @@ public extension Tensor where Scalar : Numeric {
   /// Multiplies two tensors and produces their product.
   /// - Note: `*` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointMultiply(_:_:originalValue:seed:))
+  @differentiable(reverse, adjoint: _adjointMultiply(_:_:_:_:))
   static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.mul(lhs, rhs)
   }
@@ -195,7 +195,7 @@ public extension Tensor where Scalar : Numeric {
   /// Returns the quotient of dividing the first tensor by the second.
   /// - Note: `/` supports broadcasting.
   @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointDivide(_:_:originalValue:seed:))
+  @differentiable(reverse, adjoint: _adjointDivide(_:_:_:_:))
   static func / (lhs: Tensor, rhs: Tensor) -> Tensor {
     return Raw.div(lhs, rhs)
   }
@@ -271,7 +271,7 @@ public extension Tensor where Scalar : Numeric {
 /// Performs matrix multiplication with another tensor and produces the
 /// result.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointMatmul(_:_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointMatmul(_:_:_:_:))
 public func matmul<Scalar : Numeric>(
   _ left: Tensor<Scalar>, _ right: Tensor<Scalar>
 ) -> Tensor<Scalar> {
@@ -289,7 +289,7 @@ public extension Tensor where Scalar : Numeric {
   /// result.
   @inlinable @inline(__always)
   @differentiable(reverse,
-                  adjoint: _adjointMatmulOperator(lhs:rhs:originalValue:seed:))
+                  adjoint: _adjointMatmulOperator(seed:originalValue:lhs:rhs:))
   static func • (lhs: Tensor, rhs: Tensor) -> Tensor {
     return matmul(lhs, rhs)
   }
@@ -492,7 +492,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     reverse, wrt: (self),
-    adjoint: _adjointTransposed(_:originalValue:seed:)
+    adjoint: _adjointTransposed(_:_:_:)
   )
   func transposed(
     withPermutations permutations: Tensor<Int32>
@@ -595,7 +595,7 @@ public extension Tensor {
 public extension Tensor where Scalar : SignedNumeric {
   /// Computes the negation of the specified tensor element-wise.
   @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointNegate(_:originalValue:seed:))
+  @differentiable(reverse, adjoint: _adjointNegate(_:_:_:))
   static prefix func - (rhs: Tensor) -> Tensor {
     return Raw.neg(rhs)
   }
@@ -609,91 +609,91 @@ public func abs<T : SignedNumeric>(_ x: Tensor<T>) -> Tensor<T> {
 
 /// Computes the natural logarithm of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointLog(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointLog(_:_:_:))
 public func log<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.log(x)
 }
 
 /// Computes `sin` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointSin(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointSin(_:_:_:))
 public func sin<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sin(x)
 }
 
 /// Computes `cos` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointCos(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointCos(_:_:_:))
 public func cos<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.cos(x)
 }
 
 /// Computes `tan` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointTan(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointTan(_:_:_:))
 public func tan<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.tan(x)
 }
 
 /// Computes `sinh` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointSinh(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointSinh(_:_:_:))
 public func sinh<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sinh(x)
 }
 
 /// Computes `cosh` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointCosh(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointCosh(_:_:_:))
 public func cosh<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.cosh(x)
 }
 
 /// Computes `tanh` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointTanh(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointTanh(_:_:_:))
 public func tanh<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.tanh(x)
 }
 
 /// Computes the square root of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointSqrt(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointSqrt(_:_:_:))
 public func sqrt<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.sqrt(x)
 }
 
 /// Computes the inverse square root of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointRsqrt(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointRsqrt(_:_:_:))
 public func rsqrt<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.rsqrt(x)
 }
 
 /// Computes `exp` of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointExp(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointExp(_:_:_:))
 public func exp<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.exp(x)
 }
 
 /// Computes the ceiling of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointCeil(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointCeil(_:_:_:))
 public func ceil<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.ceil(x)
 }
 
 /// Computes the floor of the specified tensor element-wise.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointFloor(_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointFloor(_:_:_:))
 public func floor<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.floor(x)
 }
 
 /// Computes the power of the first tensor to the second tensor.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointPow(_:_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointPow(_:_:_:_:))
 public func pow<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : BinaryFloatingPoint {
   return Raw.pow(lhs, rhs)
@@ -716,7 +716,7 @@ public func pow<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
 /// Computes the element-wise maximum of two tensors.
 /// - Note: `max` supports broadcasting.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointMinMax(_:_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointMinMax(_:_:_:_:))
 public func max<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return Raw.maximum(lhs, rhs)
@@ -741,7 +741,7 @@ public func max<T>(_ lhs: Tensor<T>, _ rhs: T) -> Tensor<T>
 /// Computes the element-wise minimum of two tensors.
 /// - Note: `min` supports broadcasting.
 @inlinable @inline(__always)
-@differentiable(reverse, adjoint: _adjointMinMax(_:_:originalValue:seed:))
+@differentiable(reverse, adjoint: _adjointMinMax(_:_:_:_:))
 public func min<T>(_ lhs: Tensor<T>, _ rhs: Tensor<T>) -> Tensor<T>
   where T : Numeric & Comparable {
   return Raw.minimum(lhs, rhs)
@@ -1367,7 +1367,7 @@ public extension Tensor where Scalar : BinaryFloatingPoint {
   @inlinable @inline(__always)
   @differentiable(
     reverse, wrt: (self, .0),
-    adjoint: _adjointConvolved2D(filter:strides:padding:originalValue:seed:)
+    adjoint: _adjointConvolved2D(seed:originalValue:filter:strides:padding:)
   )
   func convolved2D(
     withFilter filter: Tensor,
@@ -1392,7 +1392,7 @@ public extension Tensor where Scalar : BinaryFloatingPoint {
   @inlinable @inline(__always)
   @differentiable(
     reverse, wrt: (self),
-    adjoint: _adjointMaxPooled(kernelSize:strides:padding:originalValue:seed:)
+    adjoint: _adjointMaxPooled(seed:originalValue:kernelSize:strides:padding:)
   )
   func maxPooled(
     kernelSize: (Int32, Int32, Int32, Int32),
@@ -1417,7 +1417,7 @@ public extension Tensor where Scalar : BinaryFloatingPoint {
   @inlinable @inline(__always)
   @differentiable(
     reverse, wrt: (self),
-    adjoint: _adjointAveragePooled(kernelSize:strides:padding:originalValue:seed:)
+    adjoint: _adjointAveragePooled(seed:originalValue:kernelSize:strides:padding:)
   )
   func averagePooled(
     kernelSize: (Int32, Int32, Int32, Int32),

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -796,7 +796,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     reverse, wrt: (self),
-    adjoint: _adjointReshaped(toShape:originalValue:seed:)
+    adjoint: _adjointReshaped(seed:originalValue:toShape:)
   )
   func reshaped(toShape newShape: Tensor<Int32>) -> Tensor {
     return Raw.reshape(self, shape: newShape)
@@ -820,7 +820,7 @@ public extension Tensor {
   @inlinable @inline(__always)
   @differentiable(
     reverse, wrt: (self),
-    adjoint: _adjointExpandingShape(at:originalValue:seed:)
+    adjoint: _adjointExpandingShape(seed:originalValue:at:)
   )
   func expandingShape(at shapeIndex: Int32) -> Tensor {
     return Raw.expandDims(self, dim: Tensor<Int32>(shapeIndex))

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1833,7 +1833,7 @@ extension FloatingPoint {
   /// The adjoint of `squareRoot`. Returns the gradient of `squareRoot` with
   /// respect to `self`.
   @inlinable // FIXME(sil-serialize-all)
-  func _adjointSquareRoot(originalValue: Self, adjoint: Self) -> Self {
+  func _adjointSquareRoot(_ adjoint: Self, _ originalValue: Self) -> Self {
     return 2 * self * adjoint
   }
 
@@ -1864,8 +1864,9 @@ extension FloatingPoint {
   /// with respect to `self`, `lhs` and `rhs`.
   @inlinable
   func _adjointAddingProduct(
-    _ lhs: Self, _ rhs: Self,
-    originalValue: Self, adjoint: Self
+    _ adjoint: Self,
+    _ originalValue: Self,
+    _ lhs: Self, _ rhs: Self
   ) -> (Self, Self, Self) {
     return (1, rhs, lhs)
   }

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1746,7 +1746,8 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   static func _adjointAdd(
-    _ lhs: ${Self}, _ rhs: ${Self}, originalValue: ${Self}, adjoint: ${Self}
+    _ adjoint: ${Self}, _ originalValue: ${Self},
+    _ lhs: ${Self}, _ rhs: ${Self}
   ) -> (${Self}, ${Self}) {
     return (adjoint, adjoint)
   }
@@ -1754,7 +1755,8 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   static func _adjointSubtract(
-    _ lhs: ${Self}, _ rhs: ${Self}, originalValue: ${Self}, adjoint: ${Self}
+    _ adjoint: ${Self}, _ originalValue: ${Self},
+    _ lhs: ${Self}, _ rhs: ${Self}
   ) -> (${Self}, ${Self}) {
     return (adjoint, -adjoint)
   }
@@ -1762,7 +1764,8 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   static func _adjointMultiply(
-    _ lhs: ${Self}, _ rhs: ${Self}, originalValue: ${Self}, adjoint: ${Self}
+    _ adjoint: ${Self}, _ originalValue: ${Self},
+    _ lhs: ${Self}, _ rhs: ${Self}
   ) -> (${Self}, ${Self}) {
     return (rhs * adjoint, lhs * adjoint)
   }
@@ -1770,7 +1773,8 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   static func _adjointDivide(
-    _ lhs: ${Self}, _ rhs: ${Self}, originalValue: ${Self}, adjoint: ${Self}
+    _ adjoint: ${Self}, _ originalValue: ${Self},
+    _ lhs: ${Self}, _ rhs: ${Self}
   ) -> (${Self}, ${Self}) {
     return (adjoint / rhs, -lhs / (rhs * rhs) * adjoint)
   }

--- a/test/AutoDiff/adjoint_expr_silgen.swift
+++ b/test/AutoDiff/adjoint_expr_silgen.swift
@@ -6,12 +6,12 @@
 // Top-level function
 //===----------------------------------------------------------------------===//
 
-@differentiable(reverse, adjoint: dSquare(_:primal:seed:))
+@differentiable(reverse, adjoint: dSquare)
 func square<T : FloatingPoint>(_ x: T) -> T {
   return x * x
 }
 @_silgen_name("dsquare")
-private func dSquare<T : FloatingPoint>(_ x: T, primal: T, seed: T) -> T {
+private func dSquare<T : FloatingPoint>(_ seed: T, _ primal: T, _ x: T) -> T {
   return 2 * x
 }
 
@@ -40,27 +40,27 @@ func testTopLevelGeneric<T : FloatingPoint>(_ x: T) -> T {
 struct A {
   struct B {
     struct C {
-      @differentiable(reverse, adjoint: dAdd(a:b:primal:seed:))
+      @differentiable(reverse, adjoint: dAdd(seed:primal:a:b:))
       public static func add(a: C, b: C) -> C {
         return a
       }
 
       @usableFromInline internal static func dAdd(
-        a: C, b: C, primal: C, seed: C
+        seed: C, primal: C, a: C, b: C
       ) -> (C, C) {
         return (seed, seed)
       }
 
       @differentiable(
         reverse, wrt: (self, .0),
-        adjoint: dSubtract(a:primal:seed:)
+        adjoint: dSubtract(seed:primal:a:)
       )
       func subtract(a: C) -> C {
         return a
       }
 
       private func dSubtract(
-        a: C, primal: C, seed: C
+        seed: C, primal: C, a: C
       ) -> (C, C) {
         return (seed, seed)
       }
@@ -90,24 +90,24 @@ struct Pair {
   let y: Float
 }
 extension Pair {
-  @differentiable(reverse, adjoint: dAdd(_:_:primal:seed:))
+  @differentiable(reverse, adjoint: dAdd)
   static func + (_ a: Pair, _ b: Pair) -> Pair {
     return Pair(x: a.x+b.x, y: a.y+b.y)
   }
 
   private static func dAdd(
-    _ a: Pair, _ b: Pair, primal: Pair, seed: Pair
+    _ seed: Pair, _ primal: Pair, _ a: Pair, _ b: Pair
   ) -> (Pair, Pair) {
     return (seed, seed)
   }
 
-  @differentiable(reverse, wrt: (self, .0), adjoint: dSubtract(_:primal:seed:))
+  @differentiable(reverse, wrt: (self, .0), adjoint: dSubtract)
   func subtract(_ a: Pair) -> Pair {
     return Pair(x: x-a.x, y: y-a.y)
   }
 
   private func dSubtract(
-    _ a: Pair, primal: Pair, seed: Pair
+    _ seed: Pair, _ primal: Pair, _ a: Pair
   ) -> (Pair, Pair) {
     return (seed, Pair(x: -seed.x, y: -seed.y))
   }
@@ -146,26 +146,26 @@ func testPair() {
 //===----------------------------------------------------------------------===//
 
 struct Vector<T> {
-  @differentiable(reverse, adjoint: dMultiply(_:_:primal:seed:))
+  @differentiable(reverse, adjoint: dMultiply)
   static func * <A : FloatingPoint>(
     _ a: Vector<A>, _ b: Vector<A>
   ) -> Vector<A> {
     return a
   }
 
-  @differentiable(reverse, wrt: (self, .0), adjoint: dDivide(_:primal:seed:))
+  @differentiable(reverse, wrt: (self, .0), adjoint: dDivide)
   func divide<A : FloatingPoint>(_ a: Vector<A>) -> Vector<A> {
     return a
   }
 
   static func dMultiply<A : FloatingPoint>(
-    _ a: Vector<A>, _ b: Vector<A>, primal: Vector<A>, seed: Vector<A>
+    _ seed: Vector<A>, _ primal: Vector<A>, _ a: Vector<A>, _ b: Vector<A>
   ) -> (Vector<A>, Vector<A>) {
     return (seed, seed)
   }
 
   func dDivide<A : FloatingPoint>(
-    _ a: Vector<A>, primal: Vector<A>, seed: Vector<A>
+    _ seed: Vector<A>, _ primal: Vector<A>, _ a: Vector<A>
   ) -> (Vector, Vector<A>) {
     return (self, seed)
   }

--- a/test/AutoDiff/autodiff_basic.sil
+++ b/test/AutoDiff/autodiff_basic.sil
@@ -41,7 +41,7 @@ bb0(%0 : @trivial $Float):
 // CHECK:   %2 = function_ref @foo : $@convention(thin) (Float) -> Float
 // CHECK:   %3 = apply %2(%0) : $@convention(thin) (Float) -> Float
 // CHECK:   %4 = function_ref @foo_adj : $@convention(thin) (Float, Float, Float) -> Float
-// CHECK:   %5 = apply %4(%0, %3, %1) : $@convention(thin) (Float, Float, Float) -> Float
+// CHECK:   %5 = apply %4(%1, %3, %0) : $@convention(thin) (Float, Float, Float) -> Float
 // CHECK:   %6 = tuple (%3 : $Float, %5 : $Float)
 // CHECK:   return %6 : $(Float, Float)
 // CHECK: }

--- a/test/AutoDiff/autodiff_e2e_basic.swift
+++ b/test/AutoDiff/autodiff_e2e_basic.swift
@@ -5,7 +5,7 @@ func id(_ x: Float) -> Float {
   return x
 }
 
-func adjointId(_ x: Float, originalValue: Float, seed: Float) -> Float {
+func adjointId(_ seed: Float, _ originalValue: Float, _ x: Float) -> Float {
   return seed
 }
 
@@ -33,7 +33,7 @@ func primalSigmoid(_ x: Double) -> (checkpoints: (Double, Double, Double), resul
   return (checkpoints: (minusX, expon, plus), result: div)
 }
 
-func adjointSigmoid(_ x: Double, checkpoints: (Double, Double, Double), result: Double, seed: Double) -> Double {
+func adjointSigmoid(_ seed: Double, _ checkpoints: (Double, Double, Double), _ result: Double, _ x: Double) -> Double {
   return result * (1 - result)
 }
 

--- a/test/AutoDiff/builtin_math.sil
+++ b/test/AutoDiff/builtin_math.sil
@@ -134,51 +134,51 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK: }
 
 // CHECK-LABEL: @AD__simple_mul__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $AD__simple_mul__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %6 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__simple_mul__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %6 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %7 = tuple (%5 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32)
 // CHECK:   return %7 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: @AD__simple_div__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $AD__simple_div__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = builtin "fdiv_FPIEEE32"(%4 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %6 = builtin "fneg_FPIEEE32"(%0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %7 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__simple_div__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = builtin "fdiv_FPIEEE32"(%0 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %6 = builtin "fneg_FPIEEE32"(%3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %7 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %8 = builtin "fdiv_FPIEEE32"(%6 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %9 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %8 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %9 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %8 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %10 = tuple (%5 : $Builtin.FPIEEE32, %9 : $Builtin.FPIEEE32)
 // CHECK:   return %10 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: @AD__chain_rule__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $AD__chain_rule__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = struct_extract %2 : $AD__chain_rule__Type__src_0_wrt_0_1, #AD__chain_rule__Type__src_0_wrt_0_1.v_0
-// CHECK:   %6 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %7 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__chain_rule__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = struct_extract %1 : $AD__chain_rule__Type__src_0_wrt_0_1, #AD__chain_rule__Type__src_0_wrt_0_1.v_0
+// CHECK:   %6 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %7 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %8 = builtin "fneg_FPIEEE32"(%7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %9 = tuple (%8 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32)
 // CHECK:   return %9 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: @AD__add_literals__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $AD__add_literals__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = builtin "fneg_FPIEEE32"(%4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %6 = struct_extract %2 : $AD__add_literals__Type__src_0_wrt_0_1, #AD__add_literals__Type__src_0_wrt_0_1.v_0
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__add_literals__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = builtin "fneg_FPIEEE32"(%0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %6 = struct_extract %1 : $AD__add_literals__Type__src_0_wrt_0_1, #AD__add_literals__Type__src_0_wrt_0_1.v_0
 // CHECK:   %7 = builtin "fmul_FPIEEE32"(%5 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %8 = builtin "fmul_FPIEEE32"(%5 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %8 = builtin "fmul_FPIEEE32"(%5 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %9 = builtin "fneg_FPIEEE32"(%8 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %10 = tuple (%9 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32)
 // CHECK:   return %10 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: @AD__fanout__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $AD__fanout__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = struct_extract %2 : $AD__fanout__Type__src_0_wrt_0_1, #AD__fanout__Type__src_0_wrt_0_1.v_0
-// CHECK:   %6 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %7 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %8 = builtin "fmul_FPIEEE32"(%7 : $Builtin.FPIEEE32, %0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__fanout__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = struct_extract %1 : $AD__fanout__Type__src_0_wrt_0_1, #AD__fanout__Type__src_0_wrt_0_1.v_0
+// CHECK:   %6 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %7 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %8 = builtin "fmul_FPIEEE32"(%7 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %9 = builtin "fadd_FPIEEE32"(%6 : $Builtin.FPIEEE32, %8 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %10 = builtin "fadd_FPIEEE32"(%9 : $Builtin.FPIEEE32, %8 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %11 = float_literal $Builtin.FPIEEE32, 0x0

--- a/test/AutoDiff/differentiable_attr_access_control.swift
+++ b/test/AutoDiff/differentiable_attr_access_control.swift
@@ -4,29 +4,29 @@
 // its primal/adjoint must also be exported.
 
 // Ok: all public.
-@differentiable(reverse, adjoint: dfoo1(_:primal:seed:))
+@differentiable(reverse, adjoint: dfoo1)
 public func foo1(_ x: Float) -> Float { return 1 }
-public func dfoo1(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
+public func dfoo1(_ seed: Float, _ primal: Float,_ x: Float) -> Float { return 1 }
 
 // Ok: all internal.
 struct CheckpointsFoo {}
-@differentiable(reverse, primal: pfoo2(_:), adjoint: dfoo2(_:checkpoints:originalValue:seed:))
+@differentiable(reverse, primal: pfoo2(_:), adjoint: dfoo2)
 func foo2(_ x: Float) -> Float { return 1 }
 func pfoo2(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) { return (CheckpointsFoo(), 1) }
-func dfoo2(_ x: Float, checkpoints: CheckpointsFoo, originalValue: Float, seed: Float) -> Float { return 1 }
+func dfoo2(_ seed: Float, _ checkpoints: CheckpointsFoo, _ originalValue: Float, _ x: Float) -> Float { return 1 }
 
 // Ok: all private.
-@differentiable(reverse, adjoint: dfoo3(_:primal:seed:))
+@differentiable(reverse, adjoint: dfoo3)
 private func foo3(_ x: Float) -> Float { return 1 }
-private func dfoo3(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
+private func dfoo3(_ seed: Float, _ primal: Float, _ x: Float) -> Float { return 1 }
 
 // Error: adjoint not exported.
-@differentiable(reverse, adjoint: dbar1(_:primal:seed:)) // expected-error {{associated differentiation function 'dbar1(_:primal:seed:)' is required to either be public or @usableFromInline because the original function 'bar1' is public or @usableFromInline}}
+@differentiable(reverse, adjoint: dbar1) // expected-error {{associated differentiation function 'dbar1' is required to either be public or @usableFromInline because the original function 'bar1' is public or @usableFromInline}}
 public func bar1(_ x: Float) -> Float { return 1 }
-private func dbar1(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
+private func dbar1(_ seed: Float, primal: Float, _ x: Float) -> Float { return 1 }
 
 // Error: primal not exported.
-@differentiable(reverse, primal: pbar2(_:), adjoint: dbar2(_:checkpoints:originalValue:seed:)) // expected-error {{associated differentiation function 'pbar2' is required to either be public or @usableFromInline because the original function 'bar2' is public or @usableFromInline}}
+@differentiable(reverse, primal: pbar2(_:), adjoint: dbar2) // expected-error {{associated differentiation function 'pbar2' is required to either be public or @usableFromInline because the original function 'bar2' is public or @usableFromInline}}
 @usableFromInline func bar2(_ x: Float) -> Float { return 1 }
 func pbar2(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) { return (CheckpointsFoo(), 1) }
-func dbar2(_ x: Float, checkpoints: CheckpointsFoo, originalValue: Float, seed: Float) -> Float { return 1 }
+func dbar2(_ seed: Float, _ checkpoints: CheckpointsFoo, _ originalValue: Float, _ x: Float) -> Float { return 1 }

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -5,7 +5,7 @@
 //===----------------------------------------------------------------------===//
 
 @_silgen_name("foo")
-@differentiable(reverse, adjoint: dfoo(_:_:partial:seed:))
+@differentiable(reverse, adjoint: dfoo)
 public func foo(_ x: Float, _ y: Float) -> Float {
   return 1
 }
@@ -13,7 +13,7 @@ public func foo(_ x: Float, _ y: Float) -> Float {
 // CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 primal @foo adjoint @dfoo primitive] @foo
 
 @_silgen_name("dfoo")
-public func dfoo(_ x: Float, _ y: Float, partial: Float, seed: Float) -> (Float, Float) {
+public func dfoo(_ seed: Float, partial: Float, _ x: Float, _ y: Float) -> (Float, Float) {
   return (1, 1)
 }
 
@@ -24,7 +24,7 @@ public func dfoo(_ x: Float, _ y: Float, partial: Float, seed: Float) -> (Float,
 //===----------------------------------------------------------------------===//
 
 @_silgen_name("foo_indir_ret")
-@differentiable(reverse, adjoint: dfoo_indir_ret(_:_:_:_:))
+@differentiable(reverse, adjoint: dfoo_indir_ret)
 public func foo_indir_ret<T>(_ x: Float, _ y: T) -> T {
   return y
 }
@@ -33,19 +33,19 @@ public func foo_indir_ret<T>(_ x: Float, _ y: T) -> T {
 // CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $Float, %2 : @trivial $*T):
 
 @_silgen_name("dfoo_indir_ret")
-public func dfoo_indir_ret<T>(_ x: Float, _ y: T, _ partial: T, _ seed: T) -> (Float, T) {
+public func dfoo_indir_ret<T>(_ seed: T, _ partial: T, _ x: Float, _ y: T) -> (Float, T) {
   return (x, y)
 }
 
-// CHECK-LABEL: sil @dfoo_indir_ret : $@convention(thin) <T> (Float, @in_guaranteed T, @in_guaranteed T, @in_guaranteed T) -> (Float, @out T) {
-// CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $Float, %2 : @trivial $*T, %3 : @trivial $*T, %4 : @trivial $*T):
+// CHECK-LABEL: sil @dfoo_indir_ret : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T, Float, @in_guaranteed T) -> (Float, @out T) {
+// CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $*T, %2 : @trivial $*T, %3 : @trivial $Float, %4 : @trivial $*T):
 
 //===----------------------------------------------------------------------===//
 // Flattened types
 //===----------------------------------------------------------------------===//
 
 @_silgen_name("foo_tuple")
-@differentiable(reverse, adjoint: dfoo_tuple(_:_:partial:seed:))
+@differentiable(reverse, adjoint: dfoo_tuple)
 public func foo_tuple(_ x: ((Float, (Float, Float)), Float, ((Float))), _ y: Float) -> Float {
   return 1
 }
@@ -53,7 +53,7 @@ public func foo_tuple(_ x: ((Float, (Float, Float)), Float, ((Float))), _ y: Flo
 // CHECK-LABEL: sil [differentiable source 0 wrt 0, 1, 2, 3, 4, 5 primal @foo_tuple adjoint @dfoo_tuple primitive] @foo_tuple : $@convention(thin) (Float, Float, Float, Float, Float, Float) -> Float
 
 @_silgen_name("dfoo_tuple")
-public func dfoo_tuple(_ x: ((Float, (Float, Float)), Float, ((Float))), _ y: Float, partial: Float, seed: Float) -> (((Float, (Float, Float)), Float, ((Float))), Float) {
+public func dfoo_tuple(_ seed: Float, partial: Float, _ x: ((Float, (Float, Float)), Float, ((Float))), _ y: Float) -> (((Float, (Float, Float)), Float, ((Float))), Float) {
   return (((1, (1, 1)), 1, ((1))), 1)
 }
 

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -6,11 +6,11 @@ let x: Float = 1
 @differentiable(reverse, adjoint: dfoo) // expected-error {{@differentiable may only be used on 'func' declarations}}
 protocol P {}
 
-func dfoo(_ x: Float, primal: Float, seed: Float) -> Float {
+func dfoo(_ seed: Float, _ primal: Float, _ x: Float) -> Float {
   return 2 * x
 }
 
-@differentiable(reverse, adjoint: dfoo(_:primal:seed:)) // ok!
+@differentiable(reverse, adjoint: dfoo) // ok!
 func foo(_ x: Float) -> Float {
   return x * x
 }
@@ -28,40 +28,40 @@ func prim_but_no_adj(_ x: Float) -> Float {
 // Original function must return non-Void type.
 @differentiable(reverse, adjoint: dvoid) // expected-error {{cannot differentiate void function 'void'}}
 func void(_ a: Float) {}
-func dvoid(_ a: Float, _ x: (), _ y: ()) -> Float { return 1 }
+func dvoid(_ x: (), _ y: (), _ a: Float) -> Float { return 1 }
 
 // Primal returns custom checkpoints type.
 struct CheckpointsFoo {}
 func pfoo(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) {
   return (CheckpointsFoo(), x * x)
 }
-func dfoo_checkpointed(_ x: Float, checkpoints: CheckpointsFoo, originalValue: Float, seed: Float) -> Float {
+func dfoo_checkpointed(_ seed: Float, _ checkpoints: CheckpointsFoo, _ originalValue: Float, _ x: Float) -> Float {
   return 2 * x
 }
-@differentiable(reverse, primal: pfoo(_:), adjoint: dfoo_checkpointed(_:checkpoints:originalValue:seed:)) // ok!
+@differentiable(reverse, primal: pfoo, adjoint: dfoo_checkpointed) // ok!
 func foo_checkpointed(_ x: Float) -> Float {
   return x * x
 }
 
-func dbar(_ x: Float, _ y: Float, primal: Float, seed: Float) -> (Float, Float) {
+func dbar(_ seed: Float, primal: Float, _ x: Float, _ y: Float) -> (Float, Float) {
   return (1, 1)
 }
 
-@differentiable(reverse, adjoint: dbar(_:_:primal:seed:)) // ok!
+@differentiable(reverse, adjoint: dbar) // ok!
 func bar(_ x: Float, _ y: Float) -> Float {
   return x + y
 }
 
-@differentiable(forward, adjoint: dbar(_:_:primal:seed:)) // expected-error {{forward-mode automatic differentiation is not supported yet}}
+@differentiable(forward, adjoint: dbar) // expected-error {{forward-mode automatic differentiation is not supported yet}}
 func bar_fwd(_ x: Float, _ y: Float) -> Float {
   return x + y
 }
 
-func dfoo2_wrong_type(_ x: Float, primal: Float, seed: Double) -> Float {
+func dfoo2_wrong_type(_ seed: Double, _ primal: Float, _ x: Float) -> Float {
   return 2 * x
 }
 
-@differentiable(reverse, adjoint: dfoo2_wrong_type(_:primal:seed:)) // expected-error {{'dfoo2_wrong_type(_:primal:seed:)' does not have expected type '(Float, Float, Float) -> Float'}}
+@differentiable(reverse, adjoint: dfoo2_wrong_type) // expected-error {{'dfoo2_wrong_type' does not have expected type '(Float, Float, Float) -> Float'}}
 func foo2(_ x: Float) -> Float {
   return x * x
 }
@@ -86,11 +86,11 @@ func meow1(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
-func dmeow1_out_of_S(_ s: S, _ x: Float, _ primal: Float, _ seed: Float) -> (S, Float) {
+func dmeow1_out_of_S(_ seed: Float, _ primal: Float, _ s: S, _ x: Float) -> (S, Float) {
   return (s, x)
 }
 
-func dPlus(_ x: S, _ y: S, _ primal: S, _ seed: S) -> (S, S) {
+func dPlus(_ seed: S, _ primal: S, _ x: S, _ y: S) -> (S, S) {
   return (x, y)
 }
 
@@ -98,7 +98,7 @@ func dPlus_curried(_ x: S.Type) -> (S, S, S, S) -> (S, S) {
   fatalError("never run")
 }
 
-func dPlus(_ x: Int, _ y: S, _ primal: S, _ seed: S) -> (Int, S) {
+func dPlus(_ seed: S, _ primal: S, _ x: Int, _ y: S) -> (Int, S) {
   return (x, y)
 }
 
@@ -144,7 +144,7 @@ struct S {
     return lhs
   }
 
-  static func dMul(_ lhs: Int, _ rhs: S, _: S, _: S) -> (Int, S) {
+  static func dMul(_: S, _: S, _ lhs: Int, _ rhs: S) -> (Int, S) {
     return (lhs, rhs)
   }
 
@@ -153,7 +153,7 @@ struct S {
     return rhs
   }
 
-  @differentiable(reverse, wrt: (.0, .1), adjoint: dMul) // expected-error {{'dMul' does not have expected type '(S) -> (Int, S, S, S) -> (Int, S)'}}
+  @differentiable(reverse, wrt: (.0, .1), adjoint: dMul) // expected-error {{'dMul' does not have expected type '(S) -> (S, S, Int, S) -> (Int, S)'}}
   func instance_mul(lhs: Int, rhs: S) -> S {
     return rhs
   }
@@ -163,7 +163,7 @@ struct S {
     return self
   }
 
-  func dIdentity_wrt_self(_: S, seed: S) -> S {
+  func dIdentity_wrt_self(seed: S, _: S) -> S {
     return seed
   }
 
@@ -172,7 +172,7 @@ struct S {
     return s
   }
 
-  static func dStaticIdentity_wrt_0(_: S, _: S, seed: S) -> S {
+  static func dStaticIdentity_wrt_0(_ seed: S, _: S, _: S) -> S {
     return seed
   }
 }
@@ -188,15 +188,15 @@ func meow3(_ x: Float, _: Float, _: Float) -> Float {
 }
 
 @differentiable(reverse, wrt: (.2, self, .1), adjoint: dmeow1(_:_:_:_:)) // expected-error {{'self' parameter is only applicable to instance methods}}
-func meow4(_ x: Float, _: Float, _: Float) -> Float {
+func meow4(_ : Float, _: Float, _ x: Float) -> Float {
   return 1 + x
 }
 
-func dmeow1(_ x: Float, _: Float, _: Float, _: Float) -> (Float, Float) {
+func dmeow1(_ : Float, _: Float, _: Float, _ x: Float) -> (Float, Float) {
   return (x, x)
 }
 
-func dmeow2(_ x: Float, _: Float, _: Float, _: Float, _: Float) -> (Float, Float) {
+func dmeow2(_ : Float, _: Float, _: Float, _: Float, _ x: Float) -> (Float, Float) {
   return (x, x)
 }
 
@@ -214,7 +214,7 @@ struct E1 {
   }
 }
 extension E1 {
-  func adjoint(x: Float, _: Float, _: Float) -> Float {
+  func adjoint(_: Float, _: Float, _ x: Float) -> Float {
     return x
   }
 }
@@ -228,7 +228,7 @@ extension E2 {
   }
 }
 extension E2 {
-  func adjoint(x: Float, _: Float, _: Float) -> Float {
+  func adjoint(_: Float, _: Float, _ x: Float) -> Float {
     return x
   }
 }
@@ -256,7 +256,7 @@ extension E4 {
   }
 }
 extension E4 {
-  func adjoint_no_constraint(x: Float, _: Float, _: Float) -> Float {
+  func adjoint_no_constraint(_: Float, _: Float, _ x: Float) -> Float {
     return x
   }
 }
@@ -272,7 +272,7 @@ extension E5 {
   }
 }
 extension E5 where T == Float {
-  func adjoint_diff_constraint(x: Float, _: Float, _: Float) -> Float {
+  func adjoint_diff_constraint(_: Float, _: Float, _ x: Float) -> Float {
     return x
   }
 }
@@ -306,25 +306,25 @@ extension E6 {
     return (Checkpoints(e6: self), x)
   }
 
-  func adjoint_checkpointed(x: Float, _: Checkpoints, _: Float, _: Float) -> E6 {
+  func adjoint_checkpointed(_: Float, _: Checkpoints, _: Float, _ x: Float) -> E6 {
     return self
   }
 
-  func adjoint_checkpointed_mismatch(x: Float, _: Float, _: Float) -> E6 {
+  func adjoint_checkpointed_mismatch(_: Float, _: Float, _ x: Float) -> E6 {
     return self
   }
 }
 extension E6 {
-  func adjoint_wrt_self(x: Float, _: Float, _: Float) -> E6 {
+  func adjoint_wrt_self(_: Float, _: Float, _ x: Float) -> E6 {
     return self
   }
 }
 
 // Generic functions with no constraints.
-func dbaz1<T>(_ x: T, _ y: T, primal: T, seed: T) -> (T, T) {
+func dbaz1<T>(_ seed: T, primal: T, _ x: T, _ y: T) -> (T, T) {
   return (y, x)
 }
-@differentiable(reverse, adjoint: dbaz1(_:_:primal:seed:)) // ok!
+@differentiable(reverse, adjoint: dbaz1) // ok!
 func baz1<T>(_ x: T, _ y: T) -> T {
   return x
 }
@@ -332,19 +332,19 @@ func baz1<T>(_ x: T, _ y: T) -> T {
 func pbaz1<T>(_ x: T, _ y: T) -> ((T, T), T) {
   return ((y, y), x)
 }
-func dbaz1_checkpointed<T>(_ x: T, _ y: T, primal: (T, T), originalValue: T, seed: T) -> (T, T) {
+func dbaz1_checkpointed<T>(_ seed: T, _ primal: (T, T), originalValue: T, _ x: T, _ y: T) -> (T, T) {
   return (y, x)
 }
-@differentiable(reverse, primal: pbaz1(_:_:), adjoint: dbaz1_checkpointed(_:_:primal:originalValue:seed:)) // ok!
+@differentiable(reverse, primal: pbaz1, adjoint: dbaz1_checkpointed) // ok!
 func baz1_checkpointed<T>(_ x: T, _ y: T) -> T {
   return x
 }
 
 // Generic functions with matching constraints.
-func dbaz2<T : FloatingPoint>(_ x: T, _ y: T, primal: T, seed: T) -> (T, T) {
+func dbaz2<T : FloatingPoint>(_ seed: T, _ primal: T, _ x: T, _ y: T) -> (T, T) {
   return (1, 1)
 }
-@differentiable(reverse, adjoint: dbaz2(_:_:primal:seed:)) // ok!
+@differentiable(reverse, adjoint: dbaz2) // ok!
 func baz2<T : FloatingPoint>(_ x: T, _ y: T) -> T {
   return x + y
 }
@@ -355,20 +355,20 @@ struct CheckpointsFP<T : FloatingPoint> {
 func pbaz2<T : FloatingPoint>(_ x: T, _ y: T) -> (CheckpointsFP<T>, T) {
   return (CheckpointsFP(meow: 1), x + y)
 }
-func dbaz2_checkpointed<T : FloatingPoint>(_ x: T, _ y: T, primal: CheckpointsFP<T>, originalValue: T, seed: T) -> (T, T) {
+func dbaz2_checkpointed<T : FloatingPoint>(_ seed: T, _ primal: CheckpointsFP<T>, _ originalValue: T, _ x: T, _ y: T) -> (T, T) {
   return (1, 1)
 }
-@differentiable(reverse, primal: pbaz2(_:_:), adjoint: dbaz2_checkpointed(_:_:primal:originalValue:seed:)) // ok!
+@differentiable(reverse, primal: pbaz2, adjoint: dbaz2_checkpointed) // ok!
 func baz2_checkpointed<T : FloatingPoint>(_ x: T, _ y: T) -> T {
   return x
 }
 
 // Generic functions with different constraints.
-func dbaz3<T : Numeric>(_ x: T, _ y: T, primal: T, seed: T) -> (T, T) {
+func dbaz3<T : Numeric>(_ seed: T, _ primal: T, _ x: T, _ y: T) -> (T, T) {
   return (1, 1)
 }
-@differentiable(reverse, adjoint: dbaz3(_:_:primal:seed:))
-// expected-error @-1 {{'dbaz3(_:_:primal:seed:)' does not have expected type '<T where T : FloatingPoint> (T, T, T, T) -> (T, T)'}}
+@differentiable(reverse, adjoint: dbaz3)
+// expected-error @-1 {{'dbaz3' does not have expected type '<T where T : FloatingPoint> (T, T, T, T) -> (T, T)'}}
 func baz3<T : FloatingPoint>(_ x: T, _ y: T) -> T {
   return x + y
 }
@@ -379,10 +379,10 @@ struct CheckpointsNumeric<T : Numeric> {
 func pbaz3<T : Numeric>(_ x: T, _ y: T) -> (CheckpointsNumeric<T>, T) {
   return (CheckpointsNumeric(meow: 1), x + y)
 }
-func dbaz3_checkpointed<T : Numeric>(_ x: T, _ y: T, primal: CheckpointsNumeric<T>, originalValue: T, seed: T) -> (T, T) {
+func dbaz3_checkpointed<T : Numeric>(_ seed: T, _ primal: CheckpointsNumeric<T>, _ originalValue: T, _ x: T, _ y: T) -> (T, T) {
   return (1, 1)
 }
-@differentiable(reverse, primal: pbaz3(_:_:), adjoint: dbaz3_checkpointed(_:_:primal:originalValue:seed:))
+@differentiable(reverse, primal: pbaz3(_:_:), adjoint: dbaz3_checkpointed)
 // expected-error @-1 {{'pbaz3' does not have expected parameters' type '(T, T)'}}
 func baz3_checkpointed<T : FloatingPoint>(_ x: T, _ y: T) -> T {
   return x
@@ -422,7 +422,7 @@ func protocolParameter2(_: ParamProtocol) -> Float {
   return 1
 }
 
-func dProtocolParameter(_: ParamProtocol, _: Float, seed: Float) -> ParamProtocol {
+func dProtocolParameter(_ seed: Float, _: Float, _: ParamProtocol) -> ParamProtocol {
   return ParamProtocolStruct()
 }
 

--- a/test/AutoDiff/generic_real_vector.swift
+++ b/test/AutoDiff/generic_real_vector.swift
@@ -35,7 +35,7 @@ public func * <T>(lhs: Vector<T>, rhs: Vector<T>) -> Vector<T> {
   abort()
 }
 
-public func fakeAdj<T>(lhs: Vector<T>, rhs: Vector<T>, y: Vector<T>, seed: Vector<T>) -> (Vector<T>, Vector<T>) {
+public func fakeAdj<T>(seed: Vector<T>, y: Vector<T>, lhs: Vector<T>, rhs: Vector<T>) -> (Vector<T>, Vector<T>) {
   abort()
 }
 

--- a/test/AutoDiff/method.swift
+++ b/test/AutoDiff/method.swift
@@ -130,7 +130,7 @@ extension CustomParameter {
     return x * x
   }
 
-  func dSquared(origVal: Float, seed: Float) -> CustomParameter {
+  func dSquared(seed: Float, origVal: Float) -> CustomParameter {
     return CustomParameter(x: (2 * x).clamped(to: -10.0...10.0) * seed)
   }
 
@@ -139,7 +139,7 @@ extension CustomParameter {
     return p.x * p.x
   }
 
-  static func dSquared(_ p: CustomParameter, origVal: Float, seed: Float)
+  static func dSquared(_ seed: Float, _ origVal: Float, _ p: CustomParameter)
       -> CustomParameter {
      return CustomParameter(x: (2 * p.x).clamped(to: -10.0...10.0) * seed)
   }
@@ -162,20 +162,20 @@ extension CustomParameter {
     return x * other
   }
 
-  func dMultiplied_wrtAll(with other: Float, origVal: Float, seed: Float)
+  func dMultiplied_wrtAll(seed: Float, origVal: Float, with other: Float)
       -> (CustomParameter, Float) {
     return (CustomParameter(x: other.clamped(to: -10.0...10.0) * seed),
             x.clamped(to: -10.0...10.0) * seed)
   }
 
-  func dMultiplied_wrtOther(with other: Float, origVal: Float, seed: Float)
+  func dMultiplied_wrtOther(seed: Float, origVal: Float, with other: Float)
       -> Float {
-    return dMultiplied_wrtAll(with: other, origVal: origVal, seed: seed).1
+    return dMultiplied_wrtAll(seed: seed, origVal: origVal, with: other).1
   }
 
-  func dMultiplied_wrtSelf(with other: Float, origVal: Float, seed: Float)
+  func dMultiplied_wrtSelf(seed: Float, origVal: Float, with other: Float)
       -> CustomParameter {
-    return dMultiplied_wrtAll(with: other, origVal: origVal, seed: seed).0
+    return dMultiplied_wrtAll(seed: seed, origVal: origVal, with: other).0
   }
 
   @differentiable(reverse, adjoint: dMultiply_wrtAll)
@@ -196,23 +196,23 @@ extension CustomParameter {
     return lhs.x * rhs.x
   }
 
-  static func dMultiply_wrtAll(_ lhs: CustomParameter,_ rhs: CustomParameter,
-                               origValue: Float, seed: Float)
+  static func dMultiply_wrtAll(_ seed: Float, _ origVal: Float,
+                               _ lhs: CustomParameter,_ rhs: CustomParameter)
       -> (CustomParameter, CustomParameter) {
     return (CustomParameter(x: rhs.x.clamped(to: -10.0...10.0) * seed),
             CustomParameter(x: lhs.x.clamped(to: -10.0...10.0) * seed))
   }
 
-  static func dMultiply_wrtLhs(_ lhs: CustomParameter,_ rhs: CustomParameter,
-                               origValue: Float, seed: Float)
+  static func dMultiply_wrtLhs(_ seed: Float, _ origVal: Float,
+                               _ lhs: CustomParameter, _ rhs: CustomParameter)
       -> CustomParameter {
-    return dMultiply_wrtAll(lhs, rhs, origValue: origValue, seed: seed).0
+    return dMultiply_wrtAll(seed, origVal, lhs, rhs).0
   }
 
-  static func dMultiply_wrtRhs(_ lhs: CustomParameter, _ rhs: CustomParameter,
-                               origValue: Float, seed: Float)
+  static func dMultiply_wrtRhs(_ seed: Float, _ origVal: Float,
+                               _ lhs: CustomParameter, _ rhs: CustomParameter)
       -> CustomParameter {
-    return dMultiply_wrtAll(lhs, rhs, origValue: origValue, seed: seed).1
+    return dMultiply_wrtAll(seed, origVal, lhs, rhs).1
   }
 }
 

--- a/test/AutoDiff/simple_real_vector.swift
+++ b/test/AutoDiff/simple_real_vector.swift
@@ -36,7 +36,7 @@ public struct Vector : AdditiveArithmetic, VectorNumeric, Differentiable {
     abort()
   }
 
-  public static func fakeAdj(lhs: Vector, rhs: Vector, y: Vector, seed: Vector) -> (Vector, Vector) {
+  public static func fakeAdj(seed: Vector, y: Vector, lhs: Vector, rhs: Vector) -> (Vector, Vector) {
     abort()
   }
 }

--- a/test/AutoDiff/superset_adjoint.swift
+++ b/test/AutoDiff/superset_adjoint.swift
@@ -13,7 +13,7 @@ func mulxy(_ x: Float, _ y: Float) -> Float {
   }
   return x * y
 }
-func dmulxy(_ x: Float, _ y: Float, primal: Float, seed: Float)
+func dmulxy(_ seed: Float, _ primal: Float, _ x: Float, _ y: Float)
   -> (Float, Float) {
   return (y * seed, x * seed)
 }

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -9,12 +9,12 @@ struct CheckpointsFoo {}
 func pfoo(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) {
   return (CheckpointsFoo(), x * x)
 }
-func dfoo_checkpointed(_ x: Float, checkpoints: CheckpointsFoo, originalValue: Float, seed: Float) -> Float {
+func dfoo_checkpointed(_ seed: Float, _ checkpoints: CheckpointsFoo, _ originalValue: Float, _ x: Float) -> Float {
   return 2 * x
 }
 // CHECK-DAG: @differentiable(reverse, primal: pfoo, adjoint: dfoo_checkpointed)
 // CHECK-DAG: func foo_checkpointed(_ x: Float) -> Float
-@differentiable(reverse, primal: pfoo(_:), adjoint: dfoo_checkpointed(_:checkpoints:originalValue:seed:))
+@differentiable(reverse, primal: pfoo(_:), adjoint: dfoo_checkpointed)
 func foo_checkpointed(_ x: Float) -> Float {
   return x * x
 }
@@ -26,7 +26,7 @@ struct S<T> {
   func primal(x: Float) -> (Checkpoints, Float) {
     return (Checkpoints(s: self), x)
   }
-  func adjoint_checkpointed(x: Float, _: Checkpoints, _: Float, _: Float) -> S {
+  func adjoint_checkpointed(_: Float, _: Checkpoints, _: Float, _ x: Float) -> S {
     return self
   }
 
@@ -41,12 +41,12 @@ struct S<T> {
 func pbaz1<T>(_ x: T, _ y: T) -> ((T, T), T) {
   return ((y, y), x)
 }
-func dbaz1_checkpointed<T>(_ x: T, _ y: T, primal: (T, T), originalValue: T, seed: T) -> (T, T) {
+func dbaz1_checkpointed<T>(_ seed: T, _ primal: (T, T), _ originalValue: T, _ x: T, _ y: T) -> (T, T) {
   return (y, x)
 }
 // CHECK-DAG: @differentiable(reverse, primal: pbaz1, adjoint: dbaz1_checkpointed)
 // CHECK-DAG: func baz1_checkpointed<T>(_ x: T, _ y: T) -> T
-@differentiable(reverse, primal: pbaz1(_:_:), adjoint: dbaz1_checkpointed(_:_:primal:originalValue:seed:))
+@differentiable(reverse, primal: pbaz1(_:_:), adjoint: dbaz1_checkpointed)
 func baz1_checkpointed<T>(_ x: T, _ y: T) -> T {
   return x
 }
@@ -57,12 +57,12 @@ struct CheckpointsFP<T : FloatingPoint> {
 func pbaz2<T : FloatingPoint>(_ x: T, _ y: T) -> (CheckpointsFP<T>, T) {
   return (CheckpointsFP(meow: 1), x + y)
 }
-func dbaz2_checkpointed<T : FloatingPoint>(_ x: T, _ y: T, primal: CheckpointsFP<T>, originalValue: T, seed: T) -> (T, T) {
+func dbaz2_checkpointed<T : FloatingPoint>(_ seed: T, _ primal: CheckpointsFP<T>, _ originalValue: T, _ x: T, _ y: T) -> (T, T) {
   return (1, 1)
 }
 // CHECK-DAG: @differentiable(reverse, primal: pbaz2, adjoint: dbaz2_checkpointed)
 // CHECK-DAG: func baz2_checkpointed<T>(_ x: T, _ y: T) -> T where T : FloatingPoint
-@differentiable(reverse, primal: pbaz2(_:_:), adjoint: dbaz2_checkpointed(_:_:primal:originalValue:seed:))
+@differentiable(reverse, primal: pbaz2(_:_:), adjoint: dbaz2_checkpointed)
 func baz2_checkpointed<T : FloatingPoint>(_ x: T, _ y: T) -> T {
   return x
 }

--- a/test/TensorFlow/adjoint_expr_type_checking.swift
+++ b/test/TensorFlow/adjoint_expr_type_checking.swift
@@ -6,28 +6,28 @@ import TensorFlow
 func sin(_ x: Float) -> Float { return x }
 
 func testSpecialized(_ t: Tensor<Float>) {
-  _ = #adjoint(relu)(t, originalValue: t, seed: t)
-  _ = #adjoint(sin)(t, originalValue: t, seed: t)
+  _ = #adjoint(relu)(t, t, t)
+  _ = #adjoint(sin)(t, t, t)
 
   _ = #adjoint(Tensor<Float>.+)
   let _: (Tensor<Float>, Tensor<Float>, Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>)
     = #adjoint(Tensor.+)
 
   _ = #adjoint(Tensor<Float>.convolved2D)
-  let _: (Tensor<Float>) -> (Tensor<Float>, (Int32, Int32, Int32, Int32), Padding, Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>)
+  let _: (Tensor<Float>) -> (Tensor<Float>, Tensor<Float>, Tensor<Float>, (Int32, Int32, Int32, Int32), Padding) -> (Tensor<Float>, Tensor<Float>)
     = #adjoint(Tensor.convolved2D)
 }
 
 func testGeneric<T : BinaryFloatingPoint>( _ t: Tensor<T>) {
-  let _ = #adjoint(relu)(t, originalValue: t, seed: t)
-  let _ = #adjoint(sin)(t, originalValue: t, seed: t)
+  let _ = #adjoint(relu)(t, t, t)
+  let _ = #adjoint(sin)(t, t, t)
 
   _ = #adjoint(Tensor<T>.+)
   let _: (Tensor<T>, Tensor<T>, Tensor<T>, Tensor<T>) -> (Tensor<T>, Tensor<T>)
     = #adjoint(Tensor.+)
 
   _ = #adjoint(Tensor<T>.convolved2D)
-  let _: (Tensor<T>) -> (Tensor<T>, (Int32, Int32, Int32, Int32), Padding, Tensor<T>, Tensor<T>) -> (Tensor<T>, Tensor<T>)
+  let _: (Tensor<T>) -> (Tensor<T>, Tensor<T>, Tensor<T>, (Int32, Int32, Int32, Int32), Padding) -> (Tensor<T>, Tensor<T>)
     = #adjoint(Tensor.convolved2D)
 }
 
@@ -35,10 +35,10 @@ func testLabels<T : BinaryFloatingPoint>(_ t: Tensor<T>) {
   // If the #adjoint expression is applied directly, argument labels are
   // necessary.
   // This matches the behavior for normal function application.
-  _ = #adjoint(matmul)(t, t, originalValue: t, seed: t)
-  _ = #adjoint(Tensor.+)(t, t, originalValue: t, seed: t)
+  _ = #adjoint(matmul)(t, t, t, t)
+  _ = #adjoint(Tensor.+)(t, t, t, t)
   _ = #adjoint(Tensor.batchNormalized)(t)(
-    alongAxis: 0, offset: 0, scale: 0, epsilon: 0, originalValue: t, seed: t
+    seed: t, originalValue: t, alongAxis: 0, offset: 0, scale: 0, epsilon: 0
   )
 
   // If the #adjoint expression is unapplied and bound to a variable, argument
@@ -49,5 +49,5 @@ func testLabels<T : BinaryFloatingPoint>(_ t: Tensor<T>) {
   let dAdd = #adjoint(Tensor<T>.+)
   _ = dAdd(t, t, t, t)
   let dBatchNorm = #adjoint(Tensor<T>.batchNormalized)
-  _ = dBatchNorm(t)(0, 0, 0, 0, t, t)
+  _ = dBatchNorm(t)(t, t, 0, 0, 0, 0)
 }

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -17,7 +17,7 @@ var TensorADTests = TestSuite("TensorAD")
 TensorADTests.testAllBackends("SimpleAdjointCall") {
   let adjPlus = #adjoint(Tensor<Float>.+)
   let x = Tensor<Float>(1)
-  let (d0, d1) = adjPlus(x, x, x + x, x)
+  let (d0, d1) = adjPlus(x, x + x, x, x)
   expectNearlyEqual(1, d0.scalarized())
   expectNearlyEqual(1, d1.scalarized())
 }
@@ -76,8 +76,8 @@ TensorADTests.testAllBackends("SR-9345: OwnedCheckpoints") {
   func foo(_ x: Tensor<Float>) -> Tensor<Float> {
       return Raw.identity(x)
   }
-  func adjointFoo(_ x: Tensor<Float>, originalValue: Tensor<Float>, 
-                  seed: Tensor<Float>) -> Tensor<Float> {
+  func adjointFoo(_ seed: Tensor<Float>, _ originalValue: Tensor<Float>,
+                  _ x: Tensor<Float>) -> Tensor<Float> {
     return seed
   }
   func body(_ x: Tensor<Float>) -> Tensor<Float> {


### PR DESCRIPTION
This changes the adjoint parameter order from `(originalParameters..., checkpointsStruct?, originalResult, seed)` to `(seed, checkpointsStruct?, originalResult, originalParameters...)`.

The motivation is that this will let us form a JVP by partially applying the adjoint to `(checkpointsStruct?, originalResult, originalParameters...)`.

Of course, this will break any existing user code that defines custom adjoints. Think I should warn on some mailing lists?