### PR TITLE
[benchmark] Janitor Duty, Legacy Factor: A-C

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -496,7 +496,7 @@ class BenchmarkDoctor(object):
         num_samples = self._adjusted_1s_samples(r.samples.min)
 
         def capped(s):
-            return min(s, 2048)
+            return min(s, 200)
         run_args = [(capped(num_samples), 1), (capped(num_samples / 2), 2)]
         opts = self.driver.args.optimization
         opts = opts if isinstance(opts, list) else [opts]

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -533,7 +533,7 @@ class TestBenchmarkDoctor(unittest.TestCase):
 
         Num-samples for Benchmark Driver are calibrated to be powers of two,
         take measurements for approximately 1s
-        based on short initial runtime sampling. Capped at 2k samples.
+        based on short initial runtime sampling. Capped at 200 samples.
         """
         driver = BenchmarkDriverMock(tests=['B1'], responses=([
             # calibration run, returns a stand-in for PerformanceTestResult
@@ -541,10 +541,10 @@ class TestBenchmarkDoctor(unittest.TestCase):
                   verbose=True), _PTR(min=300))] +
             # 5x i1 series, with 300 μs runtime its possible to take 4098
             # samples/s, but it should be capped at 2k
-            ([(_run('B1', num_samples=2048, num_iters=1,
+            ([(_run('B1', num_samples=200, num_iters=1,
                     verbose=True, measure_memory=True), _PTR(min=300))] * 5) +
             # 5x i2 series
-            ([(_run('B1', num_samples=2048, num_iters=2,
+            ([(_run('B1', num_samples=200, num_iters=2,
                     verbose=True, measure_memory=True), _PTR(min=300))] * 5)
         ))
         doctor = BenchmarkDoctor(self.args, driver)
@@ -561,7 +561,7 @@ class TestBenchmarkDoctor(unittest.TestCase):
         self.assert_contains(
             ['Calibrating num-samples for B1:',
              'Runtime 300 μs yields 4096 adjusted samples per second.',
-             'Measuring B1, 5 x i1 (2048 samples), 5 x i2 (2048 samples)'],
+             'Measuring B1, 5 x i1 (200 samples), 5 x i2 (200 samples)'],
             self.logs['debug'])
 
     def test_benchmark_name_matches_capital_words_conventions(self):

--- a/benchmark/single-source/Ackermann.swift
+++ b/benchmark/single-source/Ackermann.swift
@@ -17,7 +17,7 @@ import TestsUtils
 public let Ackermann = BenchmarkInfo(
   name: "Ackermann",
   runFunction: run_Ackermann,
-  tags: [.unstable, .algorithm])
+  tags: [.algorithm])
 
 func ackermann(_ M: Int, _ N : Int) -> Int {
   if (M == 0) { return N + 1 }
@@ -39,7 +39,7 @@ let ref_result = [5, 13, 29, 61, 125, 253, 509, 1021, 2045, 4093, 8189, 16381, 3
 
 @inline(never)
 public func run_Ackermann(_ N: Int) {
-  let (m, n) = (3, 9)
+  let (m, n) = (3, 6)
   var result = 0
   for _ in 1...N {
     result = Ackermann(m, n)

--- a/benchmark/single-source/AngryPhonebook.swift
+++ b/benchmark/single-source/AngryPhonebook.swift
@@ -18,22 +18,15 @@ import Foundation
 public let AngryPhonebook = BenchmarkInfo(
   name: "AngryPhonebook",
   runFunction: run_AngryPhonebook,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  legacyFactor: 7)
 
 var words = [
   "James", "John", "Robert", "Michael", "William", "David", "Richard", "Joseph",
   "Charles", "Thomas", "Christopher", "Daniel", "Matthew", "Donald", "Anthony",
   "Paul", "Mark", "George", "Steven", "Kenneth", "Andrew", "Edward", "Brian",
   "Joshua", "Kevin", "Ronald", "Timothy", "Jason", "Jeffrey", "Gary", "Ryan",
-  "Nicholas", "Eric", "Stephen", "Jacob", "Larry", "Frank", "Jonathan", "Scott",
-  "Justin", "Raymond", "Brandon", "Gregory", "Samuel", "Patrick", "Benjamin",
-  "Jack", "Dennis", "Jerry", "Alexander", "Tyler", "Douglas", "Henry", "Peter",
-  "Walter", "Aaron", "Jose", "Adam", "Harold", "Zachary", "Nathan", "Carl",
-  "Kyle", "Arthur", "Gerald", "Lawrence", "Roger", "Albert", "Keith", "Jeremy",
-  "Terry", "Joe", "Sean", "Willie", "Jesse", "Ralph", "Billy", "Austin", "Bruce",
-  "Christian", "Roy", "Bryan", "Eugene", "Louis", "Harry", "Wayne", "Ethan",
-  "Jordan", "Russell", "Alan", "Philip", "Randy", "Juan", "Howard", "Vincent",
-  "Bobby", "Dylan", "Johnny", "Phillip", "Craig"]
+  "Nicholas", "Eric", "Stephen", "Jacob", "Larry", "Frank"]
 
 @inline(never)
 public func run_AngryPhonebook(_ N: Int) {

--- a/benchmark/single-source/AnyHashableWithAClass.swift
+++ b/benchmark/single-source/AnyHashableWithAClass.swift
@@ -26,10 +26,8 @@ public var AnyHashableWithAClass = BenchmarkInfo(
   name: "AnyHashableWithAClass",
   runFunction: run_AnyHashableWithAClass,
   tags: [.abstraction, .runtime, .cpubench],
-  legacyFactor: lf
+  legacyFactor: 500
 )
-
-let lf = 500
 
 class TestHashableBase : Hashable {
   var value: Int
@@ -58,7 +56,7 @@ class TestHashableDerived5 : TestHashableDerived4 {}
 @inline(never)
 public func run_AnyHashableWithAClass(_ N: Int) {
   let c = TestHashableDerived5(10)
-  for _ in 0...(N*500000/lf) {
+  for _ in 0...(N*1000) {
     _ = AnyHashable(c)
   }
 }

--- a/benchmark/single-source/Array2D.swift
+++ b/benchmark/single-source/Array2D.swift
@@ -17,13 +17,16 @@ public let Array2D = BenchmarkInfo(
   runFunction: run_Array2D,
   tags: [.validation, .api, .Array],
   setUpFunction: { blackHole(inputArray) },
-  tearDownFunction: { inputArray = nil })
+  tearDownFunction: { inputArray = nil },
+  legacyFactor: 16)
+
+let size = 256
 
 var inputArray: [[Int]]! = {
   var A: [[Int]] = []
-  A.reserveCapacity(1024)
-  for _ in 0 ..< 1024 {
-    A.append(Array(0 ..< 1024))
+  A.reserveCapacity(size)
+  for _ in 0 ..< size {
+    A.append(Array(0 ..< size))
   }
   return A
 }()
@@ -31,8 +34,8 @@ var inputArray: [[Int]]! = {
 @inline(never)
 func modifyArray(_ A: inout [[Int]], _ N: Int) {
   for _ in 0..<N {
-    for i in 0 ..< 1024 {
-      for y in 0 ..< 1024 {
+    for i in 0 ..< size {
+      for y in 0 ..< size {
         A[i][y] = A[i][y] + 1
         A[i][y] = A[i][y] - 1
       }

--- a/benchmark/single-source/ArrayAppend.swift
+++ b/benchmark/single-source/ArrayAppend.swift
@@ -16,40 +16,40 @@ import TestsUtils
 
 let t: [BenchmarkCategory] = [.validation, .api, .Array]
 public let ArrayAppend = [
-  BenchmarkInfo(name: "ArrayAppend", runFunction: run_ArrayAppend, tags: t),
+  BenchmarkInfo(name: "ArrayAppend", runFunction: run_ArrayAppend, tags: t, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendArrayOfInt", runFunction: run_ArrayAppendArrayOfInt, tags: t,
-    setUpFunction: ones, tearDownFunction: releaseOnes),
-  BenchmarkInfo(name: "ArrayAppendAscii", runFunction: run_ArrayAppendAscii, tags: t),
-  BenchmarkInfo(name: "ArrayAppendAsciiSubstring", runFunction: run_ArrayAppendAsciiSubstring, tags: t),
+    setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
+  BenchmarkInfo(name: "ArrayAppendAscii", runFunction: run_ArrayAppendAscii, tags: t, legacyFactor: 11),
+  BenchmarkInfo(name: "ArrayAppendAsciiSubstring", runFunction: run_ArrayAppendAsciiSubstring, tags: t, legacyFactor: 11),
   BenchmarkInfo(name: "ArrayAppendFromGeneric", runFunction: run_ArrayAppendFromGeneric, tags: t,
-    setUpFunction: ones, tearDownFunction: releaseOnes),
+    setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendGenericStructs", runFunction: run_ArrayAppendGenericStructs, tags: t,
     setUpFunction: { otherStructs = Array(repeating: S(x: 3, y: 4.2), count: 10_000) },
-    tearDownFunction: {  otherStructs = nil } ),
-  BenchmarkInfo(name: "ArrayAppendLatin1", runFunction: run_ArrayAppendLatin1, tags: t),
-  BenchmarkInfo(name: "ArrayAppendLatin1Substring", runFunction: run_ArrayAppendLatin1Substring, tags: t),
+    tearDownFunction: {  otherStructs = nil }, legacyFactor: 10),
+  BenchmarkInfo(name: "ArrayAppendLatin1", runFunction: run_ArrayAppendLatin1, tags: t, legacyFactor: 11),
+  BenchmarkInfo(name: "ArrayAppendLatin1Substring", runFunction: run_ArrayAppendLatin1Substring, tags: t, legacyFactor: 11),
   BenchmarkInfo(name: "ArrayAppendLazyMap", runFunction: run_ArrayAppendLazyMap, tags: t,
-    setUpFunction: { blackHole(array) }),
+    setUpFunction: { blackHole(array) }, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendOptionals", runFunction: run_ArrayAppendOptionals, tags: t,
     setUpFunction: { otherOptionalOnes = Array(repeating: 1, count: 10_000) },
-    tearDownFunction: {  otherOptionalOnes = nil } ),
-  BenchmarkInfo(name: "ArrayAppendRepeatCol", runFunction: run_ArrayAppendRepeatCol, tags: t),
-  BenchmarkInfo(name: "ArrayAppendReserved", runFunction: run_ArrayAppendReserved, tags: t),
-  BenchmarkInfo(name: "ArrayAppendSequence", runFunction: run_ArrayAppendSequence, tags: t),
+    tearDownFunction: {  otherOptionalOnes = nil }, legacyFactor: 10),
+  BenchmarkInfo(name: "ArrayAppendRepeatCol", runFunction: run_ArrayAppendRepeatCol, tags: t, legacyFactor: 10),
+  BenchmarkInfo(name: "ArrayAppendReserved", runFunction: run_ArrayAppendReserved, tags: t, legacyFactor: 10),
+  BenchmarkInfo(name: "ArrayAppendSequence", runFunction: run_ArrayAppendSequence, tags: t, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendStrings", runFunction: run_ArrayAppendStrings, tags: t,
     setUpFunction: { otherStrings = stride(from: 0, to: 10_000, by: 1).map { "\($0)" } },
-    tearDownFunction: {  otherStrings = nil } ),
+    tearDownFunction: {  otherStrings = nil }, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendToFromGeneric", runFunction: run_ArrayAppendToFromGeneric, tags: t,
-    setUpFunction: ones, tearDownFunction: releaseOnes),
+    setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendToGeneric", runFunction: run_ArrayAppendToGeneric, tags: t,
-    setUpFunction: ones, tearDownFunction: releaseOnes),
-  BenchmarkInfo(name: "ArrayAppendUTF16", runFunction: run_ArrayAppendUTF16, tags: t),
-  BenchmarkInfo(name: "ArrayAppendUTF16Substring", runFunction: run_ArrayAppendUTF16Substring, tags: t),
+    setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
+  BenchmarkInfo(name: "ArrayAppendUTF16", runFunction: run_ArrayAppendUTF16, tags: t, legacyFactor: 11),
+  BenchmarkInfo(name: "ArrayAppendUTF16Substring", runFunction: run_ArrayAppendUTF16Substring, tags: t, legacyFactor: 11),
   BenchmarkInfo(name: "ArrayPlusEqualArrayOfInt", runFunction: run_ArrayPlusEqualArrayOfInt, tags: t,
-    setUpFunction: ones, tearDownFunction: releaseOnes),
-  BenchmarkInfo(name: "ArrayPlusEqualFiveElementCollection", runFunction: run_ArrayPlusEqualFiveElementCollection, tags: t),
-  BenchmarkInfo(name: "ArrayPlusEqualSingleElementCollection", runFunction: run_ArrayPlusEqualSingleElementCollection, tags: t),
-  BenchmarkInfo(name: "ArrayPlusEqualThreeElements", runFunction: run_ArrayPlusEqualThreeElements, tags: t),
+    setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
+  BenchmarkInfo(name: "ArrayPlusEqualFiveElementCollection", runFunction: run_ArrayPlusEqualFiveElementCollection, tags: t, legacyFactor: 49),
+  BenchmarkInfo(name: "ArrayPlusEqualSingleElementCollection", runFunction: run_ArrayPlusEqualSingleElementCollection, tags: t, legacyFactor: 40),
+  BenchmarkInfo(name: "ArrayPlusEqualThreeElements", runFunction: run_ArrayPlusEqualThreeElements, tags: t, legacyFactor: 10),
 ]
 
 var otherOnes: [Int]!
@@ -65,11 +65,9 @@ func releaseOnes() { otherOnes = nil }
 @inline(never)
 public func run_ArrayAppend(_ N: Int) {
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [Int]()
-       for _ in 0..<40000 {
-         nums.append(1)
-       }
+    var nums = [Int]()
+    for _ in 0..<40000 {
+      nums.append(1)
     }
   }
 }
@@ -78,12 +76,10 @@ public func run_ArrayAppend(_ N: Int) {
 @inline(never)
 public func run_ArrayAppendReserved(_ N: Int) {
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [Int]()
-       nums.reserveCapacity(40000)
-       for _ in 0..<40000 {
-         nums.append(1)
-       }
+    var nums = [Int]()
+    nums.reserveCapacity(40000)
+    for _ in 0..<40000 {
+      nums.append(1)
     }
   }
 }
@@ -95,11 +91,9 @@ public func run_ArrayAppendSequence(_ N: Int) {
   let seq = stride(from: 0, to: 10_000, by: 1)
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [Int]()
-      for _ in 0..<8 {
-        nums.append(contentsOf: seq)
-      }
+    var nums = [Int]()
+    for _ in 0..<8 {
+      nums.append(contentsOf: seq)
     }
   }
 }
@@ -111,11 +105,9 @@ public func run_ArrayAppendArrayOfInt(_ N: Int) {
   let other: [Int] = otherOnes
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [Int]()
-      for _ in 0..<8 {
-        nums.append(contentsOf: other)
-      }
+    var nums = [Int]()
+    for _ in 0..<8 {
+      nums.append(contentsOf: other)
     }
   }
 }
@@ -127,11 +119,9 @@ public func run_ArrayPlusEqualArrayOfInt(_ N: Int) {
   let other: [Int] = otherOnes
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [Int]()
-      for _ in 0..<8 {
-        nums += other
-      }
+    var nums = [Int]()
+    for _ in 0..<8 {
+      nums += other
     }
   }
 }
@@ -143,12 +133,10 @@ public func run_ArrayAppendStrings(_ N: Int) {
   let other: [String] = otherStrings
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [String]()
-      // lower inner count due to string slowness
-      for _ in 0..<4 {
-        nums += other
-      }
+    var nums = [String]()
+    // lower inner count due to string slowness
+    for _ in 0..<4 {
+      nums += other
     }
   }
 }
@@ -165,11 +153,9 @@ public func run_ArrayAppendGenericStructs(_ N: Int) {
   let other: [S<Int, Double>] = otherStructs
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [S<Int, Double>]()
-      for _ in 0..<8 {
-        nums += other
-      }
+    var nums = [S<Int,Double>]()
+    for _ in 0..<8 {
+      nums += other
     }
   }
 }
@@ -181,11 +167,9 @@ public func run_ArrayAppendOptionals(_ N: Int) {
   let other: [Int?] = otherOptionalOnes
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [Int?]()
-      for _ in 0..<8 {
-        nums += other
-      }
+    var nums = [Int?]()
+    for _ in 0..<8 {
+      nums += other
     }
   }
 }
@@ -198,11 +182,9 @@ public func run_ArrayAppendLazyMap(_ N: Int) {
   let other = array.lazy.map { $0 * 2 }
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [Int]()
-      for _ in 0..<8 {
-        nums += other
-      }
+    var nums = [Int]()
+    for _ in 0..<8 {
+      nums += other
     }
   }
 }
@@ -215,11 +197,9 @@ public func run_ArrayAppendRepeatCol(_ N: Int) {
   let other = repeatElement(1, count: 10_000)
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [Int]()
-      for _ in 0..<8 {
-        nums += other
-      }
+    var nums = [Int]()
+    for _ in 0..<8 {
+      nums += other
     }
   }
 }
@@ -238,11 +218,9 @@ public func run_ArrayAppendFromGeneric(_ N: Int) {
   let other: [Int] = otherOnes
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [Int]()
-      for _ in 0..<8 {
-        appendFromGeneric(array: &nums, sequence: other)
-      }
+    var nums = [Int]()
+    for _ in 0..<8 {
+      appendFromGeneric(array: &nums, sequence: other)
     }
   }
 }
@@ -260,11 +238,9 @@ public func run_ArrayAppendToGeneric(_ N: Int) {
   let other: [Int] = otherOnes
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [Int]()
-      for _ in 0..<8 {
-        appendToGeneric(collection: &nums, array: other)
-      }
+    var nums = [Int]()
+    for _ in 0..<8 {
+      appendToGeneric(collection: &nums, array: other)
     }
   }
 }
@@ -284,11 +260,9 @@ public func run_ArrayAppendToFromGeneric(_ N: Int) {
   let other: [Int] = otherOnes
 
   for _ in 0..<N {
-    for _ in 0..<10 {
-      var nums = [Int]()
-      for _ in 0..<8 {
-        appendToFromGeneric(collection: &nums, sequence: other)
-      }
+    var nums = [Int]()
+    for _ in 0..<8 {
+      appendToFromGeneric(collection: &nums, sequence: other)
     }
   }
 }
@@ -297,11 +271,9 @@ public func run_ArrayAppendToFromGeneric(_ N: Int) {
 @inline(never)
 public func run_ArrayPlusEqualSingleElementCollection(_ N: Int) {
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [Int]()
-       for _ in 0..<40_000 {
-         nums += [1]
-       }
+    var nums = [Int]()
+    for _ in 0..<10_000 {
+      nums += [1]
     }
   }
 }
@@ -310,11 +282,9 @@ public func run_ArrayPlusEqualSingleElementCollection(_ N: Int) {
 @inline(never)
 public func run_ArrayPlusEqualFiveElementCollection(_ N: Int) {
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [Int]()
-       for _ in 0..<40_000 {
-         nums += [1, 2, 3, 4, 5]
-       }
+    var nums = [Int]()
+    for _ in 0..<10_000 {
+      nums += [1, 2, 3, 4, 5]
     }
   }
 }
@@ -326,7 +296,7 @@ public func appendThreeElements(_ a: inout [Int]) {
 
 @inline(never)
 public func run_ArrayPlusEqualThreeElements(_ N: Int) {
-  for _ in 0..<(10_000 * N) {
+  for _ in 0..<(1_000 * N) {
     var a: [Int] = []
     appendThreeElements(&a)
   }
@@ -337,11 +307,9 @@ public func run_ArrayPlusEqualThreeElements(_ N: Int) {
 public func run_ArrayAppendAscii(_ N: Int) {
   let s = "the quick brown fox jumps over the lazy dog!"
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [UInt8]()
-       for _ in 0..<10_000 {
-         nums += getString(s).utf8
-       }
+    var nums = [UInt8]()
+    for _ in 0..<10_000 {
+      nums += getString(s).utf8
     }
   }
 }
@@ -351,11 +319,9 @@ public func run_ArrayAppendAscii(_ N: Int) {
 public func run_ArrayAppendLatin1(_ N: Int) {
   let s = "the quick brown fox jumps over the lazy dog\u{00A1}"
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [UInt8]()
-       for _ in 0..<10_000 {
-         nums += getString(s).utf8
-       }
+    var nums = [UInt8]()
+    for _ in 0..<10_000 {
+      nums += getString(s).utf8
     }
   }
 }
@@ -365,11 +331,9 @@ public func run_ArrayAppendLatin1(_ N: Int) {
 public func run_ArrayAppendUTF16(_ N: Int) {
   let s = "the quick brown 🦊 jumps over the lazy dog"
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [UInt8]()
-       for _ in 0..<10_000 {
-         nums += getString(s).utf8
-       }
+    var nums = [UInt8]()
+    for _ in 0..<10_000 {
+      nums += getString(s).utf8
     }
   }
 }
@@ -379,11 +343,9 @@ public func run_ArrayAppendUTF16(_ N: Int) {
 public func run_ArrayAppendAsciiSubstring(_ N: Int) {
   let s = "the quick brown fox jumps over the lazy dog!"[...]
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [UInt8]()
-       for _ in 0..<10_000 {
-         nums += getSubstring(s).utf8
-       }
+    var nums = [UInt8]()
+    for _ in 0..<10_000 {
+      nums += getSubstring(s).utf8
     }
   }
 }
@@ -393,11 +355,9 @@ public func run_ArrayAppendAsciiSubstring(_ N: Int) {
 public func run_ArrayAppendLatin1Substring(_ N: Int) {
   let s = "the quick brown fox jumps over the lazy dog\u{00A1}"[...]
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [UInt8]()
-       for _ in 0..<10_000 {
-         nums += getSubstring(s).utf8
-       }
+    var nums = [UInt8]()
+    for _ in 0..<10_000 {
+      nums += getSubstring(s).utf8
     }
   }
 }
@@ -407,11 +367,9 @@ public func run_ArrayAppendLatin1Substring(_ N: Int) {
 public func run_ArrayAppendUTF16Substring(_ N: Int) {
   let s = "the quick brown 🦊 jumps over the lazy dog"[...]
   for _ in 0..<N {
-    for _ in 0..<10 {
-       var nums = [UInt8]()
-       for _ in 0..<10_000 {
-         nums += getSubstring(s).utf8
-       }
+    var nums = [UInt8]()
+    for _ in 0..<10_000 {
+      nums += getSubstring(s).utf8
     }
   }
 }

--- a/benchmark/single-source/ArrayAppend.swift
+++ b/benchmark/single-source/ArrayAppend.swift
@@ -19,15 +19,15 @@ public let ArrayAppend = [
   BenchmarkInfo(name: "ArrayAppend", runFunction: run_ArrayAppend, tags: t, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendArrayOfInt", runFunction: run_ArrayAppendArrayOfInt, tags: t,
     setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
-  BenchmarkInfo(name: "ArrayAppendAscii", runFunction: run_ArrayAppendAscii, tags: t, legacyFactor: 11),
-  BenchmarkInfo(name: "ArrayAppendAsciiSubstring", runFunction: run_ArrayAppendAsciiSubstring, tags: t, legacyFactor: 11),
+  BenchmarkInfo(name: "ArrayAppendAscii", runFunction: run_ArrayAppendAscii, tags: t, legacyFactor: 34),
+  BenchmarkInfo(name: "ArrayAppendAsciiSubstring", runFunction: run_ArrayAppendAsciiSubstring, tags: t, legacyFactor: 36),
   BenchmarkInfo(name: "ArrayAppendFromGeneric", runFunction: run_ArrayAppendFromGeneric, tags: t,
     setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendGenericStructs", runFunction: run_ArrayAppendGenericStructs, tags: t,
     setUpFunction: { otherStructs = Array(repeating: S(x: 3, y: 4.2), count: 10_000) },
     tearDownFunction: {  otherStructs = nil }, legacyFactor: 10),
-  BenchmarkInfo(name: "ArrayAppendLatin1", runFunction: run_ArrayAppendLatin1, tags: t, legacyFactor: 11),
-  BenchmarkInfo(name: "ArrayAppendLatin1Substring", runFunction: run_ArrayAppendLatin1Substring, tags: t, legacyFactor: 11),
+  BenchmarkInfo(name: "ArrayAppendLatin1", runFunction: run_ArrayAppendLatin1, tags: t, legacyFactor: 34),
+  BenchmarkInfo(name: "ArrayAppendLatin1Substring", runFunction: run_ArrayAppendLatin1Substring, tags: t, legacyFactor: 36),
   BenchmarkInfo(name: "ArrayAppendLazyMap", runFunction: run_ArrayAppendLazyMap, tags: t,
     setUpFunction: { blackHole(array) }, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendOptionals", runFunction: run_ArrayAppendOptionals, tags: t,
@@ -43,12 +43,12 @@ public let ArrayAppend = [
     setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
   BenchmarkInfo(name: "ArrayAppendToGeneric", runFunction: run_ArrayAppendToGeneric, tags: t,
     setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
-  BenchmarkInfo(name: "ArrayAppendUTF16", runFunction: run_ArrayAppendUTF16, tags: t, legacyFactor: 11),
-  BenchmarkInfo(name: "ArrayAppendUTF16Substring", runFunction: run_ArrayAppendUTF16Substring, tags: t, legacyFactor: 11),
+  BenchmarkInfo(name: "ArrayAppendUTF16", runFunction: run_ArrayAppendUTF16, tags: t, legacyFactor: 34),
+  BenchmarkInfo(name: "ArrayAppendUTF16Substring", runFunction: run_ArrayAppendUTF16Substring, tags: t, legacyFactor: 36),
   BenchmarkInfo(name: "ArrayPlusEqualArrayOfInt", runFunction: run_ArrayPlusEqualArrayOfInt, tags: t,
     setUpFunction: ones, tearDownFunction: releaseOnes, legacyFactor: 10),
-  BenchmarkInfo(name: "ArrayPlusEqualFiveElementCollection", runFunction: run_ArrayPlusEqualFiveElementCollection, tags: t, legacyFactor: 49),
-  BenchmarkInfo(name: "ArrayPlusEqualSingleElementCollection", runFunction: run_ArrayPlusEqualSingleElementCollection, tags: t, legacyFactor: 40),
+  BenchmarkInfo(name: "ArrayPlusEqualFiveElementCollection", runFunction: run_ArrayPlusEqualFiveElementCollection, tags: t, legacyFactor: 37),
+  BenchmarkInfo(name: "ArrayPlusEqualSingleElementCollection", runFunction: run_ArrayPlusEqualSingleElementCollection, tags: t, legacyFactor: 47),
   BenchmarkInfo(name: "ArrayPlusEqualThreeElements", runFunction: run_ArrayPlusEqualThreeElements, tags: t, legacyFactor: 10),
 ]
 
@@ -308,7 +308,7 @@ public func run_ArrayAppendAscii(_ N: Int) {
   let s = "the quick brown fox jumps over the lazy dog!"
   for _ in 0..<N {
     var nums = [UInt8]()
-    for _ in 0..<10_000 {
+    for _ in 0..<3_000 {
       nums += getString(s).utf8
     }
   }
@@ -320,7 +320,7 @@ public func run_ArrayAppendLatin1(_ N: Int) {
   let s = "the quick brown fox jumps over the lazy dog\u{00A1}"
   for _ in 0..<N {
     var nums = [UInt8]()
-    for _ in 0..<10_000 {
+    for _ in 0..<3_000 {
       nums += getString(s).utf8
     }
   }
@@ -332,7 +332,7 @@ public func run_ArrayAppendUTF16(_ N: Int) {
   let s = "the quick brown 🦊 jumps over the lazy dog"
   for _ in 0..<N {
     var nums = [UInt8]()
-    for _ in 0..<10_000 {
+    for _ in 0..<3_000 {
       nums += getString(s).utf8
     }
   }
@@ -344,7 +344,7 @@ public func run_ArrayAppendAsciiSubstring(_ N: Int) {
   let s = "the quick brown fox jumps over the lazy dog!"[...]
   for _ in 0..<N {
     var nums = [UInt8]()
-    for _ in 0..<10_000 {
+    for _ in 0..<3_000 {
       nums += getSubstring(s).utf8
     }
   }
@@ -356,7 +356,7 @@ public func run_ArrayAppendLatin1Substring(_ N: Int) {
   let s = "the quick brown fox jumps over the lazy dog\u{00A1}"[...]
   for _ in 0..<N {
     var nums = [UInt8]()
-    for _ in 0..<10_000 {
+    for _ in 0..<3_000 {
       nums += getSubstring(s).utf8
     }
   }
@@ -368,7 +368,7 @@ public func run_ArrayAppendUTF16Substring(_ N: Int) {
   let s = "the quick brown 🦊 jumps over the lazy dog"[...]
   for _ in 0..<N {
     var nums = [UInt8]()
-    for _ in 0..<10_000 {
+    for _ in 0..<3_000 {
       nums += getSubstring(s).utf8
     }
   }

--- a/benchmark/single-source/ArraySubscript.swift
+++ b/benchmark/single-source/ArraySubscript.swift
@@ -29,20 +29,18 @@ public func run_ArraySubscript(_ N: Int) {
   func bound(_ x: Int) -> Int { return min(x, numArrayElements-1) }
 
   for _ in 1...N {
-
-  var arrays = [[Int]](repeating: [], count: numArrays)
-  for i in 0..<numArrays {
-    for _ in 0..<numArrayElements {
-      arrays[i].append(Int(truncatingIfNeeded: Random()))
+    var arrays = [[Int]](repeating: [], count: numArrays)
+    for i in 0..<numArrays {
+      for _ in 0..<numArrayElements {
+        arrays[i].append(Int(truncatingIfNeeded: Random()))
+      }
     }
-  }
 
-  // Do a max up the diagonal.
-  for i in 1..<numArrays {
-    arrays[i][bound(i)] =
-      max(arrays[i-1][bound(i-1)], arrays[i][bound(i)])
-  }
-  CheckResults(arrays[0][0] <= arrays[numArrays-1][bound(numArrays-1)])
-
+    // Do a max up the diagonal.
+    for i in 1..<numArrays {
+      arrays[i][bound(i)] =
+        max(arrays[i-1][bound(i-1)], arrays[i][bound(i)])
+    }
+    CheckResults(arrays[0][0] <= arrays[numArrays-1][bound(numArrays-1)])
   }
 }

--- a/benchmark/single-source/ArraySubscript.swift
+++ b/benchmark/single-source/ArraySubscript.swift
@@ -16,16 +16,19 @@ import TestsUtils
 public let ArraySubscript = BenchmarkInfo(
   name: "ArraySubscript",
   runFunction: run_ArraySubscript,
-  tags: [.validation, .api, .Array])
+  tags: [.validation, .api, .Array],
+  legacyFactor: 4)
 
 @inline(never)
 public func run_ArraySubscript(_ N: Int) {
   SRand()
 
-  let numArrays = 200*N
+  let numArrays = 50
   let numArrayElements = 100
 
   func bound(_ x: Int) -> Int { return min(x, numArrayElements-1) }
+
+  for _ in 1...N {
 
   var arrays = [[Int]](repeating: [], count: numArrays)
   for i in 0..<numArrays {
@@ -40,4 +43,6 @@ public func run_ArraySubscript(_ N: Int) {
       max(arrays[i-1][bound(i-1)], arrays[i][bound(i)])
   }
   CheckResults(arrays[0][0] <= arrays[numArrays-1][bound(numArrays-1)])
+
+  }
 }

--- a/benchmark/single-source/COWArrayGuaranteedParameterOverhead.swift
+++ b/benchmark/single-source/COWArrayGuaranteedParameterOverhead.swift
@@ -18,7 +18,9 @@ import TestsUtils
 public let COWArrayGuaranteedParameterOverhead = BenchmarkInfo(
   name: "COWArrayGuaranteedParameterOverhead",
   runFunction: run_COWArrayGuaranteedParameterOverhead,
-  tags: [.regression, .abstraction, .refcount])
+  tags: [.regression, .abstraction, .refcount],
+  legacyFactor: 50
+)
 
 @inline(never)
 func caller() {
@@ -36,7 +38,7 @@ func callee(_ x: [Int]) -> [Int] {
 
 @inline(never)
 public func run_COWArrayGuaranteedParameterOverhead(_ N: Int) {
-  for _ in 0..<N*20000 {
+  for _ in 0..<N*400 {
     caller()
   }
 }

--- a/benchmark/single-source/COWTree.swift
+++ b/benchmark/single-source/COWTree.swift
@@ -8,7 +8,8 @@ import TestsUtils
 public var COWTree = BenchmarkInfo(
   name: "COWTree",
   runFunction: run_COWTree,
-  tags: [.validation, .abstraction, .String]
+  tags: [.validation, .abstraction, .String],
+  legacyFactor: 20
 )
 
 @inline(never)
@@ -17,7 +18,7 @@ public func run_COWTree(_ N: Int) {
   var tree2 = Tree<String>()
   var tree3 = Tree<String>()
 
-  for _ in 1...1000*N {
+  for _ in 1...50*N {
     tree1 = Tree<String>()
     tree1.insert("Emily")
     tree2 = tree1

--- a/benchmark/single-source/CSVParsing.swift
+++ b/benchmark/single-source/CSVParsing.swift
@@ -4,19 +4,19 @@ public let CSVParsing = BenchmarkInfo(
     runFunction: run_CSVParsing,
     tags: [.miniapplication, .api, .String],
     setUpFunction: { buildWorkload() },
-    tearDownFunction: nil)
+    legacyFactor: 11)
 public let CSVParsingAlt = BenchmarkInfo(
     name: "CSVParsingAlt2",
     runFunction: run_CSVParsingAlt,
     tags: [.miniapplication, .api, .String],
     setUpFunction: { buildWorkload() },
-    tearDownFunction: nil)
+    legacyFactor: 11)
 public let CSVParsingAltIndices = BenchmarkInfo(
     name: "CSVParsingAltIndices2",
     runFunction: run_CSVParsingAltIndices,
     tags: [.miniapplication, .api, .String],
     setUpFunction: { buildWorkload() },
-    tearDownFunction: nil)
+    legacyFactor: 11)
 
 struct ParseError: Error {
     var message: String
@@ -198,7 +198,7 @@ let workloadBase = """
     一,二,三,四,五,六,七,
     saquui,ta'lo,tso'i,nvgi,hisgi,sudali,galiquogi
     """
-let targetRowNumber = 500
+let targetRowNumber = 50
 let repeatCount = targetRowNumber / workloadBase.split(separator: "\n").count
 let workload: String = repeatElement(workloadBase, count: repeatCount).joined()
 
@@ -247,4 +247,3 @@ public func run_CSVParsingAltIndices(_ N: Int) {
         blackHole(contents.parseAltIndices())
     }
 }
-

--- a/benchmark/single-source/CString.swift
+++ b/benchmark/single-source/CString.swift
@@ -20,7 +20,7 @@ import Darwin
 public let CString = [
   BenchmarkInfo(name: "CStringLongAscii", runFunction: run_CStringLongAscii, tags: [.validation, .api, .String, .bridging]),
   BenchmarkInfo(name: "CStringLongNonAscii", runFunction: run_CStringLongNonAscii, tags: [.validation, .api, .String, .bridging]),
-  BenchmarkInfo(name: "CStringShortAscii", runFunction: run_CStringShortAscii, tags: [.validation, .api, .String, .bridging]),
+  BenchmarkInfo(name: "CStringShortAscii", runFunction: run_CStringShortAscii, tags: [.validation, .api, .String, .bridging], legacyFactor: 10),
   BenchmarkInfo(name: "StringWithCString2", runFunction: run_StringWithCString, tags: [.validation, .api, .String, .bridging],
       setUpFunction: { blackHole(repeatedStr) }, tearDownFunction: { repeatedStr = nil })
 ]
@@ -86,7 +86,7 @@ public func run_CStringShortAscii(_ N: Int) {
   }
 
   var res = Int.max
-  for _ in 1...100*N {
+  for _ in 1...10*N {
     let strings = input.map {
       $0.withCString(String.init(cString:))
     }

--- a/benchmark/single-source/CaptureProp.swift
+++ b/benchmark/single-source/CaptureProp.swift
@@ -15,7 +15,8 @@ import TestsUtils
 public let CaptureProp = BenchmarkInfo(
   name: "CaptureProp",
   runFunction: run_CaptureProp,
-  tags: [.validation, .api, .refcount])
+  tags: [.validation, .api, .refcount],
+  legacyFactor: 10)
 
 func sum(_ x:Int, y:Int) -> Int {
   return x + y
@@ -33,7 +34,7 @@ func benchCaptureProp<S : Sequence
 
 public func run_CaptureProp(_ N: Int) {
   let a = 1...10_000
-  for _ in 1...100*N {
+  for _ in 1...10*N {
     _ = benchCaptureProp(a, sum)
   }
 }

--- a/benchmark/single-source/ChainedFilterMap.swift
+++ b/benchmark/single-source/ChainedFilterMap.swift
@@ -1,8 +1,12 @@
 import TestsUtils
 
 public var ChainedFilterMap = [
-  BenchmarkInfo(name: "ChainedFilterMap", runFunction: run_ChainedFilterMap, tags: [.algorithm]),
-  BenchmarkInfo(name: "FatCompactMap", runFunction: run_FatCompactMap, tags: [.algorithm])
+  BenchmarkInfo(name: "ChainedFilterMap", runFunction: run_ChainedFilterMap,
+    tags: [.algorithm], setUpFunction: { blackHole(first100k) },
+    legacyFactor: 9),
+  BenchmarkInfo(name: "FatCompactMap", runFunction: run_FatCompactMap,
+    tags: [.algorithm], setUpFunction: { blackHole(first100k) },
+    legacyFactor: 10)
 ]
 
 public let first100k = Array(0...100_000-1)
@@ -10,7 +14,7 @@ public let first100k = Array(0...100_000-1)
 @inline(never)
 public func run_ChainedFilterMap(_ N: Int) {
   var result = 0
-  for _ in 1...10*N {
+  for _ in 1...N {
     let numbers = first100k.lazy
       .filter { $0 % 3 == 0 }
       .map { $0 * 2 }
@@ -25,7 +29,7 @@ public func run_ChainedFilterMap(_ N: Int) {
 @inline(never)
 public func run_FatCompactMap(_ N: Int) {
   var result = 0
-  for _ in 1...10*N {
+  for _ in 1...N {
     let numbers = first100k.lazy
       .compactMap { (x: Int) -> Int? in
         if x % 3 != 0 { return nil }

--- a/benchmark/single-source/CharacterProperties.swift
+++ b/benchmark/single-source/CharacterProperties.swift
@@ -23,25 +23,29 @@ public let CharacterPropertiesFetch = BenchmarkInfo(
   name: "CharacterPropertiesFetch",
   runFunction: run_CharacterPropertiesFetch,
   tags: [.validation, .api, .String],
-  setUpFunction: { blackHole(workload) })
+  setUpFunction: { blackHole(workload) },
+  legacyFactor: 10)
 
 public let CharacterPropertiesStashed = BenchmarkInfo(
   name: "CharacterPropertiesStashed",
   runFunction: run_CharacterPropertiesStashed,
   tags: [.validation, .api, .String],
-  setUpFunction: { setupStash() })
+  setUpFunction: { setupStash() },
+  legacyFactor: 10)
 
 public let CharacterPropertiesStashedMemo = BenchmarkInfo(
   name: "CharacterPropertiesStashedMemo",
   runFunction: run_CharacterPropertiesStashedMemo,
   tags: [.validation, .api, .String],
-  setUpFunction: { setupMemo() })
+  setUpFunction: { setupMemo() },
+  legacyFactor: 10)
 
 public let CharacterPropertiesPrecomputed = BenchmarkInfo(
   name: "CharacterPropertiesPrecomputed",
   runFunction: run_CharacterPropertiesPrecomputed,
   tags: [.validation, .api, .String],
-  setUpFunction: { setupPrecomputed() })
+  setUpFunction: { setupPrecomputed() },
+  legacyFactor: 10)
 
 extension Character {
   var firstScalar: UnicodeScalar { return unicodeScalars.first! }
@@ -253,8 +257,8 @@ func setupMemo() {
 }
 
 // Precompute whole scalar set
-func precompute(_ charSet: CharacterSet) -> Set<UInt32> {
-  var result = Set<UInt32>()
+func precompute(_ charSet: CharacterSet, capacity: Int) -> Set<UInt32> {
+  var result = Set<UInt32>(minimumCapacity: capacity)
   for plane in 0...0x10 {
     guard charSet.hasMember(inPlane: UInt8(plane)) else { continue }
     let offset = plane &* 0x1_0000
@@ -267,43 +271,53 @@ func precompute(_ charSet: CharacterSet) -> Set<UInt32> {
   }
   return result
 }
-var controlCharactersPrecomputed: Set<UInt32> = precompute(controlCharacters)
+var controlCharactersPrecomputed: Set<UInt32> =
+  precompute(controlCharacters, capacity: 24951)
 func isControlPrecomputed(_ c: Character) -> Bool {
   return controlCharactersPrecomputed.contains(c.firstScalar.value)
 }
-var alphanumericsPrecomputed: Set<UInt32> = precompute(alphanumerics)
+var alphanumericsPrecomputed: Set<UInt32> =
+  precompute(alphanumerics, capacity: 122647)
 func isAlphanumericPrecomputed(_ c: Character) -> Bool {
   return alphanumericsPrecomputed.contains(c.firstScalar.value)
 }
-var lowercaseLettersPrecomputed: Set<UInt32> = precompute(lowercaseLetters)
+var lowercaseLettersPrecomputed: Set<UInt32> =
+  precompute(lowercaseLetters, capacity: 2063)
 func isLowercasePrecomputed(_ c: Character) -> Bool {
   return lowercaseLettersPrecomputed.contains(c.firstScalar.value)
 }
-var punctuationCharactersPrecomputed: Set<UInt32> = precompute(punctuationCharacters)
+var punctuationCharactersPrecomputed: Set<UInt32> =
+  precompute(punctuationCharacters, capacity: 770)
 func isPunctuationPrecomputed(_ c: Character) -> Bool {
   return punctuationCharactersPrecomputed.contains(c.firstScalar.value)
 }
-var whitespacesPrecomputed: Set<UInt32> = precompute(whitespaces)
+var whitespacesPrecomputed: Set<UInt32> =
+  precompute(whitespaces, capacity: 19)
 func isWhitespacePrecomputed(_ c: Character) -> Bool {
   return whitespacesPrecomputed.contains(c.firstScalar.value)
 }
-var lettersPrecomputed: Set<UInt32> = precompute(letters)
+var lettersPrecomputed: Set<UInt32> =
+  precompute(letters, capacity: 121145)
 func isLetterPrecomputed(_ c: Character) -> Bool {
   return lettersPrecomputed.contains(c.firstScalar.value)
 }
-var uppercaseLettersPrecomputed: Set<UInt32> = precompute(uppercaseLetters)
+var uppercaseLettersPrecomputed: Set<UInt32> =
+  precompute(uppercaseLetters, capacity: 1733)
 func isUppercasePrecomputed(_ c: Character) -> Bool {
   return uppercaseLettersPrecomputed.contains(c.firstScalar.value)
 }
-var decimalDigitsPrecomputed: Set<UInt32> = precompute(decimalDigits)
+var decimalDigitsPrecomputed: Set<UInt32> =
+  precompute(decimalDigits, capacity: 590)
 func isDecimalPrecomputed(_ c: Character) -> Bool {
   return decimalDigitsPrecomputed.contains(c.firstScalar.value)
 }
-var newlinesPrecomputed: Set<UInt32> = precompute(newlines)
+var newlinesPrecomputed: Set<UInt32> =
+  precompute(newlines, capacity: 7)
 func isNewlinePrecomputed(_ c: Character) -> Bool {
   return newlinesPrecomputed.contains(c.firstScalar.value)
 }
-var capitalizedLettersPrecomputed: Set<UInt32> = precompute(capitalizedLetters)
+var capitalizedLettersPrecomputed: Set<UInt32> =
+  precompute(capitalizedLetters, capacity: 31)
 func isCapitalizedPrecomputed(_ c: Character) -> Bool {
   return capitalizedLettersPrecomputed.contains(c.firstScalar.value)
 }
@@ -345,7 +359,7 @@ let workload = """
 
 @inline(never)
 public func run_CharacterPropertiesFetch(_ N: Int) {
-  for _ in 1...N*10 {
+  for _ in 1...N {
     for c in workload {
         blackHole(isControl(c))
         blackHole(isAlphanumeric(c))
@@ -363,7 +377,7 @@ public func run_CharacterPropertiesFetch(_ N: Int) {
 
 @inline(never)
 public func run_CharacterPropertiesStashed(_ N: Int) {
-  for _ in 1...N*10 {
+  for _ in 1...N {
     for c in workload {
         blackHole(isControlStashed(c))
         blackHole(isAlphanumericStashed(c))
@@ -381,7 +395,7 @@ public func run_CharacterPropertiesStashed(_ N: Int) {
 
 @inline(never)
 public func run_CharacterPropertiesStashedMemo(_ N: Int) {
-  for _ in 1...N*10 {
+  for _ in 1...N {
     for c in workload {
         blackHole(isControlStashedMemo(c))
         blackHole(isAlphanumericStashedMemo(c))
@@ -399,7 +413,7 @@ public func run_CharacterPropertiesStashedMemo(_ N: Int) {
 
 @inline(never)
 public func run_CharacterPropertiesPrecomputed(_ N: Int) {
-  for _ in 1...N*10 {
+  for _ in 1...N {
     for c in workload {
         blackHole(isControlPrecomputed(c))
         blackHole(isAlphanumericPrecomputed(c))

--- a/benchmark/single-source/CharacterProperties.swift.gyb
+++ b/benchmark/single-source/CharacterProperties.swift.gyb
@@ -24,25 +24,29 @@ public let CharacterPropertiesFetch = BenchmarkInfo(
   name: "CharacterPropertiesFetch",
   runFunction: run_CharacterPropertiesFetch,
   tags: [.validation, .api, .String],
-  setUpFunction: { blackHole(workload) })
+  setUpFunction: { blackHole(workload) },
+  legacyFactor: 10)
 
 public let CharacterPropertiesStashed = BenchmarkInfo(
   name: "CharacterPropertiesStashed",
   runFunction: run_CharacterPropertiesStashed,
   tags: [.validation, .api, .String],
-  setUpFunction: { setupStash() })
+  setUpFunction: { setupStash() },
+  legacyFactor: 10)
 
 public let CharacterPropertiesStashedMemo = BenchmarkInfo(
   name: "CharacterPropertiesStashedMemo",
   runFunction: run_CharacterPropertiesStashedMemo,
   tags: [.validation, .api, .String],
-  setUpFunction: { setupMemo() })
+  setUpFunction: { setupMemo() },
+  legacyFactor: 10)
 
 public let CharacterPropertiesPrecomputed = BenchmarkInfo(
   name: "CharacterPropertiesPrecomputed",
   runFunction: run_CharacterPropertiesPrecomputed,
   tags: [.validation, .api, .String],
-  setUpFunction: { setupPrecomputed() })
+  setUpFunction: { setupPrecomputed() },
+  legacyFactor: 10)
 
 extension Character {
   var firstScalar: UnicodeScalar { return unicodeScalars.first! }
@@ -104,8 +108,8 @@ func setupMemo() {
 }
 
 // Precompute whole scalar set
-func precompute(_ charSet: CharacterSet) -> Set<UInt32> {
-  var result = Set<UInt32>()
+func precompute(_ charSet: CharacterSet, capacity: Int) -> Set<UInt32> {
+  var result = Set<UInt32>(minimumCapacity: capacity)
   for plane in 0...0x10 {
     guard charSet.hasMember(inPlane: UInt8(plane)) else { continue }
     let offset = plane &* 0x1_0000
@@ -118,8 +122,17 @@ func precompute(_ charSet: CharacterSet) -> Set<UInt32> {
   }
   return result
 }
+%{  #// Reduce wide memory range. Capacities from `print("${Set}:…` below.
+  precomputed_capacity = dict(
+    controlCharacters=24951, alphanumerics=122647, lowercaseLetters=2063,
+    punctuationCharacters=770, whitespaces=19, letters=121145,
+    uppercaseLetters=1733, decimalDigits=590, newlines=7,
+    capitalizedLetters=31
+  )
+}%
 % for Property, Set in Properties.items():
-var ${Set}Precomputed: Set<UInt32> = precompute(${Set})
+var ${Set}Precomputed: Set<UInt32> =
+  precompute(${Set}, capacity: ${precomputed_capacity[Set]})
 func is${Property}Precomputed(_ c: Character) -> Bool {
   return ${Set}Precomputed.contains(c.firstScalar.value)
 }
@@ -129,6 +142,7 @@ func setupPrecomputed() {
   blackHole(workload)
 % for Property, Set in Properties.items():
     blackHole(${Set}Precomputed)
+%#//    print("${Set}: \(${Set}Precomputed.count)")
 % end
 }
 
@@ -155,7 +169,7 @@ let workload = """
 
 @inline(never)
 public func run_CharacterPropertiesFetch(_ N: Int) {
-  for _ in 1...N*10 {
+  for _ in 1...N {
     for c in workload {
     % for Property, Set in Properties.items():
         blackHole(is${Property}(c))
@@ -166,7 +180,7 @@ public func run_CharacterPropertiesFetch(_ N: Int) {
 
 @inline(never)
 public func run_CharacterPropertiesStashed(_ N: Int) {
-  for _ in 1...N*10 {
+  for _ in 1...N {
     for c in workload {
     % for Property, Set in Properties.items():
         blackHole(is${Property}Stashed(c))
@@ -177,7 +191,7 @@ public func run_CharacterPropertiesStashed(_ N: Int) {
 
 @inline(never)
 public func run_CharacterPropertiesStashedMemo(_ N: Int) {
-  for _ in 1...N*10 {
+  for _ in 1...N {
     for c in workload {
     % for Property, Set in Properties.items():
         blackHole(is${Property}StashedMemo(c))
@@ -188,7 +202,7 @@ public func run_CharacterPropertiesStashedMemo(_ N: Int) {
 
 @inline(never)
 public func run_CharacterPropertiesPrecomputed(_ N: Int) {
-  for _ in 1...N*10 {
+  for _ in 1...N {
     for c in workload {
     % for Property, Set in Properties.items():
         blackHole(is${Property}Precomputed(c))

--- a/benchmark/single-source/Chars.swift
+++ b/benchmark/single-source/Chars.swift
@@ -17,7 +17,8 @@ public let Chars = BenchmarkInfo(
   name: "Chars2",
   runFunction: run_Chars,
   tags: [.validation, .api, .String],
-  setUpFunction: { blackHole(alphabetInput) })
+  setUpFunction: { blackHole(alphabetInput) },
+  legacyFactor: 50)
 
 var alphabetInput: [Character] = [
     "A", "B", "C", "D", "E", "F", "G",
@@ -33,7 +34,7 @@ public func run_Chars(_ N: Int) {
   // Permute some characters.
   let alphabet: [Character] = alphabetInput
 
-  for _ in 0..<50*N {
+  for _ in 0..<N {
     for firstChar in alphabet {
       for lastChar in alphabet {
         blackHole(firstChar < lastChar)

--- a/benchmark/single-source/ClassArrayGetter.swift
+++ b/benchmark/single-source/ClassArrayGetter.swift
@@ -17,7 +17,8 @@ public let ClassArrayGetter = BenchmarkInfo(
   runFunction: run_ClassArrayGetter,
   tags: [.validation, .api, .Array],
   setUpFunction: { blackHole(inputArray) },
-  tearDownFunction: { inputArray = nil })
+  tearDownFunction: { inputArray = nil },
+  legacyFactor: 10)
 
 class Box {
   var v: Int
@@ -34,7 +35,7 @@ func sumArray(_ a: [Box]) -> Int {
 }
 
 var inputArray: [Box]! = {
-  let aSize = 100_000
+  let aSize = 10_000
   var a: [Box] = []
   a.reserveCapacity(aSize)
   for i in 1...aSize {

--- a/benchmark/single-source/CountAlgo.swift
+++ b/benchmark/single-source/CountAlgo.swift
@@ -19,7 +19,8 @@ public let CountAlgo = [
   BenchmarkInfo(
     name: "CountAlgoString",
     runFunction: run_CountAlgoString,
-    tags: [.validation, .api]),
+    tags: [.validation, .api],
+    legacyFactor: 5),
 ]
 
 @inline(never)
@@ -32,7 +33,7 @@ public func run_CountAlgoArray(_ N: Int) {
 @inline(never)
 public func run_CountAlgoString(_ N: Int) {
   let vowels = Set("aeiou")
-  for _ in 1...5*N {
+  for _ in 1...N {
     CheckResults(text.count(where: vowels.contains) == 2014)
   }
 }

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -514,7 +514,7 @@ final class TestRunner {
       Int.max / 10_000, // by the inner loop multiplier inside the `testFn`.
       c.numIters ?? calibrateMeasurements())
 
-    let numSamples = c.numSamples ?? min(2000, // Cap the number of samples
+    let numSamples = c.numSamples ?? min(200, // Cap the number of samples
       c.numIters == nil ? 1 : calibrateMeasurements())
 
     samples.reserveCapacity(numSamples)

--- a/test/benchmark/Benchmark_Driver.test-sh
+++ b/test/benchmark/Benchmark_Driver.test-sh
@@ -1,5 +1,4 @@
 // REQUIRES: OS=macosx
-// REQUIRES: asserts
 // REQUIRES: benchmark
 // REQUIRES: CMAKE_GENERATOR=Ninja
 

--- a/test/benchmark/Benchmark_O.test.md
+++ b/test/benchmark/Benchmark_O.test.md
@@ -1,6 +1,5 @@
 <!--
 REQUIRES: OS=macosx
-REQUIRES: asserts
 REQUIRES: benchmark
 REQUIRES: CMAKE_GENERATOR=Ninja
 -->
@@ -15,11 +14,12 @@ as a verification of this public API to prevent its accidental breakage.
 [BD]: https://github.com/apple/swift/blob/master/benchmark/scripts/Benchmark_Driver
 [Testing]: https://github.com/apple/swift/blob/master/docs/Testing.md
 
-Note: Following tests use *Ackermann* as an example of a benchmark that is
+Note: Following tests use *HashQuadratic* as an example of a benchmark that is
 excluded from the default "pre-commit" list because it is marked `unstable` and
-the default skip-tags (`unstable,skip`) will exclude it. It's also
-alphabetically the first benchmark in the test suite (used to verify running by
-index). If these assumptions change, the test must be adapted.
+the default skip-tags (`unstable,skip`) will exclude it.  The *Ackermann* and
+*AngryPhonebook* are alphabetically the first two benchmarks in the test suite
+(used to verify running by index). If these assumptions change, the test must be
+adapted.
 
 ## List Format
 ````
@@ -27,7 +27,7 @@ RUN: %Benchmark_O --list | %FileCheck %s \
 RUN:                      --check-prefix LISTPRECOMMIT \
 RUN:                      --check-prefix LISTTAGS
 LISTPRECOMMIT: #,Test,[Tags]
-LISTPRECOMMIT-NOT: Ackermann
+LISTPRECOMMIT-NOT: HashQuadratic
 LISTPRECOMMIT: {{[0-9]+}},AngryPhonebook
 LISTTAGS-SAME: ,[
 LISTTAGS-NOT: TestsUtils.BenchmarkCategory.
@@ -35,14 +35,14 @@ LISTTAGS-SAME: String, api, validation
 LISTTAGS-SAME: ]
 ````
 
-Verify Ackermann is listed when skip-tags are explicitly empty and that it is
-marked unstable:
+Verify HashQuadratic is listed when skip-tags are explicitly empty and that it
+is marked unstable:
 
 ````
 RUN: %Benchmark_O --list --skip-tags= | %FileCheck %s --check-prefix LISTALL
-LISTALL: Ackermann
-LISTALL-SAME: unstable
 LISTALL: AngryPhonebook
+LISTALL: HashQuadratic
+LISTALL-SAME: unstable
 ````
 
 ## Benchmark Selection
@@ -54,8 +54,8 @@ It provides us with ability to do a "dry run".
 Run benchmark by name (even if its tags match the skip-tags) or test number:
 
 ````
-RUN: %Benchmark_O Ackermann --list | %FileCheck %s --check-prefix NAMEDSKIP
-NAMEDSKIP: Ackermann
+RUN: %Benchmark_O HashQuadratic --list | %FileCheck %s --check-prefix NAMEDSKIP
+NAMEDSKIP: HashQuadratic
 
 RUN: %Benchmark_O 1 --list | %FileCheck %s --check-prefix RUNBYNUMBER
 RUNBYNUMBER: Ackermann


### PR DESCRIPTION
This PR is first part of benchmarks clean-up to enable [robust performance measurements](https://forums.swift.org/t/towards-robust-performance-measurement/11490) by adjusting workloads to run in reasonable time (< 1000 μs), minimizing the accumulated error. To maintain long-term performance tracking, it applies [legacy factor](https://github.com/apple/swift/pull/20212) where necessary.

Legacy factor for benchmarks that had non-linear workload scaling (`ArrayAppend...`) is tuned for `-O` builds, which means some changes in measured times for `-Osize` and `-Onone` builds are unavoidable and to be expected, as a consequence of these workload scaling loops being fixed.