### PR TITLE
[5.0] IRGen: Consider the superclass bound of archetypes in searchTyp…

### DIFF
--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -124,6 +124,14 @@ bool FulfillmentMap::searchTypeMetadata(IRGenModule &IGM, CanType type,
                                            source, MetadataPath(path), keys);
     }
 
+    // Consider its super class bound.
+    if (metadataState == MetadataState::Complete) {
+      if (auto superclassTy = keys.getSuperclassBound(type)) {
+        hadFulfillment |= searchNominalTypeMetadata(
+            IGM, superclassTy, metadataState, source, std::move(path), keys);
+      }
+    }
+
     // Add the fulfillment.
     hadFulfillment |= addFulfillment({type, nullptr},
                                      source, std::move(path), metadataState);

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -285,8 +285,8 @@ func takes_metatype<T>(_: T.Type) {}
 // CHECK:      [[ISA_ADDR:%.*]] = bitcast %T22class_bounded_generics1AC.1* %0 to %swift.type**
 // CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK:      call swiftcc void @"$s22class_bounded_generics14takes_metatypeyyxmlF"(%swift.type* %T, %swift.type* %T)
-// CHECK-NEXT: [[ISA_PTR:%.*]] = bitcast %swift.type* [[ISA]] to %swift.type**
-// CHECK-NEXT: [[U_ADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[ISA_PTR]], i64 10
+// CHECK-NEXT: [[T:%.*]] = bitcast %swift.type* %T to %swift.type**
+// CHECK-NEXT: [[U_ADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T]], i64 10
 // CHECK-NEXT: [[U:%.*]] = load %swift.type*, %swift.type** [[U_ADDR]]
 // CHECK:      call swiftcc void @"$s22class_bounded_generics14takes_metatypeyyxmlF"(%swift.type* %U, %swift.type* %U)
 // CHECK:      ret void

--- a/test/IRGen/fulfillment.sil
+++ b/test/IRGen/fulfillment.sil
@@ -53,3 +53,33 @@ bb0(%0 : $A<A<T>>, %1 : $A<T>):
   %2 = tuple ()
   return %2 : $()
 }
+
+protocol A2 {
+  associatedtype AssocTy
+}
+
+protocol C {
+}
+
+extension A2 where Self.AssocTy : C {
+}
+
+class K<T> : A2 where T : C {
+  typealias AssocTy = T
+}
+
+sil @callee : $@convention(method) <τ_0_0 where τ_0_0 : A2, τ_0_0.AssocTy : C> (@in_guaranteed τ_0_0) -> ()
+
+// CHECK-LABEL: define{{.*}} swiftcc void @caller(%T11fulfillment1KC** {{.*}}, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK: entry:
+// CHECK:   %1 = bitcast %swift.type* %Self to i8***
+// CHECK:   %2 = getelementptr inbounds i8**, i8*** %1, i64 11
+// CHECK:   %"\CF\84_1_0.C" = load i8**, i8*** %2
+// CHECK:   call swiftcc void @callee(%swift.type* %Self, i8** %SelfWitnessTable, i8** %"\CF\84_1_0.C"
+sil @caller : $@convention(witness_method: A2) <τ_0_0><τ_1_0 where τ_0_0 : K<τ_1_0>, τ_1_0 : C> (@in_guaranteed τ_0_0) -> () {
+bb0(%0 : $*τ_0_0):
+  %1 = function_ref @callee : $@convention(method) <τ_0_0 where τ_0_0 : A2, τ_0_0.AssocTy : C> (@in_guaranteed τ_0_0) -> ()
+  %2 = apply %1<τ_0_0>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : A2, τ_0_0.AssocTy : C> (@in_guaranteed τ_0_0) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}


### PR DESCRIPTION
…eMetadata

We need to search the type metadata of superclass bounds to handle signatures like:

class K<T> {}

 $@convention(witness_method: A2) <τ_0_0><τ_1_0 where τ_0_0 : K<τ_1_0>, τ_1_0 : C> (@in_guaranteed τ_0_0) -> ()

rdar://46173958
SR-9305

Should be Not ABI affecting (slight risk that it is).
Not needed for convergence.