### PR TITLE
[benchmark] DictTest4Legacy: Add dummy hash(into:)

### DIFF
--- a/benchmark/single-source/DictTest4Legacy.swift
+++ b/benchmark/single-source/DictTest4Legacy.swift
@@ -56,6 +56,10 @@ struct LargeKey: Hashable {
     return hash
   }
 
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(self.hashValue)
+  }
+
   init(_ value: Int) {
     self.i = value
     self.j = 2 * value


### PR DESCRIPTION
(This PR was originally part of #20685.)

SE-0206 deprecated `hashValue` as a `Hashable` requirement, replacing it with `hash(into:)`. This PR updates the benchmarking suite accordingly.

rdar://problem/46344811