### PR TITLE
[SourceKit] SourceKitdUID: Implement hash(into:) rather than hashValue

### DIFF
--- a/tools/SourceKit/tools/swift-lang/SourceKitdUID.swift
+++ b/tools/SourceKit/tools/swift-lang/SourceKitdUID.swift
@@ -33,7 +33,7 @@ public struct SourceKitdUID: Equatable, Hashable, CustomStringConvertible {
     return String(cString: sourcekitd_uid_get_string_ptr(uid))
   }
 
-  public var hashValue: Int {
-    return uid.hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(uid)
   }
 }


### PR DESCRIPTION
(This PR was originally part of #20685.)

SE-0206 deprecated hashValue as a Hashable requirement. This PR updates SourceKit to migrate to the new hashing interface, `hash(into:)`. The change will make SourceKitUIDs hash a little faster, but otherwise, it's effectively NFC.

I plan to add a compiler warning for hashValue-based Hashable conformances; this is a preemptive fix for that warning.