### PR TITLE
[5.0] Add -Xclang-linker option to the compiler.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -748,6 +748,9 @@ def Xcc : Separate<["-"], "Xcc">, Flags<[FrontendOption]>,
   MetaVarName<"<arg>">,
   HelpText<"Pass <arg> to the C/C++/Objective-C compiler">;
 
+def Xclang_linker : Separate<["-"], "Xclang-linker">, Flags<[HelpHidden]>,
+  MetaVarName<"<arg>">, HelpText<"Pass <arg> to Clang when it is use for linking.">;
+
 def Xllvm : Separate<["-"], "Xllvm">,
   Flags<[FrontendOption, HelpHidden]>,
   MetaVarName<"<arg>">, HelpText<"Pass <arg> to LLVM.">;

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -328,6 +328,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   // These custom arguments should be right before the object file at the end.
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
+  context.Args.AddAllArgValues(Arguments, options::OPT_Xclang_linker);
 
   // This should be the last option, for convenience in checking output.
   Arguments.push_back("-o");

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -164,6 +164,7 @@ toolchains::Windows::constructInvocation(const LinkJobAction &job,
 
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
+  context.Args.AddAllArgValues(Arguments, options::OPT_Xclang_linker);
 
   // Run clang++ in verbose mode if "-v" is set
   if (context.Args.hasArg(options::OPT_v)) {

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -49,6 +49,12 @@
 // RUN: %swiftc_driver -driver-print-jobs -target armv7-unknown-linux-gnueabihf -Xlinker -rpath -Xlinker customrpath -L foo %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-linker-order %s < %t.linux.txt
 
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -Xclang-linker -foo -Xclang-linker foopath %s 2>&1 > %t.linux.txt
+// RUN: %FileCheck -check-prefix LINUX-clang-linker-order %s < %t.linux.txt
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -Xclang-linker -foo -Xclang-linker foopath %s 2>&1 > %t.windows.txt
+// RUN: %FileCheck -check-prefix WINDOWS-clang-linker-order %s < %t.windows.txt
+
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -g %s | %FileCheck -check-prefix DEBUG %s
 
 // RUN: %empty-directory(%t)
@@ -310,6 +316,20 @@
 // LINUX-linker-order: -Xlinker -rpath -Xlinker customrpath
 // LINUX-linker-order: -o {{.*}}
 
+// LINUX-clang-linker-order: swift
+// LINUX-clang-linker-order: -o [[OBJECTFILE:.*]]
+
+// LINUX-clang-linker-order: clang++{{"? }}
+// LINUX-clang-linker-order: -foo foopath
+// LINUX-clang-linker-order: -o {{.*}}
+
+// WINDOWS-clang-linker-order: swift
+// WINDOWS-clang-linker-order: -o [[OBJECTFILE:.*]]
+
+// WINDOWS-clang-linker-order: clang++{{"? }}
+// WINDOWS-clang-linker-order: -foo foopath
+// WINDOWS-clang-linker-order: -o {{.*}}
+
 // DEBUG: bin/swift
 // DEBUG-NEXT: bin/swift
 // DEBUG-NEXT: bin/ld{{"? }}
@@ -390,4 +410,3 @@
 
 // Clean up the test executable because hard links are expensive.
 // RUN: rm -rf %t/DISTINCTIVE-PATH/usr/bin/swiftc
-


### PR DESCRIPTION
In the Darwin toolchain the linker is invoked directly, and compiler_rt
is used if it is found, but in Unix platforms, clang++ is invoked
instead, and the clang driver will invoke the linker. Howerver there was
no way of modifying this clang++ invocation, so there's no way of
providing `--rtlib=` and change the platform default (which is normally
libgcc). The only workaround is doing the work that the Swift driver is
doing "manually".

The change adds a new option (with help hidden, but we can change that)
to allow providing extra arguments to the clang++ invocation. The change
is done in the two places in the Unix and Windows toolchains that I
found the clang driver was being used.

Includes some simple tests.

Cherry-picked from #20441.