### PR TITLE
[ObjectiveC] Selector: Synthesize Equatable and Hashable

### DIFF
--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -112,21 +112,10 @@ public struct Selector : ExpressibleByStringLiteral {
   }
 }
 
-extension Selector : Equatable, Hashable {
-  public static func ==(lhs: Selector, rhs: Selector) -> Bool {
-    return sel_isEqual(lhs, rhs)
-  }
-
-  /// The hash value.
-  ///
-  /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
-  ///
-  /// - Note: the hash value is not guaranteed to be stable across
-  ///   different invocations of the same program.  Do not persist the
-  ///   hash value across program runs.
-  public var hashValue: Int {
-    return ptr.hashValue
-  }
+extension Selector: Equatable, Hashable {
+  // Note: The implementations for `==` and `hash(into:)` are synthesized by the
+  // compiler. The generated implementations use the value of `ptr` as the basis
+  // for equality.
 }
 
 extension Selector : CustomStringConvertible {


### PR DESCRIPTION
(This PR was originally part of #20685.)

SE-0206 deprecated `hashValue` as a `Hashable` requirement, replacing it with `hash(into:)`. 

This PR removes the explicit `Selector.hashValue` implementation, allowing the compiler to provide a (faster) synthesized Hashable implementation, based on `hash(into:)`. For symmetry, it also removes the explicit definition of `==`. (The compiler-synthesized pointer comparison is documented to have the same semantics as `sel_isEqual`.)