### PR TITLE
[CoreGraphics] CGFloat: Implement better hashing

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -380,6 +380,16 @@ extension CGFloat : Hashable {
   public var hashValue: Int {
     return native.hashValue
   }
+
+  /// Hashes the essential components of this value by feeding them into the
+  /// given hasher.
+  ///
+  /// - Parameter hasher: The hasher to use when combining the components
+  ///   of this instance.
+  @inlinable @_transparent
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(native)
+  }
 }
 
 % for dst_ty in all_integer_types(word_bits):

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -390,6 +390,11 @@ extension CGFloat : Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(native)
   }
+
+  @inlinable @_transparent
+  public func _rawHashValue(seed: Int) -> Int {
+    return native._rawHashValue(seed: seed)
+  }
 }
 
 % for dst_ty in all_integer_types(word_bits):


### PR DESCRIPTION
(This PR was originally part of #20685.)

SE-0206 deprecated `hashValue` as a `Hashable` requirement, replacing it with `hash(into:)`. This PR adds a direct implementation of `CGFloat.hash(into:)` and `CGFloat._rawHashValue(seed:)`, modernizing its hashing and bringing it to the same performance as that of `Float` and `Double`.

rdar://problem/43394032