### PR TITLE
Revert "[5.0] Change Default Linker to Gold for AArch64"

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -103,7 +103,6 @@ ToolChain::InvocationInfo toolchains::GenericUnix::constructInvocation(
 std::string toolchains::GenericUnix::getDefaultLinker() const {
   switch (getTriple().getArch()) {
   case llvm::Triple::arm:
-  case llvm::Triple::aarch64:
   case llvm::Triple::armeb:
   case llvm::Triple::thumb:
   case llvm::Triple::thumbeb:


### PR DESCRIPTION
Reverts apple/swift#20846

Temporarily backing out pending convergence of `swift-5.0-branch`