### PR TITLE
Re-apply [5.0] Change Default Linker to Gold for AArch64

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -103,6 +103,7 @@ ToolChain::InvocationInfo toolchains::GenericUnix::constructInvocation(
 std::string toolchains::GenericUnix::getDefaultLinker() const {
   switch (getTriple().getArch()) {
   case llvm::Triple::arm:
+  case llvm::Triple::aarch64:
   case llvm::Triple::armeb:
   case llvm::Triple::thumb:
   case llvm::Triple::thumbeb:


### PR DESCRIPTION
Reverts apple/swift#20876

This should be applied when `pending-convergence` limitations for `swift-5.0-branch` has been lifted.

cc @futurejones