### PR TITLE
[5.0][TypeChecker] Improve error about mutating self capture by escaping c…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2942,8 +2942,11 @@ ERROR(closure_implicit_capture_without_noescape,none,
       "escaping closures can only capture inout parameters explicitly by value",
       ())
 ERROR(closure_implicit_capture_mutating_self,none,
-      "closure cannot implicitly capture a mutating self parameter",
+      "escaping closure cannot capture a mutating self parameter",
       ())
+NOTE(create_mutating_copy_or_capture_self,none,
+     "create a mutating copy of self, or explicitly capture self for immutability",
+     ())
 ERROR(nested_function_with_implicit_capture_argument,none,
       "nested function with %select{an |}0implicitly captured inout "
       "parameter%select{|s}0 can only be used as a non-escaping argument", (bool))

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -402,7 +402,9 @@ public:
     if (isInOut && !AFR.isKnownNoEscape() && !isNested) {
       if (D->getBaseName() == D->getASTContext().Id_self) {
         TC.diagnose(DRE->getLoc(),
-          diag::closure_implicit_capture_mutating_self);
+                    diag::closure_implicit_capture_mutating_self);
+        TC.diagnose(DRE->getLoc(),
+                    diag::create_mutating_copy_or_capture_self);
       } else {
         TC.diagnose(DRE->getLoc(),
           diag::closure_implicit_capture_without_noescape);

--- a/test/Sema/diag_invalid_inout_captures.swift
+++ b/test/Sema/diag_invalid_inout_captures.swift
@@ -6,7 +6,8 @@ func do_escape(_ not_a_price_you_are_willing_to_pay: @escaping () -> ()) {}
 struct you_cry_in_your_tea {
   mutating func which_you_hurl_in_the_sea_when_you_see_me_go_by() {
     no_escape { _ = self } // OK
-    do_escape { _ = self } // expected-error {{closure cannot implicitly capture a mutating self parameter}}
+    do_escape { _ = self } // expected-error {{escaping closure cannot capture a mutating self parameter}}
+    // expected-note@-1 {{create a mutating copy of self, or explicitly capture self for immutability}}
     do_escape {
       [self] in
       _ = self // OK
@@ -39,4 +40,24 @@ func remember(line: inout String) -> () -> Void {
 // SILOptimizer/exclusivity_static_diagnostics.swift.
 func its_complicated(condition: inout Int) {
   no_escape(condition == 0 ? { condition = 1 } : { condition = 2}) // expected-error 2 {{escaping closures can only capture inout parameters explicitly by value}}
+}
+
+// rdar://problem/46322943 - Improve error message about mutating self capture in escaping closures
+func rdar46322943() {
+  struct S {
+    var bar = 1
+
+    func foo(_ fn: () -> Void) {
+      fn()
+    }
+
+    mutating func main() {
+      let fn = {
+        self.bar += 1
+        // expected-error@-1 {{escaping closure cannot capture a mutating self parameter}}
+        // expected-note@-2 {{create a mutating copy of self, or explicitly capture self for immutability}}
+      }
+      self.foo(fn)
+    }
+  }
 }


### PR DESCRIPTION
…losure

Closures can't explicitly capture a mutating self parameter, so
let's re-word diagnostic to point what what actual problem here
is, and add a note about ways to fix the code.

Thanks to Cory Benfield for message suggestion.

Resolves: [SR-9314](https://bugs.swift.org/browse/SR-9314)
Resolves: rdar://problem/46322943
(cherry picked from commit 8a79fa1a9f19f71bcfc614888464e347ba518a09)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
