### PR TITLE
[Foundation] Measurement: Add a correct hash(into:) implementation

### DIFF
--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -36,8 +36,16 @@ public struct Measurement<UnitType : Unit> : ReferenceConvertible, Comparable, E
         self.unit = unit
     }
 
-    public var hashValue: Int {
-        return Int(bitPattern: __CFHashDouble(value))
+    public func hash(into hasher: inout Hasher) {
+        if let dimension = self.unit as? Dimension {
+            let baseUnit = type(of: dimension).baseUnit()
+            let baseValue = dimension.converter.baseUnitValue(fromValue: value)
+            hasher.combine(baseValue)
+            hasher.combine(baseUnit)
+        } else {
+            hasher.combine(value)
+            hasher.combine(unit)
+        }
     }
 }
 

--- a/test/stdlib/TestMeasurement.swift
+++ b/test/stdlib/TestMeasurement.swift
@@ -151,6 +151,14 @@ class TestMeasurement : TestMeasurementSuper {
         expectTrue(fiveKM <= fiveThousandM)
     }
 
+    func testHashing() {
+        let m1 = Measurement<UnitLength>(value: 1, unit: .inches)
+        let m2 = m1.converted(to: .millimeters)
+
+        expectTrue(m1 == m2)
+        expectTrue(m1.hashValue == m2.hashValue)
+    }
+
     func test_AnyHashableContainingMeasurement() {
         let values: [Measurement<UnitLength>] = [
           Measurement(value: 100, unit: UnitLength.meters),
@@ -190,6 +198,7 @@ if #available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
     MeasurementTests.test("testMeasurementFormatter") { TestMeasurement().testMeasurementFormatter() }
     MeasurementTests.test("testEquality") { TestMeasurement().testEquality() }
     MeasurementTests.test("testComparison") { TestMeasurement().testComparison() }
+    MeasurementTests.test("testHashing") { TestMeasurement().testHashing() }
     MeasurementTests.test("test_AnyHashableContainingMeasurement") { TestMeasurement().test_AnyHashableContainingMeasurement() }
   MeasurementTests.test("test_AnyHashableCreatedFromNSMeasurement") { TestMeasurement().test_AnyHashableCreatedFromNSMeasurement() }
     runAllTests()


### PR DESCRIPTION
The new definition normalizes measurements with dimensional units to their base unit, ensuring that the generated hash values are consistent with the definition of ==. It also feeds the unit to the hasher, not just the numerical value.

The old `hashValue` definition was invalid, and has been removed. (I.e., replaced by a compiler-supplied implementation that works in terms of `hash(into:)`.)

rdar://problem/46187171

(This PR was split out of #20685)
