### PR TITLE
Fix overwriting the command line args on Windows

### DIFF
--- a/test/Driver/batch_mode_with_supplementary_filelist_unicode.swift
+++ b/test/Driver/batch_mode_with_supplementary_filelist_unicode.swift
@@ -1,9 +1,25 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'print("Hello, World!")' >%t/main.swift
-// RUN: touch %t/𝔼-file-01.swift %t/😂-file-02.swift %t/Ω-file-03.swift
+// RUN: echo "" > %t/𝔼-file-01.swift 
+// RUN: echo "" > %t/😂-file-02.swift 
+// RUN: echo "" > %t/Ω-file-03.swift
 //
 // If the supplementary output file map does not escape the characters in the
 // source files, the frontend won't recognize the desired outputs.
 //
 // RUN: cd %t && %target-build-swift -c -emit-dependencies -serialize-diagnostics -driver-filelist-threshold=0 -j2 main.swift  𝔼-file-01.swift 😂-file-02.swift Ω-file-03.swift -module-name mod
-// RUN: cd %t && test -e 😂-file-02.d -a -e 😂-file-02.dia -a -e 😂-file-02.o -a -e 😂-file-02.swift -a -e 𝔼-file-01.d -a -e 𝔼-file-01.dia -a -e 𝔼-file-01.o -a -e 𝔼-file-01.swift -a -e main.d -a -e main.dia -a -e Ω-file-03.d -a -e Ω-file-03.dia -a -e Ω-file-03.o -a -e Ω-file-03.swift
+// RUN: %check-file-exists(%/t/main.d)
+// RUN: %check-file-exists(%/t/main.dia)
+// RUN: %check-file-exists(%/t/main.o)
+// RUN: %check-file-exists(%/t/Ω-file-03.d)
+// RUN: %check-file-exists(%/t/Ω-file-03.dia)
+// RUN: %check-file-exists(%/t/Ω-file-03.o)
+// RUN: %check-file-exists(%/t/Ω-file-03.swift)
+// RUN: %check-file-exists(%/t/𝔼-file-01.d)
+// RUN: %check-file-exists(%/t/𝔼-file-01.dia)
+// RUN: %check-file-exists(%/t/𝔼-file-01.o)
+// RUN: %check-file-exists(%/t/𝔼-file-01.swift)
+// RUN: %check-file-exists(%/t/😂-file-02.d)
+// RUN: %check-file-exists(%/t/😂-file-02.dia)
+// RUN: %check-file-exists(%/t/😂-file-02.o)
+// RUN: %check-file-exists(%/t/😂-file-02.swift)

--- a/test/Driver/parseable_output_unicode.swift
+++ b/test/Driver/parseable_output_unicode.swift
@@ -63,8 +63,8 @@
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "merge-module",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?}} -frontend -merge-modules -emit-module {{.*[\\/]}}你好-[[OUTPUT]].swiftmodule {{.*}} -o {{.*[\\/]}}parseable_output_unicode.swift.tmp.swiftmodule",
-// CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?}}",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.EXE)?(\\")?}} -frontend -merge-modules -emit-module {{.*[\\/]}}你好-[[OUTPUT]].swiftmodule{{(\\")?}} {{.*}} -o {{.*[\\/]}}parseable_output_unicode.swift.tmp.swiftmodule{{(\\")?}}",
+// CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.EXE)?(\\")?}}",
 // CHECK-NEXT:   "command_arguments": [
 // CHECK-NEXT:     "-frontend",
 // CHECK-NEXT:     "-merge-modules",
@@ -112,10 +112,10 @@
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "link",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}ld{{(\\")?}} {{.*[\\/]}}你好-[[OUTPUT]].o {{.*}} -o {{.*[\\/]}}parseable_output_unicode.swift.tmp.out",
-// CHECK-NEXT:   "command_executable": "{{.*[\\/]}}ld{{(\\")?}}",
+// CHECK-NEXT:   "command": "{{.*[\\/](ld|clang\+\+.exe)(\\")?}} {{.*[\\/]}}你好-[[OUTPUT]].o{{(\\")?}}{{.*}}-o {{.*[\\/]}}parseable_output_unicode.swift.tmp.out{{(\\")?}}",
+// CHECK-NEXT:   "command_executable": "{{.*[\\/](ld|clang\+\+.exe)(\\")?}}",
 // CHECK-NEXT:   "command_arguments": [
-// CHECK-NEXT:     "{{.*[\\/]}}你好-[[OUTPUT]].o",
+// CHECK:          "{{.*[\\/]}}你好-[[OUTPUT]].o",
 // CHECK:          "-o",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output_unicode.swift.tmp.out"
 // CHECK-NEXT:   ],

--- a/test/Driver/response-file.swift
+++ b/test/Driver/response-file.swift
@@ -28,10 +28,10 @@
 // RUN: %target-build-swift -typecheck @%t.5.resp %s 2>&1 | %FileCheck %s -check-prefix=LONG
 // LONG: warning: result of call to 'abs' is unused
 // RUN: %empty-directory(%t/tmp)
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver %s @%t.5.resp -save-temps -o %t/main
+// RUN: env TMPDIR=%t/tmp/ TMP=%t/tmp/ %target-swiftc_driver %s @%t.5.resp -save-temps -o %t/main
 // RUN: ls %t/tmp/arguments-*.resp
 // RUN: %target-build-swift -typecheck -v @%t.5.resp %s 2>&1 | %FileCheck %s -check-prefix=VERBOSE
-// VERBOSE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp # -frontend -typecheck -primary-file
+// VERBOSE: @{{[^ ]*}}arguments-{{[0-9a-zA-Z]+}}.resp{{"?}} # -frontend -typecheck -primary-file
 // RUN: not %target-swiftc_driver %s @%t.5.resp -Xfrontend -debug-crash-immediately 2>&1 | %FileCheck %s -check-prefix=CRASH
 // CRASH: Program arguments: {{[^ ]*}}swift -frontend -c -primary-file
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1292,6 +1292,8 @@ config.substitutions.append(('%scale-test',
                                  config.scale_test, config.swiftc)))
 config.substitutions.append(('%empty-directory\(([^)]+)\)',
                              SubstituteCaptures(r'rm -rf "\1" && mkdir -p "\1"')))
+config.substitutions.append(('%check-file-exists\(([^)]+)\)',
+                             SubstituteCaptures(r'''%r -c 'import os; exit(0) if os.path.exists("\1") else exit(1)' ''' % sys.executable)))
 
 config.substitutions.append(('%target-sil-opt', config.target_sil_opt))
 config.substitutions.append(('%target-sil-func-extractor', config.target_sil_func_extractor))

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -49,8 +49,12 @@ constants.""")
         replacement, pattern = s.split('=', 1)
         stdin = stdin.replace(pattern, replacement)
 
-    p = subprocess.Popen(
-        [args.file_check_path] + unknown_args, stdin=subprocess.PIPE)
+    if sys.version_info[0] > 2:
+        p = subprocess.Popen(
+            [args.file_check_path] + unknown_args, stdin=subprocess.PIPE, text=True)
+    else:
+        p = subprocess.Popen(
+            [args.file_check_path] + unknown_args, stdin=subprocess.PIPE)
     stdout, stderr = p.communicate(stdin)
     if stdout is not None:
         print(stdout)


### PR DESCRIPTION
To get proper UTF-8 encoding on Windows, llvm queries the command line arguments directly from the Windows API and overwrites the references it was passed (see https://github.com/apple/swift-llvm/blob/stable/lib/Support/InitLLVM.cpp). Since the arguments are expanded before the PROGRAM_START call, it replaces the expanded arguments with the original ones, which then get passed to the rest of the program unexpanded.

This change expands the arguments after registering so that doesn't happen. However, it has the effect of registering the unexpanded arguments with the stacktrace rather than the expanded ones as before. Is this something that matters a lot? I supposed I could instead add a specific windows path that does something like expanding the arguments, registers, then expands again.
