### PR TITLE
swift-api-digester: avoid synthesizing nominal types from the same module.

### DIFF
--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -96,3 +96,7 @@ infix operator ..*..
 class UsableFromInlineClass {
   private var Prop = 1
 }
+
+class InternalType {}
+
+extension InternalType {}

--- a/test/api-digester/stability-stdlib-abi.swift
+++ b/test/api-digester/stability-stdlib-abi.swift
@@ -1,7 +1,7 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.tmp)
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
-// RUN: %api-digester -dump-sdk -module Swift -o %t.tmp/current-stdlib.json -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -abi
+// RUN: %api-digester -dump-sdk -module Swift -o %t.tmp/current-stdlib.json -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -abi -avoid-location
 // RUN: %api-digester -diagnose-sdk -input-paths %S/Inputs/stdlib-stable-abi.json -input-paths %t.tmp/current-stdlib.json -abi -o %t.tmp/changes.txt
 // RUN: %clang -E -P -x c %S/Outputs/stability-stdlib-abi.swift.expected -o - | sed '/^\s*$/d' | sort > %t.tmp/stability-stdlib-abi.swift.expected
 // RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' | sort > %t.tmp/changes.txt.tmp

--- a/test/api-digester/stability-stdlib-source.swift
+++ b/test/api-digester/stability-stdlib-source.swift
@@ -1,7 +1,7 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t.tmp)
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
-// RUN: %api-digester -dump-sdk -module Swift -o %t.tmp/current-stdlib.json -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk
+// RUN: %api-digester -dump-sdk -module Swift -o %t.tmp/current-stdlib.json -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -avoid-location
 // RUN: %api-digester -diagnose-sdk -input-paths %S/Inputs/stdlib-stable.json -input-paths %t.tmp/current-stdlib.json -o %t.tmp/changes.txt
 // RUN: %clang -E -P -x c %S/Outputs/stability-stdlib-source.swift.expected -o - | sed '/^\s*$/d' | sort > %t.tmp/stability-stdlib-source.swift.expected
 // RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' | sort > %t.tmp/changes.txt.tmp

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1,3 +1,4 @@
+#include "llvm/ADT/STLExtras.h"
 #include <ModuleAnalyzerNodes.h>
 #include <algorithm>
 
@@ -1535,7 +1536,11 @@ void SwiftDeclCollector::lookupVisibleDecls(ArrayRef<ModuleDecl *> Modules) {
   for (auto *D: KnownDecls) {
     if (auto *Ext = dyn_cast<ExtensionDecl>(D)) {
       if (HandledExtensions.find(Ext) == HandledExtensions.end()) {
-        ExtensionMap[Ext->getExtendedNominal()].push_back(Ext);
+        auto *NTD = Ext->getExtendedNominal();
+        // Check if the extension is from other modules.
+        if (!llvm::is_contained(Modules, NTD->getModuleContext())) {
+          ExtensionMap[NTD].push_back(Ext);
+        }
       }
     }
   }


### PR DESCRIPTION
Synthesizing types from the same module may bring back types that are not part the ABI/API, leading to false positives.

Resolves: SR-9372