### PR TITLE
[5.0] Limit access of implicit typealiases for associated type witnesses

### DIFF
--- a/test/attr/accessibility_print_inferred_type_witnesses.swift
+++ b/test/attr/accessibility_print_inferred_type_witnesses.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -print-access -source-filename=%s -swift-version 4| %FileCheck -check-prefix=CHECK -check-prefix=CHECK-4 %s
+// RUN: %target-swift-frontend -emit-module-path %t/accessibility_print.swiftmodule -module-name accessibility_print %s -swift-version 4
+// RUN: %target-swift-ide-test -skip-deinit=false -print-module -print-access -module-to-print=accessibility_print -I %t -source-filename=%s -swift-version 4 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-4 %s
+
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -print-access -source-filename=%s -swift-version 5 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-5 %s
+// RUN: %target-swift-frontend -emit-module-path %t/accessibility_print.swiftmodule -module-name accessibility_print %s -swift-version 5
+// RUN: %target-swift-ide-test -skip-deinit=false -print-module -print-access -module-to-print=accessibility_print -I %t -source-filename=%s -swift-version 5 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-5 %s
+
+// Enabling resilience means opting into the new behavior.
+// RUN: %target-swift-frontend -emit-module-path %t/accessibility_print.swiftmodule -module-name accessibility_print %s -swift-version 4 -enable-resilience
+// RUN: %target-swift-ide-test -skip-deinit=false -print-module -print-access -module-to-print=accessibility_print -I %t -source-filename=%s -swift-version 4 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-5 %s
+
+internal struct InternalStruct {}
+
+public protocol PublicAssocTypeProto {
+  associatedtype PublicValue
+  var publicValue: PublicValue { get }
+}
+fileprivate protocol FilePrivateAssocTypeProto {
+  associatedtype FilePrivateValue
+  var filePrivateValue: FilePrivateValue { get }
+}
+
+// CHECK-LABEL: private{{(\*/)?}} class PrivateImpl : PublicAssocTypeProto, FilePrivateAssocTypeProto {
+private class PrivateImpl: PublicAssocTypeProto, FilePrivateAssocTypeProto {
+  fileprivate var publicValue: InternalStruct?
+  fileprivate var filePrivateValue: Int?
+  // CHECK-DAG: {{^}} fileprivate typealias PublicValue
+  // CHECK-DAG: {{^}} fileprivate typealias FilePrivateValue
+} // CHECK: {{^[}]}}
+
+// CHECK-LABEL: public{{(\*/)?}} class PublicImpl : PublicAssocTypeProto, FilePrivateAssocTypeProto {
+public class PublicImpl: PublicAssocTypeProto, FilePrivateAssocTypeProto {
+  public var publicValue: Int?
+  fileprivate var filePrivateValue: InternalStruct?
+  // CHECK-DAG: {{^}} public typealias PublicValue
+  // CHECK-4-DAG: {{^}} internal typealias FilePrivateValue
+  // CHECK-5-DAG: {{^}} fileprivate typealias FilePrivateValue
+} // CHECK: {{^[}]}}


### PR DESCRIPTION
- **Explanation**: When conformance checking infers an associated type, it makes a new typealias to represent that type. Unfortunately, the access of that typealias was always the same as the conforming type's, which (1) might have leaked implementation details if the protocol wasn't as public as the conforming type, and (2) might have been straight-up incorrect if the /inferred type/ wasn't as public as the conforming type.

    Fix this in pre-Swift-5 modes by limiting the access to fit the underlying type (technically source-breaking, but most code that relied on this would have failed to link anyway), and in Swift 5 mode by using the minimum possible access (the intersection of the protocol and conforming type).

    It's much easier to make this change in Swift 5 than later because there are no binary-stable modules yet.

- **Scope**: Affects typealiases implicitly synthesized for conformances where the conforming type has broader access than the protocol. The Swift 5 mode behavior is a language change.

- **Issue**: rdar://problem/46143405

- **Risk**: Medium. It's unlikely but possible for this to break source compatibility for real projects.

- **Testing**: Passed regression tests and the source compat suite.

- **Reviewed by**: @slavapestov 