### PR TITLE
Add partial support for withDevice(.deviceType) {}

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1505,6 +1505,9 @@ FUNCTION(TFC_OpSetAttrOptionalTensorShapeArray,
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
+FUNCTION(TFC_OpSetDeviceFromScope, _swift_tfc_OpSetDeviceFromScope,
+         C_CC, RETURNS(VoidTy), ARGS(Int8PtrTy, Int8PtrTy), ATTRS(NoUnwind))
+
 // The swift function signature is (CTFEOp, UnsafePointer<Int8>, String) -> ().
 // In LLVM IR, the String gets exploded to (BridgeObjectPtrTy, Int64Ty), so
 // IRGen passes those two values in place of the Swift String.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2843,15 +2843,8 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
   }
 
   // Set the device.
-  opDevice = deviceInfo->handleDevicePlacement(opInfo.getOperationName(),
-                                               opDevice, i->getAttributes());
-  assert(!opDevice.empty());
-  if (opDevice != TF_ALL_DEVICES) {
-    auto *setDeviceFn = IGM.getTFE_OpSetDeviceFn();
-    auto device = IGM.getAddrOfGlobalString(opDevice);
-    Builder.CreateCall(setDeviceFn, {op, device, status});
-    checkOk(status);
-  }
+  Builder.CreateCall(IGM.getTFC_OpSetDeviceFromScopeFn(), {op, status});
+  checkOk(status);
 
   // If we have any opaque TensorGroup results, then we need to do extra runtime
   // work to determine the number of TensorFlow outputs and to allocate space

--- a/stdlib/private/TensorFlowUnittest/TensorFlowUnittest.swift
+++ b/stdlib/private/TensorFlowUnittest/TensorFlowUnittest.swift
@@ -53,10 +53,13 @@ public func printT(_ message: String) {
 }
 
 extension TestSuite {
+  static let willTargetGPU: Bool =
+    CommandLine.arguments.contains("--target=gpu")
   // If the macro TPU is not specified, run the tests with CPU or GPU. Otherwise
   // use TPU.
   // For GPU execution, TensorFlow must have been built with --config=cuda,
   // and a gpu device must be available.
+  @inline(never)
   public func testAllBackends(_ name: String, _ body: @escaping () -> Void) {
 #if !TPU
     testCPUOrGPU(name, body)
@@ -66,12 +69,14 @@ extension TestSuite {
   }
   public func testCPUOrGPU(_ name: String, _ body: @escaping () -> Void) {
 #if !TPU
-    test(name + "_CPU_OR_GPU") {
+    test(name + (TestSuite.willTargetGPU ? "_GPU" : "_CPU")) {
       _RuntimeConfig.executionMode = .auto
       _RuntimeConfig.usesTFEagerAPI = true
       _RuntimeConfig.gpuMemoryAllowGrowth = true
       _RuntimeConfig.printsDebugLog = false
-      body()
+      withDevice(TestSuite.willTargetGPU ? .gpu : .cpu) {
+        body()
+      }
     }
 #endif // TPU
   }

--- a/test/TensorFlowRuntime/accelerator_only.swift
+++ b/test/TensorFlowRuntime/accelerator_only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // RUN: %target-swift-frontend -emit-sil -O %s -verify | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize

--- a/test/TensorFlowRuntime/codable.swift
+++ b/test/TensorFlowRuntime/codable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: objc_interop

--- a/test/TensorFlowRuntime/conflicting_module.swift
+++ b/test/TensorFlowRuntime/conflicting_module.swift
@@ -7,7 +7,7 @@
 // RUN: %target-build-swift %S/Inputs/ConflictingModule1.swift -emit-module -emit-library -module-name ConflictingModule1 -o %t/libConflictingModule1.%target-dylib-extension -emit-module-path %t/ConflictingModule1.swiftmodule
 // RUN: %target-build-swift %S/Inputs/ConflictingModule2.swift -emit-module -emit-library -module-name ConflictingModule2 -o %t/libConflictingModule2.%target-dylib-extension -emit-module-path %t/ConflictingModule2.swiftmodule
 // RUN: %target-build-swift %s -I %t -L %t -lConflictingModule1 -lConflictingModule2 -Xlinker -rpath -Xlinker %t -o %t/a.out
-// RUN: %target-run %t/a.out
+// RUN: %target-run %t/a.out %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/control_flow_objc.swift
+++ b/test/TensorFlowRuntime/control_flow_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: OS=macosx

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //
@@ -100,7 +100,6 @@ DatasetTests.testAllBackends("Basic") {
   // OneShotIterator is not supported on GPU.
   model()
 }
-#endif
 
 DatasetTests.testAllBackends("MultiValue") {
   enableCPU()
@@ -137,5 +136,6 @@ DatasetTests.testAllBackends("MultiValue") {
   expectEqual(2, Tensor(handle: next.0).scalarized())
   expectEqual(12, Tensor(handle: next.1).scalarized())
 }
+#endif
 
 runAllTests()

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -1,6 +1,6 @@
 // TODO: Revert to %target-run-simple-swift once we complete send/recv support for resource/variant tensors.
-// RUN: %target-run-send-recv-handle-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-send-recv-handle-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 
@@ -19,15 +19,14 @@ var DatasetGlobalTests = TestSuite("DatasetGlobal")
 // Fatal error: No unary variant device copy function found for direction: 1 and Variant type_name: tensorflow::DatasetVariantWrapper
 #if !CUDA
 
-let scalars = Tensor<Float>([0, 1, 2])
-let dataset = Dataset(elements: scalars)
-var iterator = dataset.makeIterator()
-
 DatasetGlobalTests.testCPUOrGPU("RuntimeConfigTest") {
   expectTrue(_RuntimeConfig.usesTFEagerAPI)
 }
 
 DatasetGlobalTests.testCPUOrGPU("DatasetAsGlobalVar") {
+  let scalars = Tensor<Float>([0, 1, 2])
+  let dataset = Dataset(elements: scalars)
+
   var expectedVal: Float = 0.0
   for item in dataset {
     _hostOp(item)
@@ -37,6 +36,10 @@ DatasetGlobalTests.testCPUOrGPU("DatasetAsGlobalVar") {
 }
 
 DatasetGlobalTests.testCPUOrGPU("IteratorAsGlobalVar") {
+  let scalars = Tensor<Float>([0, 1, 2])
+  let dataset = Dataset(elements: scalars)
+  var iterator = dataset.makeIterator()
+
   var expectedVal: Float = 0.0
 	while let item = iterator.next() {
     _hostOp(item)

--- a/test/TensorFlowRuntime/dynamic_attributes.swift
+++ b/test/TensorFlowRuntime/dynamic_attributes.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: tensorflow
 
@@ -181,7 +181,7 @@ let convExpectedResult = ShapedArray<Float>(
 
 // ==== Actual Tests ====
 
-DynamicAttributeTests.test("NormalAttribute Bool") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Bool") {
   let input = Tensor<Int32>([[1, 2], [2, 1]])
   let reductionIndices = Tensor<Int32>(0)
 
@@ -198,7 +198,7 @@ DynamicAttributeTests.test("NormalAttribute Bool") {
   expectEqual(expectedResultKeepDimsFalse, resultKeepDimsFalse.array)
 }
 
-DynamicAttributeTests.test("NormalAttribute Int64") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Int64") {
   let input = Tensor<Int32>([1, 2, 3, 4, 5])
 
   let shuffled1 = Raw.randomShuffle(value: input, seed: loadInt64_1(),
@@ -212,7 +212,7 @@ DynamicAttributeTests.test("NormalAttribute Int64") {
   expectEqual(expectedResult2, shuffled2.array)
 }
 
-DynamicAttributeTests.test("NormalAttribute Double") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Double") {
   let x = Tensor<Double>(1)
   let y = Tensor<Double>(1.5)
 
@@ -223,7 +223,7 @@ DynamicAttributeTests.test("NormalAttribute Double") {
   expectEqual(false, result2.scalar!)
 }
 
-DynamicAttributeTests.test("NormalAttribute Float") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Float") {
   let x = Tensor<Float>(1)
   let y = Tensor<Float>(1.5)
 
@@ -238,7 +238,7 @@ DynamicAttributeTests.test("NormalAttribute Float") {
   expectEqual(false, result2.scalar!)
 }
 
-DynamicAttributeTests.test("NormalAttribute String") {
+DynamicAttributeTests.testAllBackends("NormalAttribute String") {
   let result: Tensor<Float> = #tfop("Conv2D", convImage, convFilter,
                                     T$dtype: Float.tensorFlowDataType,
                                     strides: [1, 1, 1, 1] as [Int32],
@@ -246,18 +246,18 @@ DynamicAttributeTests.test("NormalAttribute String") {
   expectEqual(convExpectedResult, result.array)
 }
 
-DynamicAttributeTests.test("NormalAttribute Array<Bool>") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Array<Bool>") {
   // There aren't any ops that take bool list attributes!
 }
 
-DynamicAttributeTests.test("NormalAttribute Array<Int32>") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int32>") {
   let result = convImage.convolved2D(withFilter: convFilter,
                                      strides: loadStridesInt32(),
                                      padding: .valid)
   expectEqual(convExpectedResult, result.array)
 }
 
-DynamicAttributeTests.test("NormalAttribute Array<Int64>") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Array<Int64>") {
   let result: Tensor<Float> = #tfop("Conv2D", convImage, convFilter,
                                     T$dtype: Float.tensorFlowDataType,
                                     strides: loadStridesInt64(),
@@ -265,14 +265,14 @@ DynamicAttributeTests.test("NormalAttribute Array<Int64>") {
   expectEqual(convExpectedResult, result.array)
 }
 
-DynamicAttributeTests.test("NormalAttribute Array<Double>") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Array<Double>") {
   let input = Tensor<Double>([-1, 0.1, 4.3, 1.2])
   let result = Raw.bucketize(input, boundaries: loadBoundariesDouble())
   let expectedResult = ShapedArray<Int32>([0, 1, 4, 2])
   expectEqual(expectedResult, result.array)
 }
 
-DynamicAttributeTests.test("NormalAttribute Array<Float>") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Array<Float>") {
   let input = Tensor<Float>([-1, 0.1, 4.3, 1.2])
   let result: Tensor<Int32> = #tfop("Bucketize", input,
                                     T$dtype: Float.tensorFlowDataType,
@@ -307,7 +307,7 @@ func check(dataset: VariantHandle) {
 
 #if !CUDA
 // TensorSliceDataset not available on GPU.
-DynamicAttributeTests.test("NormalAttribute Array<TensorShape>") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Array<TensorShape>") {
   let elements1 = Tensor<Int32>([[1], [2]])
   let elements2 = Tensor<Int32>([[1, 1], [2, 2]])
   let dataset: VariantHandle = #tfop(
@@ -318,7 +318,7 @@ DynamicAttributeTests.test("NormalAttribute Array<TensorShape>") {
   check(dataset: dataset)
 }
 
-DynamicAttributeTests.test("NormalAttribute Array<TensorShape?>") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Array<TensorShape?>") {
   let elements1 = Tensor<Int32>([[1], [2]])
   let elements2 = Tensor<Int32>([[1, 1], [2, 2]])
   let dataset: VariantHandle = #tfop(
@@ -329,7 +329,7 @@ DynamicAttributeTests.test("NormalAttribute Array<TensorShape?>") {
   check(dataset: dataset)
 }
 
-DynamicAttributeTests.test("NormalAttribute Array<String>") {
+DynamicAttributeTests.testAllBackends("NormalAttribute Array<String>") {
   // "ParseSingleExample" is the easiest-to-test Op with a list(string) attr,
   // so we use "ParseSingleExample" for this test.
 
@@ -357,7 +357,7 @@ DynamicAttributeTests.test("NormalAttribute Array<String>") {
 }
 #endif // !CUDA
 
-DynamicAttributeTests.test("TFDataTypeAttribute TensorDataType") {
+DynamicAttributeTests.testAllBackends("TFDataTypeAttribute TensorDataType") {
   let t1 = Tensor<Int32>(-1)
   let t1Result: Tensor<Int32> = #tfop("Abs", t1, T$dtype: loadDtypeInt32())
   expectEqual(1, t1Result.scalar!)
@@ -369,7 +369,7 @@ DynamicAttributeTests.test("TFDataTypeAttribute TensorDataType") {
 
 #if !CUDA
 // TensorSliceDataset not available on GPU.
-DynamicAttributeTests.test("TFDataTypeAttribute Array<TensorDataType>") {
+DynamicAttributeTests.testAllBackends("TFDataTypeAttribute Array<TensorDataType>") {
   let elements1 = Tensor<Int32>([[1], [2]])
   let elements2 = Tensor<Int32>([[1, 1], [2, 2]])
   let dataset: VariantHandle = #tfop(
@@ -381,14 +381,14 @@ DynamicAttributeTests.test("TFDataTypeAttribute Array<TensorDataType>") {
 }
 #endif // !CUDA
 
-DynamicAttributeTests.test("ShapeAttribute TensorShape") {
+DynamicAttributeTests.testAllBackends("ShapeAttribute TensorShape") {
   let t = Tensor<Float>([5.0])
   let result: Tensor<Float> = #tfop("EnsureShape", t, shape$shape: loadShape(),
                                     T$dtype: Float.tensorFlowDataType)
   expectEqual(t, result)
 }
 
-DynamicAttributeTests.test("ShapeAttribute TensorShape? non-nil") {
+DynamicAttributeTests.testAllBackends("ShapeAttribute TensorShape? non-nil") {
   let t = Tensor<Float>([5.0])
   let result: Tensor<Float> = #tfop("EnsureShape", t,
                                     shape$shape: loadOptionalShape(),
@@ -396,7 +396,7 @@ DynamicAttributeTests.test("ShapeAttribute TensorShape? non-nil") {
   expectEqual(t, result)
 }
 
-DynamicAttributeTests.test("ShapeAttribute TensorShape? nil") {
+DynamicAttributeTests.testAllBackends("ShapeAttribute TensorShape? nil") {
   let t = Tensor<Float>([5.0])
   let result: Tensor<Float> = #tfop("EnsureShape", t,
                                     shape$shape: loadUnknownShape(),

--- a/test/TensorFlowRuntime/dynamic_compilation.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation.swift
@@ -1,5 +1,5 @@
 // TODO: Revert to %target-run-simple-swift once we fold dynamic compilation into -Onone.
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 
 import CTensorFlow

--- a/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
+++ b/test/TensorFlowRuntime/dynamic_compilation_tensor_group.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 
 import TensorFlow

--- a/test/TensorFlowRuntime/gpu_negative_tests.swift
+++ b/test/TensorFlowRuntime/gpu_negative_tests.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // XFAIL: *

--- a/test/TensorFlowRuntime/hangers.swift
+++ b/test/TensorFlowRuntime/hangers.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/models.swift
+++ b/test/TensorFlowRuntime/models.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/random.swift
+++ b/test/TensorFlowRuntime/random.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/raw_ops.swift
+++ b/test/TensorFlowRuntime/raw_ops.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow_swift_bindings

--- a/test/TensorFlowRuntime/retain_release_1.swift
+++ b/test/TensorFlowRuntime/retain_release_1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/runtime_entry_points.swift
+++ b/test/TensorFlowRuntime/runtime_entry_points.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/sese_regions.swift
+++ b/test/TensorFlowRuntime/sese_regions.swift
@@ -1,6 +1,6 @@
 // This test has various test cases to check that SESE regions are computed correctly.
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -emit-sil -O %s -verify | %FileCheck %s
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/string.swift
+++ b/test/TensorFlowRuntime/string.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sync_runtime.swift
+++ b/test/TensorFlowRuntime/sync_runtime.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
 //
 // TODO(SR-9110): Make this pass in dynamic compilation mode.
 // %target-run-dynamic-compilation-swift

--- a/test/TensorFlowRuntime/tensor_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_debuglog.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_xla_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_xla_debuglog.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/top_level_1.swift
+++ b/test/TensorFlowRuntime/top_level_1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 
@@ -13,10 +13,12 @@ import StdlibUnittest
 
 var TopLevelTests = TestSuite("TopLevel")
 
+#if !CUDA
 TopLevelTests.testCPUOrGPU("TopLevel") {
   var x = Tensor<Int8>([1,2,3])*2
   x = x + x
   expectEqual(x.array, ShapedArray(shape: [3], scalars: [4, 8, 12]))
 }
+#endif
 
 runAllTests()

--- a/test/TensorFlowRuntime/top_level_2.swift
+++ b/test/TensorFlowRuntime/top_level_2.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-run-dynamic-compilation-swift
+// RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-dynamic-compilation-swift %swift-tensorflow-test-run-extra-options
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -328,6 +328,7 @@ lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
 # SWIFT_ENABLE_TENSORFLOW
+swift_tensorflow_test_run_extra_options = ""
 swift_tensorflow_extra_options = ""
 swift_tensorflow_path = lit_config.params.get('swift_tensorflow_path', None)
 if swift_tensorflow_path:
@@ -336,10 +337,12 @@ swift_tensorflow_gpu = lit_config.params.get('swift_tensorflow_gpu', None)
 # Can use #if on CUDA to selectively disable tests for GPU.
 if swift_tensorflow_gpu:
     swift_tensorflow_extra_options += ' -Xllvm -tf-target-gpu -DCUDA'
+    swift_tensorflow_test_run_extra_options += "--target=gpu"
     config.substitutions.append( ('%filecheck-tensorflow-extra-options', ' --check-prefix=CHECK-GPU --check-prefix=CHECK' ) )
 else:
     config.substitutions.append( ('%filecheck-tensorflow-extra-options', "") )
 config.substitutions.append( ('%swift-tensorflow-extra-options', swift_tensorflow_extra_options) )
+config.substitutions.append( ('%swift-tensorflow-test-run-extra-options', swift_tensorflow_test_run_extra_options) )
 
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
 if test_options:


### PR DESCRIPTION
Add a deviceScopes stack to CompilerRuntime to be consulted by the eager op dispatch.

Unfortunately, this info gets ignored when any ops get extracted out into a
graph, but hopefully static analysis of these calls could remove some of those differences.