### PR TITLE
[5.0] Assorted String bridging improvements

### DIFF
--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -137,6 +137,10 @@ _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
                                          _swift_shims_UInt8 *buffer,
                                          _swift_shims_CFIndex maxLength,
                                          unsigned long encoding);
+
+SWIFT_RUNTIME_STDLIB_API
+__swift_uintptr_t
+_swift_stdlib_unsafeAddressOfClass(id _Nonnull obj);
   
 #endif // __OBJC2__
 

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -182,6 +182,7 @@ extension String.UTF16View: BidirectionalCollection {
 
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     // TODO(String performance) known-ASCII fast path
+    
     if _slowPath(_guts.isForeign) {
       return _foreignIndex(i, offsetBy: n)
     }
@@ -461,10 +462,12 @@ extension String.UTF16View {
     // Trivial and common: start
     if idx == startIndex { return 0 }
 
+    if _guts.isASCII { return idx.encodedOffset }
+    
     if idx.encodedOffset < _shortHeuristic || !_guts.hasBreadcrumbs {
       return _distance(from: startIndex, to: idx)
     }
-
+    
     // Simple and common: endIndex aka `length`.
     let breadcrumbsPtr = _guts.getBreadcrumbsPtr()
     if idx == endIndex { return breadcrumbsPtr.pointee.utf16Length }
@@ -480,7 +483,7 @@ extension String.UTF16View {
   internal func _nativeGetIndex(for offset: Int) -> Index {
     // Trivial and common: start
     if offset == 0 { return startIndex }
-
+    
     if offset < _shortHeuristic || !_guts.hasBreadcrumbs {
       return _index(startIndex, offsetBy: offset)
     }

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -175,6 +175,11 @@ swift::_swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
 
 }
 
+__swift_uintptr_t
+swift::_swift_stdlib_unsafeAddressOfClass(id _Nonnull obj) {
+  return (__swift_uintptr_t)object_getClass(obj); //TODO: do direct isa access when in the OS
+}
+
 
 #endif
 

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -230,10 +230,8 @@ Var Hasher._core has declared type change from _BufferingHasher<Hasher._Core> to
 Var Hasher._Core._buffer is added to a non-resilient type
 Var Hasher._Core._state in a non-resilient type changes position from 0 to 1
 
-Class _AbstractStringStorage has been removed
 Constructor _StringGuts.init(_:) has been removed
 Constructor _StringObject.init(_:) has been removed
-Constructor _StringStorage.init() has been removed
 Var _StringObject.nativeStorage has been removed
 Var _StringStorage._countAndFlags has been removed
 Var _StringStorage._realCapacityAndFlags has been removed
@@ -517,3 +515,15 @@ Func LazyCollectionProtocol.reversed() has been removed
 Var LazyCollectionProtocol.lazy has declared type change from LazyCollection<τ_0_0.Elements> to LazySequence<τ_0_0.Elements>
 
 Func Sequence.reduce(into:_:) has parameter 0 changing from Default to Owned
+
+Class _AbstractStringStorage has been changed to a Protocol
+Class _AbstractStringStorage has generic signature change from to <τ_0_0 : _NSCopying>
+Class _AbstractStringStorage has removed conformance to _NSCopying
+Class _AbstractStringStorage has removed conformance to _NSStringCore
+Class _AbstractStringStorage has removed conformance to _ShadowProtocol
+Class _AbstractStringStorage is now without @_fixed_layout
+Class _SharedStringStorage has changed its super class from _AbstractStringStorage to __SwiftNativeNSString
+Class _StringStorage has changed its super class from _AbstractStringStorage to __SwiftNativeNSString
+Constructor _AbstractStringStorage.init() has been removed
+Func _AbstractStringStorage.copy(with:) has been removed
+Func _AbstractStringStorage.getOrComputeBreadcrumbs() has been removed


### PR DESCRIPTION

Explanation: 
• Convert _AbstractStringStorage to a protocol, and the free functions used to deduplicate implementations to extensions on that protocol.
• Move 'start' into the abstract type and use that to simplify some code
• Move the ASCII fast path for length into UTF16View.
• Add a weirder but faster way to check which (if any) of our NSString subclasses a given object is, and adopt it

Scope: This changes most operations on Swift Strings which are bridged into ObjC, but in relatively minor ways. This is a performance improvement, but is primarily important for Swift 5.0 because it will cause merge conflicts repeatedly if we don't have it.

Risk: Low-Medium. The main risk would be if someone is somehow relying on KVO subclassing of bridged Swift Strings, but since KVO doesn't actually work on NSStrings, 

Testing: Passed regression tests, and the perf test suite exercises these operations over the bridge as well.

Reviewed by: @milseman 