### PR TITLE
Improve attr_implements_fp.swift test.

### DIFF
--- a/test/attr/attr_implements_fp.swift
+++ b/test/attr/attr_implements_fp.swift
@@ -13,8 +13,10 @@
 public var comparedAsCauxmparablesCount : Int = 0
 public var comparedAsFauxtsCount : Int = 0
 
+infix operator  .<  : ComparisonPrecedence
+
 public protocol Cauxmparable {
-  static func < (lhs: Self, rhs: Self) -> Bool
+  static func .< (lhs: Self, rhs: Self) -> Bool
 }
 
 public protocol FauxtingPoint : Cauxmparable {
@@ -28,8 +30,8 @@ public protocol BinaryFauxtingPoint: FauxtingPoint {
 }
 
 public extension BinaryFauxtingPoint {
-  // This version of < will be called in a context that only knows it has a Cauxmparable.
-  @_implements(Cauxmparable, <(_:_:))
+  // This version of .< will be called in a context that only knows it has a Cauxmparable.
+  @_implements(Cauxmparable, .<(_:_:))
   static func _CauxmparableLessThan(_ lhs: Fauxt, _ rhs: Fauxt) -> Bool {
     print("compared as Cauxmparables")
     comparedAsCauxmparablesCount += 1
@@ -74,11 +76,11 @@ extension Fauxt: BinaryFauxtingPoint {
 }
 
 public extension Fauxt {
-  // This version of < will be called in a context that knows it has a Fauxt.
+  // This version of .< will be called in a context that knows it has a Fauxt.
   // It is inside an extension of Fauxt rather than the declaration of Fauxt
   // itself in order to avoid a warning about near-matches with the defaulted
-  // requirement from Cauxmparable.< up above.
-  static func <(_ lhs: Fauxt, _ rhs: Fauxt) -> Bool {
+  // requirement from Cauxmparable..< up above.
+  static func .<(_ lhs: Fauxt, _ rhs: Fauxt) -> Bool {
     print("compared as Fauxts")
     comparedAsFauxtsCount += 1
     if lhs.state == .Nan || rhs.state == .Nan {
@@ -90,15 +92,15 @@ public extension Fauxt {
 }
 
 public func compare_Cauxmparables<T:Cauxmparable>(_ x: T, _ y: T) -> Bool {
-  return x < y
+  return x .< y
 }
 
 public func compare_FauxtingPoint<T:FauxtingPoint>(_ x: T, _ y: T) -> Bool {
-  return x < y
+  return x .< y
 }
 
 public func compare_Fauxts(_ x: Fauxt, _ y: Fauxt) -> Bool {
-  return x < y
+  return x .< y
 }
 
 public func main() {

--- a/test/attr/attr_implements_fp.swift
+++ b/test/attr/attr_implements_fp.swift
@@ -89,6 +89,10 @@ public func compare_Comparables<T:Comparable>(_ x: T, _ y: T) -> Bool {
   return x < y
 }
 
+public func compare_FauxtingPoint<T:FauxtingPoint>(_ x: T, _ y: T) -> Bool {
+  return x < y
+}
+
 public func compare_Fauxts(_ x: Fauxt, _ y: Fauxt) -> Bool {
   return x < y
 }
@@ -102,6 +106,16 @@ public func main() {
   // CHECK: compared as Comparables
   assert(!compare_Comparables(Fauxt.nan, Fauxt.one))
   assert(comparedAsComparablesCount == 3)
+  // CHECK: compared as Comparables
+
+  assert(compare_FauxtingPoint(Fauxt.one, Fauxt.two))
+  assert(comparedAsComparablesCount == 4)
+  // CHECK: compared as Comparables
+  assert(compare_FauxtingPoint(Fauxt.one, Fauxt.nan))
+  assert(comparedAsComparablesCount == 5)
+  // CHECK: compared as Comparables
+  assert(!compare_FauxtingPoint(Fauxt.nan, Fauxt.one))
+  assert(comparedAsComparablesCount == 6)
   // CHECK: compared as Comparables
 
   assert(compare_Fauxts(Fauxt.one, Fauxt.two))

--- a/test/attr/attr_implements_fp.swift
+++ b/test/attr/attr_implements_fp.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'main()' >%t/main.swift
-// RUN: %target-swiftc_driver -o %t/a.out %s %t/main.swift
+// RUN: %target-swiftc_driver -o %t/a.out %s %t/main.swift -Xfrontend -enable-operator-designated-types -Xfrontend -solver-enable-operator-designated-types
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
@@ -13,7 +13,7 @@
 public var comparedAsCauxmparablesCount : Int = 0
 public var comparedAsFauxtsCount : Int = 0
 
-infix operator  .<  : ComparisonPrecedence
+infix operator  .<  : ComparisonPrecedence, BinaryFauxtingPoint, Cauxmparable
 
 public protocol Cauxmparable {
   static func .< (lhs: Self, rhs: Self) -> Bool

--- a/test/attr/attr_implements_fp.swift
+++ b/test/attr/attr_implements_fp.swift
@@ -26,6 +26,8 @@ public protocol FauxtingPoint : Cauxmparable {
 }
 
 public protocol BinaryFauxtingPoint: FauxtingPoint {
+  @_nonoverride static func .< (lhs: Self, rhs: Self) -> Bool
+
   var bitPattern: UInt8 { get }
 }
 

--- a/test/attr/attr_implements_fp.swift
+++ b/test/attr/attr_implements_fp.swift
@@ -101,6 +101,10 @@ public func compare_FauxtingPoint<T:FauxtingPoint>(_ x: T, _ y: T) -> Bool {
   return x .< y
 }
 
+public func compare_BinaryFauxtingPoint<T:BinaryFauxtingPoint>(_ x: T, _ y: T) -> Bool {
+  return x .< y
+}
+
 public func compare_Fauxts(_ x: Fauxt, _ y: Fauxt) -> Bool {
   return x .< y
 }
@@ -135,4 +139,15 @@ public func main() {
   assert(!compare_Fauxts(Fauxt.nan, Fauxt.one))
   assert(comparedAsFauxtsCount == 3)
   // CHECK: compared as Fauxts
+
+  assert(compare_BinaryFauxtingPoint(Fauxt.one, Fauxt.two))
+  assert(comparedAsFauxtsCount == 4)
+  // CHECK: compared as Fauxts
+  assert(!compare_BinaryFauxtingPoint(Fauxt.one, Fauxt.nan))
+  assert(comparedAsFauxtsCount == 5)
+  // CHECK: compared as Fauxts
+  assert(!compare_BinaryFauxtingPoint(Fauxt.nan, Fauxt.one))
+  assert(comparedAsFauxtsCount == 6)
+  // CHECK: compared as Fauxts
+
 }

--- a/test/attr/attr_implements_fp.swift
+++ b/test/attr/attr_implements_fp.swift
@@ -10,10 +10,14 @@
 // when only known to be comparable".
 
 // Could calls to the different comparison operators.
-public var comparedAsComparablesCount : Int = 0
+public var comparedAsCauxmparablesCount : Int = 0
 public var comparedAsFauxtsCount : Int = 0
 
-public protocol FauxtingPoint : Comparable {
+public protocol Cauxmparable {
+  static func < (lhs: Self, rhs: Self) -> Bool
+}
+
+public protocol FauxtingPoint : Cauxmparable {
   static var nan: Self { get }
   static var one: Self { get }
   static var two: Self { get }
@@ -24,11 +28,11 @@ public protocol BinaryFauxtingPoint: FauxtingPoint {
 }
 
 public extension BinaryFauxtingPoint {
-  // This version of < will be called in a context that only knows it has a Comparable.
-  @_implements(Comparable, <(_:_:))
-  static func _ComparableLessThan(_ lhs: Fauxt, _ rhs: Fauxt) -> Bool {
-    print("compared as Comparables")
-    comparedAsComparablesCount += 1
+  // This version of < will be called in a context that only knows it has a Cauxmparable.
+  @_implements(Cauxmparable, <(_:_:))
+  static func _CauxmparableLessThan(_ lhs: Fauxt, _ rhs: Fauxt) -> Bool {
+    print("compared as Cauxmparables")
+    comparedAsCauxmparablesCount += 1
     return lhs.bitPattern < rhs.bitPattern
   }
 }
@@ -73,7 +77,7 @@ public extension Fauxt {
   // This version of < will be called in a context that knows it has a Fauxt.
   // It is inside an extension of Fauxt rather than the declaration of Fauxt
   // itself in order to avoid a warning about near-matches with the defaulted
-  // requirement from Comparable.< up above.
+  // requirement from Cauxmparable.< up above.
   static func <(_ lhs: Fauxt, _ rhs: Fauxt) -> Bool {
     print("compared as Fauxts")
     comparedAsFauxtsCount += 1
@@ -85,7 +89,7 @@ public extension Fauxt {
   }
 }
 
-public func compare_Comparables<T:Comparable>(_ x: T, _ y: T) -> Bool {
+public func compare_Cauxmparables<T:Cauxmparable>(_ x: T, _ y: T) -> Bool {
   return x < y
 }
 
@@ -98,25 +102,25 @@ public func compare_Fauxts(_ x: Fauxt, _ y: Fauxt) -> Bool {
 }
 
 public func main() {
-  assert(compare_Comparables(Fauxt.one, Fauxt.two))
-  assert(comparedAsComparablesCount == 1)
-  // CHECK: compared as Comparables
-  assert(compare_Comparables(Fauxt.one, Fauxt.nan))
-  assert(comparedAsComparablesCount == 2)
-  // CHECK: compared as Comparables
-  assert(!compare_Comparables(Fauxt.nan, Fauxt.one))
-  assert(comparedAsComparablesCount == 3)
-  // CHECK: compared as Comparables
+  assert(compare_Cauxmparables(Fauxt.one, Fauxt.two))
+  assert(comparedAsCauxmparablesCount == 1)
+  // CHECK: compared as Cauxmparables
+  assert(compare_Cauxmparables(Fauxt.one, Fauxt.nan))
+  assert(comparedAsCauxmparablesCount == 2)
+  // CHECK: compared as Cauxmparables
+  assert(!compare_Cauxmparables(Fauxt.nan, Fauxt.one))
+  assert(comparedAsCauxmparablesCount == 3)
+  // CHECK: compared as Cauxmparables
 
   assert(compare_FauxtingPoint(Fauxt.one, Fauxt.two))
-  assert(comparedAsComparablesCount == 4)
-  // CHECK: compared as Comparables
+  assert(comparedAsCauxmparablesCount == 4)
+  // CHECK: compared as Cauxmparables
   assert(compare_FauxtingPoint(Fauxt.one, Fauxt.nan))
-  assert(comparedAsComparablesCount == 5)
-  // CHECK: compared as Comparables
+  assert(comparedAsCauxmparablesCount == 5)
+  // CHECK: compared as Cauxmparables
   assert(!compare_FauxtingPoint(Fauxt.nan, Fauxt.one))
-  assert(comparedAsComparablesCount == 6)
-  // CHECK: compared as Comparables
+  assert(comparedAsCauxmparablesCount == 6)
+  // CHECK: compared as Cauxmparables
 
   assert(compare_Fauxts(Fauxt.one, Fauxt.two))
   assert(comparedAsFauxtsCount == 1)

--- a/test/attr/attr_implements_serial.swift
+++ b/test/attr/attr_implements_serial.swift
@@ -13,15 +13,15 @@
 import AttrImplFP
 
 public func client() {
-  precondition(compare_Comparables(Fauxt.one, Fauxt.two))
-  precondition(comparedAsComparablesCount == 1)
-  // CHECK: compared as Comparables
-  precondition(compare_Comparables(Fauxt.one, Fauxt.nan))
-  precondition(comparedAsComparablesCount == 2)
-  // CHECK: compared as Comparables
-  precondition(!compare_Comparables(Fauxt.nan, Fauxt.one))
-  precondition(comparedAsComparablesCount == 3)
-  // CHECK: compared as Comparables
+  precondition(compare_Cauxmparables(Fauxt.one, Fauxt.two))
+  precondition(comparedAsCauxmparablesCount == 1)
+  // CHECK: compared as Cauxmparables
+  precondition(compare_Cauxmparables(Fauxt.one, Fauxt.nan))
+  precondition(comparedAsCauxmparablesCount == 2)
+  // CHECK: compared as Cauxmparables
+  precondition(!compare_Cauxmparables(Fauxt.nan, Fauxt.one))
+  precondition(comparedAsCauxmparablesCount == 3)
+  // CHECK: compared as Cauxmparables
 
   precondition(compare_Fauxts(Fauxt.one, Fauxt.two))
   precondition(comparedAsFauxtsCount == 1)

--- a/test/attr/attr_implements_serial.swift
+++ b/test/attr/attr_implements_serial.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'client()' >%t/main.swift
-// RUN: %target-build-swift-dylib(%t/libAttrImplFP.%target-dylib-extension) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift
+// RUN: %target-build-swift-dylib(%t/libAttrImplFP.%target-dylib-extension) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift -Xfrontend -enable-operator-designated-types -Xfrontend -solver-enable-operator-designated-types
 // RUN: %target-build-swift -I %t -o %t/a.out %s %t/main.swift -L %t -Xlinker -rpath -Xlinker %t -lAttrImplFP
 // RUN: %target-codesign %t/a.out
 // RUN: %target-codesign %t/libAttrImplFP.%target-dylib-extension


### PR DESCRIPTION
Reapply https://github.com/apple/swift/pull/20841 without https://github.com/apple/swift/pull/20841/commits/3f12f29c91727b4dc9bde7e1d7bdb68987ef9647.

For some reason using `%target-build-swift` results in optimized test runs failing.