### PR TITLE
[AST] Don't suggest unusable values for typo correction and code completion

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -637,15 +637,6 @@ static bool isPlausibleTypo(DeclRefKind refKind, DeclName typedName,
   return true;
 }
 
-static bool isLocInVarInit(TypeChecker &TC, VarDecl *var, SourceLoc loc) {
-  auto binding = var->getParentPatternBinding();
-  if (!binding || binding->isImplicit())
-    return false;
-
-  auto initRange = binding->getSourceRange();
-  return TC.Context.SourceMgr.rangeContainsTokenLoc(initRange, loc);
-}
-
 void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
                                         Type baseTypeOrNull,
                                         NameLookupOptions lookupOptions,
@@ -669,12 +660,6 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
     // not a plausible typo.
     if (!isPlausibleTypo(refKind, corrections.WrittenName, decl))
       return;
-
-    // Don't suggest a variable within its own initializer.
-    if (auto var = dyn_cast<VarDecl>(decl)) {
-      if (isLocInVarInit(*this, var, corrections.Loc.getBaseNameLoc()))
-        return;
-    }
 
     auto candidateName = decl->getFullName();
 

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -75,6 +75,14 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_1 | %FileCheck %s -check-prefix=IN_TUPLE_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_2 | %FileCheck %s -check-prefix=IN_TUPLE_2
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_1 | %FileCheck %s -check-prefix=OWN_INIT_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_2 | %FileCheck %s -check-prefix=OWN_INIT_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_3 | %FileCheck %s -check-prefix=OWN_INIT_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_4 | %FileCheck %s -check-prefix=OWN_INIT_4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_5 | %FileCheck %s -check-prefix=OWN_INIT_5
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_6 | %FileCheck %s -check-prefix=OWN_INIT_6
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_7 | %FileCheck %s -check-prefix=OWN_INIT_7
+
 //
 // Test code completion at the beginning of expr-postfix.
 //
@@ -435,8 +443,7 @@ func testInForEach1(arg: Int) {
   let after = 4
 // IN_FOR_EACH_1-NOT: Decl[LocalVar]
 // IN_FOR_EACH_1: Decl[LocalVar]/Local:               local[#Int#];
-// FIXME: shouldn't show 'after' here.
-// IN_FOR_EACH_1: Decl[LocalVar]/Local:               after[#Int#];
+// IN_FOR_EACH_1-NOT: after
 // IN_FOR_EACH_1: Decl[LocalVar]/Local:               arg[#Int#];
 // IN_FOR_EACH_1-NOT: Decl[LocalVar]
 }
@@ -448,8 +455,7 @@ func testInForEach2(arg: Int) {
   let after = 4
 // IN_FOR_EACH_2-NOT: Decl[LocalVar]
 // IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: local[#Int#];
-// FIXME: shouldn't show 'after' here.
-// IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: after[#Int#];
+// IN_FOR_EACH_2-NOT: after
 // IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: arg[#Int#];
 // IN_FOR_EACH_2-NOT: Decl[LocalVar]
 }
@@ -463,8 +469,7 @@ func testInForEach3(arg: Int) {
 // IN_FOR_EACH_3: Decl[LocalVar]/Local:               index[#Int#];
 // IN_FOR_EACH_3-NOT: Decl[LocalVar]
 // IN_FOR_EACH_3: Decl[LocalVar]/Local:               local[#Int#];
-// FIXME: shouldn't show 'after' here.
-// IN_FOR_EACH_3: Decl[LocalVar]/Local:               after[#Int#];
+// IN_FOR_EACH_3-NOT: after
 // IN_FOR_EACH_3: Decl[LocalVar]/Local:               arg[#Int#];
 // IN_FOR_EACH_3-NOT: Decl[LocalVar]
 }
@@ -503,8 +508,7 @@ func testInForEach9(arg: Int) {
 // NOTE: [Convertible] to AnyHashable.
 // IN_FOR_EACH_4-NOT: Decl[LocalVar]
 // IN_FOR_EACH_4: Decl[LocalVar]/Local/TypeRelation[Convertible]: local[#Int#];
-// FIXME: shouldn't show 'after' here.
-// IN_FOR_EACH_4: Decl[LocalVar]/Local/TypeRelation[Convertible]: after[#Int#];
+// IN_FOR_EACH_4-NOT: after
 // IN_FOR_EACH_4: Decl[LocalVar]/Local/TypeRelation[Convertible]: arg[#Int#];
 // IN_FOR_EACH_4-NOT: Decl[LocalVar]
 }
@@ -555,3 +559,31 @@ func testTuple(localInt: Int) {
 // IN_TUPLE_2: Decl[LocalVar]/Local:               localStr[#String#]; name=localStr
 // IN_TUPLE_2: Decl[LocalVar]/Local/TypeRelation[Identical]: localInt[#Int#]; name=localInt
 // IN_TUPLE_2: End completions
+
+var ownInit1: Int = #^OWN_INIT_1^#
+// OWN_INIT_1: Begin completions
+// OWN_INIT_1-NOT: ownInit1
+var ownInit2: () -> Void = { #^OWN_INIT_2^# }
+// OWN_INIT_2: Begin completions
+// OWN_INIT_2-NOT: ownInit2
+struct OwnInitTester {
+  var ownInit3: Int = #^OWN_INIT_3^#
+  // OWN_INIT_3: Begin completions
+  // OWN_INIT_3-NOT: ownInit3
+  var ownInit4: () -> Void = { #^OWN_INIT_4^# }
+  // OWN_INIT_4: Begin completions
+  // OWN_INIT_4-NOT: ownInit4
+}
+func ownInitTesting() {
+  var ownInit5: Int = #^OWN_INIT_5^#
+  // OWN_INIT_5: Begin completions
+  // OWN_INIT_5-NOT: ownInit5
+  var ownInit6: () -> Void = { #^OWN_INIT_6^# }
+  // OWN_INIT_6: Begin completions
+  // OWN_INIT_6-NOT: ownInit6
+}
+func ownInitTestingShadow(ownInit7: Int) {
+  var ownInit7: Int = #^OWN_INIT_7^#
+  // OWN_INIT_7: Begin completions
+  // OWN_INIT_7: Decl[LocalVar]/Local/TypeRelation[Identical]: ownInit7[#Int#];
+}

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typo-correction-limit 22
+// RUN: %target-typecheck-verify-swift -typo-correction-limit 23
 // RUN: not %target-swift-frontend -typecheck -disable-typo-correction %s 2>&1 | %FileCheck %s -check-prefix=DISABLED
 // RUN: not %target-swift-frontend -typecheck -typo-correction-limit 0 %s 2>&1 | %FileCheck %s -check-prefix=DISABLED
 // RUN: not %target-swift-frontend -typecheck -DIMPORT_FAIL %s 2>&1 | %FileCheck %s -check-prefix=DISABLED
@@ -190,4 +190,10 @@ func test_underscored_match() {
   let _eggs = 4 // expected-note {{'_eggs' declared here}}
   _ = _fggs + 1
   // expected-error@-1 {{use of unresolved identifier '_fggs'; did you mean '_eggs'?}}
+}
+
+// Don't show values before declaration.
+func testFwdRef() {
+  let _ = forward_refX + 1 // expected-error {{use of unresolved identifier 'forward_refX'}}
+  let forward_ref1 = 4
 }


### PR DESCRIPTION
Filter out:
- use within its own initial value
- use before declaration for local values

rdar://problem/25068938