### PR TITLE
Don't map Bool back to ObjCBool for SIL types in unbridged contexts

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -38,6 +38,16 @@ class NominalTypeDecl;
 
 enum class KnownProtocolKind : uint8_t;
 
+enum class Bridgeability : unsigned {
+  /// This context does not permit bridging at all.  For example, the
+  /// target of a C pointer.
+  None,
+
+  /// This context permits all kinds of bridging.  For example, the
+  /// imported result of a method declaration.
+  Full
+};
+
 /// Records dependencies on files outside of the current module;
 /// implemented in terms of a wrapped clang::DependencyCollector.
 class DependencyTracker {

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -31,6 +31,7 @@ namespace clang {
 
 namespace swift {
   class AnyFunctionRef;
+  enum class Bridgeability : unsigned;
   class ForeignErrorConvention;
   enum IsInitialization_t : bool;
   enum IsTake_t : bool;
@@ -851,6 +852,7 @@ public:
   /// Map an AST-level type to the corresponding foreign representation type we
   /// implicitly convert to for a given calling convention.
   Type getLoweredBridgedType(AbstractionPattern pattern, Type t,
+                             Bridgeability bridging,
                              SILFunctionTypeRepresentation rep,
                              BridgedTypePurpose purpose);
 
@@ -871,7 +873,8 @@ public:
   /// Given a function type, yield its bridged formal type.
   CanAnyFunctionType getBridgedFunctionType(AbstractionPattern fnPattern,
                                             CanAnyFunctionType fnType,
-                                            AnyFunctionType::ExtInfo extInfo);
+                                            AnyFunctionType::ExtInfo extInfo,
+                                            Bridgeability bridging);
 
   /// Given a referenced value and the substituted formal type of a
   /// resulting l-value expression, produce the substituted formal
@@ -975,22 +978,26 @@ private:
   CanType getLoweredRValueType(AbstractionPattern origType, CanType substType);
 
   Type getLoweredCBridgedType(AbstractionPattern pattern, Type t,
-                              bool canBridgeBool,
-                              bool bridgedCollectionsAreOptional);
+                              Bridgeability bridging,
+                              SILFunctionTypeRepresentation rep,
+                              BridgedTypePurpose purpose);
 
   AnyFunctionType::Param
   getBridgedParam(SILFunctionTypeRepresentation rep,
                   AbstractionPattern pattern,
-                  AnyFunctionType::Param param);
+                  AnyFunctionType::Param param,
+                  Bridgeability bridging);
 
   void getBridgedParams(SILFunctionTypeRepresentation rep,
                         AbstractionPattern pattern,
                         ArrayRef<AnyFunctionType::Param> params,
-                        SmallVectorImpl<AnyFunctionType::Param> &bridged);
+                        SmallVectorImpl<AnyFunctionType::Param> &bridged,
+                        Bridgeability bridging);
 
   CanType getBridgedResultType(SILFunctionTypeRepresentation rep,
                                AbstractionPattern pattern,
                                CanType result,
+                               Bridgeability bridging,
                                bool suppressOptional);
 };
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -181,16 +181,6 @@ enum class ImportTypeKind {
   Enum
 };
 
-enum class Bridgeability {
-  /// This context does not permit bridging at all.  For example, the
-  /// target of a C pointer.
-  None,
-
-  /// This context permits all kinds of bridging.  For example, the
-  /// imported result of a method declaration.
-  Full
-};
-
 /// Controls whether a typedef for \p type should name the fully-bridged Swift
 /// type or the original Clang type.
 ///

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1472,9 +1472,16 @@ CanType TypeConverter::getLoweredRValueType(AbstractionPattern origType,
     auto extInfo = substFnType->getExtInfo();
     if (getSILFunctionLanguage(extInfo.getSILRepresentation())
           == SILFunctionLanguage::C) {
+      // The importer only applies fully-reversible bridging to the
+      // component types of C function pointers.
+      auto bridging = Bridgeability::Full;
+      if (extInfo.getSILRepresentation()
+                        == SILFunctionTypeRepresentation::CFunctionPointer)
+        bridging = Bridgeability::None;
+
       // Bridge the parameters and result of the function type.
       auto bridgedFnType = getBridgedFunctionType(origType, substFnType,
-                                                  extInfo);
+                                                  extInfo, bridging);
       substFnType = bridgedFnType;
 
       // Also rewrite the type of the abstraction pattern.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -76,7 +76,8 @@ getIndirectApplyAbstractionPattern(SILGenFunction &SGF,
     // bridged to a foreign type.
     auto bridgedType =
       SGF.SGM.Types.getBridgedFunctionType(pattern, fnType,
-                                           fnType->getExtInfo());
+                                           fnType->getExtInfo(),
+                                           Bridgeability::Full);
     pattern.rewriteType(CanGenericSignature(), bridgedType);
     return pattern;
   }

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -358,7 +358,8 @@ expandTupleTypes(AnyFunctionType::CanParamArrayRef params) {
 static CanAnyFunctionType getBridgedBlockType(SILGenModule &SGM,
                                               CanAnyFunctionType blockType) {
   return SGM.Types.getBridgedFunctionType(AbstractionPattern(blockType),
-                                         blockType, blockType->getExtInfo());
+                                         blockType, blockType->getExtInfo(),
+                                         Bridgeability::Full);
 }
 
 static void buildFuncToBlockInvokeBody(SILGenFunction &SGF,

--- a/test/ClangImporter/Inputs/custom-modules/BlocksReturningBool.h
+++ b/test/ClangImporter/Inputs/custom-modules/BlocksReturningBool.h
@@ -1,0 +1,5 @@
+typedef unsigned long size_t;
+typedef _Bool (^predicate_t)(size_t);
+typedef struct {
+  void (*takePredicate)(predicate_t);
+} Aggregate;

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -203,6 +203,10 @@ module ObjCBridgeNonconforming {
   header "ObjCBridgeNonconforming.h"
 }
 
+module BlocksReturningBool {
+  header "BlocksReturningBool.h"
+}
+
 module Warnings1 { header "Warnings1.h" }
 module Warnings2 { header "Warnings2.h" }
 module Warnings3 { header "Warnings3.h" }

--- a/test/ClangImporter/blocks_returning_bool.swift
+++ b/test/ClangImporter/blocks_returning_bool.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -I %S/Inputs/ | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+import BlocksReturningBool
+
+// rdar://43656704
+
+// CHECK-LABEL: sil {{.*}} @$sSo9Aggregatea13takePredicateABySbSicSgXCSg_tcfC
+// CHECK-SAME: Optional<@convention(c) (Optional<@convention(block) (Int) -> Bool>) -> ()>
+func foo() -> Aggregate {
+  return Aggregate(takePredicate: nil)
+}

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -40,8 +40,8 @@ func test_infiniteLoop() {
 }
 
 func recursive(a: Int) -> Int {
-  if a == 0 { return 0 }     // expected-note {{exceeded instruction limit: 512 when evaluating the expression at compile time}}
-  return recursive(a: a-1)
+   // expected-note@+1 {{exceeded instruction limit: 512 when evaluating the expression at compile time}}
+  return a == 0 ? 0 : recursive(a: a-1)
 }
 
 func test_recursive() {


### PR DESCRIPTION
When the Clang importer imports the components of a C function pointer type, it generally translates foreign types into their native equivalents, just for the convenience of Swift code working with those functions. However, this translation must be unambiguously reversible, so (among other things) it cannot do this when the native type is also a valid foreign type.  Specifically, this means that the Clang importer cannot import `ObjCBool` as `Swift.Bool` in these positions because `Swift.Bool`  also corresponds directly to the C type `_Bool`.

SIL type lowering manually reverses the type-import process using a combination of duplicated logic and an abstraction pattern which includes information about the original Clang type that was imported.
This abstraction pattern is generally able to tell SIL type lowering exactly what type to reverse to.  However, `@convention(c)` function types may appear in positions from which it is impossible to recover the original Clang function type; therefore the reversal must be faithful to the proper rules.  To do this we must propagate bridgeability just as the imported would.

This reversal system is absolutely crazy, and we should really just
- record an unbridged function type for imported declarations and
- record an unbridged function type and Clang function type for `@convention (c)` function types whenever we create them.
But for now, it's what we've got.

rdar://43656704