### PR TITLE
SwiftPrivateThreadExtras: fix windows build

### DIFF
--- a/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
@@ -120,15 +120,15 @@ public func _stdlib_thread_join<Result>(
   let result = WaitForSingleObject(thread, 0xffffffff);
   // TODO(compnerd) modularize WinBase.h for WAIT_OBJECT_0 (0)
   if result == 0 {
-    let threadResult: DWORD = 0
+    var threadResult: DWORD = 0
     GetExitCodeThread(thread, &threadResult)
     CloseHandle(thread)
 
-    return (result,
+    return (CInt(result),
             UnsafeMutablePointer<DWORD>(&threadResult)
                 .withMemoryRebound(to: Result.self, capacity: 1){ $0.pointee })
   } else {
-    return (result, nil)
+    return (CInt(result), nil)
   }
 #else
   var threadResultRawPtr: UnsafeMutableRawPointer?


### PR DESCRIPTION
Missed casts and a let vs var issue.  This was missed in the last bundle
of patches.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
