### PR TITLE
test: correct lit configuration typo

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -833,7 +833,7 @@ elif run_os in ['windows-msvc']:
     subst_target_swift_frontend_mock_sdk_after = ''
 
     config.target_build_swift_dylib =                                            \
-            ("%r -parse-as-library -emit-librar -o '\\1'" % (config.target_build_swift))
+            ("%r -parse-as-library -emit-library -o '\\1'" % (config.target_build_swift))
     config.target_clang =                                                        \
             ('clang++ -target %s %s' % (config.variant_triple, clang_mcp_opt))
     config.target_ld =                                                           \


### PR DESCRIPTION
`-library` had a missing y.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
