### PR TITLE
Rebase swift's component system ontop of LLVM's component system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -948,7 +948,7 @@ endif()
 
 add_subdirectory(cmake/modules)
 
-swift_install_in_component(license
+swift_install_in_component(license swift-license
   FILES "LICENSE.txt"
   DESTINATION "share/swift")
 

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1418,7 +1418,7 @@ function(add_swift_host_library name)
     INSTALL_IN_COMPONENT "dev"
     )
 
-  swift_install_in_component(dev
+  swift_install_in_component(dev ${name}
     TARGETS ${name}
     ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX}
     LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
@@ -2000,7 +2000,7 @@ function(add_swift_target_library name)
             WORLD_READ)
       endif()
 
-      swift_install_in_component("${SWIFTLIB_INSTALL_IN_COMPONENT}"
+      swift_install_in_component("${SWIFTLIB_INSTALL_IN_COMPONENT}" ${name}
           FILES "${UNIVERSAL_LIBRARY_NAME}"
           DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}"
           PERMISSIONS ${file_permissions})
@@ -2008,7 +2008,7 @@ function(add_swift_target_library name)
         foreach(arch ${SWIFT_SDK_WINDOWS_ARCHITECTURES})
           if(TARGET ${name}-windows-${arch}_IMPLIB)
             get_target_property(import_library ${name}-windows-${arch}_IMPLIB IMPORTED_LOCATION)
-            swift_install_in_component(${SWIFTLIB_INSTALL_IN_COMPONENT}
+            swift_install_in_component(${SWIFTLIB_INSTALL_IN_COMPONENT} ${import_library}
               FILES ${import_library}
               DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${arch}"
               PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
@@ -2043,7 +2043,7 @@ function(add_swift_target_library name)
                                OUTPUT
                                  "${UNIVERSAL_LIBRARY_NAME}"
                                ${THIN_INPUT_TARGETS_STATIC})
-        swift_install_in_component("${SWIFTLIB_INSTALL_IN_COMPONENT}"
+        swift_install_in_component("${SWIFTLIB_INSTALL_IN_COMPONENT}" ${name}
             FILES "${UNIVERSAL_LIBRARY_NAME}"
             DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift_static/${resource_dir_sdk_subdir}"
             PERMISSIONS
@@ -2403,7 +2403,7 @@ function(add_swift_host_tool executable)
 
   # And then create the install rule if we are asked to.
   if (ADDSWIFTHOSTTOOL_SWIFT_COMPONENT)
-    swift_install_in_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
+    swift_install_in_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT} ${executable}
       TARGETS ${executable}
       RUNTIME DESTINATION bin)
 

--- a/cmake/modules/SwiftManpage.cmake
+++ b/cmake/modules/SwiftManpage.cmake
@@ -11,7 +11,7 @@ find_program(POD2MAN pod2man)
 #     MAN_SECTION N
 #     INSTALL_IN_COMPONENT comp
 #     )
-function(manpage)
+function(manpage name)
   cmake_parse_arguments(
       MP # prefix
       "" # options
@@ -38,7 +38,7 @@ function(manpage)
       DEPENDS "${MP_SOURCE}"
       ALL)
 
-  swift_install_in_component("${MP_INSTALL_IN_COMPONENT}"
+  swift_install_in_component("${MP_INSTALL_IN_COMPONENT}" ${name}
       FILES "${output_file_name}"
       DESTINATION "share/man/man${MP_MAN_SECTION}")
 endfunction()

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -348,7 +348,7 @@ function(_compile_swift_files
     list(APPEND module_outputs "${interface_file}")
   endif()
 
-  swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
+  swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}" ${module_base}-module
     FILES ${module_outputs}
     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}")
 
@@ -377,7 +377,7 @@ function(_compile_swift_files
     list(APPEND depends_create_apinotes "${apinote_input_file}")
 
     list(APPEND apinote_files "${apinote_file}")
-    swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
+    swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}" ${apinote_module}-apinotes
       FILES ${apinote_file}
       DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}")
   endforeach()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -174,7 +174,7 @@ if (DOXYGEN_FOUND)
     add_dependencies(doxygen doxygen-swift)
   endif()
 
-  swift_install_in_component(dev
+  swift_install_in_component(dev swift-doxygen-html
       DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doxygen/html"
       DESTINATION "docs/html")
 endif()

--- a/docs/tools/CMakeLists.txt
+++ b/docs/tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(SwiftManpage)
 
 manpage(
+    swift-pod
     SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/swift.pod"
     PAGE_HEADER "Swift Documentation"
     MAN_FILE_BASENAME swift

--- a/include/swift/SwiftRemoteMirror/CMakeLists.txt
+++ b/include/swift/SwiftRemoteMirror/CMakeLists.txt
@@ -4,7 +4,7 @@ list(APPEND swift_remote_mirror_headers
        Platform.h
        SwiftRemoteMirror.h
        SwiftRemoteMirrorTypes.h)
-swift_install_in_component("swift-remote-mirror-headers"
+swift_install_in_component("swift-remote-mirror-headers" swift-remote-mirror-headers
                            FILES
                              ${swift_remote_mirror_headers}
                            DESTINATION

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -51,7 +51,7 @@ if(SWIFT_BUILD_STATIC_STDLIB)
           "${SWIFT_SOURCE_DIR}/utils/gen-static-stdlib-link-args")
 
       list(APPEND static_stdlib_lnk_file_list ${swift_static_stdlib_${sdk}_args})
-      swift_install_in_component(stdlib
+      swift_install_in_component(stdlib ${lowercase_sdk}-linkfile
         FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
         DESTINATION "lib/swift_static/${lowercase_sdk}")
     endif()

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -38,7 +38,7 @@ add_custom_target("symlink_migrator_data"
     DEPENDS "${output_dir}" "${outputs}"
     COMMENT "Symlinking migrator data to ${output_dir}")
 
-swift_install_in_component(compiler
+swift_install_in_component(compiler symlink-migrator-data
   FILES ${datafiles}
 DESTINATION "lib/swift/migrator")
 

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -7,7 +7,7 @@ add_swift_host_library(swiftDemangle
                   C_COMPILE_FLAGS
                     -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 
-swift_install_in_component(compiler
+swift_install_in_component(compiler swift-demangle-host
     TARGETS swiftDemangle
     LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
     ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}")

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -114,7 +114,7 @@ foreach(sdk ${SWIFT_SDKS})
     #        It is not relocatable to the target platform itself.
     #        This affects any cross-comipled targets that use glibc.modulemap.
 
-    swift_install_in_component(sdk-overlay
+    swift_install_in_component(sdk-overlay glibc
         FILES "${glibc_modulemap_out}"
         DESTINATION "lib/swift/${arch_subdir}")
 

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -131,13 +131,13 @@ add_custom_command_target(unused_var
     COMMENT "Symlinking Clang resource headers into ${SWIFTLIB_DIR}/clang")
 add_dependencies(copy_shim_headers symlink_clang_headers)
 
-swift_install_in_component(compiler
+swift_install_in_component(compiler symlink-clang-headers-helper
     FILES ${sources}
     DESTINATION "lib/swift/shims")
 
 # Install Clang headers under the Swift library so that an installed Swift's
 # module importer can find the compiler headers corresponding to its Clang.
-swift_install_in_component(clang-builtin-headers
+swift_install_in_component(clang-builtin-headers clang-builtin-headers-helper
     DIRECTORY "${clang_headers_location}/"
     DESTINATION "lib/swift/clang"
     PATTERN "*.h")
@@ -151,6 +151,7 @@ swift_install_symlink_component(clang-resource-dir-symlink
 # need to use a different version of the headers than the installed Clang. This
 # should be used in conjunction with clang-resource-dir-symlink.
 swift_install_in_component(clang-builtin-headers-in-clang-resource-dir
+    clang-builtin-headers-in-clang-resource-dir-helper
     DIRECTORY "${SWIFT_PATH_TO_CLANG_BUILD}/lib/clang"
     DESTINATION "lib"
     PATTERN "*.h")

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -123,7 +123,7 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
         "${LibraryLocation}/${CMAKE_STATIC_LIBRARY_PREFIX}swiftImageInspectionShared${CMAKE_STATIC_LIBRARY_SUFFIX}"
       DEPENDS
          ${FragileSupportLibrary})
-    swift_install_in_component(stdlib
+    swift_install_in_component(stdlib ${FragileSupportLibrary}
       FILES $<TARGET_FILE:${FragileSupportLibrary}>
       DESTINATION "lib/swift_static/${lowercase_sdk}/${arch}")
   endforeach()
@@ -137,7 +137,7 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
       "${LibraryLocationPrimary}/${CMAKE_STATIC_LIBRARY_PREFIX}swiftImageInspectionShared${CMAKE_STATIC_LIBRARY_SUFFIX}"
       DEPENDS
          ${FragileSupportLibraryPrimary})
-    swift_install_in_component(stdlib
+    swift_install_in_component(stdlib $<TARGET_FILE:${FragileSupportLibraryPrimary}>
       FILES $<TARGET_FILE:${FragileSupportLibraryPrimary}>
       DESTINATION "lib/swift_static/${lowercase_sdk}")
 
@@ -154,7 +154,7 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
       "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk")
 
   list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
-  swift_install_in_component(stdlib
+  swift_install_in_component(stdlib ${lowercase_sdk}-linkfile
     FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
     DESTINATION "lib/swift_static/${lowercase_sdk}")
   add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
@@ -230,14 +230,14 @@ foreach(sdk ${SWIFT_CONFIGURED_SDKS})
                                 DEPENDS
                                   "${swiftrtObject}")
       if(SWIFT_BUILD_DYNAMIC_STDLIB)
-        swift_install_in_component(stdlib
+        swift_install_in_component(stdlib swiftImageRegistration-${arch_suffix}-dynamic
                                    FILES
                                      "${shared_runtime_registrar}"
                                    DESTINATION
                                      "lib/swift/${arch_subdir}")
       endif()
       if(SWIFT_BUILD_STATIC_STDLIB)
-        swift_install_in_component(stdlib
+        swift_install_in_component(stdlib swiftImageRegistration-${arch_suffix}-static
                                    FILES
                                      "${static_runtime_registrar}"
                                    DESTINATION

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ function(swift_configure_lit_site_cfg source_path destination_path installed_nam
   configure_file("${source_path}" "${destination_path}" @ONLY)
 
   if(NOT "${installed_name}" STREQUAL "")
-    swift_install_in_component(testsuite-tools
+    swift_install_in_component(testsuite-tools testsuite-tools
         FILES "${destination_path}"
         RENAME "${installed_name}"
         DESTINATION "share/swift/testsuite")

--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -175,7 +175,7 @@ if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     add_dependencies(dispatch libdispatch-install)
     add_dependencies(BlocksRuntime libdispatch-install)
 
-    swift_install_in_component(sourcekit-inproc
+    swift_install_in_component(sourcekit-inproc sourcekit-inproc-dispatch-blocksruntime
                                FILES
                                  $<TARGET_FILE:dispatch>
                                  $<TARGET_FILE:BlocksRuntime>

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -196,12 +196,12 @@ macro(add_sourcekit_library name)
       set(SOURCEKITLIB_INSTALL_IN_COMPONENT dev)
     endif()
   endif()
-  swift_install_in_component("${SOURCEKITLIB_INSTALL_IN_COMPONENT}"
+  swift_install_in_component("${SOURCEKITLIB_INSTALL_IN_COMPONENT}" ${name}
       TARGETS ${name}
       LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
       ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
       RUNTIME DESTINATION "bin")
-  swift_install_in_component("${SOURCEKITLIB_INSTALL_IN_COMPONENT}"
+  swift_install_in_component("${SOURCEKITLIB_INSTALL_IN_COMPONENT}" ${name}-headers
     FILES ${SOURCEKITLIB_HEADERS}
     DESTINATION "include/SourceKit")
   set_target_properties(${name} PROPERTIES FOLDER "SourceKit libraries")
@@ -335,7 +335,7 @@ macro(add_sourcekit_framework name)
 
 
   if (SOURCEKIT_DEPLOYMENT_OS MATCHES "^macosx")
-    swift_install_in_component(${SOURCEKITFW_INSTALL_IN_COMPONENT}
+    swift_install_in_component(${SOURCEKITFW_INSTALL_IN_COMPONENT} ${name}
         TARGETS ${name}
         LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
         ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX}
@@ -354,7 +354,7 @@ macro(add_sourcekit_framework name)
                           MACOSX_FRAMEWORK_BUNDLE_VERSION "${SOURCEKIT_VERSION_STRING}"
                           PUBLIC_HEADER "${headers}")
   else()
-    swift_install_in_component(${SOURCEKITFW_INSTALL_IN_COMPONENT}
+    swift_install_in_component(${SOURCEKITFW_INSTALL_IN_COMPONENT} ${name}
         DIRECTORY ${framework_location}
         DESTINATION lib${LLVM_LIBDIR_SUFFIX}
         USE_SOURCE_PERMISSIONS)

--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
@@ -24,6 +24,6 @@ if(SWIFT_ANALYZE_CODE_COVERAGE)
     LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
 endif()
 
-swift_install_in_component(tools
+swift_install_in_component(tools complete-test
     TARGETS complete-test
     RUNTIME DESTINATION bin)

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -27,7 +27,7 @@ if(HAVE_UNICODE_LIBEDIT)
       LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
   endif()
 
-  swift_install_in_component(tools
+  swift_install_in_component(tools sourcekitd-repl
       TARGETS sourcekitd-repl
       RUNTIME DESTINATION bin)
 endif()

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -32,6 +32,6 @@ if(SWIFT_ANALYZE_CODE_COVERAGE)
     LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
 endif()
 
-swift_install_in_component(tools
+swift_install_in_component(tools sourcekitd-test
     TARGETS sourcekitd-test
     RUNTIME DESTINATION bin)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -38,12 +38,12 @@ if(NOT SWIFT_BUILT_STANDALONE)
   add_dependencies(swift clang-headers)
 endif()
 
-swift_install_in_component(compiler
+swift_install_in_component(compiler swiftc
     FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swiftc${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "bin")
-swift_install_in_component(autolink-driver
+swift_install_in_component(autolink-driver swift-autolink-extract
     FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-autolink-extract${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "bin")
-swift_install_in_component(editor-integration
+swift_install_in_component(editor-integration swift-format
     FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-format${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "bin")

--- a/tools/swift-stdlib-tool/CMakeLists.txt
+++ b/tools/swift-stdlib-tool/CMakeLists.txt
@@ -4,7 +4,7 @@ add_swift_host_tool(swift-stdlib-tool
 find_library(FOUNDATION NAMES Foundation)
 target_link_libraries(swift-stdlib-tool PRIVATE ${FOUNDATION})
 
-swift_install_in_component(compiler
+swift_install_in_component(compiler swift-stdlib-tool
     TARGETS swift-stdlib-tool
     RUNTIME DESTINATION "bin")
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,15 +1,15 @@
 add_subdirectory(vim)
 add_subdirectory(lldb)
 
-swift_install_in_component(editor-integration
+swift_install_in_component(editor-integration swift-mode-el
     FILES swift-mode.el
     DESTINATION "share/emacs/site-lisp")
 
-swift_install_in_component(tools
+swift_install_in_component(tools swift-api-dump-py
     FILES swift-api-dump.py
     DESTINATION bin)
 
 # We install LLVM's FileCheck, if requested.
-swift_install_in_component(toolchain-dev-tools
+swift_install_in_component(toolchain-dev-tools swift-FileCheck
     FILES "${SWIFT_PATH_TO_LLVM_BUILD}/bin/FileCheck"
     DESTINATION bin)

--- a/utils/vim/CMakeLists.txt
+++ b/utils/vim/CMakeLists.txt
@@ -1,4 +1,4 @@
-swift_install_in_component(editor-integration
+swift_install_in_component(editor-integration vim-editor-integration
     DIRECTORY
       ftdetect
       syntax


### PR DESCRIPTION
LLVM's component system works by all installable things having individual
install-* targets. Swift's component system is intended to categorize
installable things with high level categories like a package maintainer would
want (e.x. compiler, editor-integration, etc). What this commit does is:

1. If a swift component is supposed to be installed, rather than just setting a
variable, we also define an install-${swift_component} custom target.

2. When we call swift_install_in_category, we now require a 2nd argument which
is a custom target install name. This must be a unique name since we will define
a rule based off of the provided name (install-${target_install_name}). If one
is trying to install a target, please use the target name as the target install
name. If one is installing a file or directory, this must just be a unique name
among all targets.

This allows for us to plug into LLVM's cmake install component system without
giving up the nice high level components for swift.
