### PR TITLE
Remove dot character when replacing contextual enum with full name

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -206,6 +206,12 @@ InFlightDiagnostic &InFlightDiagnostic::fixItReplace(SourceRange R,
     if (isspace(extractCharBefore(SM, charRange.getStart())))
       Str = Str.drop_front();
   }
+  
+  if (!Str.empty()) {
+      size_t dotPos = Str.find('.');
+      if (extractCharBefore(SM, charRange.getStart()) == '.' && dotPos != StringRef::npos)
+          charRange = toCharSourceRange(SM, SourceRange(R.Start.getAdvancedLoc(-1), R.End));
+  }
 
   Engine->getActiveDiagnostic().addFixIt(Diagnostic::FixIt(charRange, Str));
   return *this;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes  issue by going back one character when suggesting fixit replacement of contextual enum with fully typed name. All the unit tests passing with this change locally. Couldn't figure out where to add the unit test for this specific change.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8147](https://bugs.swift.org/browse/SR-8147).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->