### PR TITLE
Basic: prefer the move assignment for TreeScopeHashTableDetachedScope

### DIFF
--- a/include/swift/Basic/TreeScopedHashTable.h
+++ b/include/swift/Basic/TreeScopedHashTable.h
@@ -150,10 +150,8 @@ class TreeScopedHashTableDetachedScope {
   const ImplTy *getImpl() { return DetachedImpl; }
 
 public:
-  TreeScopedHashTableDetachedScope &operator=(
-                            const TreeScopedHashTableDetachedScope &) = default;
-  TreeScopedHashTableDetachedScope &operator=(
-                                 TreeScopedHashTableDetachedScope &&) = default;
+  TreeScopedHashTableDetachedScope &
+  operator=(TreeScopedHashTableDetachedScope &&) = default;
 
   TreeScopedHashTableDetachedScope() : DetachedImpl(0) {}
 


### PR DESCRIPTION
MSVC objects to the const assignment and move assignment operator.  Simply
prefer the move semantics.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
