### PR TITLE
[semantic-arc] Move semantic arc opts past definite initialization.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -82,9 +82,6 @@ static void addDefiniteInitialization(SILPassPipelinePlan &P) {
 static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
                                     const SILOptions &Options) {
   P.startPipeline("Guaranteed Passes");
-  if (Options.EnableMandatorySemanticARCOpts) {
-    P.addSemanticARCOpts();
-  }
   P.addDiagnoseStaticExclusivity();
   P.addCapturePromotion();
 
@@ -95,6 +92,9 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addAllocBoxToStack();
   P.addNoReturnFolding();
   addDefiniteInitialization(P);
+  if (Options.EnableMandatorySemanticARCOpts) {
+    P.addSemanticARCOpts();
+  }
   P.addClosureLifetimeFixup();
   P.addOwnershipModelEliminator();
   P.addMandatoryInlining();


### PR DESCRIPTION
To be clear this only runs on the stdlibs/overlays since it is gated behind a
flag that is set in our cmake.

I can not move it past closure lifetime fixup since the transformation as
written does not express all of the necessary ownership constraints explicitly
in the IR by using addresses.
