### PR TITLE
Restore a complex_expressions test that we no longer need disabled.

### DIFF
--- a/test/Sema/complex_expressions.swift
+++ b/test/Sema/complex_expressions.swift
@@ -2,9 +2,7 @@
 
 // SR-139:
 // Infinite recursion parsing bitwise operators
-// Temporarily disable to get SIMD stuff working. Ideally we can reinstate this
-// with Mark's changes.
-// let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF);
+let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF);
 
 // SR-838:
 // expression test_seconds() was too complex to be solved in reasonable time


### PR DESCRIPTION
Restores a test that was disabled as part of the original simd work. Now that we've moved the operators aside into an optional module, that's no longer necessary.