### PR TITLE
[stdlib] Silence warnings related to uninhabited types

### DIFF
--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -34,8 +34,6 @@ extension Never: Equatable {}
 
 extension Never: Comparable {
   public static func < (lhs: Never, rhs: Never) -> Bool {
-    switch (lhs, rhs) {
-    }
   }
 }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -772,7 +772,7 @@ public enum UnboundedRange_ {
   /// The unbounded range operator (`...`) is valid only within a collection's
   /// subscript.
   public static postfix func ... (_: UnboundedRange_) -> () {
-    fatalError("uncallable")
+    // This function is uncallable
   }
 }
 


### PR DESCRIPTION
PR #20528 was merged yesterday, which inserts an `unreachable` in
functions with uninhabited parameters. Unfortunately this means any
statement in the function body, even ones that themselves are
never-returning or don't have any executable code, cause the warning.

Silence the warnings by deleting the bodies of these functions.