### PR TITLE
master-next: Fix up recent Swift changes to work with newer VFS code.

### DIFF
--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -367,7 +367,7 @@ static bool buildSwiftModuleFromSwiftInterface(
   return !RunSuccess || SubError;
 }
 
-static bool serializedASTLooksValidOrCannotBeRead(clang::vfs::FileSystem &FS,
+static bool serializedASTLooksValidOrCannotBeRead(llvm::vfs::FileSystem &FS,
                                                   StringRef ModPath) {
   auto ModBuf = FS.getBufferForFile(ModPath, /*FileSize=*/-1,
                                     /*RequiresNullTerminator=*/false);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -60,12 +60,12 @@ std::error_code SerializedModuleLoaderBase::openModuleFiles(
   // If there are no buffers to load into, simply check for the existence of
   // the module file.
   if (!(ModuleBuffer || ModuleDocBuffer)) {
-    llvm::ErrorOr<clang::vfs::Status> statResult = FS.status(Scratch);
+    llvm::ErrorOr<llvm::vfs::Status> statResult = FS.status(Scratch);
     if (!statResult)
       return statResult.getError();
     if (!statResult->exists())
       return std::make_error_code(std::errc::no_such_file_or_directory);
-    // FIXME: clang::vfs::FileSystem doesn't give us information on whether or
+    // FIXME: llvm::vfs::FileSystem doesn't give us information on whether or
     // not we can /read/ the file without actually trying to do so.
     return std::error_code();
   }
@@ -110,17 +110,17 @@ std::error_code SerializedModuleLoader::openModuleFiles(
 bool SerializedModuleLoader::maybeDiagnoseArchitectureMismatch(
     SourceLoc sourceLocation, StringRef moduleName, StringRef archName,
     StringRef directoryPath) {
-  clang::vfs::FileSystem &fs = *Ctx.SourceMgr.getFileSystem();
+  llvm::vfs::FileSystem &fs = *Ctx.SourceMgr.getFileSystem();
 
   std::error_code errorCode;
   std::string foundArchs;
-  for (clang::vfs::directory_iterator directoryIterator =
+  for (llvm::vfs::directory_iterator directoryIterator =
            fs.dir_begin(directoryPath, errorCode), endIterator;
        directoryIterator != endIterator;
        directoryIterator.increment(errorCode)) {
     if (errorCode)
       return false;
-    StringRef filePath = directoryIterator->getName();
+    StringRef filePath = directoryIterator->path();
     StringRef extension = llvm::sys::path::extension(filePath);
     if (file_types::lookupTypeForExtension(extension) ==
           file_types::TY_SwiftModuleFile) {
@@ -183,7 +183,7 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
 
     currPath = path;
     llvm::sys::path::append(currPath, moduleFilename.str());
-    llvm::ErrorOr<clang::vfs::Status> statResult = fs.status(currPath);
+    llvm::ErrorOr<llvm::vfs::Status> statResult = fs.status(currPath);
 
     if (statResult && statResult->isDirectory()) {
       // A .swiftmodule directory contains architecture-specific files.


### PR DESCRIPTION
The main different here is that VFS moved from clang to llvm.