### PR TITLE
[Exclusivity] Hoist global_addr instructions used by access scopes to prologues

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -56,6 +56,8 @@ PASS(ABCOpt, "abcopts",
      "Array Bounds Check Optimization")
 PASS(AccessEnforcementDom, "access-enforcement-dom",
      "Remove dominated access checks with no nested conflict")
+PASS(AccessEnforcementGlobalHoisting, "access-enforcement-global",
+     "Access Enforcement Global Address Hoisting")
 PASS(AccessEnforcementOpts, "access-enforcement-opts",
      "Access Enforcement Optimization")
 PASS(AccessEnforcementReleaseSinking, "access-enforcement-release",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -195,6 +195,7 @@ void addHighLevelLoopOptPasses(SILPassPipelinePlan &P) {
   P.addSimplifyCFG();
   // Optimize access markers for better LICM: might merge accesses
   // It will also set the no_nested_conflict for dynamic accesses
+  P.addAccessEnforcementGlobalHoisting();
   P.addAccessEnforcementReleaseSinking();
   P.addAccessEnforcementOpts();
   P.addHighLevelLICM();
@@ -467,6 +468,7 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
   P.addCodeSinking();
   // Optimize access markers for better LICM: might merge accesses
   // It will also set the no_nested_conflict for dynamic accesses
+  P.addAccessEnforcementGlobalHoisting();
   P.addAccessEnforcementReleaseSinking();
   P.addAccessEnforcementOpts();
   P.addLICM();

--- a/lib/SILOptimizer/Transforms/AccessEnforcementGlobalHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementGlobalHoisting.cpp
@@ -1,0 +1,85 @@
+//===--- AccessEnforcementGlobalHoisting.cpp - global hoist opt ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This function pass hoists global_addr used by access scopes to entry blocks
+///
+/// General case:
+/// Loop:
+/// %A = global_addr
+/// begin_access %A
+/// ...
+/// end_access
+///
+/// The global_addr instruction can be hoisted to a function's entry block.
+/// This might expose some potenital for access enforcement optimizations,
+/// such as hoisting the begin_access out of the loop
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "access-enforcement-global"
+
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+static void processBlock(SILBasicBlock &currBlock, SILBasicBlock *entry) {
+  TermInst *term = entry->getTerminator();
+  assert(term && "Expected a terminator for entry block");
+  for (SILInstruction &instr : currBlock) {
+    BeginAccessInst *beginAccess = dyn_cast<BeginAccessInst>(&instr);
+    if (!beginAccess)
+      continue;
+    GlobalAddrInst *globalAddr =
+        dyn_cast<GlobalAddrInst>(beginAccess->getSource());
+    if (!globalAddr)
+      continue;
+    if (globalAddr->getParent() == entry) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Skipping " << *beginAccess
+                 << ", global_addr instruction already in entry block\n");
+      continue;
+    }
+    LLVM_DEBUG(llvm::dbgs()
+               << "Moving " << *globalAddr << " Before " << *term << "\n");
+    globalAddr->moveBefore(term);
+  }
+}
+
+namespace {
+struct AccessEnforcementGlobalHoisting : public SILFunctionTransform {
+  void run() override {
+    SILFunction *func = getFunction();
+    if (func->empty())
+      return;
+
+    SILBasicBlock *entry = func->getEntryBlock();
+    if (!entry)
+      return;
+
+    LLVM_DEBUG(llvm::dbgs() << "Running AccessEnforcementGlobalHoisting on "
+                            << func->getName() << "\n");
+
+    for (SILBasicBlock &currBB : *func) {
+      if (&currBB == entry) {
+        LLVM_DEBUG(llvm::dbgs() << "Skipping entry block - no need to hoist\n");
+        continue;
+      }
+      processBlock(currBB, entry);
+    }
+  }
+};
+} // namespace
+
+SILTransform *swift::createAccessEnforcementGlobalHoisting() {
+  return new AccessEnforcementGlobalHoisting();
+}

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 silopt_register_sources(
   ARCCodeMotion.cpp
   AccessEnforcementDom.cpp
+  AccessEnforcementGlobalHoisting.cpp
   AccessEnforcementOpts.cpp
   AccessEnforcementReleaseSinking.cpp 
   AccessEnforcementWMO.cpp

--- a/test/SILOptimizer/access_hoist.sil
+++ b/test/SILOptimizer/access_hoist.sil
@@ -1,0 +1,55 @@
+// RUN: %target-sil-opt -access-enforcement-global -assume-parsing-unqualified-ownership-sil %s -enable-sil-verify-all | %FileCheck %s --check-prefix=TESTPASS
+// RUN: %target-sil-opt -access-enforcement-global -licm -assume-parsing-unqualified-ownership-sil %s -enable-sil-verify-all | %FileCheck %s --check-prefix=TESTALL
+//
+// Test the AccessEnforcementHoistGlobal pass in isolation.
+// This ensures that no upstream passes have removed SIL-level access markers
+// that are required to ensure the pass is not overly optimistic.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct X {
+  @_hasStorage var i: Int64 { get set }
+  init(i: Int64)
+  init()
+}
+
+var globalX: X
+
+sil_global hidden @globalX : $X
+
+sil hidden_external [global_init] @globalAddressor : $@convention(thin) () -> Builtin.RawPointer
+
+// TESTPASS-LABEL: sil @testHoistGlobal : $@convention(thin) () -> () {
+// TESTPASS: [[GLOBAL:%.*]] = global_addr @globalX : $*X
+// TESTPASS-NEXT: br bb1
+// TESTPASS-LABEL: } // end sil function 'testHoistGlobal'
+
+
+// TESTALL-LABEL: sil @testHoistGlobal : $@convention(thin) () -> () {
+// TESTALL: [[GLOBAL:%.*]] = global_addr @globalX : $*X
+// TESTALL-NEXT: integer_literal
+// TESTALL-NEXT: begin_access
+// TESTALL-NEXT: br bb1
+// TESTALL: bb2
+// TESTALL: end_access
+// TESTALL-LABEL: } // end sil function 'testHoistGlobal'
+sil @testHoistGlobal : $@convention(thin) () -> () {
+bb0:
+  br bb1
+  
+bb1:
+  %global = global_addr @globalX: $*X
+  %4 = begin_access [read] [dynamic] %global : $*X
+  %5 = load %4 : $*X
+  end_access %4 : $*X
+  %cond = integer_literal $Builtin.Int1, 1
+  cond_br %cond, bb1, bb2
+
+bb2:
+  %7 = tuple ()
+  return %7 : $()
+}


### PR DESCRIPTION
General case:
Loop:
%A = global_addr
begin_access %A

The global_addr instruction can be hoisted to a function's entry block.

This might expose some potenital for access enforcement optimizations, such as hoisting the begin_access out of the loop

rdar://problem/46382837
