### PR TITLE
[ParseableInterface] Include "import Swift" in swiftinterface files

### DIFF
--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -528,8 +528,7 @@ static void printImports(raw_ostream &out, ModuleDecl *M) {
   publicImportSet.insert(publicImports.begin(), publicImports.end());
 
   for (auto import : allImports) {
-    if (import.second->isStdlibModule() ||
-        import.second->isOnoneSupportModule() ||
+    if (import.second->isOnoneSupportModule() ||
         import.second->isBuiltinModule()) {
       continue;
     }

--- a/test/ParseableInterface/imports-submodule-order.swift
+++ b/test/ParseableInterface/imports-submodule-order.swift
@@ -17,6 +17,7 @@
 // CHECK-NOT: import
 // CHECK: import X.Submodule{{$}}
 // CHECK-NEXT: import Y.Submodule{{$}}
+// CHECK-NEXT: {{^}}import Swift{{$}}
 // CHECK-NEXT: import X{{$}}
 // CHECK-NEXT: import Y{{$}}
 // CHECK-NOT: import

--- a/test/ParseableInterface/imports.swift
+++ b/test/ParseableInterface/imports.swift
@@ -15,5 +15,6 @@ import D
 // CHECK-NEXT: {{^}}import B.B3{{$}}
 // CHECK-NEXT: {{^}}import C/*.c*/{{$}}
 // CHECK-NEXT: {{^}}import D{{$}}
+// CHECK-NEXT: {{^}}import Swift{{$}}
 // CHECK-NEXT: {{^}}@_exported import empty{{$}}
 // CHECK-NOT: import


### PR DESCRIPTION
Otherwise we've got a problem with modules that use -parse-stdlib but aren't the stdlib themselves. Ideally we'd *only* print this in that case, but we don't have that information at this point in the pipeline and I'm not sure it would be a good idea to include it in the set of options we pass through.