### PR TITLE
[String] Fix corner case in comparison fast-path.

### DIFF
--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -136,7 +136,9 @@ internal func _stringCompare(
     let nfcQC = leftScalar._isNFCQCYes && rightScalar._isNFCQCYes
     let isSegmentEnd = left.hasNormalizationBoundary(before: idx + leftLen)
                     && right.hasNormalizationBoundary(before: idx + rightLen)
-    if _fastPath(nfcQC && isSegmentEnd) {
+    let isSegmentStart = leftScalar._hasNormalizationBoundaryBefore
+                      && rightScalar._hasNormalizationBoundaryBefore
+    if _fastPath(nfcQC && isSegmentEnd && isSegmentStart) {
       return expecting == _lexicographicalCompare(leftScalar, rightScalar)
     }
   }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2064,6 +2064,7 @@ struct ComparisonTestCase {
         expectEqual(pair.0, pair.1)
       }
     }
+    expectEqualSequence(strings, opaqueStrings)
 #endif
   }
   
@@ -2079,6 +2080,7 @@ struct ComparisonTestCase {
       let expectedResult: _Ordering = string1 < string2 ? .less : (string1 > string2 ? .greater : .equal)
       let opaqueResult: _Ordering = opaqueString < string2 ? .less : (opaqueString > string2 ? .greater : .equal)
       
+      expectEqual(string1, opaqueString)
       expectEqual(opaqueResult, expectedResult)
     }
 #endif
@@ -2133,6 +2135,9 @@ let comparisonTestCases = [
   ComparisonTestCase(["\u{f90b}", "\u{5587}"], .equal),
   
   ComparisonTestCase(["a\u{1D160}a", "a\u{1D158}\u{1D1C7}"], .less),
+
+  ComparisonTestCase(["a\u{305}\u{315}", "a\u{315}\u{305}"], .equal),
+  ComparisonTestCase(["a\u{315}bz", "a\u{315}\u{305}az"], .greater),
   
   ComparisonTestCase(["\u{212b}", "\u{00c5}"], .equal),
   ComparisonTestCase([


### PR DESCRIPTION
When in a post-binary-prefix-scan fast-path, we need to make sure we
are comparing a full-segment scalar, otherwise we miss situations
where a combining end-of-segment scalar would be reordered with a
prior combining scalar in the same segment under normalization in one
string but not the other.

This was hidden by the fact that many combining scalars are
NFC_QC=maybe, but those which are not present in any precomposed form
have NFC_QC=yes. Added tests.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
