### PR TITLE
getAutoDiffAssociatedFunctionType improvements

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -171,8 +171,12 @@ public:
   ///   if "Self" and "C" are in the set,
   ///   ==> pushes {Self, C} to `paramTypes`.
   ///
+  /// Pass `selfUncurried = true` when the function type is for a method whose
+  /// self parameter has been uncurried as in (A, B, C, Self) -> R.
+  ///
   void getSubsetParameterTypes(AnyFunctionType *functionType,
-                               SmallVectorImpl<Type> &paramTypes) const;
+                               SmallVectorImpl<Type> &paramTypes,
+                               bool selfUncurried = false) const;
 
   /// Returns a bitvector for the SILFunction parameters corresponding to the
   /// parameters in this set. In particular, this explodes tuples and puts the
@@ -193,7 +197,11 @@ public:
   ///   ==> returns 1110
   ///   (because the lowered SIL type is (A, B, C, D) -> R)
   ///
-  llvm::SmallBitVector getLowered(AnyFunctionType *functionType) const;
+  /// Pass `selfUncurried = true` when the function type is for a method whose
+  /// self parameter has been uncurried as in (A, B, C, Self) -> R.
+  ///
+  llvm::SmallBitVector getLowered(AnyFunctionType *functionType,
+                                  bool selfUncurried = false) const;
 };
 
 /// Differentiability of a function specifies the differentiation mode,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3115,9 +3115,16 @@ public:
     return getExtInfo().getDifferentiability();
   }
 
+  /// Given `indices`, `differentiationOrder`, and `kind`, calculates the type
+  /// of the corresponding autodiff associated function.
+  ///
+  /// Pass `selfUncurried = true` when the function type is for a method whose
+  /// self parameter has been uncurried as in (A, B, C, Self) -> R.
   AnyFunctionType *getAutoDiffAssociatedFunctionType(
       const AutoDiffParameterIndices &indices, unsigned differentiationOrder,
-      AutoDiffAssociatedFunctionKind kind);
+      AutoDiffAssociatedFunctionKind kind,
+      LookupConformanceFn lookupConformance, bool selfUncurried = false);
+
   AnyFunctionType *
   getAutoDiffAdjointFunctionType(const AutoDiffParameterIndices &indices,
                                  const TupleType *primalResultTy);
@@ -4155,7 +4162,8 @@ public:
   /// a function of this type.
   CanSILFunctionType getAutoDiffAssociatedFunctionType(
       const SmallBitVector &parameterIndices, unsigned differentiationOrder,
-      AutoDiffAssociatedFunctionKind kind, SILModule &module);
+      AutoDiffAssociatedFunctionKind kind, SILModule &module,
+      LookupConformanceFn lookupConformance);
 
   /// If this is a @convention(witness_method) function with a protocol
   /// constrained self parameter, return the protocol constraint for

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -176,14 +176,26 @@ void AutoDiffParameterIndices::setSelfParameter() {
 ///   if "Self" and "C" are in the set,
 ///   ==> pushes {Self, C} to `paramTypes`.
 ///
+/// Pass `selfUncurried = true` when the function type is for a method whose
+/// self parameter has been uncurried as in (A, B, C, Self) -> R.
+///
 void AutoDiffParameterIndices::getSubsetParameterTypes(
-    AnyFunctionType *functionType, SmallVectorImpl<Type> &paramTypes) const {
-  AnyFunctionType *unwrapped = unwrapSelfParameter(functionType, isMethodFlag);
-  if (isMethodFlag && indices[indices.size() - 1])
-    paramTypes.push_back(functionType->getParams()[0].getPlainType());
-  for (unsigned paramIndex : range(unwrapped->getNumParams()))
-    if (indices[paramIndex])
-      paramTypes.push_back(unwrapped->getParams()[paramIndex].getPlainType());
+    AnyFunctionType *functionType, SmallVectorImpl<Type> &paramTypes,
+    bool selfUncurried) const {
+  if (selfUncurried && isMethodFlag) {
+    if (isMethodFlag && indices[indices.size() - 1])
+      paramTypes.push_back(functionType->getParams()[functionType->getNumParams() - 1].getPlainType());
+    for (unsigned paramIndex : range(functionType->getNumParams() - 1))
+      if (indices[paramIndex])
+        paramTypes.push_back(functionType->getParams()[paramIndex].getPlainType());
+  } else {
+    AnyFunctionType *unwrapped = unwrapSelfParameter(functionType, isMethodFlag);
+    if (isMethodFlag && indices[indices.size() - 1])
+      paramTypes.push_back(functionType->getParams()[0].getPlainType());
+    for (unsigned paramIndex : range(unwrapped->getNumParams()))
+      if (indices[paramIndex])
+        paramTypes.push_back(unwrapped->getParams()[paramIndex].getPlainType());
+  }
 }
 
 static unsigned countNumFlattenedElementTypes(Type type) {
@@ -214,10 +226,16 @@ static unsigned countNumFlattenedElementTypes(Type type) {
 ///   ==> returns 1110
 ///   (because the lowered SIL type is (A, B, C, D) -> R)
 ///
+/// Pass `selfUncurried = true` when the function type is a for method whose
+/// self parameter has been uncurried as in (A, B, C, Self) -> R.
+///
 llvm::SmallBitVector
-AutoDiffParameterIndices::getLowered(AnyFunctionType *functionType) const {
+AutoDiffParameterIndices::getLowered(AnyFunctionType *functionType,
+                                     bool selfUncurried) const {
   // Calculate the lowered sizes of all the parameters.
-  AnyFunctionType *unwrapped = unwrapSelfParameter(functionType, isMethodFlag);
+  AnyFunctionType *unwrapped = selfUncurried
+      ? functionType
+      : unwrapSelfParameter(functionType, isMethodFlag);
   SmallVector<unsigned, 8> paramLoweredSizes;
   unsigned totalLoweredSize = 0;
   auto addLoweredParamInfo = [&](Type type) {
@@ -227,7 +245,7 @@ AutoDiffParameterIndices::getLowered(AnyFunctionType *functionType) const {
   };
   for (auto &param : unwrapped->getParams())
     addLoweredParamInfo(param.getPlainType());
-  if (isMethodFlag)
+  if (isMethodFlag && !selfUncurried)
     addLoweredParamInfo(functionType->getParams()[0].getPlainType());
 
   // Construct the result by setting each range of bits that corresponds to each

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -221,7 +221,7 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
   auto &ctx = getASTContext();
 
   unsigned numParamsWithoutSelf = hasSelfParam() ? getNumParameters() - 1
-                                           : getNumParameters();
+                                                 : getNumParameters();
   auto testParamIndex = [&](unsigned index) -> bool {
     return index < parameterIndices.size()  && parameterIndices[index];
   };

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -674,9 +674,9 @@ getAssociatedFunctionType(SILValue function,
   auto fnTy = function->getType().castTo<SILFunctionType>();
   assert(fnTy->getExtInfo().isDifferentiable());
   // FIXME: Get indices from the @autodiff function type.
-  auto assocFnTy = fnTy->getAutoDiffAssociatedFunctionType(SmallBitVector(),
-                                                           differentiationOrder,
-                                                           kind, module);
+  auto assocFnTy = fnTy->getAutoDiffAssociatedFunctionType(
+      SmallBitVector(), differentiationOrder, kind, module,
+      LookUpConformanceInModule(module.getSwiftModule()));
   return SILType::getPrimitiveObjectType(assocFnTy);
 }
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1270,7 +1270,8 @@ public:
                 "The JVP function must not be @autodiff");
         auto expectedJVPType = origTy->getAutoDiffAssociatedFunctionType(
             adfi->getParameterIndices(), order,
-            AutoDiffAssociatedFunctionKind::JVP, F.getModule());
+            AutoDiffAssociatedFunctionKind::JVP, F.getModule(),
+            LookUpConformanceInModule(F.getModule().getSwiftModule()));
         require(expectedJVPType == jvpType, "Unexpected JVP function type");
         auto vjpType = pair.second->getType().getAs<SILFunctionType>();
         require(vjpType, "The VJP function must have a function type");
@@ -1278,7 +1279,8 @@ public:
                 "The VJP function must not be @autodiff");
         auto expectedVJPType = origTy->getAutoDiffAssociatedFunctionType(
             adfi->getParameterIndices(), order,
-            AutoDiffAssociatedFunctionKind::VJP, F.getModule());
+            AutoDiffAssociatedFunctionKind::VJP, F.getModule(),
+            LookUpConformanceInModule(F.getModule().getSwiftModule()));
         require(expectedVJPType == vjpType, "Unexpected VJP function type");
       }
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2514,7 +2514,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   if (attr->getJVP()) {
     AnyFunctionType *expectedJVPFnTy =
         originalFnTy->getAutoDiffAssociatedFunctionType(
-            *checkedWrtParamIndices, 1, AutoDiffAssociatedFunctionKind::JVP);
+            *checkedWrtParamIndices, 1, AutoDiffAssociatedFunctionKind::JVP,
+            LookUpConformanceInModule(D->getDeclContext()->getParentModule()));
 
     auto isValidJVP = [&](FuncDecl *jvpCandidate) {
       TC.validateDeclForNameLookup(jvpCandidate);
@@ -2539,7 +2540,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   if (attr->getVJP()) {
     AnyFunctionType *expectedVJPFnTy =
         originalFnTy->getAutoDiffAssociatedFunctionType(
-            *checkedWrtParamIndices, 1, AutoDiffAssociatedFunctionKind::VJP);
+            *checkedWrtParamIndices, 1, AutoDiffAssociatedFunctionKind::VJP,
+            LookUpConformanceInModule(D->getDeclContext()->getParentModule()));
 
     auto isValidVJP = [&](FuncDecl *vjpCandidate) {
       TC.validateDeclForNameLookup(vjpCandidate);


### PR DESCRIPTION
Adds more features to `AnyFunctionType::getAutoDiffAssociatedFunctionType` and `SILFunctionType::getAutoDiffAssociatedFunctionType`:
* adds `lookupConformance` argument so that they can find tangent/cotangents for generic parameters
* special-cases builtin types so that they can find tangent/cotangents for builtin types
* teaches `SILFunctionType::getAutoDiffAssociatedFunctionType` to handle parameter indexes
* teaches `SILFunctionType::getAutoDiffAssociatedFunctionType` to handle methods
* adds `selfUncurried` to `AnyFunctionType::getAutoDiffAssociatedFunctionType` so that it can handle method types that have been uncurried
* makes `AnyFunctionType::getAutoDiffAssociatedFunctionType` preserve function extinfo

I have split this stuff out into its own PR because both https://github.com/apple/swift/pull/20759 and my in-progress VJP synthesizer depend on these new features.