### PR TITLE
test: use FileCheck instead of grep, count

### DIFF
--- a/test/CircularReferences/extensions.swift
+++ b/test/CircularReferences/extensions.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -debug-cycles > %t.log 2>&1
-// RUN: not grep "CYCLE DETECTED" %t.log | count 0
+// RUN: %target-typecheck-verify-swift -debug-cycles 2>&1 | %FileCheck --allow-empty %s
 
 // Verify that extension lookups don't cause cyclic dependencies.
 
@@ -7,3 +6,6 @@
 
 struct A { }
 extension A { }
+
+// CHECK-NOT: CYCLE DETECTED
+


### PR DESCRIPTION
Use FileCheck instead of grep and count.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
