### PR TITLE
[SILGen][stdlib] Remove _getBool

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -52,6 +52,7 @@ namespace swift {
   enum class Associativity : unsigned char;
   class BoundGenericType;
   class ClangNode;
+  class ConstructorDecl;
   class Decl;
   class DeclContext;
   class DefaultArgumentInitializer;
@@ -512,6 +513,9 @@ public:
   /// If this is true, the method getAllocateUninitializedArray
   /// promises to return non-null.
   bool hasArrayLiteralIntrinsics(LazyResolver *resolver) const;
+
+  /// Retrieve the declaration of Swift.Bool.init(_builtinBooleanLiteral:)
+  ConstructorDecl *getBoolBuiltinInitDecl() const;
 
   /// Retrieve the declaration of Swift.==(Int, Int) -> Bool.
   FuncDecl *getEqualIntDecl() const;

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -513,9 +513,6 @@ public:
   /// promises to return non-null.
   bool hasArrayLiteralIntrinsics(LazyResolver *resolver) const;
 
-  /// Retrieve the declaration of Swift._getBool.
-  FuncDecl *getGetBoolDecl(LazyResolver *resolver) const;
-
   /// Retrieve the declaration of Swift.==(Int, Int) -> Bool.
   FuncDecl *getEqualIntDecl() const;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3458,8 +3458,6 @@ ERROR(pointer_argument_intrinsics_not_found,none,
 ERROR(array_literal_intrinsics_not_found,none,
       "broken standard library: cannot find intrinsic operations on "
       "Array<T>", ())
-ERROR(bool_intrinsics_not_found,none,
-      "broken standard library: cannot find intrinsic operations on Bool", ())
 ERROR(class_super_access,none,
       "class %select{must be declared %select{"
       "%select{private|fileprivate|internal|%error|%error}1|private or fileprivate}3"

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1876,7 +1876,7 @@ RValue RValueEmitter::visitIsExpr(IsExpr *E, SGFContext C) {
   // Ensure it is actually an initializer
   assert(::isa<ConstructorDecl>(members[0]));
 
-  auto init = dyn_cast<ConstructorDecl>(members[0]);
+  auto init = cast<ConstructorDecl>(members[0]);
   Type builtinArgType = BuiltinIntegerType::get(1, ctx);
   RValue builtinArg(SGF, ManagedValue::forUnmanaged(isa),
                     builtinArgType->getCanonicalType());
@@ -1919,7 +1919,7 @@ RValue RValueEmitter::visitEnumIsCaseExpr(EnumIsCaseExpr *E,
   // Ensure it is actually an initializer
   assert(::isa<ConstructorDecl>(members[0]));
 
-  auto init = dyn_cast<ConstructorDecl>(members[0]);
+  auto init = cast<ConstructorDecl>(members[0]);
   Type builtinArgType = BuiltinIntegerType::get(1, ctx);
   RValue builtinArg(SGF, ManagedValue::forUnmanaged(selected),
                     builtinArgType->getCanonicalType());

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1866,17 +1866,7 @@ RValue RValueEmitter::visitIsExpr(IsExpr *E, SGFContext C) {
 
   // Call the Bool(_builtinBooleanLiteral:) initializer
   ASTContext &ctx = SGF.getASTContext();
-  DeclName name(ctx, DeclBaseName::createConstructor(),
-                { ctx.Id_builtinBooleanLiteral });
-  auto members = ctx.getBoolDecl()->lookupDirect(name);
-  
-  // Ensure we just have one initializer
-  assert(members.size() == 1);
-
-  // Ensure it is actually an initializer
-  assert(::isa<ConstructorDecl>(members[0]));
-
-  auto init = cast<ConstructorDecl>(members[0]);
+  auto init = ctx.getBoolBuiltinInitDecl();
   Type builtinArgType = BuiltinIntegerType::get(1, ctx);
   RValue builtinArg(SGF, ManagedValue::forUnmanaged(isa),
                     builtinArgType->getCanonicalType());
@@ -1884,7 +1874,6 @@ RValue RValueEmitter::visitIsExpr(IsExpr *E, SGFContext C) {
     SGF.emitApplyAllocatingInitializer(E, ConcreteDeclRef(init),
                                        std::move(builtinArg), Type(),
                                        C);
-
   return result;
 }
 
@@ -1909,17 +1898,7 @@ RValue RValueEmitter::visitEnumIsCaseExpr(EnumIsCaseExpr *E,
   }
   
   // Call the Bool(_builtinBooleanLiteral:) initializer
-  DeclName name(ctx, DeclBaseName::createConstructor(),
-                { ctx.Id_builtinBooleanLiteral });
-  auto members = ctx.getBoolDecl()->lookupDirect(name);
-  
-  // Ensure we just have one initializer
-  assert(members.size() == 1);
-  
-  // Ensure it is actually an initializer
-  assert(::isa<ConstructorDecl>(members[0]));
-
-  auto init = cast<ConstructorDecl>(members[0]);
+  auto init = ctx.getBoolBuiltinInitDecl();
   Type builtinArgType = BuiltinIntegerType::get(1, ctx);
   RValue builtinArg(SGF, ManagedValue::forUnmanaged(selected),
                     builtinArgType->getCanonicalType());

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1471,6 +1471,10 @@ public:
                                      ArrayRef<ManagedValue> args,
                                      SGFContext ctx);
 
+  RValue emitApplyAllocatingInitializer(SILLocation loc, ConcreteDeclRef init,
+                                        RValue &&args, Type overriddenSelfType,
+                                        SGFContext ctx);
+
   CleanupHandle emitBeginApply(SILLocation loc, ManagedValue fn,
                                SubstitutionMap subs, ArrayRef<ManagedValue> args,
                                CanSILFunctionType substFnType,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3252,7 +3252,7 @@ namespace {
       // SIL-generation magically turns this into a Bool; make sure it can.
       DeclName initName(tc.Context, DeclBaseName::createConstructor(),
                         { tc.Context.Id_builtinBooleanLiteral });
-      auto members = cs.getASTContext().getBoolDecl()->lookupDirect(initName);
+      auto members = tc.Context.getBoolDecl()->lookupDirect(initName);
       
       if (members.size() != 1) {
         tc.diagnose(expr->getLoc(), diag::broken_bool);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3250,18 +3250,9 @@ namespace {
       }
 
       // SIL-generation magically turns this into a Bool; make sure it can.
-      DeclName initName(tc.Context, DeclBaseName::createConstructor(),
-                        { tc.Context.Id_builtinBooleanLiteral });
-      auto members = tc.Context.getBoolDecl()->lookupDirect(initName);
-      
-      if (members.size() != 1) {
+      if (!tc.Context.getBoolBuiltinInitDecl()) {
         tc.diagnose(expr->getLoc(), diag::broken_bool);
         // Continue anyway.
-      } else {
-        if (!isa<ConstructorDecl>(members[0])) {
-          tc.diagnose(expr->getLoc(), diag::broken_bool);
-          // Continue anyway.
-        }
       }
 
       // Dig through the optionals in the from/to types.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3250,9 +3250,18 @@ namespace {
       }
 
       // SIL-generation magically turns this into a Bool; make sure it can.
-      if (!cs.getASTContext().getGetBoolDecl(&cs.getTypeChecker())) {
-        tc.diagnose(expr->getLoc(), diag::bool_intrinsics_not_found);
+      DeclName initName(tc.Context, DeclBaseName::createConstructor(),
+                        { tc.Context.Id_builtinBooleanLiteral });
+      auto members = cs.getASTContext().getBoolDecl()->lookupDirect(initName);
+      
+      if (members.size() != 1) {
+        tc.diagnose(expr->getLoc(), diag::broken_bool);
         // Continue anyway.
+      } else {
+        if (!isa<ConstructorDecl>(members[0])) {
+          tc.diagnose(expr->getLoc(), diag::broken_bool);
+          // Continue anyway.
+        }
       }
 
       // Dig through the optionals in the from/to types.

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -187,11 +187,6 @@ extension Bool : CustomStringConvertible {
   }
 }
 
-// This is a magic entry point known to the compiler.
-@_transparent
-public // COMPILER_INTRINSIC
-func _getBool(_ v: Builtin.Int1) -> Bool { return Bool(v) }
-
 extension Bool: Equatable {
   @_transparent
   public static func == (lhs: Bool, rhs: Bool) -> Bool {

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -70,10 +70,10 @@ if true {
   // CHECK-NEXT: true
   
   var bo3 = Builtin.castToBridgeObject(C(), 0._builtinWordValue)
-  print(_getBool(Builtin.isUnique(&bo3)))
+  print(Bool(_builtinBooleanLiteral: Builtin.isUnique(&bo3)))
   // CHECK-NEXT: true
   let bo4 = bo3
-  print(_getBool(Builtin.isUnique(&bo3)))
+  print(Bool(_builtinBooleanLiteral: Builtin.isUnique(&bo3)))
   // CHECK-NEXT: false
   _fixLifetime(bo3)
   _fixLifetime(bo4)
@@ -98,10 +98,10 @@ if true {
   // CHECK-NEXT: true
   
   var bo3 = Builtin.castToBridgeObject(C(), NATIVE_SPARE_BITS._builtinWordValue)
-  print(_getBool(Builtin.isUnique(&bo3)))
+  print(Bool(_builtinBooleanLiteral: Builtin.isUnique(&bo3)))
   // CHECK-NEXT: true
   let bo4 = bo3
-  print(_getBool(Builtin.isUnique(&bo3)))
+  print(Bool(_builtinBooleanLiteral: Builtin.isUnique(&bo3)))
   // CHECK-NEXT: false
   _fixLifetime(bo3)
   _fixLifetime(bo4)
@@ -132,7 +132,7 @@ if true {
   print(x === x2)
 
   var bo3 = nonNativeBridgeObject(NSNumber(value: 22))
-  print(_getBool(Builtin.isUnique(&bo3)))
+  print(Bool(_builtinBooleanLiteral: Builtin.isUnique(&bo3)))
   // CHECK-NEXT: false
   _fixLifetime(bo3)
 }
@@ -154,7 +154,7 @@ if true {
   print(x === x2)
   
   var bo3 = nonNativeBridgeObject(unTaggedString)
-  print(_getBool(Builtin.isUnique(&bo3)))
+  print(Bool(_builtinBooleanLiteral: Builtin.isUnique(&bo3)))
   // CHECK-NEXT: false
   _fixLifetime(bo3)
 }

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -588,7 +588,7 @@ func castBitPatternFromBridgeObject(_ bo: Builtin.BridgeObject) -> Builtin.Word 
 // CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Optional<Builtin.NativeObject>
 // CHECK: return
 func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
-  return _getBool(Builtin.isUnique(&ref))
+  return Bool(_builtinBooleanLiteral: Builtin.isUnique(&ref))
 }
 
 // NativeObject nonNull
@@ -598,7 +598,7 @@ func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
 // CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Builtin.NativeObject
 // CHECK: return
 func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
-  return _getBool(Builtin.isUnique(&ref))
+  return Bool(_builtinBooleanLiteral: Builtin.isUnique(&ref))
 }
 
 // UnknownObject (ObjC)
@@ -608,7 +608,7 @@ func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
 // CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Optional<Builtin.UnknownObject>
 // CHECK: return
 func isUnique(_ ref: inout Builtin.UnknownObject?) -> Bool {
-  return _getBool(Builtin.isUnique(&ref))
+  return Bool(_builtinBooleanLiteral: Builtin.isUnique(&ref))
 }
 
 // UnknownObject (ObjC) nonNull
@@ -618,7 +618,7 @@ func isUnique(_ ref: inout Builtin.UnknownObject?) -> Bool {
 // CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Builtin.UnknownObject
 // CHECK: return
 func isUnique(_ ref: inout Builtin.UnknownObject) -> Bool {
-  return _getBool(Builtin.isUnique(&ref))
+  return Bool(_builtinBooleanLiteral: Builtin.isUnique(&ref))
 }
 
 // BridgeObject nonNull
@@ -628,7 +628,7 @@ func isUnique(_ ref: inout Builtin.UnknownObject) -> Bool {
 // CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Builtin.BridgeObject
 // CHECK: return
 func isUnique(_ ref: inout Builtin.BridgeObject) -> Bool {
-  return _getBool(Builtin.isUnique(&ref))
+  return Bool(_builtinBooleanLiteral: Builtin.isUnique(&ref))
 }
 
 // BridgeObject nonNull native
@@ -638,7 +638,7 @@ func isUnique(_ ref: inout Builtin.BridgeObject) -> Bool {
 // CHECK: [[CAST:%.*]] = unchecked_addr_cast [[WRITE]] : $*Builtin.BridgeObject to $*Builtin.NativeObject
 // CHECK: return
 func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
-  return _getBool(Builtin.isUnique_native(&ref))
+  return Bool(_builtinBooleanLiteral: Builtin.isUnique_native(&ref))
 }
 
 // ----------------------------------------------------------------------------

--- a/test/SILGen/generic_casts.swift
+++ b/test/SILGen/generic_casts.swift
@@ -29,10 +29,10 @@ func opaque_archetype_is_opaque_archetype
   // CHECK:   [[N:%.*]] = integer_literal $Builtin.Int1, 0
   // CHECK:   br [[CONT]]([[N]] : $Builtin.Int1)
   // CHECK: [[CONT]]([[I1:%.*]] : @trivial $Builtin.Int1):
-  // -- apply the _getBool library fn
-  // CHECK-NEXT:  function_ref Swift._getBool
-  // CHECK-NEXT:  [[GETBOOL:%.*]] = function_ref @$ss8_getBoolySbBi1_F :
-  // CHECK-NEXT:  [[RES:%.*]] = apply [[GETBOOL]]([[I1]])
+  // CHECK-NEXT:  [[META:%.*]] = metatype $@thin Bool.Type
+  // CHECK-NEXT:  function_ref Swift.Bool.init(_builtinBooleanLiteral: Builtin.Int1)
+  // CHECK-NEXT:  [[BOOL:%.*]] = function_ref @$sSb22_builtinBooleanLiteralSbBi1__tcfC :
+  // CHECK-NEXT:  [[RES:%.*]] = apply [[BOOL]]([[I1]], [[META]])
   // -- we don't consume the checked value
   // CHECK:   return [[RES]] : $Bool
 }

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -11,6 +11,7 @@ Func MutableCollection._partition(within:by:) has parameter 0 type change from R
 Func BinaryInteger._description(radix:uppercase:) has been removed
 Struct _Buffer32 has been removed
 Struct _Buffer72 has been removed
+Func _getBool(_:) has been removed
 Func _int64ToString(_:radix:uppercase:) has been removed
 Func _int64ToStringImpl(_:_:_:_:_:) has been removed
 Func _uint64ToStringImpl(_:_:_:_:_:) has been removed

--- a/test/stdlib/Builtins.swift
+++ b/test/stdlib/Builtins.swift
@@ -68,12 +68,12 @@ tests.test("_isUnique/NativeObjectWithUnownedRef") {
 
 tests.test("_isUniquelyReferenced/OptionalNativeObject") {
   var a: Builtin.NativeObject? = Builtin.castToNativeObject(X())
-  StdlibUnittest.expectTrue(_getBool(Builtin.isUnique(&a)))
+  StdlibUnittest.expectTrue(Bool(_builtinBooleanLiteral: Builtin.isUnique(&a)))
   var b = a
-  expectFalse(_getBool(Builtin.isUnique(&a)))
-  expectFalse(_getBool(Builtin.isUnique(&b)))
+  expectFalse(Bool(_builtinBooleanLiteral: Builtin.isUnique(&a)))
+  expectFalse(Bool(_builtinBooleanLiteral: Builtin.isUnique(&b)))
   var x: Builtin.NativeObject? = nil
-  expectFalse(_getBool(Builtin.isUnique(&x)))
+  expectFalse(Bool(_builtinBooleanLiteral: Builtin.isUnique(&x)))
 }
 
 #if _runtime(_ObjC)

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -721,9 +721,10 @@ var AvailabilityVersionsTestSuite = TestSuite("AvailabilityVersions")
 
 AvailabilityVersionsTestSuite.test("_stdlib_isOSVersionAtLeast") {
   func isAtLeastOS(_ major: Int, _ minor: Int, _ patch: Int) -> Bool {
-    return _getBool(_stdlib_isOSVersionAtLeast(major._builtinWordValue,
-                                               minor._builtinWordValue,
-                                               patch._builtinWordValue))
+    return Bool(_builtinBooleanLiteral: _stdlib_isOSVersionAtLeast(
+                                          major._builtinWordValue,
+                                          minor._builtinWordValue,
+                                          patch._builtinWordValue))
   }
 
 // _stdlib_isOSVersionAtLeast is broken for


### PR DESCRIPTION
This removes the `_getBool` intrinsic function from the standard library and replaces occurrences of `_getBool` with `Bool(_builtinBooleanLiteral:)`.

cc: @slavapestov @jckarter 