### PR TITLE
Reuse the container when requesting for a new nested container with the old key in JSONEncoder and PlistEncoder

### DIFF
--- a/stdlib/public/Darwin/Foundation/JSONEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/JSONEncoder.swift
@@ -499,8 +499,9 @@ fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCon
     }
 
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
-        let dictionary = NSMutableDictionary()
-        self.container[_converted(key).stringValue] = dictionary
+        let containerKey = _converted(key).stringValue
+        let dictionary = self.container[containerKey] as? NSMutableDictionary ?? NSMutableDictionary()
+        self.container[containerKey] = dictionary
 
         self.codingPath.append(key)
         defer { self.codingPath.removeLast() }
@@ -510,8 +511,9 @@ fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCon
     }
 
     public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-        let array = NSMutableArray()
-        self.container[_converted(key).stringValue] = array
+        let containerKey = _converted(key).stringValue
+        let array = self.container[containerKey] as? NSMutableArray ?? NSMutableArray()
+        self.container[containerKey] = array
 
         self.codingPath.append(key)
         defer { self.codingPath.removeLast() }

--- a/stdlib/public/Darwin/Foundation/JSONEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/JSONEncoder.swift
@@ -500,7 +500,10 @@ fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCon
 
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
         let containerKey = _converted(key).stringValue
-        let dictionary = self.container[containerKey] as? NSMutableDictionary ?? NSMutableDictionary()
+        let existingContainer = self.container[containerKey]
+        precondition(existingContainer is NSMutableDictionary?,
+                     "Attempt to request for keyed container with the key that previously unkeyed container already requested.")
+        let dictionary = existingContainer as? NSMutableDictionary ?? NSMutableDictionary()
         self.container[containerKey] = dictionary
 
         self.codingPath.append(key)
@@ -512,7 +515,10 @@ fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCon
 
     public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
         let containerKey = _converted(key).stringValue
-        let array = self.container[containerKey] as? NSMutableArray ?? NSMutableArray()
+        let existingContainer = self.container[containerKey]
+        precondition(existingContainer is NSMutableArray?,
+                     "Attempt to request for unkeyed container with the key that previously keyed container already requested.")
+        let array = existingContainer as? NSMutableArray ?? NSMutableArray()
         self.container[containerKey] = array
 
         self.codingPath.append(key)

--- a/stdlib/public/Darwin/Foundation/PlistEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/PlistEncoder.swift
@@ -266,9 +266,9 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
 
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
         let containerKey = key.stringValue
-				let existingContainer = self.container[containerKey]
+	let existingContainer = self.container[containerKey]
         precondition(existingContainer is NSMutableDictionary?,
-          "Attempt to request for keyed container with the key that previously unkeyed container already requested.")
+            "Attempt to request for keyed container with the key that previously unkeyed container already requested.")
         let dictionary = existingContainer as? NSMutableDictionary ?? NSMutableDictionary()
         self.container[containerKey] = dictionary
 
@@ -283,8 +283,8 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
         let containerKey = key.stringValue
         let existingContainer = self.container[containerKey]
         precondition(existingContainer is NSMutableArray?,
-					"Attempt to request for unkeyed container with the key that previously keyed container already requested.")
-				let array = existingContainer as? NSMutableArray ?? NSMutableArray()
+	    "Attempt to request for unkeyed container with the key that previously keyed container already requested.")
+        let array = existingContainer as? NSMutableArray ?? NSMutableArray()
         self.container[containerKey] = array
 
         self.codingPath.append(key)

--- a/stdlib/public/Darwin/Foundation/PlistEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/PlistEncoder.swift
@@ -266,9 +266,9 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
 
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
         let containerKey = key.stringValue
-	let existingContainer = self.container[containerKey]
+        let existingContainer = self.container[containerKey]
         precondition(existingContainer is NSMutableDictionary?,
-            "Attempt to request for keyed container with the key that previously unkeyed container already requested.")
+                     "Attempt to request for keyed container with the key that previously unkeyed container already requested.")
         let dictionary = existingContainer as? NSMutableDictionary ?? NSMutableDictionary()
         self.container[containerKey] = dictionary
 
@@ -283,7 +283,7 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
         let containerKey = key.stringValue
         let existingContainer = self.container[containerKey]
         precondition(existingContainer is NSMutableArray?,
-	    "Attempt to request for unkeyed container with the key that previously keyed container already requested.")
+	                 "Attempt to request for unkeyed container with the key that previously keyed container already requested.")
         let array = existingContainer as? NSMutableArray ?? NSMutableArray()
         self.container[containerKey] = array
 

--- a/stdlib/public/Darwin/Foundation/PlistEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/PlistEncoder.swift
@@ -266,12 +266,18 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
 
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
         let containerKey = key.stringValue
-        let existingContainer = self.container[containerKey]
-        precondition(existingContainer is NSMutableDictionary?,
-                     "Attempt to request for keyed container with the key that previously unkeyed container already requested.")
-        let dictionary = existingContainer as? NSMutableDictionary ?? NSMutableDictionary()
-        self.container[containerKey] = dictionary
-
+        let dictionary: NSMutableDictionary
+        if let existingContainer = self.container[containerKey] {
+            precondition(
+                existingContainer is NSMutableDictionary,
+                "Attempt to re-encode into nested KeyedEncodingContainer<\(Key.self)> for key \"\(containerKey)\" is invalid: non-keyed container already encoded for this key"
+            )
+            dictionary = existingContainer as! NSMutableDictionary
+        } else {
+            dictionary = NSMutableDictionary()
+            self.container[containerKey] = dictionary
+        }
+        
         self.codingPath.append(key)
         defer { self.codingPath.removeLast() }
 
@@ -281,11 +287,17 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
 
     public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
         let containerKey = key.stringValue
-        let existingContainer = self.container[containerKey]
-        precondition(existingContainer is NSMutableArray?,
-                     "Attempt to request for unkeyed container with the key that previously keyed container already requested.")
-        let array = existingContainer as? NSMutableArray ?? NSMutableArray()
-        self.container[containerKey] = array
+        let array: NSMutableArray
+        if let existingContainer = self.container[containerKey] {
+            precondition(
+                existingContainer is NSMutableArray, 
+                "Attempt to re-encode into nested UnkeyedEncodingContainer for key \"\(containerKey)\" is invalid: keyed container/single value already encoded for this key"
+            )
+            array = existingContainer as! NSMutableArray
+        } else {
+            array = NSMutableArray()
+            self.container[containerKey] = array
+        }
 
         self.codingPath.append(key)
         defer { self.codingPath.removeLast() }

--- a/stdlib/public/Darwin/Foundation/PlistEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/PlistEncoder.swift
@@ -265,8 +265,9 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
     }
 
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
-        let dictionary = NSMutableDictionary()
-        self.container[key.stringValue] = dictionary
+        let containerKey = key.stringValue
+        let dictionary = self.container[containerKey] as? NSMutableDictionary ?? NSMutableDictionary()
+        self.container[containerKey] = dictionary
 
         self.codingPath.append(key)
         defer { self.codingPath.removeLast() }
@@ -276,8 +277,9 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
     }
 
     public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-        let array = NSMutableArray()
-        self.container[key.stringValue] = array
+        let containerKey = key.stringValue
+        let array = self.container[containerKey] as? NSMutableArray ?? NSMutableArray()
+        self.container[containerKey] = array
 
         self.codingPath.append(key)
         defer { self.codingPath.removeLast() }

--- a/stdlib/public/Darwin/Foundation/PlistEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/PlistEncoder.swift
@@ -283,7 +283,7 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
         let containerKey = key.stringValue
         let existingContainer = self.container[containerKey]
         precondition(existingContainer is NSMutableArray?,
-	                 "Attempt to request for unkeyed container with the key that previously keyed container already requested.")
+                     "Attempt to request for unkeyed container with the key that previously keyed container already requested.")
         let array = existingContainer as? NSMutableArray ?? NSMutableArray()
         self.container[containerKey] = array
 

--- a/stdlib/public/Darwin/Foundation/PlistEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/PlistEncoder.swift
@@ -266,7 +266,10 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
 
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
         let containerKey = key.stringValue
-        let dictionary = self.container[containerKey] as? NSMutableDictionary ?? NSMutableDictionary()
+				let existingContainer = self.container[containerKey]
+        precondition(existingContainer is NSMutableDictionary?,
+          "Attempt to request for keyed container with the key that previously unkeyed container already requested.")
+        let dictionary = existingContainer as? NSMutableDictionary ?? NSMutableDictionary()
         self.container[containerKey] = dictionary
 
         self.codingPath.append(key)
@@ -278,7 +281,10 @@ fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCo
 
     public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
         let containerKey = key.stringValue
-        let array = self.container[containerKey] as? NSMutableArray ?? NSMutableArray()
+        let existingContainer = self.container[containerKey]
+        precondition(existingContainer is NSMutableArray?,
+					"Attempt to request for unkeyed container with the key that previously keyed container already requested.")
+				let array = existingContainer as? NSMutableArray ?? NSMutableArray()
         self.container[containerKey] = array
 
         self.codingPath.append(key)

--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -193,7 +193,6 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     let model = Model.testValue
     // This following test would fail as it attempts to re-encode into already encoded container is invalid. This will always fail
     if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
-      let expectedJSON = "{\"top\":{\"first\":\"Johnny Appleseed\",\"second\":\"appleseed@apple.com\"}}".data(using: .utf8)!
       _testEncodeFailure(of: model)
     } else {
       _testEncodeFailure(of: model)
@@ -1713,10 +1712,10 @@ JSONEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestJSONEncode
 JSONEncoderTests.test("testEncodingClassWhichSharesEncoderWithSuper") { TestJSONEncoder().testEncodingClassWhichSharesEncoderWithSuper() }
 JSONEncoderTests.test("testEncodingTopLevelNullableType") { TestJSONEncoder().testEncodingTopLevelNullableType() }
 JSONEncoderTests.test("testEncodingMultipleNestedContainersWithTheSameTopLevelKey") { TestJSONEncoder().testEncodingMultipleNestedContainersWithTheSameTopLevelKey() }
-JSONEncoderTests.test("testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey")
-  .xfail(.always("Attempt to re-encode into already encoded container is invalid. This will always fail"))
-  .code {
+JSONEncoderTests.test("testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey") {
+  expectCrash() {
     TestJSONEncoder().testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey()
+  }
 }
 JSONEncoderTests.test("testEncodingOutputFormattingDefault") { TestJSONEncoder().testEncodingOutputFormattingDefault() }
 JSONEncoderTests.test("testEncodingOutputFormattingPrettyPrinted") { TestJSONEncoder().testEncodingOutputFormattingPrettyPrinted() }

--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -102,6 +102,62 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     _testRoundTrip(of: TopLevelWrapper(EnhancedBool.false), expectedJSON: "{\"value\":false}".data(using: .utf8)!)
     _testRoundTrip(of: TopLevelWrapper(EnhancedBool.fileNotFound), expectedJSON: "{\"value\":null}".data(using: .utf8)!)
   }
+  
+  // MARK: - Multiple Nested Keys with the same top-level key Encoding Tests
+  func testEncodingMultipleNestedContainersWithTheSameTopLevelKey() {
+    struct Model : Codable, Equatable {
+      let first: String
+      let second: String
+      
+      init(from coder: Decoder) throws {
+        let container = try coder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        let firstNestedContainer = try container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        self.first = try firstNestedContainer.decode(String.self, forKey: .first)
+        
+        let secondNestedContainer = try container.nestedContainer(keyedBy: SecondNestedCodingKeys.self, forKey: .top)
+        self.second = try secondNestedContainer.decode(String.self, forKey: .second)
+      }
+      
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        var firstNestedContainer = container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        try firstNestedContainer.encode(self.first, forKey: .first)
+        
+        var secondNestedContainer = container.nestedContainer(keyedBy: SecondNestedCodingKeys.self, forKey: .top)
+        try secondNestedContainer.encode(self.second, forKey: .second)
+      }
+      
+      init(first: String, second: String) {
+        self.first = first
+        self.second = second
+      }
+      
+      static var testValue: Model {
+        return Model(first: "Johnny Appleseed",
+                     second: "appleseed@apple.com")
+      }
+    }
+    
+    enum TopLevelCodingKeys : String, CodingKey {
+      case top
+    }
+    
+    enum FirstNestedCodingKeys : String, CodingKey {
+      case first
+    }
+    enum SecondNestedCodingKeys : String, CodingKey {
+      case second
+    }
+    let model = Model.testValue
+    if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+      let expectedJSON = "{\"top\":{\"first\":\"Johnny Appleseed\",\"second\":\"appleseed@apple.com\"}}".data(using: .utf8)!
+      _testRoundTrip(of: model, expectedJSON: expectedJSON, outputFormatting: [.sortedKeys])
+    } else {
+      _testRoundTrip(of: model)
+    }
+  }
 
   // MARK: - Output Formatting Tests
   func testEncodingOutputFormattingDefault() {
@@ -1615,6 +1671,7 @@ JSONEncoderTests.test("testEncodingTopLevelStructuredSingleClass") { TestJSONEnc
 JSONEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestJSONEncoder().testEncodingTopLevelDeepStructuredType()}
 JSONEncoderTests.test("testEncodingClassWhichSharesEncoderWithSuper") { TestJSONEncoder().testEncodingClassWhichSharesEncoderWithSuper() }
 JSONEncoderTests.test("testEncodingTopLevelNullableType") { TestJSONEncoder().testEncodingTopLevelNullableType() }
+JSONEncoderTests.test("testEncodingMultipleNestedContainersWithTheSameTopLevelKey") { TestJSONEncoder().testEncodingMultipleNestedContainersWithTheSameTopLevelKey() }
 JSONEncoderTests.test("testEncodingOutputFormattingDefault") { TestJSONEncoder().testEncodingOutputFormattingDefault() }
 JSONEncoderTests.test("testEncodingOutputFormattingPrettyPrinted") { TestJSONEncoder().testEncodingOutputFormattingPrettyPrinted() }
 JSONEncoderTests.test("testEncodingOutputFormattingSortedKeys") { TestJSONEncoder().testEncodingOutputFormattingSortedKeys() }

--- a/test/stdlib/TestPlistEncoder.swift
+++ b/test/stdlib/TestPlistEncoder.swift
@@ -874,10 +874,10 @@ PropertyListEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestPr
 PropertyListEncoderTests.test("testEncodingClassWhichSharesEncoderWithSuper") { TestPropertyListEncoder().testEncodingClassWhichSharesEncoderWithSuper() }
 PropertyListEncoderTests.test("testEncodingTopLevelNullableType") { TestPropertyListEncoder().testEncodingTopLevelNullableType() }
 PropertyListEncoderTests.test("testEncodingMultipleNestedContainersWithTheSameTopLevelKey") { TestPropertyListEncoder().testEncodingMultipleNestedContainersWithTheSameTopLevelKey() }
-PropertyListEncoderTests.test("testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey")
-  .xfail(.always("Attempt to re-encode into already encoded container is invalid. This will always fail"))
-  .code {
+PropertyListEncoderTests.test("testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey") {
+  expectCrash() {
     TestPropertyListEncoder().testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey()
+  }
 }
 PropertyListEncoderTests.test("testNestedContainerCodingPaths") { TestPropertyListEncoder().testNestedContainerCodingPaths() }
 PropertyListEncoderTests.test("testSuperEncoderCodingPaths") { TestPropertyListEncoder().testSuperEncoderCodingPaths() }

--- a/test/stdlib/TestPlistEncoder.swift
+++ b/test/stdlib/TestPlistEncoder.swift
@@ -163,23 +163,74 @@ class TestPropertyListEncoder : TestPropertyListEncoderSuper {
         return Model(first: "Johnny Appleseed",
                      second: "appleseed@apple.com")
       }
+      enum TopLevelCodingKeys : String, CodingKey {
+        case top
+      }
+      
+      enum FirstNestedCodingKeys : String, CodingKey {
+        case first
+      }
+      enum SecondNestedCodingKeys : String, CodingKey {
+        case second
+      }
     }
     
-    enum TopLevelCodingKeys : String, CodingKey {
-      case top
-    }
-    
-    enum FirstNestedCodingKeys : String, CodingKey {
-      case first
-    }
-    enum SecondNestedCodingKeys : String, CodingKey {
-      case second
-    }
     let model = Model.testValue
     let expectedXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n\t<key>top</key>\n\t<dict>\n\t\t<key>first</key>\n\t\t<string>Johnny Appleseed</string>\n\t\t<key>second</key>\n\t\t<string>appleseed@apple.com</string>\n\t</dict>\n</dict>\n</plist>\n".data(using: .utf8)!
     _testRoundTrip(of: model, in: .xml, expectedPlist: expectedXML)
   }
-
+  
+  func testEncodingConfilictedTypeNestedContainersWithTheSameTopLevelKey() {
+    struct Model : Codable, Equatable {
+      let first: String
+      let second: String
+      
+      init(from coder: Decoder) throws {
+        let container = try coder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        let firstNestedContainer = try container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        self.first = try firstNestedContainer.decode(String.self, forKey: .first)
+        
+        let secondNestedContainer = try container.nestedContainer(keyedBy: SecondNestedCodingKeys.self, forKey: .top)
+        self.second = try secondNestedContainer.decode(String.self, forKey: .second)
+      }
+      
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        var firstNestedContainer = container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        try firstNestedContainer.encode(self.first, forKey: .first)
+        
+        var secondNestedContainer = container.nestedUnkeyedContainer(forKey: .top)
+        try secondNestedContainer.encode(self.second)
+      }
+      
+      init(first: String, second: String) {
+        self.first = first
+        self.second = second
+      }
+      
+      static var testValue: Model {
+        return Model(first: "Johnny Appleseed",
+                     second: "appleseed@apple.com")
+      }
+      enum TopLevelCodingKeys : String, CodingKey {
+        case top
+      }
+      
+      enum FirstNestedCodingKeys : String, CodingKey {
+        case first
+      }
+      enum SecondNestedCodingKeys : String, CodingKey {
+        case second
+      }
+    }
+    
+    let model = Model.testValue
+    let expectedXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n\t<key>top</key>\n\t<dict>\n\t\t<key>first</key>\n\t\t<string>Johnny Appleseed</string>\n\t\t<key>second</key>\n\t\t<string>appleseed@apple.com</string>\n\t</dict>\n</dict>\n</plist>\n".data(using: .utf8)!
+    _testRoundTrip(of: model, in: .xml, expectedPlist: expectedXML)
+  }
+  
   // MARK: - Encoder Features
   func testNestedContainerCodingPaths() {
     let encoder = JSONEncoder()
@@ -839,6 +890,11 @@ PropertyListEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestPr
 PropertyListEncoderTests.test("testEncodingClassWhichSharesEncoderWithSuper") { TestPropertyListEncoder().testEncodingClassWhichSharesEncoderWithSuper() }
 PropertyListEncoderTests.test("testEncodingTopLevelNullableType") { TestPropertyListEncoder().testEncodingTopLevelNullableType() }
 PropertyListEncoderTests.test("testEncodingMultipleNestedContainersWithTheSameTopLevelKey") { TestPropertyListEncoder().testEncodingMultipleNestedContainersWithTheSameTopLevelKey() }
+PropertyListEncoderTests.test("testEncodingConfilictedTypeNestedContainersWithTheSameTopLevelKey")
+  .xfail(.always("Attempt to re-encode into already encoded container is invalid. This will always fail"))
+  .code {
+    TestPropertyListEncoder().testEncodingConfilictedTypeNestedContainersWithTheSameTopLevelKey()
+}
 PropertyListEncoderTests.test("testNestedContainerCodingPaths") { TestPropertyListEncoder().testNestedContainerCodingPaths() }
 PropertyListEncoderTests.test("testSuperEncoderCodingPaths") { TestPropertyListEncoder().testSuperEncoderCodingPaths() }
 PropertyListEncoderTests.test("testEncodingTopLevelData") { TestPropertyListEncoder().testEncodingTopLevelData() }


### PR DESCRIPTION
<!-- What's in this pull request? -->
At the moment, JSONEncoder and PlistEncoder always create a new container when asking for nested keyed container and nested unkeyed container. It works fine for most of the case. But this causes a bug in the case when a type may need to ask for 2 separate nested containers for the same key.

This PR change the logic of both encoders to check for the existing container and reuse it if one found, otherwise will create a new container like the old behavior.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-9385](https://bugs.swift.org/browse/SR-9385).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
