### PR TITLE
[gardening] Make edits for stdlib style [NFC]

### DIFF
--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -134,9 +134,9 @@ _swift_stdlib_NSStringCStringUsingEncodingTrampoline(id _Nonnull obj,
 SWIFT_RUNTIME_STDLIB_API
 __swift_uint8_t
 _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
-                                         _swift_shims_UInt8 *_Nonnull buffer,
-                                         _swift_shims_CFIndex maxLength,
-                                         unsigned long encoding);
+                                           _swift_shims_UInt8 *_Nonnull buffer,
+                                           _swift_shims_CFIndex maxLength,
+                                           unsigned long encoding);
 
 SWIFT_RUNTIME_STDLIB_API
 __swift_uintptr_t


### PR DESCRIPTION
@Catfish-Man made some very exciting improvements to string bridging in #20383, #20452, and #20623.

This PR includes no functional changes but aligns the code with stdlib style, as [pointed out](https://github.com/apple/swift/pull/20452/files#r233637267) by @milseman [at various places](https://github.com/apple/swift/pull/20623#discussion_r234327938).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->