### PR TITLE
[WIP]  [test] Switch %clang-importer-sdk over to using parseable interfaces

### DIFF
--- a/test/APINotes/blocks.swift
+++ b/test/APINotes/blocks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift -Xfrontend %clang-importer-sdk %s -emit-ir
+// RUN: %target-build-swift %clang-importer-sdk %s -emit-ir
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop

--- a/test/APINotes/irgen-prop-getter-setter.swift
+++ b/test/APINotes/irgen-prop-getter-setter.swift
@@ -1,8 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-frontend %clang-importer-sdk-nosource -I %t %s -emit-ir
-// REQUIRES: executable_test
+// RUN: %target-swift-frontend %clang-importer-sdk %s -emit-ir
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/Inputs/cfuncs.swift
+++ b/test/ClangImporter/Inputs/cfuncs.swift
@@ -1,3 +1,0 @@
-@_exported import cfuncs
-
-public func cfunc_in_swift(_ x: Int) -> Int {}

--- a/test/ClangImporter/Inputs/cfuncs.swiftinterface
+++ b/test/ClangImporter/Inputs/cfuncs.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name cfuncs
+
+@_exported import cfuncs
+
+public func cfunc_in_swift(_ x: Int) -> Int

--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -1,16 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -R %S/Inputs/mixed-target %t
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -enable-objc-interop -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -enable-objc-interop -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -I %S/../Inputs/custom-modules -typecheck %s -verify
 
 // RUN: rm -rf %t/mixed-target/
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -I %S/../Inputs/custom-modules -typecheck %s -verify
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/MixedSource/import-mixed-with-header.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header.swift
@@ -1,16 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -R %S/Inputs/mixed-target %t
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -enable-objc-interop -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -enable-objc-interop -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -enable-objc-interop -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -enable-objc-interop -typecheck %s -verify
 
 // RUN: rm -rf %t/mixed-target/
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -enable-objc-interop -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -enable-objc-interop -typecheck %s -verify
 
 // REQUIRES: SR7768
 

--- a/test/ClangImporter/MixedSource/resolve-cross-language.swift
+++ b/test/ClangImporter/MixedSource/resolve-cross-language.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -enable-objc-interop -emit-objc-header -o %t %S/Inputs/resolve-cross-language/Base.swift -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -enable-objc-interop -emit-objc-header -o %t %S/Inputs/resolve-cross-language/Base.swift -disable-objc-attr-requires-foundation-module
 // RUN: cp %S/Inputs/resolve-cross-language/Base-module.map %t/module.map
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -I %t -F %clang-importer-sdk-path/frameworks -F %S/Inputs/resolve-cross-language %s -verify
 

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -1,10 +1,7 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -emit-ir %s -D IRGEN | %FileCheck %s
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -typecheck %s -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -emit-ir %s -D IRGEN | %FileCheck %s
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -print-module -source-filename="%s" -module-to-print SwiftPrivateAttr > %t.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -print-module -source-filename="%s" -module-to-print SwiftPrivateAttr > %t.txt
 // RUN: %FileCheck -check-prefix=GENERATED-NEGATIVE %s < %t.txt
 // RUN: diff -U3 %S/Inputs/SwiftPrivateAttr.txt %t.txt
 

--- a/test/ClangImporter/generic_compatibility_alias.swift
+++ b/test/ClangImporter/generic_compatibility_alias.swift
@@ -1,6 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -module-name generic_compat_alias -I %S/Inputs/custom-modules -typecheck -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name generic_compat_alias -I %S/Inputs/custom-modules -typecheck -verify %s
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx

--- a/test/ClangImporter/nullability_silgen.swift
+++ b/test/ClangImporter/nullability_silgen.swift
@@ -1,7 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-silgen -I %S/Inputs/custom-modules %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %S/Inputs/custom-modules %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/objc_class_subscript.swift
+++ b/test/ClangImporter/objc_class_subscript.swift
@@ -1,7 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -typecheck -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -1,7 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -target x86_64-apple-macosx10.51 -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target x86_64-apple-macosx10.51 -typecheck %s -verify
 
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -1,7 +1,4 @@
-
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -module-name objc_ir -I %S/Inputs/custom-modules -emit-ir -g -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name objc_ir -I %S/Inputs/custom-modules -emit-ir -g -o - -primary-file %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx

--- a/test/ClangImporter/objc_protocol_renaming.swift
+++ b/test/ClangImporter/objc_protocol_renaming.swift
@@ -1,13 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -emit-module -o %t %S/Inputs/ImplementProtoRenaming.swift
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t) -emit-module -o %t %S/Inputs/ImplementProtoRenaming.swift
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t) -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -I %t -typecheck %s -verify
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/objc_subscript.swift
+++ b/test/ClangImporter/objc_subscript.swift
@@ -1,7 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/private_frameworks.swift
+++ b/test/ClangImporter/private_frameworks.swift
@@ -1,38 +1,33 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
 // Build the overlay with private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -F %S/Inputs/privateframeworks/withprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -F %S/Inputs/privateframeworks/withprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift
 
 // Use the overlay with private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h -verify
 
 // Use the overlay without private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h %s
 
 // Build the overlay with public frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -F %S/Inputs/privateframeworks/withoutprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -F %S/Inputs/privateframeworks/withoutprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift
 
 // Use the overlay with private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h -verify
 
 // Use the overlay without private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h 
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h 
 
 // Use something that uses the overlay.
 // RUN: echo 'import private_frameworks; testErrorConformance()' > %t/main.swift
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %t/main.swift -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate %t/main.swift -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-module -o %t -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %t/main.swift -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate %t/main.swift -verify
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %t/main.swift -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate %t/main.swift -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-module -o %t -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %t/main.swift -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate %t/main.swift -verify
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/private_frameworks_autolink.swift
+++ b/test/ClangImporter/private_frameworks_autolink.swift
@@ -1,12 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
 // Check that the autolink information is appropriate (do not link against SomeKitCore).
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-ir -o %t/private_frameworks_autolink.ll -F %S/Inputs/privateframeworks/withprivate-autolink %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o %t/private_frameworks_autolink.ll -F %S/Inputs/privateframeworks/withprivate-autolink %s
 // RUN: %FileCheck %s < %t/private_frameworks_autolink.ll
 // CHECK-NOT: !{!"-framework", !"SomeKitCore"}
 

--- a/test/ClangImporter/private_frameworks_autolink2.swift
+++ b/test/ClangImporter/private_frameworks_autolink2.swift
@@ -1,12 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
 // Check that the autolink information is appropriate (do not link against SomeKitCore).
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-ir -o %t/private_frameworks_autolink2.ll -F %S/Inputs/privateframeworks/withprivate-autolink %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o %t/private_frameworks_autolink2.ll -F %S/Inputs/privateframeworks/withprivate-autolink %s
 // RUN: %FileCheck %s < %t/private_frameworks_autolink2.ll
 // CHECK-NOT: !{!"-framework", !"SomeKit"}
 // CHECK: !{!"-framework", !"SomeKitCore"}

--- a/test/Constraints/disambiguate_iuo_param.swift
+++ b/test/Constraints/disambiguate_iuo_param.swift
@@ -1,7 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -import-objc-header %S/Inputs/disambiguate_iuo_param.h %s -emit-ir | %FileCheck %s
-// -module-name objc_ir -I %S/Inputs/custom-modules -emit-ir -g -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/disambiguate_iuo_param.h %s -emit-ir | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Driver/emit-objc-header-single-vs-multi-file.swift
+++ b/test/Driver/emit-objc-header-single-vs-multi-file.swift
@@ -1,11 +1,5 @@
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Darwin.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swiftc_driver %clang-importer-sdk-nosource -emit-module -o %t.1.swiftmodule -emit-objc-header -emit-objc-header-path %t.1.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -I %t
-// RUN: %target-swiftc_driver %clang-importer-sdk-nosource -emit-module -o %t.2.swiftmodule -emit-objc-header -emit-objc-header-path %t.2.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -force-single-frontend-invocation -I %t
+// RUN: %target-swiftc_driver %clang-importer-sdk -emit-module -o %t.1.swiftmodule -emit-objc-header -emit-objc-header-path %t.1.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift
+// RUN: %target-swiftc_driver %clang-importer-sdk -emit-module -o %t.2.swiftmodule -emit-objc-header -emit-objc-header-path %t.2.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -force-single-frontend-invocation
 // RUN: diff %t.1.h %t.2.h
 
 // REQUIRES: objc_interop

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -39,9 +39,10 @@
 // CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
 // CHECK-MULTIPLE-OUTPUTS-NOT: {{ }}:{{ }}
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
+// RUN: %target-swift-frontend -emit-module -o %t %S/../Inputs/empty.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 // CHECK-IMPORT-LABEL: - :
 // CHECK-IMPORT: dependencies.swift
@@ -50,19 +51,18 @@
 // CHECK-IMPORT-DAG: Inputs/dependencies{{/|\\}}UserClangModule.h
 // CHECK-IMPORT-DAG: Inputs/dependencies/extra-header.h
 // CHECK-IMPORT-DAG: Inputs/dependencies{{/|\\}}module.modulemap
-// CHECK-IMPORT-DAG: ObjectiveC.swift
-// CHECK-IMPORT-DAG: Foundation.swift
-// CHECK-IMPORT-DAG: CoreGraphics.swift
+// CHECK-IMPORT-DAG: empty.swiftmodule
 // CHECK-IMPORT-NOT: {{[^\\]}}:
 
 // CHECK-IMPORT-TRACK-SYSTEM-LABEL: - :
 // CHECK-IMPORT-TRACK-SYSTEM: dependencies.swift
 // CHECK-IMPORT-TRACK-SYSTEM-DAG: Swift.swiftmodule
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: empty.swiftmodule
 // CHECK-IMPORT-TRACK-SYSTEM-DAG: SwiftOnoneSupport.swiftmodule
-// CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreFoundation.swift
-// CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreGraphics.swift
-// CHECK-IMPORT-TRACK-SYSTEM-DAG: Foundation.swift
-// CHECK-IMPORT-TRACK-SYSTEM-DAG: ObjectiveC.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreFoundation.swiftinterface
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreGraphics.swiftinterface
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Foundation.swiftinterface
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: ObjectiveC.swiftinterface
 // CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies/$$$$$$$$$$.h
 // CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies{{/|\\}}UserClangModule.h
 // CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies/extra-header.h
@@ -85,17 +85,16 @@
 // CHECK-IMPORT-YAML-DAG: "{{.*}}Inputs/dependencies{{/|\\\\}}UserClangModule.h"
 // CHECK-IMPORT-YAML-DAG: "{{.*}}Inputs/dependencies/extra-header.h"
 // CHECK-IMPORT-YAML-DAG: "{{.*}}Inputs/dependencies{{/|\\\\}}module.modulemap"
-// CHECK-IMPORT-YAML-DAG: "{{.*}}{{/|\\\\}}ObjectiveC.swift"
-// CHECK-IMPORT-YAML-DAG: "{{.*}}{{/|\\\\}}Foundation.swift"
-// CHECK-IMPORT-YAML-DAG: "{{.*}}{{/|\\\\}}CoreGraphics.swift"
+// CHECK-IMPORT-YAML-DAG: "{{.*(/|\\\\)}}empty.swiftmodule"
 // CHECK-IMPORT-YAML-NOT: {{^-}}
 // CHECK-IMPORT-YAML-NOT: {{:$}}
 
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT %s
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 
 import Foundation
+import empty
 import UserClangModule
 
 class Test: NSObject {}

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -39,9 +39,9 @@
 // CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
 // CHECK-MULTIPLE-OUTPUTS-NOT: {{ }}:{{ }}
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 // CHECK-IMPORT-LABEL: - :
 // CHECK-IMPORT: dependencies.swift
@@ -91,8 +91,8 @@
 // CHECK-IMPORT-YAML-NOT: {{^-}}
 // CHECK-IMPORT-YAML-NOT: {{:$}}
 
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT %s
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -enable-source-import -I %S/../Inputs/clang-importer-sdk/swift-modules/) -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 
 import Foundation

--- a/test/IDE/compatibility_alias.swift
+++ b/test/IDE/compatibility_alias.swift
@@ -1,9 +1,6 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=CompatibilityAlias > %t.printed.CompatibilityAlias.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=CompatibilityAlias > %t.printed.CompatibilityAlias.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.CompatibilityAlias.txt
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t %s
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -I %S/Inputs/custom-modules %s
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/compatibility_alias.swift
+++ b/test/IDE/compatibility_alias.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=CompatibilityAlias > %t.printed.CompatibilityAlias.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.CompatibilityAlias.txt
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t %s
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t %s
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/import_as_member_cf.swift
+++ b/test/IDE/import_as_member_cf.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t -I %S/Inputs/custom-modules) -print-module -source-filename %s -module-to-print=ImportAsMember.C -always-argument-labels > %t.printed.C.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=ImportAsMember.C -always-argument-labels > %t.printed.C.txt
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -2,7 +2,7 @@
 // RUN: %build-clang-importer-objc-overlays
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=Newtype -skip-unavailable -access-filter-public > %t.printed.A.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.A.txt
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t
 // REQUIRES: objc_interop
 
 // PRINT-LABEL: struct ErrorDomain : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -1,8 +1,6 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=Newtype -skip-unavailable -access-filter-public > %t.printed.A.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=Newtype -skip-unavailable -access-filter-public > %t.printed.A.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.A.txt
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -I %S/Inputs/custom-modules
 // REQUIRES: objc_interop
 
 // PRINT-LABEL: struct ErrorDomain : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {

--- a/test/IDE/newtype_objc.swift
+++ b/test/IDE/newtype_objc.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=NewtypeObjC > %t.printed.NewtypeObjC.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.NewtypeObjC.txt
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t %s
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t %s
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/newtype_objc.swift
+++ b/test/IDE/newtype_objc.swift
@@ -1,9 +1,6 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=NewtypeObjC > %t.printed.NewtypeObjC.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=NewtypeObjC > %t.printed.NewtypeObjC.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.NewtypeObjC.txt
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t %s
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -I %S/Inputs/custom-modules %s
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -3,14 +3,10 @@
 // Build swift modules this test depends on.
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/foo_swift_module.swift -enable-objc-interop -disable-objc-attr-requires-foundation-module
 //
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -enable-objc-interop -disable-objc-attr-requires-foundation-module
-// FIXME: END -enable-source-import hackaround
-//
 // This file should not have any syntax or type checker errors.
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -typecheck -verify %s -F %S/Inputs/mock-sdk -enable-objc-interop -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -swift-version 4 -typecheck -verify %s -F %S/Inputs/mock-sdk -enable-objc-interop -disable-objc-attr-requires-foundation-module
 //
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=false -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %t -swift-version 4 -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=false -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_COMMON -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_PRINT_AST -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_RW_PROP_GET_SET -strict-whitespace < %t.printed.txt
@@ -21,7 +17,7 @@
 // RUN: %FileCheck %s -check-prefix=PREFER_TYPE_PRINTING -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_QUAL_UNQUAL -strict-whitespace < %t.printed.txt
 //
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=true -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %t -swift-version 4 -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=true -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_COMMON -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_PRINT_AST -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_RW_PROP_GET_SET -strict-whitespace < %t.printed.txt
@@ -32,8 +28,8 @@
 // RUN: %FileCheck %s -check-prefix=PREFER_TYPE_REPR_PRINTING -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_QUAL_UNQUAL -strict-whitespace < %t.printed.txt
 //
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -emit-module -o %t -F %S/Inputs/mock-sdk -enable-objc-interop -disable-objc-attr-requires-foundation-module %s
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -skip-deinit=false -print-module -source-filename %s -F %S/Inputs/mock-sdk -module-to-print=print_ast_tc_decls -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -swift-version 4 -emit-module -o %t -F %S/Inputs/mock-sdk -enable-objc-interop -disable-objc-attr-requires-foundation-module %s
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %t -swift-version 4 -skip-deinit=false -print-module -source-filename %s -F %S/Inputs/mock-sdk -module-to-print=print_ast_tc_decls -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_COMMON -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_PRINT_MODULE_INTERFACE -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_RW_PROP_NO_GET_SET -strict-whitespace < %t.printed.txt
@@ -45,13 +41,13 @@
 // RUN: %FileCheck %s -check-prefix=PASS_QUAL_UNQUAL -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_EXPLODE_PATTERN -strict-whitespace < %t.printed.txt
 //
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -skip-deinit=false -print-module -source-filename %s -F %S/Inputs/mock-sdk -I %t -module-to-print=print_ast_tc_decls -synthesize-sugar-on-types=true -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %t -skip-deinit=false -print-module -source-filename %s -F %S/Inputs/mock-sdk -I %t -module-to-print=print_ast_tc_decls -synthesize-sugar-on-types=true -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_PRINT_MODULE_INTERFACE -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_QUAL_UNQUAL -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=SYNTHESIZE_SUGAR_ON_TYPES -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_EXPLODE_PATTERN -strict-whitespace < %t.printed.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -skip-deinit=false -print-module -source-filename %s -F %S/Inputs/mock-sdk -I %t -module-to-print=print_ast_tc_decls -synthesize-sugar-on-types=true -fully-qualified-types-if-ambiguous=true -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %t -skip-deinit=false -print-module -source-filename %s -F %S/Inputs/mock-sdk -I %t -module-to-print=print_ast_tc_decls -synthesize-sugar-on-types=true -fully-qualified-types-if-ambiguous=true -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_PRINT_MODULE_INTERFACE -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_QUAL_IF_AMBIGUOUS -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=SYNTHESIZE_SUGAR_ON_TYPES -strict-whitespace < %t.printed.txt

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -2,27 +2,20 @@
 
 // REQUIRES: objc_interop
 
-// This file deliberately does not use %clang-importer-sdk for most RUN lines.
-// Instead, it generates custom overlay modules itself, and uses -I %t when it
-// wants to use them.
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -enable-objc-interop -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=ctypes -function-definitions=false -prefer-type-repr=true > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=ctypes -function-definitions=false -prefer-type-repr=true > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=TAG_DECLS_AND_TYPEDEFS -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=NEGATIVE -strict-whitespace < %t.printed.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=FOUNDATION -strict-whitespace < %t.printed.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=ctypes.bits -function-definitions=false -prefer-type-repr=true > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=ctypes.bits -function-definitions=false -prefer-type-repr=true > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=CTYPESBITS -strict-whitespace < %t.printed.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=nullability -function-definitions=false -prefer-type-repr=true > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=nullability -function-definitions=false -prefer-type-repr=true > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-NULLABILITY -strict-whitespace < %t.printed.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=bridged_typedef -function-definitions=false -prefer-type-repr=true > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=bridged_typedef -function-definitions=false -prefer-type-repr=true > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-BRIDGED-TYPEDEF -strict-whitespace < %t.printed.txt
 
 // TAG_DECLS_AND_TYPEDEFS: {{^}}struct FooStruct1 {{{$}}

--- a/test/IDE/print_clang_decls_AppKit.swift
+++ b/test/IDE/print_clang_decls_AppKit.swift
@@ -1,17 +1,6 @@
-// RUN: %empty-directory(%t)
-
-// This file deliberately does not use %clang-importer-sdk for most RUN lines.
-// Instead, it generates custom overlay modules itself, and uses -I %t when it
-// wants to use them.
-
 // REQUIRES: OS=macosx
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
-
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=AppKit -function-definitions=false -prefer-type-repr=true > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=AppKit -function-definitions=false -prefer-type-repr=true > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=APPKIT -strict-whitespace < %t.printed.txt
 
 // APPKIT-LABEL: {{^}}extension NSString {{{$}}

--- a/test/IDE/print_clang_framework.swift
+++ b/test/IDE/print_clang_framework.swift
@@ -27,8 +27,7 @@
 // RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-module -source-filename %s -module-to-print=Foo -function-definitions=false -prefer-type-repr=true -annotate-print > %t/Foo.annotated.txt
 // RUN: diff -u %S/Inputs/mock-sdk/Foo.annotated.txt %t/Foo.annotated.txt
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=FOUNDATION -strict-whitespace < %t.printed.txt
 
 // This test is in general platform-independent, but it happens to check

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -1,28 +1,22 @@
-// RUN: %empty-directory(%t)
-
 // REQUIRES: objc_interop
 // FIXME: this is failing on simulators
 // REQUIRES: OS=macosx
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=ObjectiveC -function-definitions=false -prefer-type-repr=true  > %t.ObjectiveC.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=ObjectiveC -function-definitions=false -prefer-type-repr=true  > %t.ObjectiveC.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-OBJECTIVEC -strict-whitespace < %t.ObjectiveC.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true -skip-unavailable -skip-parameter-names > %t.Foundation.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true -skip-unavailable -skip-parameter-names > %t.Foundation.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-FOUNDATION -strict-whitespace < %t.Foundation.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t -I %S/../ClangImporter/Inputs/custom-modules) -print-module -source-filename %s -module-to-print=CoreCooling -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.CoreCooling.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %S/../ClangImporter/Inputs/custom-modules -print-module -source-filename %s -module-to-print=CoreCooling -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.CoreCooling.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-CORECOOLING -strict-whitespace < %t.CoreCooling.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t -I %S/Inputs/custom-modules) -print-module -source-filename %s -module-to-print=OmitNeedlessWords -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.OmitNeedlessWords.txt 2> %t.OmitNeedlessWords.diagnostics.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=OmitNeedlessWords -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.OmitNeedlessWords.txt 2> %t.OmitNeedlessWords.diagnostics.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-OMIT-NEEDLESS-WORDS -strict-whitespace < %t.OmitNeedlessWords.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-OMIT-NEEDLESS-WORDS-DIAGS -strict-whitespace < %t.OmitNeedlessWords.diagnostics.txt
 
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=errors -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.errors.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=errors -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.errors.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-ERRORS -strict-whitespace < %t.errors.txt
 
 // Note: SEL -> "Selector"

--- a/test/IDE/print_omit_needless_words_appkit.swift
+++ b/test/IDE/print_omit_needless_words_appkit.swift
@@ -1,14 +1,7 @@
-// RUN: %empty-directory(%t)
-
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
-
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=AppKit -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.AppKit.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=AppKit -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.AppKit.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-APPKIT -strict-whitespace < %t.AppKit.txt
 
 // Note: class method name stripping context type.

--- a/test/IRGen/objc_properties_imported.swift
+++ b/test/IRGen/objc_properties_imported.swift
@@ -1,8 +1,9 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -enable-source-import -emit-ir -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-ir -o - -primary-file %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 
-// FIXME: This test uses IRGen with -enable-source-import; it may fail with -g.
+// FIXME: This test uses IRGen with -enable-source-import (via
+// %clang-importer-sdk); it may fail with -g.
 
 import Properties
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/AVFoundation.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/AVFoundation.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name AVFoundation -enable-resilience
+
+@_exported import AVFoundation // Clang module

--- a/test/Inputs/clang-importer-sdk/swift-modules/AVFoundation.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/AVFoundation.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name AVFoundation -enable-resilience
+// swift-module-flags: -module-name AVFoundation -enable-library-evolution
 
 @_exported import AVFoundation // Clang module

--- a/test/Inputs/clang-importer-sdk/swift-modules/AppKit.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/AppKit.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name AppKit -enable-resilience
+// swift-module-flags: -module-name AppKit -enable-library-evolution
 
 @_exported import AppKit
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/AppKit.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/AppKit.swiftinterface
@@ -1,0 +1,12 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name AppKit -enable-resilience
+
+@_exported import AppKit
+
+extension String {
+  public static func someFactoryMethod() -> Int
+}
+
+extension String {
+  static func someMethod() -> Int
+}

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreFoundation.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreFoundation.swiftinterface
@@ -1,6 +1,11 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name CoreFoundation -enable-resilience
+// swift-module-flags: -module-name CoreFoundation -enable-library-evolution
 
 @_exported import CoreFoundation
 
-protocol _CFObject {}
+public protocol _CFObject: class, Hashable {}
+extension _CFObject {
+  public var hashValue: Int { get }
+  public func hash(into hasher: inout Hasher)
+  public static func ==(left: Self, right: Self) -> Bool
+}

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreFoundation.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreFoundation.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name CoreFoundation -enable-resilience
+
+@_exported import CoreFoundation
+
+protocol _CFObject {}

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swiftinterface
@@ -1,0 +1,56 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name CoreGraphics -enable-resilience
+
+@_exported import ObjectiveC
+@_exported import CoreGraphics
+
+@inlinable public func == (lhs: CGPoint, rhs: CGPoint) -> Bool {
+  return lhs.x == rhs.x  &&  lhs.y == rhs.y
+}
+
+@_fixed_layout
+public struct CGFloat {
+#if arch(i386) || arch(arm)
+  public typealias UnderlyingType = Float
+#elseif arch(x86_64) || arch(arm64)
+  public typealias UnderlyingType = Double
+#endif
+
+  @inlinable public init() { 
+    self.value = 0.0
+  }
+
+  @inlinable public init(_ value: Int) { 
+    self.value = UnderlyingType(value)
+  }
+
+  @inlinable public init(_ value: Float) { 
+    self.value = UnderlyingType(value)
+  }
+
+  @inlinable public init(_ value: Double) { 
+    self.value = UnderlyingType(value)
+  }
+
+  @_hasStorage @usableFromInline internal var value: UnderlyingType
+}
+
+@inlinable public func ==(lhs: CGFloat, rhs: CGFloat) -> Bool {
+  return lhs.value == rhs.value
+}
+
+extension CGFloat : ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral, Equatable {
+  @inlinable public init(integerLiteral value: UnderlyingType) {
+    self.value = value
+  }
+
+  @inlinable public init(floatLiteral value: UnderlyingType) {
+    self.value = value
+  }
+}
+
+public extension Double {
+  @inlinable init(_ value: CGFloat) {
+    self = Double(value.value)
+  }
+}

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name CoreGraphics -enable-resilience
+// swift-module-flags: -module-name CoreGraphics -enable-library-evolution
 
 @_exported import ObjectiveC
 @_exported import CoreGraphics

--- a/test/Inputs/clang-importer-sdk/swift-modules/Darwin.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Darwin.swiftinterface
@@ -1,0 +1,43 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Darwin -enable-resilience
+
+@_exported import Darwin // Clang module
+
+
+//===----------------------------------------------------------------------===//
+// MacTypes.h
+//===----------------------------------------------------------------------===//
+public let noErr: OSStatus
+
+/// The `Boolean` type declared in MacTypes.h and used throughout Core
+/// Foundation.
+///
+/// The C type is a typedef for `unsigned char`.
+@_fixed_layout
+public struct DarwinBoolean : ExpressibleByBooleanLiteral {
+  @_hasStorage @usableFromInline internal var value: UInt8
+
+  @inlinable public init(_ value: Bool) {
+    self.value = value ? 1 : 0
+  }
+
+  /// The value of `self`, expressed as a `Bool`.
+  @inlinable public var boolValue: Bool {
+    return value != 0
+  }
+
+  /// Create an instance initialized to `value`.
+  @_transparent
+  public init(booleanLiteral value: Bool) {
+    self.init(value)
+  }
+}
+
+@inlinable public // COMPILER_INTRINSIC
+func _convertBoolToDarwinBoolean(_ x: Bool) -> DarwinBoolean {
+  return DarwinBoolean(x)
+}
+@inlinable public // COMPILER_INTRINSIC
+func _convertDarwinBooleanToBool(_ x: DarwinBoolean) -> Bool {
+  return x.boolValue
+}

--- a/test/Inputs/clang-importer-sdk/swift-modules/Darwin.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Darwin.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name Darwin -enable-resilience
+// swift-module-flags: -module-name Darwin -enable-library-evolution
 
 @_exported import Darwin // Clang module
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/Dispatch.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Dispatch.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Dispatch -enable-resilience
+
+@_exported import Dispatch // Clang module
+
+typealias dispatch_block_t = @convention(block) () -> Void

--- a/test/Inputs/clang-importer-sdk/swift-modules/Dispatch.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Dispatch.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name Dispatch -enable-resilience
+// swift-module-flags: -module-name Dispatch -enable-library-evolution
 
 @_exported import Dispatch // Clang module
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name Foundation -enable-resilience
+// swift-module-flags: -module-name Foundation -enable-library-evolution
 
 @_exported import ObjectiveC
 @_exported import CoreGraphics

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swiftinterface
@@ -1,0 +1,284 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foundation -enable-resilience
+
+@_exported import ObjectiveC
+@_exported import CoreGraphics
+@_exported import Foundation
+
+public let NSUTF8StringEncoding: UInt = 8
+
+extension AnyHashable : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSObject
+  public static func _forceBridgeFromObjectiveC(_ x: NSObject,
+                                                result: inout AnyHashable?)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSObject,
+    result: inout AnyHashable?
+  ) -> Bool
+  public static func _unconditionallyBridgeFromObjectiveC(_ x: NSObject?) -> AnyHashable
+}
+
+extension String : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSString
+  public static func _forceBridgeFromObjectiveC(_ x: NSString,
+                                                result: inout String?)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSString,
+    result: inout String?
+  ) -> Bool
+  public static func _unconditionallyBridgeFromObjectiveC(_ x: NSString?) -> String
+}
+
+extension Int : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSNumber
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSNumber, 
+    result: inout Int?
+  )
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSNumber,
+    result: inout Int?
+  ) -> Bool
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ x: NSNumber?
+  ) -> Int
+}
+
+extension Bool: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSNumber
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSNumber, 
+    result: inout Bool?
+  )
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSNumber,
+    result: inout Bool?
+  ) -> Bool
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ x: NSNumber?
+  ) -> Bool
+}
+
+extension Array : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSArray
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSArray,
+    result: inout Array?
+  )
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSArray,
+    result: inout Array?
+  ) -> Bool
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ x: NSArray?
+  ) -> Array
+}
+
+extension Dictionary : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSDictionary
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSDictionary,
+    result: inout Dictionary?
+  )
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSDictionary,
+    result: inout Dictionary?
+  ) -> Bool
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ x: NSDictionary?
+  ) -> Dictionary
+}
+
+extension Set : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSSet
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSSet,
+    result: inout Set?
+  )
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSSet,
+    result: inout Set?
+  ) -> Bool
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ x: NSSet?
+  ) -> Set
+}
+
+extension CGFloat : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSNumber
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSNumber,
+    result: inout CGFloat?
+  )
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSNumber,
+    result: inout CGFloat?
+  ) -> Bool
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ x: NSNumber?
+  ) -> CGFloat
+}
+
+extension NSRange : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSValue
+
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSValue,
+    result: inout NSRange?
+  )
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSValue,
+    result: inout NSRange?
+  ) -> Bool
+
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ x: NSValue?
+  ) -> NSRange
+}
+
+public struct URL : _ObjectiveCBridgeable {
+  public init()
+
+  public init?(string: String)
+
+  public func _bridgeToObjectiveC() -> NSURL
+  public static func _forceBridgeFromObjectiveC(_ x: NSURL,
+                                                result: inout URL?)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSURL,
+    result: inout URL?
+  ) -> Bool
+  public static func _unconditionallyBridgeFromObjectiveC(_ x: NSURL?) -> URL
+}
+
+extension NSError : Error {
+  @inlinable public var _domain: String { return domain }
+  @inlinable public var _code: Int { return code }
+}
+
+internal enum _GenericObjCError : Error {
+  case nilError
+}
+
+public func _convertNSErrorToError(_ error: NSError?) -> Error
+
+public func _convertErrorToNSError(_ x: Error) -> NSError
+
+extension _SwiftNewtypeWrapper where Self.RawValue == Error {
+  @inlinable // FIXME(sil-serialize-all)
+  public func _bridgeToObjectiveC() -> NSError {
+    return rawValue as NSError
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public static func _forceBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) {
+    result = Self(rawValue: source)
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) -> Bool {
+    result = Self(rawValue: source)
+    return result != nil
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSError?
+  ) -> Self {
+    return Self(rawValue: _convertNSErrorToError(source))!
+  }
+}
+
+
+
+extension NSArray {
+  @objc(methodIntroducedInOverlay) public func introducedInOverlay()
+}
+
+/// An internal protocol to represent Swift error enums that map to standard
+/// Cocoa NSError domains.
+public protocol _ObjectiveCBridgeableError : Error {
+  /// Produce a value of the error type corresponding to the given NSError,
+  /// or return nil if it cannot be bridged.
+  init?(_bridgedNSError: NSError)
+}
+
+/// Describes a bridged error that stores the underlying NSError, so
+/// it can be queried.
+public protocol _BridgedStoredNSError : _ObjectiveCBridgeableError {
+  /// The type of an error code.
+  associatedtype Code: _ErrorCodeProtocol
+
+  /// The error code for the given error.
+  var code: Code { get }
+
+  //// Retrieves the embedded NSError.
+  var _nsError: NSError { get }
+
+  /// Create a new instance of the error type with the given embedded
+  /// NSError.
+  ///
+  /// The \c error must have the appropriate domain for this error
+  /// type.
+  init(_nsError error: NSError)
+}
+
+public protocol _ErrorCodeProtocol {
+  /// The corresponding error code.
+  associatedtype _ErrorType
+}
+
+public extension _BridgedStoredNSError {
+  init?(_bridgedNSError error: NSError) {
+    self.init(_nsError: error)
+  }
+}
+
+/// Various helper implementations for _BridgedStoredNSError
+public extension _BridgedStoredNSError
+    where Code: RawRepresentable, Code.RawValue: SignedInteger {
+  // FIXME: Generalize to Integer.
+  var code: Code { get }
+
+  /// Initialize an error within this domain with the given ``code``
+  /// and ``userInfo``.
+  init(_ code: Code, userInfo: [String : Any] = [:])
+
+  /// The user-info dictionary for an error that was bridged from
+  /// NSError.
+  var userInfo: [String : Any] { get }
+}
+
+/// Various helper implementations for _BridgedStoredNSError
+public extension _BridgedStoredNSError
+    where Code: RawRepresentable, Code.RawValue: UnsignedInteger {
+  // FIXME: Generalize to Integer.
+  var code: Code { get }
+
+  /// Initialize an error within this domain with the given ``code``
+  /// and ``userInfo``.
+  init(_ code: Code, userInfo: [String : Any] = [:])
+}
+
+extension NSDictionary {
+  @objc public subscript(_: Any) -> Any? {
+    @objc(__swift_objectForKeyedSubscript:)
+    get
+  }
+
+  public func nonObjCExtensionMethod<T>(_: T) {}
+}
+extension NSMutableDictionary {
+  public override subscript(_: Any) -> Any? {
+    get
+    @objc(__swift_setObject:forKeyedSubscript:)
+    set
+  }
+}

--- a/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name ObjectiveC -enable-resilience -disable-objc-attr-requires-foundation-module
+// swift-module-flags: -module-name ObjectiveC -enable-library-evolution -disable-objc-attr-requires-foundation-module
 
 @_exported import ObjectiveC // Clang module
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swiftinterface
@@ -1,0 +1,92 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name ObjectiveC -enable-resilience -disable-objc-attr-requires-foundation-module
+
+@_exported import ObjectiveC // Clang module
+
+// The iOS/arm64 target uses _Bool for Objective-C's BOOL.  We include
+// x86_64 here as well because the iOS simulator also uses _Bool.
+#if ((os(iOS) || os(tvOS)) && (arch(arm64) || arch(x86_64))) || os(watchOS)
+@_fixed_layout
+public struct ObjCBool {
+  @usableFromInline internal var value : Bool
+
+  @inlinable public init(_ value: Bool) {
+    self.value = value
+  }
+
+  @inlinable public var boolValue: Bool {
+    return value
+  }
+}
+
+#else
+
+@_fixed_layout
+public struct ObjCBool {
+  @usableFromInline internal var value : UInt8
+
+  @inlinable public init(_ value: Bool) {
+    self.value = value ? 1 : 0
+  }
+
+  @inlinable public init(_ value: UInt8) {
+    self.value = value
+  }
+
+  @inlinable public var boolValue: Bool {
+    if value == 0 { return false }
+    return true
+  }
+}
+#endif
+
+extension ObjCBool : ExpressibleByBooleanLiteral {
+  @inlinable public init(booleanLiteral: Bool) {
+    self.init(booleanLiteral)
+  }
+}
+
+@_fixed_layout
+public struct Selector : ExpressibleByStringLiteral {
+  @usableFromInline internal var ptr : OpaquePointer
+
+  public init(_ value: String)
+
+  public init(unicodeScalarLiteral value: String)
+
+  public init(extendedGraphemeClusterLiteral value: String)
+
+  public init (stringLiteral value: String)
+
+  public var hashValue: Int { get }
+}
+
+extension Selector : Equatable, Hashable {}
+
+@inlinable public func ==(lhs: Selector, rhs: Selector) -> Bool {
+  return sel_isEqual(lhs, rhs)
+}
+
+@_fixed_layout
+public struct NSZone {
+  public var pointer : OpaquePointer
+}
+
+@inlinable public func _convertBoolToObjCBool(_ x: Bool) -> ObjCBool {
+  return ObjCBool(x)
+}
+
+@inlinable public func _convertObjCBoolToBool(_ x: ObjCBool) -> Bool {
+  return x.boolValue
+}
+
+public func ~=(x: NSObject, y: NSObject) -> Bool
+
+extension NSObject : Equatable, Hashable {
+  @nonobjc public var hashValue: Int { get }
+
+  @inlinable public static func == (lhs: NSObject, rhs: NSObject) -> Bool {
+    return lhs.isEqual(rhs)
+  }
+}
+

--- a/test/Inputs/clang-importer-sdk/swift-modules/Security.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Security.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name Security -enable-resilience
+// swift-module-flags: -module-name Security -enable-library-evolution
 
 @_exported import Security // Clang module
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/Security.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Security.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Security -enable-resilience
+
+@_exported import Security // Clang module
+
+public let errSecSuccess: OSStatus

--- a/test/Inputs/clang-importer-sdk/swift-modules/simd.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/simd.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name simd -enable-resilience
+// swift-module-flags: -module-name simd -enable-library-evolution
 
 @_fixed_layout @_alignment(16) public struct float3 { public var x, y, z: Float }
 @_fixed_layout @_alignment(16) public struct float4 { public var x, y, z, w: Float }

--- a/test/Inputs/clang-importer-sdk/swift-modules/simd.swiftinterface
+++ b/test/Inputs/clang-importer-sdk/swift-modules/simd.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name simd -enable-resilience
+
+@_fixed_layout @_alignment(16) public struct float3 { public var x, y, z: Float }
+@_fixed_layout @_alignment(16) public struct float4 { public var x, y, z, w: Float }
+@_fixed_layout @_alignment(16) public struct double2 { public var x, y: Double }
+@_fixed_layout @_alignment(16) public struct int3 { public var x, y, z: Int32 }
+@_fixed_layout @_alignment(16) public struct uint4 { public var x, y, z, w: UInt32 }

--- a/test/NameBinding/multi-file-with-main.swift
+++ b/test/NameBinding/multi-file-with-main.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -enable-source-import -primary-file %s %S/Inputs/multi-file-with-main/main.swift -module-name=MultiFile -sdk "" -verify
+// RUN: %target-swift-frontend -typecheck -primary-file %s %S/Inputs/multi-file-with-main/main.swift -module-name=MultiFile -sdk "" -verify
 
 func testOperator() {
   let x: Int = 1 +++ "abc" // expected-error {{binary operator '+++' cannot be applied to operands of type 'Int' and 'String'}} expected-note {{expected an argument list of type '(Int, Int)'}}

--- a/test/PrintAsObjC/any_as_id.swift
+++ b/test/PrintAsObjC/any_as_id.swift
@@ -4,14 +4,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/any_as_id.swiftmodule -typecheck -emit-objc-header-path %t/any_as_id.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/any_as_id.swiftmodule -typecheck -emit-objc-header-path %t/any_as_id.h
 
 // RUN: %FileCheck %s < %t/any_as_id.h
 

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -emit-module-doc -o %t %s -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/cdecl.swiftmodule -typecheck -emit-objc-header-path %t/cdecl.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/cdecl.h
 // RUN: %check-in-clang %t/cdecl.h

--- a/test/PrintAsObjC/circularity-errors.swift
+++ b/test/PrintAsObjC/circularity-errors.swift
@@ -4,14 +4,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity-errors.swiftmodule -typecheck -emit-objc-header-path %t/circularity-errors.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/circularity.h -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity-errors.swiftmodule -typecheck -emit-objc-header-path %t/circularity-errors.h
 
 // RUN: %FileCheck %s < %t/circularity-errors.h
 // RUN: not %check-in-clang %t/circularity-errors.h

--- a/test/PrintAsObjC/circularity.swift
+++ b/test/PrintAsObjC/circularity.swift
@@ -4,14 +4,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity.swiftmodule -typecheck -emit-objc-header-path %t/circularity.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/circularity.h -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity.swiftmodule -typecheck -emit-objc-header-path %t/circularity.h
 
 // RUN: %FileCheck %s < %t/circularity.h
 

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -4,16 +4,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
-// FIXME: END -enable-source-import hackaround
-
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/classes.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/classes.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -parse-as-library %t/classes.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/classes.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/classes.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/classes.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/classes.h

--- a/test/PrintAsObjC/comments.swift
+++ b/test/PrintAsObjC/comments.swift
@@ -1,7 +1,7 @@
 // Please keep this file in alphabetical order!
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -module-name comments %S/../Inputs/comment_to_something_conversion.swift -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -module-name comments %S/../Inputs/comment_to_something_conversion.swift -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/comments.swiftmodule -typecheck -emit-objc-header-path %t/comments.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: awk '/A000/,0' %t/comments.h > %t/comments.h-cleaned
 // RUN: diff -u %t/comments.h-cleaned %S/Inputs/comments-expected-output.h

--- a/test/PrintAsObjC/depends-on-swift-framework.swift
+++ b/test/PrintAsObjC/depends-on-swift-framework.swift
@@ -1,15 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %S/Inputs/depends-on-swift-framework-helper.swift -module-name OtherModule
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/Inputs/depends-on-swift-framework-helper.swift -module-name OtherModule
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/../Inputs/empty.h -emit-module -o %t %s -module-name main
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/../Inputs/empty.h -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/main.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -import-objc-header %S/../Inputs/empty.h -emit-module -o %t %s -module-name main
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -import-objc-header %S/../Inputs/empty.h -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/main.h
 
 // RUN: %FileCheck %s < %t/main.h
 

--- a/test/PrintAsObjC/dynamicself.swift
+++ b/test/PrintAsObjC/dynamicself.swift
@@ -2,16 +2,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
-// FIXME: END -enable-source-import hackaround
-
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/dynamicself.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/dynamicself.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/dynamicself.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/dynamicself.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/dynamicself.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/dynamicself.h
 

--- a/test/PrintAsObjC/enums-frozen.swift
+++ b/test/PrintAsObjC/enums-frozen.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module -enable-library-evolution -module-name enums
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module -enable-library-evolution -module-name enums
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -typecheck -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module -enable-library-evolution
 // RUN: %FileCheck %s < %t/enums.h
 // RUN: %check-in-clang %t/enums.h

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -typecheck -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/enums.h
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/enums.h
 // RUN: %check-in-clang %t/enums.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/enums.h -include ctypes.h -include CoreFoundation.h
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -o /dev/null -emit-module-doc-path /dev/null -module-name enums %s -emit-objc-header-path %t/enums.WMO.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o /dev/null -emit-module-doc-path /dev/null -module-name enums %s -emit-objc-header-path %t/enums.WMO.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/enums.WMO.h
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/enums.WMO.h
 // RUN: %check-in-clang %t/enums.WMO.h

--- a/test/PrintAsObjC/error-delegate.swift
+++ b/test/PrintAsObjC/error-delegate.swift
@@ -4,14 +4,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/error-delegate.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/error-delegate.h -parse-as-library %t/error-delegate.swiftmodule -typecheck -emit-objc-header-path %t/error-delegate.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/error-delegate.h -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/error-delegate.h -parse-as-library %t/error-delegate.swiftmodule -typecheck -emit-objc-header-path %t/error-delegate.h
 
 // RUN: %FileCheck %s < %t/error-delegate.h
 // RUN: %check-in-clang %t/error-delegate.h

--- a/test/PrintAsObjC/interfering-macros.swift
+++ b/test/PrintAsObjC/interfering-macros.swift
@@ -1,12 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) %s -typecheck -emit-objc-header-path %t/interfering-macros.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/interfering-macros.h
 // RUN: %check-in-clang -fsyntax-only -Werror %t/interfering-macros.h -D'any=UNWANTED_MACRO_SUBSTITUTION'
 
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/newtype.swift
+++ b/test/PrintAsObjC/newtype.swift
@@ -4,14 +4,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/newtype.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/newtype.h -parse-as-library %t/newtype.swiftmodule -typecheck -emit-objc-header-path %t/newtype.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/newtype.h -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/newtype.h -parse-as-library %t/newtype.swiftmodule -typecheck -emit-objc-header-path %t/newtype.h
 
 // RUN: %FileCheck %s < %t/newtype.h
 

--- a/test/PrintAsObjC/override.swift
+++ b/test/PrintAsObjC/override.swift
@@ -1,14 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -parse-as-library %t/override.swiftmodule -typecheck -emit-objc-header-path %t/override.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/override.swiftmodule -typecheck -emit-objc-header-path %t/override.h
 // RUN: %FileCheck %s < %t/override.h
 // RUN: %check-in-clang %t/override.h -I %S/Inputs/custom-modules -Wno-super-class-method-mismatch -Wno-overriding-method-mismatch
 // RUN: not %check-in-clang %t/override.h -Wno-super-class-method-mismatch -I %S/Inputs/custom-modules 2>&1 | %FileCheck -check-prefix=CLANG %s

--- a/test/PrintAsObjC/pragma-clang.swift
+++ b/test/PrintAsObjC/pragma-clang.swift
@@ -1,12 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) %s -import-objc-header %S/Inputs/bridging-header.h -typecheck -emit-objc-header-path %t/pragma-clang.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -import-objc-header %S/Inputs/bridging-header.h -typecheck -emit-objc-header-path %t/pragma-clang.h
 // RUN: %check-in-clang -fsyntax-only -Werror %t/pragma-clang.h
 // RUN: %FileCheck %s < %t/pragma-clang.h
 

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -2,14 +2,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -I %t -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -I %t -parse-as-library %t/protocols.swiftmodule -typecheck -emit-objc-header-path %t/protocols.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -parse-as-library %t/protocols.swiftmodule -typecheck -emit-objc-header-path %t/protocols.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/protocols.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/protocols.h
 // RUN: %check-in-clang %t/protocols.h

--- a/test/PrintAsObjC/reintroduced-new.m
+++ b/test/PrintAsObjC/reintroduced-new.m
@@ -2,16 +2,12 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../../test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/Inputs/reintroduced-new.swift -swift-version 4 -disable-objc-attr-requires-foundation-module -module-name main
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/generated.h -disable-objc-attr-requires-foundation-module -swift-version 4
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %S/Inputs/reintroduced-new.swift -swift-version 4 -disable-objc-attr-requires-foundation-module -module-name main
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/generated.h -disable-objc-attr-requires-foundation-module -swift-version 4
 // RUN: not %clang -fsyntax-only -x objective-c %s -include %t/generated.h -fobjc-arc -fmodules -Werror -F %clang-importer-sdk-path/frameworks -isysroot %S/../../test/Inputs/clang-importer-sdk 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-4 %s
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/Inputs/reintroduced-new.swift -disable-objc-attr-requires-foundation-module -module-name main -swift-version 5
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../../test/Inputs/clang-importer-sdk -I %t) -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/generated.h -disable-objc-attr-requires-foundation-module -swift-version 5
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %S/Inputs/reintroduced-new.swift -disable-objc-attr-requires-foundation-module -module-name main -swift-version 5
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/main.swiftmodule -typecheck -emit-objc-header-path %t/generated.h -disable-objc-attr-requires-foundation-module -swift-version 5
 // RUN: not %clang -fsyntax-only -x objective-c %s -include %t/generated.h -fobjc-arc -fmodules -Werror -F %clang-importer-sdk-path/frameworks -isysroot %S/../../test/Inputs/clang-importer-sdk 2>&1 | %FileCheck  -check-prefix=CHECK -check-prefix=CHECK-5 %s
 
 // CHECK-NOT: error:

--- a/test/PrintAsObjC/simd.swift
+++ b/test/PrintAsObjC/simd.swift
@@ -1,14 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/simd.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -emit-module-doc -o %t -module-name simd_test %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -parse-as-library %t/simd_test.swiftmodule -typecheck -emit-objc-header-path %t/simd.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -emit-module-doc -o %t -module-name simd_test %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/simd_test.swiftmodule -typecheck -emit-objc-header-path %t/simd.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/simd.h
 // RUN: %check-in-clang %t/simd.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/simd.h

--- a/test/PrintAsObjC/swift3_deprecated_objc_inference.swift
+++ b/test/PrintAsObjC/swift3_deprecated_objc_inference.swift
@@ -2,21 +2,13 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
-// FIXME: END -enable-source-import hackaround
-
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference -warn-swift3-objc-inference-minimal
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/swift3_deprecated_objc_inference.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/swift3_deprecated_objc_inference.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference -warn-swift3-objc-inference-minimal
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference -warn-swift3-objc-inference-minimal
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/swift3_deprecated_objc_inference.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/swift3_deprecated_objc_inference.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference -warn-swift3-objc-inference-minimal
 // RUN: %FileCheck %s < %t/swift3_deprecated_objc_inference.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/swift3_deprecated_objc_inference.h
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t/swift3_deprecated_objc_inference_nowarn.swiftmodule %s -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/swift3_deprecated_objc_inference_nowarn.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/swift3_deprecated_objc_inference_nowarn.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t/swift3_deprecated_objc_inference_nowarn.swiftmodule %s -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/swift3_deprecated_objc_inference_nowarn.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/swift3_deprecated_objc_inference_nowarn.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference
 // RUN: %FileCheck -check-prefix=CHECK-NOWARN %s < %t/swift3_deprecated_objc_inference_nowarn.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/swift3_deprecated_objc_inference_nowarn.h
 

--- a/test/PrintAsObjC/swift_name.swift
+++ b/test/PrintAsObjC/swift_name.swift
@@ -4,14 +4,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/swift_name.h -emit-module -o %t %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/swift_name.h -parse-as-library %t/swift_name.swiftmodule -typecheck -emit-objc-header-path %t/swift_name.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/swift_name.h -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/swift_name.h -parse-as-library %t/swift_name.swiftmodule -typecheck -emit-objc-header-path %t/swift_name.h
 
 // RUN: %FileCheck %s < %t/swift_name.h
 // RUN: %check-in-clang %t/swift_name.h

--- a/test/PrintAsObjC/versioned.swift
+++ b/test/PrintAsObjC/versioned.swift
@@ -2,15 +2,8 @@
 
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module -swift-version 4
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/versioned.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/versioned.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module -swift-version 4
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/versioned.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/versioned.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4
 // RUN: %FileCheck %s < %t/versioned.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/versioned.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/versioned.h -include VersionedFMWK.h

--- a/test/SIL/Parser/unnamed_struct_identifiers.sil
+++ b/test/SIL/Parser/unnamed_struct_identifiers.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sdk %clang-importer-sdk-path %s
+// RUN: %target-sil-opt %clang-importer-sdk %s
 
 import ctypes
 

--- a/test/SILGen/dynamic_lookup_throws.swift
+++ b/test/SILGen/dynamic_lookup_throws.swift
@@ -1,8 +1,4 @@
-
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk-nosource -I %t) -module-name dynamic_lookup_throws -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name dynamic_lookup_throws -parse-as-library %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -1,7 +1,4 @@
-
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk-nosource -I %t) -module-name foreign_errors -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name foreign_errors -parse-as-library %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk -I %t) -module-name newtype -I %S/Inputs -I %S/Inputs -I %S/../IDE/Inputs/custom-modules -enable-objc-interop -enable-source-import %s | %FileCheck %s -check-prefix=CHECK-RAW
-// RUN: %target-swift-emit-sil(mock-sdk: %clang-importer-sdk -I %t) -module-name newtype -I %S/Inputs -I %S/Inputs -I %S/../IDE/Inputs/custom-modules -enable-objc-interop -enable-source-import %s | %FileCheck %s -check-prefix=CHECK-CANONICAL
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk -I %t) -module-name newtype -I %S/Inputs -I %S/../IDE/Inputs/custom-modules -enable-objc-interop %s | %FileCheck %s -check-prefix=CHECK-RAW
+// RUN: %target-swift-emit-sil(mock-sdk: %clang-importer-sdk -I %t) -module-name newtype -I %S/Inputs -I %S/../IDE/Inputs/custom-modules -enable-objc-interop %s | %FileCheck %s -check-prefix=CHECK-CANONICAL
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -1,8 +1,4 @@
-
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk-nosource -I %t) -module-name objc_error %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name objc_error %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/constantprop-wrongscope.swift
+++ b/test/SILOptimizer/constantprop-wrongscope.swift
@@ -1,10 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I \
-// RUN:   %S/../ClangImporter/Inputs/custom-modules -emit-sil -o /dev/null \
-// RUN:   -primary-file %s -Xllvm -sil-print-debuginfo -module-name patatino \
-// RUN:   -Onone -Xllvm -sil-print-after=diagnostic-constant-propagation \
-// RUN:   2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -primary-file %s -Xllvm -sil-print-debuginfo -module-name patatino -Onone -Xllvm -sil-print-after=diagnostic-constant-propagation 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
@@ -12,12 +6,11 @@
 // Make sure that the destroy_addr instruction has the same scope of the
 // instructions surrounding it.
 
-// CHECK:   destroy_addr %7 : $*Any, loc {{.*}}:22:19, scope 2
-// CHECK:   dealloc_stack %12 : $*Optional<Any>, loc {{.*}}:22:23, scope 2
-// CHECK:   dealloc_stack %7 : $*Any, loc {{.*}}:22:23, scope 2
-// CHECK:   dealloc_stack %6 : $*A, loc {{.*}}:22:7, scope 2
-
 import Foundation
 func indexedSubscripting(b b: B, idx: Int, a: A) {
   var a2 = b[idx] as! A
+  // CHECK:   destroy_addr %7 : $*Any, loc {{.*}}:[[@LINE-1]]:19, scope 2
+  // CHECK:   dealloc_stack %12 : $*Optional<Any>, loc {{.*}}:[[@LINE-2]]:23, scope 2
+  // CHECK:   dealloc_stack %7 : $*Any, loc {{.*}}:[[@LINE-3]]:23, scope 2
+  // CHECK:   dealloc_stack %6 : $*A, loc {{.*}}:[[@LINE-4]]:7, scope 2
 }

--- a/test/Serialization/basic_sil_objc.swift
+++ b/test/Serialization/basic_sil_objc.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend %clang-importer-sdk -I %S/../Inputs/clang-importer-sdk/swift-modules -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/def_basic_objc.swiftmodule %S/Inputs/def_basic_objc.sil
+// RUN: %target-build-swift %clang-importer-sdk -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/def_basic_objc.swiftmodule %S/Inputs/def_basic_objc.sil
 // RUN: llvm-bcanalyzer %t/def_basic_objc.swiftmodule | %FileCheck %s
 
-// RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-sil -I %t %s -o %t/basic_sil_objc.sil
+// RUN: %target-build-swift %clang-importer-sdk -emit-sil -I %t %s -o %t/basic_sil_objc.sil
 // RUN: %target-sil-opt %t/basic_sil_objc.sil -performance-linker -I %t | %FileCheck %S/Inputs/def_basic_objc.sil
 
 // This test currently is written such that no optimizations are assumed.

--- a/test/Serialization/imported_enum_merge.swift
+++ b/test/Serialization/imported_enum_merge.swift
@@ -1,11 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t/UsesImportedEnums-a.swiftmodule -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -merge-modules -module-name UsesImportedEnums -emit-module -o %t/UsesImportedEnums.swiftmodule %t/UsesImportedEnums-a.swiftmodule
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/UsesImportedEnums-a.swiftmodule -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -merge-modules -module-name UsesImportedEnums -emit-module -o %t/UsesImportedEnums.swiftmodule %t/UsesImportedEnums-a.swiftmodule
 
 // REQUIRES: objc_interop

--- a/test/Serialization/objc_optional_reqs.swift
+++ b/test/Serialization/objc_optional_reqs.swift
@@ -1,12 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Darwin.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/Inputs/def_objc_conforming.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %S/Inputs/def_objc_conforming.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -typecheck %s -verify
 
 // REQUIRES: objc_interop
 

--- a/test/Serialization/objc_xref.swift
+++ b/test/Serialization/objc_xref.swift
@@ -1,13 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Darwin.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/AppKit.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/Inputs/def_objc_xref.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %S/Inputs/def_objc_xref.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -typecheck %s -verify
 
 // REQUIRES: objc_interop
 

--- a/test/Serialization/sil-imported-enums.swift
+++ b/test/Serialization/sil-imported-enums.swift
@@ -1,12 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -emit-sil %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SourceKit/CursorInfo/cursor_info_async.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_async.swift
@@ -2,15 +2,12 @@ import Foo
 
 // REQUIRES: objc_interop
 
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
 // Perform 8 concurrent cursor infos, which is often enough to cause
 // contention.  We disable printing the requests to minimize delay.
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- \
 // RUN:                  -F %S/../Inputs/libIDE-mock-sdk %mcp_opt \
-// RUN:                   -target %target-triple %clang-importer-sdk-nosource -I %t \
+// RUN:                  -target %target-triple %clang-importer-sdk \
 // RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
 // RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
 // RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -23,10 +23,7 @@ func foo3(a: Float, b: Bool) {}
 
 // REQUIRES: objc_interop
 
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %sourcekitd-test -req=cursor -pos=3:18 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-OVERLAY %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:18 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-OVERLAY %s
 // CHECK-OVERLAY:      source.lang.swift.ref.var.global
 // CHECK-OVERLAY-NEXT: NSUTF8StringEncoding
 // CHECK-OVERLAY-NEXT: s:10Foundation20NSUTF8StringEncodingSuv
@@ -36,39 +33,39 @@ func foo3(a: Float, b: Bool) {}
 // CHECK-OVERLAY-NEXT: SYSTEM
 // CHECK-OVERLAY-NEXT: <Declaration>let NSUTF8StringEncoding: <Type usr="s:Su">UInt</Type></Declaration>
 
-// RUN: %sourcekitd-test -req=cursor -pos=5:13 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-ITERATOR %s
+// RUN: %sourcekitd-test -req=cursor -pos=5:13 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-ITERATOR %s
 // CHECK-ITERATOR-NOT: _AnyIteratorBase
 // CHECK-ITERATOR: <Group>Collection/Type-erased</Group>
 
-// RUN: %sourcekitd-test -req=cursor -pos=8:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT1 %s
+// RUN: %sourcekitd-test -req=cursor -pos=8:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT1 %s
 // CHECK-REPLACEMENT1: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT1: <Declaration>{{.*}}func sorted() -&gt; [<Type usr="s:Si">Int</Type>]</Declaration>
 // CHECK-REPLACEMENT1: RELATED BEGIN
 // CHECK-REPLACEMENT1: sorted(by:)</RelatedName>
 // CHECK-REPLACEMENT1: RELATED END
 
-// RUN: %sourcekitd-test -req=cursor -pos=9:8 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT2 %s
+// RUN: %sourcekitd-test -req=cursor -pos=9:8 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT2 %s
 // CHECK-REPLACEMENT2: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT2: <Declaration>{{.*}}mutating func append(_ newElement: <Type usr="s:Si">Int</Type>)</Declaration>
 
-// RUN: %sourcekitd-test -req=cursor -pos=15:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT3 %s
+// RUN: %sourcekitd-test -req=cursor -pos=15:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT3 %s
 // CHECK-REPLACEMENT3: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT3: func sorted(by areInIncreasingOrder: (<Type usr="s:13cursor_stdlib2S1V">S1</Type>
 // CHECK-REPLACEMENT3: sorted()</RelatedName>
 
-// RUN: %sourcekitd-test -req=cursor -pos=18:8 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
+// RUN: %sourcekitd-test -req=cursor -pos=18:8 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
 // CHECK-REPLACEMENT4: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT4: <Declaration>{{.*}}mutating func append(_ newElement: <Type usr="s:13cursor_stdlib2S1V">S1</Type>)</Declaration>
 
-// RUN: %sourcekitd-test -req=cursor -pos=21:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-MODULE-GROUP1 %s
+// RUN: %sourcekitd-test -req=cursor -pos=21:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-MODULE-GROUP1 %s
 // CHECK-MODULE-GROUP1: MODULE GROUPS BEGIN
 // CHECK-MODULE-GROUP1-DAG: Math
 // CHECK-MODULE-GROUP1-DAG: Collection
 // CHECK-MODULE-GROUP1-DAG: Collection/Array
 // CHECK-MODULE-GROUP1: MODULE GROUPS END
 
-// RUN: %sourcekitd-test -req=cursor -pos=22:17 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-FLOAT1 %s
+// RUN: %sourcekitd-test -req=cursor -pos=22:17 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-FLOAT1 %s
 // CHECK-FLOAT1: s:Sf
 
-// RUN: %sourcekitd-test -req=cursor -pos=22:25 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-BOOL1 %s
+// RUN: %sourcekitd-test -req=cursor -pos=22:25 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-BOOL1 %s
 // CHECK-BOOL1: s:Sb

--- a/test/SourceKit/DocSupport/doc_clang_module.swift
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift
@@ -1,11 +1,8 @@
 // REQUIRES: objc_interop
 
 // FIXME: the test output we're comparing to is specific to macOS.
-// REQUIRES-ANY: OS=macosx
-
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
+// REQUIRES: OS=macosx
 
 // RUN: %sourcekitd-test -req=doc-info -module Foo -- -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response

--- a/test/SourceKit/Indexing/index_bad_modulename.swift
+++ b/test/SourceKit/Indexing/index_bad_modulename.swift
@@ -1,8 +1,6 @@
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-// RUN: %sourcekitd-test -req=index %s -- %s -module-name Swift %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response1
+// RUN: %sourcekitd-test -req=index %s -- %s -module-name Swift %mcp_opt -target %target-triple %clang-importer-sdk | %sed_clean > %t.response1
 // RUN: diff -u %s.response %t.response1
-// RUN: %sourcekitd-test -req=index %s -- %s -module-name 12345 %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response2
+// RUN: %sourcekitd-test -req=index %s -- %s -module-name 12345 %mcp_opt -target %target-triple %clang-importer-sdk | %sed_clean > %t.response2
 // RUN: diff -u %s.response %t.response2
 
 import ObjectiveC

--- a/test/SourceKit/Indexing/index_bad_modulename.swift.response
+++ b/test/SourceKit/Indexing/index_bad_modulename.swift.response
@@ -9,7 +9,7 @@
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "ObjectiveC",
-      key.filepath: ObjectiveC.swiftmodule,
+      key.filepath: ObjectiveC-CACHED.swiftmodule,
       key.is_system: 1,
       key.dependencies: [
         {
@@ -46,27 +46,27 @@
       key.kind: source.lang.swift.ref.module,
       key.name: "ObjectiveC",
       key.usr: "c:@M@ObjectiveC",
-      key.line: 8,
+      key.line: 6,
       key.column: 8
     },
     {
       key.kind: source.lang.swift.decl.var.global,
       key.name: "v",
       key.usr: "s:4main1vSo8NSObjectCSgvp",
-      key.line: 9,
+      key.line: 7,
       key.column: 5,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.accessor.getter,
           key.usr: "s:4main1vSo8NSObjectCSgvg",
-          key.line: 9,
+          key.line: 7,
           key.column: 5,
           key.is_implicit: 1
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:4main1vSo8NSObjectCSgvs",
-          key.line: 9,
+          key.line: 7,
           key.column: 5,
           key.is_implicit: 1
         }
@@ -76,7 +76,7 @@
       key.kind: source.lang.swift.ref.class,
       key.name: "NSObject",
       key.usr: "c:objc(cs)NSObject",
-      key.line: 9,
+      key.line: 7,
       key.column: 8
     }
   ]

--- a/test/SourceKit/Indexing/index_with_clang_module.swift
+++ b/test/SourceKit/Indexing/index_with_clang_module.swift
@@ -1,10 +1,7 @@
 // REQUIRES: objc_interop
 
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
 // RUN: %sourcekitd-test -req=index %s -- %s -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck %s
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck %s
 
 import Foo
 

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -8,36 +8,34 @@ var x: FooClassBase
 // REQUIRES-ANY: OS=macosx
 
 // RUN: %empty-directory(%t.overlays)
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
 //
 // RUN: %target-swift-frontend -emit-module -o %t.overlays -F %S/../Inputs/libIDE-mock-sdk %S/Inputs/Foo.swift
 //
 // RUN: %sourcekitd-test -req=interface-gen -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk > %t.response
 // RUN: diff -u %s.response %t.response
 
 // RUN: %sourcekitd-test -req=interface-gen -module Foo.FooSub -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.sub.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk > %t.sub.response
 // RUN: diff -u %s.sub.response %t.sub.response
 
 // RUN: %sourcekitd-test -req=interface-gen -module FooHelper -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.helper.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk > %t.helper.response
 // RUN: diff -u %s.helper.response %t.helper.response
 
 // RUN: %sourcekitd-test -req=interface-gen -module FooHelper.FooHelperExplicit -- -I %t.overlays \
-// RUN:         -F %S/../Inputs/libIDE-mock-sdk  %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.helper.explicit.response
+// RUN:         -F %S/../Inputs/libIDE-mock-sdk  %mcp_opt -target %target-triple %clang-importer-sdk > %t.helper.explicit.response
 // RUN: diff -u %s.helper.explicit.response %t.helper.explicit.response
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk \
 // RUN:      == -req=cursor -pos=205:67 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooClassBase' inside the list of base classes, see 'gen_clang_module.swift.response'
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk \
 // RUN:   == -req=cursor -pos=3:11 %s -- %s -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK1 %s
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK1 %s
 
 // CHECK1: source.lang.swift.ref.class ({{.*}}Foo.framework/Headers/Foo.h:147:12-147:24)
 // CHECK1: FooClassBase
@@ -46,7 +44,7 @@ var x: FooClassBase
 // CHECK1-NEXT: /<interface-gen>
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk \
 // RUN:      == -req=cursor -pos=232:20 | %FileCheck -check-prefix=CHECK2 %s
 // The cursor points inside the interface, see 'gen_clang_module.swift.response'
 
@@ -57,22 +55,22 @@ var x: FooClassBase
 // CHECK2-NEXT: /<interface-gen>
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk \
 // RUN:      == -req=find-usr -usr "c:objc(cs)FooClassDerived(im)fooInstanceFunc0" | %FileCheck -check-prefix=CHECK-USR %s
 // The returned line:col points inside the interface, see 'gen_clang_module.swift.response'
 
 // CHECK-USR: (232:15-232:33)
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk \
 // RUN:   == -req=find-interface -module Foo -- %s -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-IFACE %s
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK-IFACE %s
 
 // CHECK-IFACE: DOC: (/<interface-gen>)
 // CHECK-IFACE: ARGS: [-target x86_64-{{.*}} -sdk {{.*}} -F {{.*}}/libIDE-mock-sdk -I {{.*}}.overlays {{.*}} -module-cache-path {{.*}} ]
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk \
 // RUN:      == -req=cursor -pos=1:8 == -req=cursor -pos=1:12 \
 // RUN:      == -req=cursor -pos=2:10 \
 // RUN:      == -req=cursor -pos=3:10 | %FileCheck -check-prefix=CHECK-IMPORT %s
@@ -92,8 +90,8 @@ var x: FooClassBase
 // CHECK-IMPORT-NEXT: FooHelper{{$}}
 
 // RUN: %sourcekitd-test -req=interface-gen -module APINotesTests -- -swift-version 4 -F %S/Inputs/mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource > %t.apinotes_swift3.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk > %t.apinotes_swift3.response
 // RUN: diff -u %s.apinotes_swift3.response %t.apinotes_swift3.response
 // RUN: %sourcekitd-test -req=interface-gen -module APINotesTests -- -swift-version 5 -F %S/Inputs/mock-sdk \
-// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource > %t.apinotes_swift4.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk > %t.apinotes_swift4.response
 // RUN: diff -u %s.apinotes_swift4.response %t.apinotes_swift4.response

--- a/test/SourceKit/InterfaceGen/gen_mixed_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_mixed_module.swift
@@ -3,13 +3,11 @@ var x = 10
 // REQUIRES: objc_interop
 
 // FIXME: the test output we're comparing to is specific to macOS.
-// REQUIRES-ANY: OS=macosx
+// REQUIRES: OS=macosx
 
 // RUN: %empty-directory(%t.overlays)
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
 
 // RUN: %target-swift-frontend -emit-module -o %t.overlays -F %S/../Inputs/libIDE-mock-sdk %S/../Inputs/libIDE-mock-sdk/Mixed.swift -import-underlying-module -module-name Mixed -disable-objc-attr-requires-foundation-module
-// RUN: %sourcekitd-test -req=interface-gen -module Mixed -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=interface-gen -module Mixed -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk %mcp_opt -target %target-triple %clang-importer-sdk | %FileCheck -check-prefix=CHECK1 %s
 
 // CHECK1: PureSwiftClass

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift
@@ -1,12 +1,9 @@
 // REQUIRES: objc_interop
 
-// RUN: %empty-directory(%t)
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %sourcekitd-test -req=interface-gen %S/Inputs/Foo2.swift -- %S/Inputs/Foo2.swift %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.response
+// RUN: %sourcekitd-test -req=interface-gen %S/Inputs/Foo2.swift -- %S/Inputs/Foo2.swift %mcp_opt -target %target-triple %clang-importer-sdk > %t.response
 // RUN: diff -u %s.response %t.response
 
-// RUN: %sourcekitd-test -req=interface-gen-open %S/Inputs/Foo2.swift -- %S/Inputs/Foo2.swift %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
+// RUN: %sourcekitd-test -req=interface-gen-open %S/Inputs/Foo2.swift -- %S/Inputs/Foo2.swift %mcp_opt -target %target-triple %clang-importer-sdk \
 // RUN: == -req=cursor -pos=18:49 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooOverlayClassBase' inside the list of base classes, see 'gen_swift_source.swift.response'
 

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -10,6 +10,7 @@ elif 'swift_evolve' in config.available_features:
 
 else:
     sed_clean = r"sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule[/\\\\].*\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"
+    sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)-[0-9A-Z]*\\.swiftmodule\"/key.filepath: \\1-CACHED.swiftmodule/g'"
     sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"
     sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swift\"/key.filepath: \\1.swift/g'"
     sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)-[0-9A-Z]*\\.pcm\"/key.filepath: \\1.pcm/g'"

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1603,6 +1603,27 @@
         },
         {
           "kind": "Conformance",
+          "name": "_ObjectiveCBridgeable",
+          "printedName": "_ObjectiveCBridgeable",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "_ObjectiveCType",
+              "printedName": "_ObjectiveCType",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "NSNumber",
+                  "printedName": "NSNumber",
+                  "usr": "c:objc(cs)NSNumber"
+                }
+              ]
+            }
+          ],
+          "usr": "s:s21_ObjectiveCBridgeableP"
+        },
+        {
+          "kind": "Conformance",
           "name": "MirrorPath",
           "printedName": "MirrorPath",
           "usr": "s:s10MirrorPathP"

--- a/test/api-digester/apinotes-diags.swift
+++ b/test/api-digester/apinotes-diags.swift
@@ -2,9 +2,9 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %api-digester %clang-importer-sdk-nosource -dump-sdk -module APINotesTest -o %t.dump1.json -module-cache-path %t.module-cache -swift-version 5 -I %S/Inputs/APINotesLeft
-// RUN: %api-digester %clang-importer-sdk-nosource -dump-sdk -module APINotesTest -o %t.dump2.json -module-cache-path %t.module-cache -swift-version 4 -I %S/Inputs/APINotesRight
-// RUN: %api-digester %clang-importer-sdk-nosource -dump-sdk -module APINotesTest -o %t.dump3.json -module-cache-path %t.module-cache -swift-version 5 -I %S/Inputs/APINotesRight
+// RUN: %api-digester %clang-importer-sdk -dump-sdk -module APINotesTest -o %t.dump1.json -module-cache-path %t.module-cache -swift-version 5 -I %S/Inputs/APINotesLeft
+// RUN: %api-digester %clang-importer-sdk -dump-sdk -module APINotesTest -o %t.dump2.json -module-cache-path %t.module-cache -swift-version 4 -I %S/Inputs/APINotesRight
+// RUN: %api-digester %clang-importer-sdk -dump-sdk -module APINotesTest -o %t.dump3.json -module-cache-path %t.module-cache -swift-version 5 -I %S/Inputs/APINotesRight
 // RUN: %api-digester -diagnose-sdk -print-module -input-paths %t.dump1.json -input-paths %t.dump3.json -o %t.result
 
 // RUN: %clang -E -P -x c %S/Outputs/apinotes-diags.txt -o - | sed '/^\s*$/d' > %t.expected

--- a/test/api-digester/apinotes-migrator-gen.swift
+++ b/test/api-digester/apinotes-migrator-gen.swift
@@ -2,8 +2,8 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -swift-version 5 -I %S/Inputs/APINotesLeft
-// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -swift-version 5 -I %S/Inputs/APINotesRight
+// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk -swift-version 5 -I %S/Inputs/APINotesLeft
+// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk -swift-version 5 -I %S/Inputs/APINotesRight
 // RUN: %api-digester -generate-migration-script --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result -json
 // RUN: diff -u %S/Outputs/apinotes-migrator-gen.json %t.result
 // RUN: %api-digester -generate-migration-script --input-paths %t.dump2.json -input-paths %t.dump1.json -o %t.result -json

--- a/test/api-digester/clang-module-dump.swift
+++ b/test/api-digester/clang-module-dump.swift
@@ -2,5 +2,5 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %api-digester -dump-sdk -module Foo -o %t.result -module-cache-path %t.module-cache %clang-importer-sdk-nosource -swift-version 4 -I %S/Inputs/Foo -avoid-location
+// RUN: %api-digester -dump-sdk -module Foo -o %t.result -module-cache-path %t.module-cache %clang-importer-sdk -swift-version 4 -I %S/Inputs/Foo -avoid-location
 // RUN: diff -u %S/Outputs/clang-module-dump.txt %t.result

--- a/test/api-digester/compare-clang-dump.swift
+++ b/test/api-digester/compare-clang-dump.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %api-digester -dump-sdk -module Foo -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/Foo -avoid-location
-// RUN: %api-digester -dump-sdk -module Foo -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %S/Inputs/Foo-new-version -avoid-location
+// RUN: %api-digester -dump-sdk -module Foo -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk -I %S/Inputs/Foo -avoid-location
+// RUN: %api-digester -dump-sdk -module Foo -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk -I %S/Inputs/Foo-new-version -avoid-location
 // RUN: %api-digester -diagnose-sdk -protocol-requirement-white-list %S/Inputs/Foo-prot-whitelist.txt -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result
 
 // RUN: %clang -E -P -x c %S/Outputs/Foo-diff.txt -o - | sed '/^\s*$/d' > %t.expected

--- a/test/api-digester/compare-dump-abi-parsable-interface.swift
+++ b/test/api-digester/compare-dump-abi-parsable-interface.swift
@@ -3,8 +3,8 @@
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
 
-// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod1/cake.swiftinterface %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
-// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod2/cake.swiftinterface %S/Inputs/cake_current/cake.swift -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod1/cake.swiftinterface %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod2/cake.swiftinterface %S/Inputs/cake_current/cake.swift -I %S/Inputs/APINotesRight %clang-importer-sdk -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
 // RUN: %api-digester -diagnose-sdk -print-module -module cake -BI %t.mod1 -BI %S/Inputs/APINotesLeft -I %t.mod2 -I %S/Inputs/APINotesRight -sdk %clang-importer-sdk-path -bsdk %clang-importer-sdk-path -module-cache-path %t.module-cache -o %t.result -abi
 
 // RUN: %clang -E -P -x c %S/Outputs/Cake-abi.txt -o - | sed '/^\s*$/d' > %t.expected

--- a/test/api-digester/compare-dump-abi.swift
+++ b/test/api-digester/compare-dump-abi.swift
@@ -2,10 +2,10 @@
 // RUN: %empty-directory(%t.mod2)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource
-// RUN: %swift -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource
-// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft -abi > %t.dump1.json
-// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod2 -I %S/Inputs/APINotesLeft -abi > %t.dump2.json
+// RUN: %swift -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk
+// RUN: %swift -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk
+// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk -I %t.mod1 -I %S/Inputs/APINotesLeft -abi > %t.dump1.json
+// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk -I %t.mod2 -I %S/Inputs/APINotesLeft -abi > %t.dump2.json
 // RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -abi -o %t.result
 // RUN: %clang -E -P -x c %S/Outputs/Cake-abi.txt -o - | sed '/^\s*$/d' > %t.abi.expected
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.abi.result.tmp

--- a/test/api-digester/compare-dump-parsable-interface.swift
+++ b/test/api-digester/compare-dump-parsable-interface.swift
@@ -3,8 +3,8 @@
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
 
-// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod1/cake.swiftinterface %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
-// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod2/cake.swiftinterface %S/Inputs/cake_current/cake.swift -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod1/cake.swiftinterface %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod2/cake.swiftinterface %S/Inputs/cake_current/cake.swift -I %S/Inputs/APINotesRight %clang-importer-sdk -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
 // RUN: %api-digester -diagnose-sdk -print-module -module cake -BI %t.mod1 -BI %S/Inputs/APINotesLeft -I %t.mod2 -I %S/Inputs/APINotesRight -sdk %clang-importer-sdk-path -bsdk %clang-importer-sdk-path -module-cache-path %t.module-cache -o %t.result
 
 // RUN: %clang -E -P -x c %S/Outputs/Cake.txt -o - | sed '/^\s*$/d' > %t.expected

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -2,10 +2,10 @@
 // RUN: %empty-directory(%t.mod2)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name cake
-// RUN: %swift -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name cake
-// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft > %t.dump1.json
-// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod2 -I %S/Inputs/APINotesLeft > %t.dump2.json
+// RUN: %swift -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk -module-name cake
+// RUN: %swift -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk -module-name cake
+// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk -I %t.mod1 -I %S/Inputs/APINotesLeft > %t.dump1.json
+// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk -I %t.mod2 -I %S/Inputs/APINotesLeft > %t.dump2.json
 // RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result
 
 // RUN: %clang -E -P -x c %S/Outputs/Cake.txt -o - | sed '/^\s*$/d' > %t.expected
@@ -13,10 +13,10 @@
 // RUN: diff -u %t.expected %t.result.tmp
 
 // Run another module API checking without -enable-library-evolution
-// RUN: %swift -emit-module -o %t.mod1/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name color
-// RUN: %swift -emit-module -o %t.mod2/color.swiftmodule %S/Inputs/cake_current/color.swift -parse-as-library -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name color
-// RUN: %api-digester -dump-sdk -module color -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft > %t.dump1.json
-// RUN: %api-digester -dump-sdk -module color -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod2 -I %S/Inputs/APINotesLeft > %t.dump2.json
+// RUN: %swift -emit-module -o %t.mod1/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -I %S/Inputs/APINotesLeft %clang-importer-sdk -module-name color
+// RUN: %swift -emit-module -o %t.mod2/color.swiftmodule %S/Inputs/cake_current/color.swift -parse-as-library -I %S/Inputs/APINotesRight %clang-importer-sdk -module-name color
+// RUN: %api-digester -dump-sdk -module color -o - -module-cache-path %t.module-cache %clang-importer-sdk -I %t.mod1 -I %S/Inputs/APINotesLeft > %t.dump1.json
+// RUN: %api-digester -dump-sdk -module color -o - -module-cache-path %t.module-cache %clang-importer-sdk -I %t.mod2 -I %S/Inputs/APINotesLeft > %t.dump2.json
 // RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result
 
 // RUN: %clang -E -P -x c %S/Outputs/color.txt -o - | sed '/^\s*$/d' > %t.expected

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
-// RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk
+// RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk
 // RUN: diff -u %S/Outputs/cake.json %t.dump.json
-// RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -abi -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -abi -I %S/Inputs/ClangCake %clang-importer-sdk
 // RUN: diff -u %S/Outputs/cake-abi.json %t.dump.json
 // RUN: %api-digester -diagnose-sdk --input-paths %t.dump.json -input-paths %S/Outputs/cake.json
 

--- a/test/api-digester/internal-extension.swift
+++ b/test/api-digester/internal-extension.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
-// RUN: %swift -emit-module -o %t.mod/main.swiftmodule %s -parse-as-library -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
-// RUN: %api-digester -dump-sdk -module main -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk-nosource
+// RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library -I %S/Inputs/ClangCake %clang-importer-sdk
+// RUN: %swift -emit-module -o %t.mod/main.swiftmodule %s -parse-as-library -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk
+// RUN: %api-digester -dump-sdk -module main -o %t.dump.json -module-cache-path %t.module-cache -swift-only -I %t.mod -I %S/Inputs/ClangCake %clang-importer-sdk
 // RUN: %FileCheck %s < %t.dump.json
 
 import cake

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference
-// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference | %FileCheck %s
-// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference > %t.ast
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %s -swift-version 4 -enable-swift3-objc-inference
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-swift3-objc-inference > %t.ast
 // RUN: %FileCheck -check-prefix CHECK-DUMP %s < %t.ast
 // REQUIRES: objc_interop
 

--- a/test/attr/attr_objc_swift4.swift
+++ b/test/attr/attr_objc_swift4.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 4 -enable-source-import -I %S/Inputs
-// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs | %FileCheck %s
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 4
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/attr/hasInitialValue.swift
+++ b/test/attr/hasInitialValue.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -swift-version 4 -enable-source-import -I %S/Inputs | %FileCheck %s
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -swift-version 4 | %FileCheck %s
 
 // CHECK-LABEL: {{^}}class C {
 class C {

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -1,12 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Darwin.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -typecheck %s -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -dump-ast -verify | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -dump-ast -verify | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/expr/primary/selector/fixits.swift
+++ b/test/expr/primary/selector/fixits.swift
@@ -3,25 +3,19 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t.overlays)
 
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t.overlays %clang-importer-sdk-path/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t.overlays %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t.overlays %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
-
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t.overlays %S/Inputs/fixits_helper.swift -module-name Helper
 
 // Make sure we get the right diagnostics.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t.overlays) -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t.overlays -typecheck %s -verify
 
 // Copy the source, apply the Fix-Its, and compile it again, making
 // sure that we've cleaned up all of the deprecation warnings.
 // RUN: %empty-directory(%t.sources)
 // RUN: %empty-directory(%t.remapping)
 // RUN: cp %s %t.sources/fixits.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t.overlays) -typecheck %t.sources/fixits.swift -fixit-all -emit-fixits-path %t.remapping/fixits.remap
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t.overlays -typecheck %t.sources/fixits.swift -fixit-all -emit-fixits-path %t.remapping/fixits.remap
 // RUN: %{python} %utils/apply-fixit-edits.py %t.remapping
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t.overlays) -typecheck %t.sources/fixits.swift 2> %t.result
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t.overlays -typecheck %t.sources/fixits.swift 2> %t.result
 
 // RUN: %FileCheck %s < %t.result
 // RUN: grep -c "warning:" %t.result | grep 3

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -422,18 +422,9 @@ config.substitutions.append(
 config.clang_include_dir = make_path(config.swift, '..', '..', 'include')
 config.substitutions.append( ('%clang-include-dir', config.clang_include_dir) )
 
-# Use this to build the basic set of Objective-C overlays.
-config.substitutions.append(('%build-clang-importer-objc-overlays',
-                             '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module && '
-                             '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift && '
-                             '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift'))
-
 # FIXME: BEGIN -enable-source-import hackaround
 config.substitutions.append(('%clang-importer-sdk-path',
                              '%r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
-
-config.substitutions.append(('%clang-importer-sdk-nosource',
-                             '-sdk %r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
 # FIXME: END -enable-source-import hackaround
 
 config.substitutions.append(('%clang-importer-sdk',

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -437,8 +437,8 @@ config.substitutions.append(('%clang-importer-sdk-nosource',
 # FIXME: END -enable-source-import hackaround
 
 config.substitutions.append(('%clang-importer-sdk',
-                             '-enable-source-import -sdk %r -I %r ' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
-                                                                       make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules'))))
+                             '-sdk %r -I %r ' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
+                                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules'))))
 
 config.substitutions.append( ('%clang_apinotes',
                               "%r -cc1apinotes" %


### PR DESCRIPTION
The mock SDK has mock overlays to go with its mock headers, and until now such overlays have always been manually compiled to swiftmodules or included via the old-and-broken -enable-source-import. Instead, we can use the new-and-exciting swiftinterface format to have them automatically compiled and cached each test run.

Still to fix:

- Move all the "-enable-source-import hackaround" manual compilers of overlays over to this.

- Dependency tracking is including the cached module files, which seems like a bad idea. (See test/Frontend/dependencies.swift.)

- We're definitely compiling the same swiftinterface with more than one configuration in the same compilation, and we need to not do that. (I suspect this is the difference between a top-level import and a recursive import.)