### PR TITLE
SE-0235: Add Result<Success, Failure: Error> to Standard Library

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -116,6 +116,7 @@ set(SWIFTLIB_ESSENTIAL
   ReflectionMirror.swift
   Repeat.swift
   REPL.swift
+  Result.swift
   Reverse.swift
   Runtime.swift.gyb
   RuntimeFunctionCounters.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -220,5 +220,8 @@
     "Comparable.swift",
     "Codable.swift",
     "MigrationSupport.swift"
+  ],
+  "Result": [
+    "Result.swift"
   ]
 }

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -128,15 +128,4 @@ extension Result where Error == Swift.Error {
 
 extension Result : Equatable where Value : Equatable, Error : Equatable { }
 
-extension Result : Hashable where Value : Hashable, Error : Hashable {
-  public func hash(into hasher: inout Hasher) {
-    switch self {
-    case let .value(value):
-      hasher.combine(value)
-      hasher.combine(Optional<Error>.none)
-    case let .error(error):
-      hasher.combine(Optional<Value>.none)
-      hasher.combine(error)
-    }
-  }
-}
+extension Result : Hashable where Value : Hashable, Error : Hashable { }

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -13,15 +13,15 @@
 /// A value that represents either a success or failure, capturing associated
 /// values in both cases.
 @_frozen
-public enum Result<Value, Error: Swift.Error> {
-  /// A success, storing a `Value`.
-  case value(Value)
+public enum Result<Success, Failure: Error> {
+  /// A success, storing a `Success` value.
+  case success(Success)
   
-  /// A failure, storing an `Error`.
-  case error(Error)
+  /// A failure, storing a `Failure` value.
+  case failure(Failure)
   
   /// Evaluates the given transform closure when this `Result` instance is
-  /// `.value`, passing the value as a parameter.
+  /// `.success`, passing the value as a parameter.
   ///
   /// Use the `map` method with a closure that returns a non-`Result` value.
   ///
@@ -29,19 +29,19 @@ public enum Result<Value, Error: Swift.Error> {
   ///   instance.
   /// - Returns: A new `Result` instance with the result of the transform, if
   ///   it was applied.
-  public func map<NewValue>(
-    _ transform: (Value) -> NewValue
-  ) -> Result<NewValue, Error> {
+  public func map<NewSuccess>(
+    _ transform: (Success) -> NewSuccess
+  ) -> Result<NewSuccess, Failure> {
     switch self {
-    case let .value(value):
-      return .value(transform(value))
-    case let .error(error):
-      return .error(error)
+    case let .success(success):
+      return .success(transform(success))
+    case let .failure(failure):
+      return .failure(failure)
     }
   }
   
   /// Evaluates the given transform closure when this `Result` instance is
-  /// `.error`, passing the error as a parameter.
+  /// `.failure`, passing the error as a parameter.
   ///
   /// Use the `mapError` method with a closure that returns a non-`Result`
   /// value.
@@ -50,82 +50,82 @@ public enum Result<Value, Error: Swift.Error> {
   ///   instance.
   /// - Returns: A new `Result` instance with the result of the transform, if
   ///   it was applied.
-  public func mapError<NewError>(
-    _ transform: (Error) -> NewError
-  ) -> Result<Value, NewError> {
+  public func mapError<NewFailure>(
+    _ transform: (Failure) -> NewFailure
+  ) -> Result<Success, NewFailure> {
     switch self {
-    case let .value(value):
-      return .value(value)
-    case let .error(error):
-      return .error(transform(error))
+    case let .success(success):
+      return .success(success)
+    case let .failure(failure):
+      return .failure(transform(failure))
     }
   }
   
   /// Evaluates the given transform closure when this `Result` instance is
-  /// `.value`, passing the value as a parameter and flattening the result.
+  /// `.success`, passing the value as a parameter and flattening the result.
   ///
   /// - Parameter transform: A closure that takes the successful value of the
   ///   instance.
   /// - Returns: A new `Result` instance, either from the transform or from
   ///   the previous error value.
-  public func flatMap<NewValue>(
-    _ transform: (Value) -> Result<NewValue, Error>
-  ) -> Result<NewValue, Error> {
+  public func flatMap<NewSuccess>(
+    _ transform: (Success) -> Result<NewSuccess, Failure>
+  ) -> Result<NewSuccess, Failure> {
     switch self {
-    case let .value(value):
-      return transform(value)
-    case let .error(error):
-      return .error(error)
+    case let .success(success):
+      return transform(success)
+    case let .failure(failure):
+      return .failure(failure)
     }
   }
   
   /// Evaluates the given transform closure when this `Result` instance is
-  /// `.error`, passing the error as a parameter and flattening the result.
+  /// `.failure`, passing the error as a parameter and flattening the result.
   ///
   /// - Parameter transform: A closure that takes the error value of the
   ///   instance.
   /// - Returns: A new `Result` instance, either from the transform or from
   ///   the previous success value.
-  public func flatMapError<NewError>(
-    _ transform: (Error) -> Result<Value, NewError>
-  ) -> Result<Value, NewError> {
+  public func flatMapError<NewFailure>(
+    _ transform: (Failure) -> Result<Success, NewFailure>
+  ) -> Result<Success, NewFailure> {
     switch self {
-    case let .value(value):
-      return .value(value)
-    case let .error(error):
-      return transform(error)
+    case let .success(success):
+      return .success(success)
+    case let .failure(failure):
+      return transform(failure)
     }
   }
   
-  /// Unwraps the `Result` into a throwing expression.
+  /// Attempts to get the `success` value as a throwing expression.
   ///
   /// - Returns: The success value, if the instance is a success.
-  /// - Throws:  The error value, if the instance is a failure.
-  public func unwrapped() throws -> Value {
+  /// - Throws:  The failure value, if the instance is a failure.
+  public func get() throws -> Success {
     switch self {
-    case let .value(value):
-      return value
-    case let .error(error):
-      throw error
+    case let .success(success):
+      return success
+    case let .failure(failure):
+      throw failure
     }
   }
 }
 
-extension Result where Error == Swift.Error {
+extension Result where Failure == Swift.Error {
   /// Create an instance by capturing the output of a throwing closure.
   ///
   /// - Parameter catching: A throwing closure to evaluate.
   @_transparent
-  public init(catching body: () throws -> Value) {
+  public init(catching body: () throws -> Success) {
     do {
       let value = try body()
-      self = .value(value)
+      self = .success(value)
     } catch {
-      self = .error(error)
+      self = .failure(error)
     }
   }
 }
 
-extension Result : Equatable where Value : Equatable, Error : Equatable { }
+extension Result : Equatable where Success : Equatable, Failure : Equatable { }
 
-extension Result : Hashable where Value : Hashable, Error : Hashable { }
+extension Result : Hashable where Success : Hashable, Failure : Hashable { }

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A value that represents either a success or failure, capturing associated
+/// values in both cases.
+@_frozen
+public enum Result<Value, Error: Swift.Error> {
+  /// A success, storing a `Value`.
+  case value(Value)
+  
+  /// A failure, storing an `Error`.
+  case error(Error)
+  
+  /// Evaluates the given transform closure when this `Result` instance is
+  /// `.value`, passing the value as a parameter.
+  ///
+  /// Use the `map` method with a closure that returns a non-`Result` value.
+  ///
+  /// - Parameter transform: A closure that takes the successful value of the
+  ///   instance.
+  /// - Returns: A new `Result` instance with the result of the transform, if
+  ///   it was applied.
+  public func map<NewValue>(
+    _ transform: (Value) -> NewValue
+  ) -> Result<NewValue, Error> {
+    switch self {
+    case let .value(value):
+      return .value(transform(value))
+    case let .error(error):
+      return .error(error)
+    }
+  }
+  
+  /// Evaluates the given transform closure when this `Result` instance is
+  /// `.error`, passing the error as a parameter.
+  ///
+  /// Use the `mapError` method with a closure that returns a non-`Result`
+  /// value.
+  ///
+  /// - Parameter transform: A closure that takes the failure value of the
+  ///   instance.
+  /// - Returns: A new `Result` instance with the result of the transform, if
+  ///   it was applied.
+  public func mapError<NewError>(
+    _ transform: (Error) -> NewError
+  ) -> Result<Value, NewError> {
+    switch self {
+    case let .value(value):
+      return .value(value)
+    case let .error(error):
+      return .error(transform(error))
+    }
+  }
+  
+  /// Evaluates the given transform closure when this `Result` instance is
+  /// `.value`, passing the value as a parameter and flattening the result.
+  ///
+  /// - Parameter transform: A closure that takes the successful value of the
+  ///   instance.
+  /// - Returns: A new `Result` instance, either from the transform or from
+  ///   the previous error value.
+  public func flatMap<NewValue>(
+    _ transform: (Value) -> Result<NewValue, Error>
+  ) -> Result<NewValue, Error> {
+    switch self {
+    case let .value(value):
+      return transform(value)
+    case let .error(error):
+      return .error(error)
+    }
+  }
+  
+  /// Evaluates the given transform closure when this `Result` instance is
+  /// `.error`, passing the error as a parameter and flattening the result.
+  ///
+  /// - Parameter transform: A closure that takes the error value of the
+  ///   instance.
+  /// - Returns: A new `Result` instance, either from the transform or from
+  ///   the previous success value.
+  public func flatMapError<NewError>(
+    _ transform: (Error) -> Result<Value, NewError>
+  ) -> Result<Value, NewError> {
+    switch self {
+    case let .value(value):
+      return .value(value)
+    case let .error(error):
+      return transform(error)
+    }
+  }
+  
+  /// Unwraps the `Result` into a throwing expression.
+  ///
+  /// - Returns: The success value, if the instance is a success.
+  /// - Throws:  The error value, if the instance is a failure.
+  public func unwrapped() throws -> Value {
+    switch self {
+    case let .value(value):
+      return value
+    case let .error(error):
+      throw error
+    }
+  }
+}
+
+extension Result where Error == Swift.Error {
+  /// Create an instance by capturing the output of a throwing closure.
+  ///
+  /// - Parameter catching: A throwing closure to evaluate.
+  @_transparent
+  public init(catching body: () throws -> Value) {
+    do {
+      let value = try body()
+      self = .value(value)
+    } catch {
+      self = .error(error)
+    }
+  }
+}
+
+extension Result : Equatable where Value : Equatable, Error : Equatable { }
+
+extension Result : Hashable where Value : Hashable, Error : Hashable {
+  public func hash(into hasher: inout Hasher) {
+    switch self {
+    case let .value(value):
+      hasher.combine(value)
+      hasher.combine(Optional<Error>.none)
+    case let .error(error):
+      hasher.combine(Optional<Value>.none)
+      hasher.combine(error)
+    }
+  }
+}

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -23,8 +23,6 @@ public enum Result<Success, Failure: Error> {
   /// Evaluates the given closure when this `Result` instance is `.success`,
   /// passing the success value as a parameter.
   ///
-  /// Use the `map` method with a closure that returns a non-`Result` value.
-  ///
   /// - Parameter transform: A closure that takes the success value of the
   ///   instance.
   /// - Returns: A `Result` instance with the result of evaluating the given 
@@ -42,9 +40,6 @@ public enum Result<Success, Failure: Error> {
   
   /// Evaluates the given closure when this `Result` instance is `.failure`,
   /// passing the failure value as a parameter.
-  ///
-  /// Use the `mapError` method with a closure that returns a non-`Result`
-  /// value.
   ///
   /// - Parameter transform: A closure that takes the failure value of the
   ///   instance.

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A value that represents either a success or failure, capturing associated
-/// values in both cases.
+/// A value that represents either a success or a failure, including an
+/// associated value in each case.
 @_frozen
 public enum Result<Success, Failure: Error> {
   /// A success, storing a `Success` value.
@@ -20,13 +20,24 @@ public enum Result<Success, Failure: Error> {
   /// A failure, storing a `Failure` value.
   case failure(Failure)
   
-  /// Evaluates the given closure when this `Result` instance is `.success`,
-  /// passing the success value as a parameter.
+  /// Returns a new result, mapping any success value using the given
+  /// transformation.
   ///
-  /// - Parameter transform: A closure that takes the success value of the
+  /// Use this method when you need to transform the value of a `Result`
+  /// instance when it represents a success. The following example transforms
+  /// the integer success value of a result into a string:
+  ///
+  ///     func getNextInteger() -> Result<Int, Error> { ... }
+  ///
+  ///     let integerResult = getNextInteger()
+  ///     // integerResult == .success(5)
+  ///     let stringResult = integerResult.map({ String($0) })
+  ///     // stringResult == .success("5")
+  ///
+  /// - Parameter transform: A closure that takes the success value of this
   ///   instance.
-  /// - Returns: A `Result` instance with the result of evaluating the given 
-  ///   closure as the new success value if this instance is `.success`.
+  /// - Returns: A `Result` instance with the result of evaluating `transform`
+  ///   as the new success value if this instance represents a success.
   public func map<NewSuccess>(
     _ transform: (Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
@@ -38,13 +49,32 @@ public enum Result<Success, Failure: Error> {
     }
   }
   
-  /// Evaluates the given closure when this `Result` instance is `.failure`,
-  /// passing the failure value as a parameter.
+  /// Returns a new result, mapping any failure value using the given
+  /// transformation.
+  ///
+  /// Use this method when you need to transform the value of a `Result`
+  /// instance when it represents a failure. The following example transforms
+  /// the error value of a result by wrapping it in a custom `Error` type:
+  ///
+  ///     struct DatedError: Error {
+  ///         var error: Error
+  ///         var date: Date
+  ///
+  ///         init(_ error: Error) {
+  ///             self.error = error
+  ///             self.date = Date()
+  ///         }
+  ///     }
+  ///
+  ///     let result: Result<Int, Error> = ...
+  ///     // result == .failure(<error value>)
+  ///     let resultWithDatedError = result.mapError({ e in DatedError(e) })
+  ///     // result == .failure(DatedError(error: <error value>, date: <date>))
   ///
   /// - Parameter transform: A closure that takes the failure value of the
   ///   instance.
-  /// - Returns: A `Result` instance with the result of evaluating the given
-  ///   closure as the new failure value if this instance is `.failure`.
+  /// - Returns: A `Result` instance with the result of evaluating `transform`
+  ///   as the new failure value if this instance represents a failure.
   public func mapError<NewFailure>(
     _ transform: (Failure) -> NewFailure
   ) -> Result<Success, NewFailure> {
@@ -56,13 +86,13 @@ public enum Result<Success, Failure: Error> {
     }
   }
   
-  /// Evaluates the given closure when this `Result` instance is `.success`,
-  /// passing the success value as a parameter.
+  /// Returns a new result, mapping any success value using the given
+  /// transformation and unwrapping the produced result.
   ///
   /// - Parameter transform: A closure that takes the success value of the
   ///   instance.
-  /// - Returns: A`Result` instance, either from the closure or the previous 
-  ///   `.failure`.
+  /// - Returns: A `Result` instance with the result of evaluating `transform`
+  ///   as the new failure value if this instance represents a failure.
   public func flatMap<NewSuccess>(
     _ transform: (Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
@@ -74,8 +104,8 @@ public enum Result<Success, Failure: Error> {
     }
   }
   
-  /// Evaluates the given closure when this `Result` instance is `.failure`,
-  /// passing the failure value as a parameter.
+  /// Returns a new result, mapping any failure value using the given
+  /// transformation and unwrapping the produced result.
   ///
   /// - Parameter transform: A closure that takes the failure value of the
   ///   instance.
@@ -92,10 +122,22 @@ public enum Result<Success, Failure: Error> {
     }
   }
   
-  /// Get the success value as a throwing expression.
+  /// Returns the success value as a throwing expression.
   ///
-  /// - Returns: The success value, if the instance is `.success`.
-  /// - Throws:  The failure value, if the instance is `.failure`.
+  /// Use this method to retrieve the value of this result if it represents a
+  /// success, or to catch the value if it represents a failure.
+  ///
+  ///     let integerResult: Result<Int, Error> = .success(5)
+  ///     do {
+  ///         let value = try integerResult.get()
+  ///         print("The value is \(value).")
+  ///     } catch error {
+  ///         print("Error retrieving the value: \(error)")
+  ///     }
+  ///     // Prints "The value is 5."
+  ///
+  /// - Returns: The success value, if the instance represent a success.
+  /// - Throws: The failure value, if the instance represents a failure.
   public func get() throws -> Success {
     switch self {
     case let .success(success):
@@ -107,10 +149,10 @@ public enum Result<Success, Failure: Error> {
 }
 
 extension Result where Failure == Swift.Error {
-  /// Create an instance by evaluating a throwing closure, capturing the 
-  /// returned value as a `.success` or any thrown error as `.failure`.
+  /// Creates a new result by evaluating a throwing closure, capturing the
+  /// returned value as a success, or any thrown error as a failure.
   ///
-  /// - Parameter catching: A throwing closure to evaluate.
+  /// - Parameter body: A throwing closure to evaluate.
   @_transparent
   public init(catching body: () throws -> Success) {
     do {

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -20,15 +20,15 @@ public enum Result<Success, Failure: Error> {
   /// A failure, storing a `Failure` value.
   case failure(Failure)
   
-  /// Evaluates the given transform closure when this `Result` instance is
-  /// `.success`, passing the value as a parameter.
+  /// Evaluates the given closure when this `Result` instance is `.success`,
+  /// passing the success value as a parameter.
   ///
   /// Use the `map` method with a closure that returns a non-`Result` value.
   ///
-  /// - Parameter transform: A closure that takes the successful value of the
+  /// - Parameter transform: A closure that takes the success value of the
   ///   instance.
-  /// - Returns: A new `Result` instance with the result of the transform, if
-  ///   it was applied.
+  /// - Returns: A `Result` instance with the result of evaluating the given 
+  ///   closure as the new success value if this instance is `.success`.
   public func map<NewSuccess>(
     _ transform: (Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
@@ -40,16 +40,16 @@ public enum Result<Success, Failure: Error> {
     }
   }
   
-  /// Evaluates the given transform closure when this `Result` instance is
-  /// `.failure`, passing the error as a parameter.
+  /// Evaluates the given closure when this `Result` instance is `.failure`,
+  /// passing the failure value as a parameter.
   ///
   /// Use the `mapError` method with a closure that returns a non-`Result`
   /// value.
   ///
   /// - Parameter transform: A closure that takes the failure value of the
   ///   instance.
-  /// - Returns: A new `Result` instance with the result of the transform, if
-  ///   it was applied.
+  /// - Returns: A `Result` instance with the result of evaluating the given
+  ///   closure as the new failure value if this instance is `.failure`.
   public func mapError<NewFailure>(
     _ transform: (Failure) -> NewFailure
   ) -> Result<Success, NewFailure> {
@@ -61,13 +61,13 @@ public enum Result<Success, Failure: Error> {
     }
   }
   
-  /// Evaluates the given transform closure when this `Result` instance is
-  /// `.success`, passing the value as a parameter and flattening the result.
+  /// Evaluates the given closure when this `Result` instance is `.success`,
+  /// passing the success value as a parameter.
   ///
-  /// - Parameter transform: A closure that takes the successful value of the
+  /// - Parameter transform: A closure that takes the success value of the
   ///   instance.
-  /// - Returns: A new `Result` instance, either from the transform or from
-  ///   the previous error value.
+  /// - Returns: A`Result` instance, either from the closure or the previous 
+  ///   `.failure`.
   public func flatMap<NewSuccess>(
     _ transform: (Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
@@ -79,13 +79,13 @@ public enum Result<Success, Failure: Error> {
     }
   }
   
-  /// Evaluates the given transform closure when this `Result` instance is
-  /// `.failure`, passing the error as a parameter and flattening the result.
+  /// Evaluates the given closure when this `Result` instance is `.failure`,
+  /// passing the failure value as a parameter.
   ///
-  /// - Parameter transform: A closure that takes the error value of the
+  /// - Parameter transform: A closure that takes the failure value of the
   ///   instance.
-  /// - Returns: A new `Result` instance, either from the transform or from
-  ///   the previous success value.
+  /// - Returns: A `Result` instance, either from the closure or the previous 
+  ///   `.success`.
   public func flatMapError<NewFailure>(
     _ transform: (Failure) -> Result<Success, NewFailure>
   ) -> Result<Success, NewFailure> {
@@ -97,10 +97,10 @@ public enum Result<Success, Failure: Error> {
     }
   }
   
-  /// Attempts to get the `success` value as a throwing expression.
+  /// Get the success value as a throwing expression.
   ///
-  /// - Returns: The success value, if the instance is a success.
-  /// - Throws:  The failure value, if the instance is a failure.
+  /// - Returns: The success value, if the instance is `.success`.
+  /// - Throws:  The failure value, if the instance is `.failure`.
   public func get() throws -> Success {
     switch self {
     case let .success(success):
@@ -112,20 +112,20 @@ public enum Result<Success, Failure: Error> {
 }
 
 extension Result where Failure == Swift.Error {
-  /// Create an instance by capturing the output of a throwing closure.
+  /// Create an instance by evaluating a throwing closure, capturing the 
+  /// returned value as a `.success` or any thrown error as `.failure`.
   ///
   /// - Parameter catching: A throwing closure to evaluate.
   @_transparent
   public init(catching body: () throws -> Success) {
     do {
-      let value = try body()
-      self = .success(value)
+      self = .success(try body())
     } catch {
       self = .failure(error)
     }
   }
 }
 
-extension Result : Equatable where Success : Equatable, Failure : Equatable { }
+extension Result: Equatable where Success: Equatable, Failure: Equatable { }
 
-extension Result : Hashable where Success : Hashable, Failure : Hashable { }
+extension Result: Hashable where Success: Hashable, Failure: Hashable { }

--- a/test/multifile/typealias/two-modules/main.swift
+++ b/test/multifile/typealias/two-modules/main.swift
@@ -10,6 +10,7 @@
 // RUN: %target-build-swift -g %S/main.swift %t/linker/library.o -I %t/linker/ -L %t/linker/ -o %t/linker/main
 
 import library
+import enum library.Result
 
 func testFunction<T>(withCompletion completion: (Result<T, Error>) -> Void) { }
 testFunction { (result: GenericResult<Int>) in }

--- a/test/stdlib/Result.swift
+++ b/test/stdlib/Result.swift
@@ -21,14 +21,14 @@ fileprivate extension Result {
     case .error:
       return nil
     }
-    
-    var error: Error? {
-      switch self {
-      case .value:
-        return nil
-      case let .error(error):
-        return error
-      }
+  }
+  
+  var error: Error? {
+    switch self {
+    case .value:
+      return nil
+    case let .error(error):
+      return error
     }
   }
 }
@@ -71,14 +71,7 @@ ResultTests.test("Throwing Initialization and Unwrapping") {
   let result1 = Result { try throwing() }
   let result2 = Result { try notThrowing() }
   
-  // Kept getting enum case 'error' cannot be used as an instance member, so get value manually.
-  switch result1 {
-  case let .error(error):
-    expectEqual(error as? Err, Err.err)
-  case .value:
-    expectUnreachable() 
-  }
-  
+  expectEqual(result1.error as? Err, Err.err)
   expectEqual(result2.value, string)
     
   do {

--- a/test/stdlib/Result.swift
+++ b/test/stdlib/Result.swift
@@ -55,7 +55,7 @@ ResultTests.test("Construction") {
     }
   }()
 
-  expectEqual(string1, string)
+  expectEqual(string, string1)
   expectEqual(error, .err)
 }
 

--- a/test/stdlib/Result.swift
+++ b/test/stdlib/Result.swift
@@ -1,0 +1,178 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import Swift
+
+let ResultTests = TestSuite("Result")
+
+fileprivate enum Err: Error, Equatable {
+  case err
+  case derr
+}
+
+fileprivate let string = "string"
+
+fileprivate extension Result {
+  var value: Value? {
+    switch self {
+    case let .value(value):
+      return value
+    case .error:
+      return nil
+    }
+    
+    var error: Error? {
+      switch self {
+      case .value:
+        return nil
+      case let .error(error):
+        return error
+      }
+    }
+  }
+}
+
+ResultTests.test("Construction") {
+  let result1: Result<String, Err> = .value(string)
+  let result2: Result<String, Err> = .error(.err)
+  let string1: String? = {
+    switch result1 {
+      case let .value(string): 
+        return string
+      case .error: 
+        expectUnreachable()
+        return nil
+    }
+  }()
+  let error: Err? = {
+    switch result2 {
+      case let .error(error): 
+        return error
+      case .value: 
+        expectUnreachable()
+        return nil
+    }
+  }()
+
+  expectEqual(string1, string)
+  expectEqual(error, .err)
+}
+
+ResultTests.test("Throwing Initialization and Unwrapping") {
+  func notThrowing() throws -> String {
+    return string
+  }
+
+  func throwing() throws -> String {
+    throw Err.err
+  }
+    
+  let result1 = Result { try throwing() }
+  let result2 = Result { try notThrowing() }
+  
+  // Kept getting enum case 'error' cannot be used as an instance member, so get value manually.
+  switch result1 {
+  case let .error(error):
+    expectEqual(error as? Err, Err.err)
+  case .value:
+    expectUnreachable() 
+  }
+  
+  expectEqual(result2.value, string)
+    
+  do {
+    _ = try result1.unwrapped()
+  } catch let error as Err {
+    expectEqual(error, Err.err)
+  } catch {
+    expectUnreachable()
+  }
+    
+  do {
+    let unwrapped = try result2.unwrapped()
+    expectEqual(unwrapped, string)
+  } catch {
+    expectUnreachable()
+  }
+    
+  // Test unwrapping strongly typed error.
+  let result3 = Result<String, Err>.error(Err.err)
+  do {
+    _ = try result3.unwrapped()
+  } catch let error as Err {
+    expectEqual(error, Err.err)
+  } catch {
+    expectUnreachable()
+  }
+}
+
+ResultTests.test("Functional Transforms") {
+  func transformDouble(_ int: Int) -> Int {
+    return 2 * int
+  }
+  
+  func transformTriple(_ int: Int) -> Int {
+    return 3 * int
+  }
+  
+  func transformError(_ err: Err) -> Err {
+    if err == .err {
+      return .derr
+    } else {
+      return .err
+    }
+  }
+
+  func resultValueTransform(_ int: Int) -> Result<Int, Err> {
+    return .value(transformDouble(int))
+  }
+  
+  func resultErrorTransform(_ err: Err) -> Result<Int, Err> {
+    return .error(transformError(err))
+  }
+    
+  let result1: Result<Int, Err> = .value(1)
+  let newResult1 = result1.map(transformDouble)
+    
+  expectEqual(newResult1, .value(2))
+    
+  let result2: Result<Int, Err> = .error(.err)
+  let newResult2 = result2.mapError(transformError)
+    
+  expectEqual(newResult2, .error(.derr))
+    
+  let result3: Result<Int, Err> = .value(1)
+  let newResult3 = result3.flatMap(resultValueTransform)
+    
+  expectEqual(newResult3, .value(2))
+    
+  let result4: Result<Int, Err> = .error(.derr)
+  let newResult4 = result4.flatMapError(resultErrorTransform)
+    
+  expectEqual(newResult4, .error(.err))
+}
+
+ResultTests.test("Equatable") {
+  let result1: Result<Int, Err> = .value(1)
+  let result2: Result<Int, Err> = .error(.err)
+
+  expectEqual(result1, .value(1))
+  expectNotEqual(result1, .value(2))
+  expectNotEqual(result1, .error(.err))
+  expectNotEqual(result1, .error(.derr))
+
+  expectNotEqual(result2, .value(1))
+  expectNotEqual(result2, .value(2))
+  expectEqual(result2, .error(.err))
+  expectNotEqual(result2, .error(.derr))
+}
+
+ResultTests.test("Hashable") {
+  let result1: Result<Int, Err> = .value(1)
+  let result2: Result<Int, Err> = .value(2)
+  let result3: Result<Int, Err> = .error(.err)
+  checkHashable([result1, result2, result3], equalityOracle: { $0 == $1 })
+}
+
+runAllTests()

--- a/test/stdlib/Result.swift
+++ b/test/stdlib/Result.swift
@@ -56,7 +56,7 @@ ResultTests.test("Construction") {
   }()
 
   expectEqual(string, string1)
-  expectEqual(error, .err)
+  expectEqual(.err, error)
 }
 
 ResultTests.test("Throwing Initialization and Unwrapping") {

--- a/test/stdlib/Result.swift
+++ b/test/stdlib/Result.swift
@@ -159,6 +159,15 @@ ResultTests.test("Equatable") {
   expectNotEqual(result2, .success(2))
   expectEqual(result2, .failure(.err))
   expectNotEqual(result2, .failure(.derr))
+  
+  let confusables: [Result<Err, Err>] = [
+    .success(.err),
+    .success(.derr),
+    .failure(.err),
+    .failure(.derr)
+  ]
+  
+  checkEquatable(confusables, oracle: { $0 == $1 })
 }
 
 ResultTests.test("Hashable") {
@@ -166,6 +175,14 @@ ResultTests.test("Hashable") {
   let result2: Result<Int, Err> = .success(2)
   let result3: Result<Int, Err> = .failure(.err)
   checkHashable([result1, result2, result3], equalityOracle: { $0 == $1 })
+
+  let confusables: [Result<Err, Err>] = [
+    .success(.err),
+    .success(.derr),
+    .failure(.err),
+    .failure(.derr)
+  ]
+  checkHashable(confusables, equalityOracle: { $0 == $1 })
 }
 
 runAllTests()


### PR DESCRIPTION
This PR adds the updated `Result` implementation for [SE-0235](https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md), as I broke the last PR when trying to rebase off of @rjmccall's `Error` self conformance PR. Previous PR discussion and review was [here](https://github.com/apple/swift/pull/19982).

This PR includes [#20629](https://github.com/apple/swift/pull/20629), as `Error` self conformance is required for this implementation of `Result`.