### PR TITLE
remote-run: make tests partially pass on Windows

### DIFF
--- a/test/remote-run/custom-options.test-sh
+++ b/test/remote-run/custom-options.test-sh
@@ -1,4 +1,4 @@
-RUN: %utils/remote-run -n --remote-dir /xyz-REMOTE -o FIRST_OPT -o SECOND_OPT --output-prefix %t some_user@some_host:12345 cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck %s
+RUN: %remote-run -n --remote-dir /xyz-REMOTE -o FIRST_OPT -o SECOND_OPT --output-prefix %/t some_user@some_host:12345 cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck %s
 
 CHECK: /usr/bin/ssh -n
 CHECK-DAG: -p 12345

--- a/test/remote-run/dry-run-remote.test-sh
+++ b/test/remote-run/dry-run-remote.test-sh
@@ -1,4 +1,4 @@
-RUN: %utils/remote-run -n --remote-dir /xyz-REMOTE --input-prefix %S/Inputs/ some_user@some_host ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s
+RUN: %remote-run -n --remote-dir /xyz-REMOTE --input-prefix %S/Inputs/ some_user@some_host ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s
 
 CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/input/upload'
 CHECK-INPUT-NEXT: /usr/bin/sftp
@@ -10,7 +10,7 @@ CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' 'ls'
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t/nested)
 RUN: touch %t/nested/input %t/nested/BAD
-RUN: %utils/remote-run -n --remote-dir /xyz-REMOTE --output-prefix %t some_user@some_host cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-OUTPUT %s
+RUN: %remote-run -n --remote-dir /xyz-REMOTE --output-prefix %/t some_user@some_host cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
 CHECK-OUTPUT-NEXT: /usr/bin/sftp

--- a/test/remote-run/dry-run.test-sh
+++ b/test/remote-run/dry-run.test-sh
@@ -1,3 +1,5 @@
+REQUIRES: shell
+
 RUN: %empty-directory(%t)
 RUN: %debug-remote-run -n --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s
 RUN: test -z "`ls %t`"

--- a/test/remote-run/env.test-sh
+++ b/test/remote-run/env.test-sh
@@ -1,3 +1,5 @@
+REQUIRES: shell
+
 RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run sh -c 'echo ":${FOO}:" ":${BAR}:"' | %FileCheck %s
 RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run -v sh -c 'echo ":${FOO}:" ":${BAR}:"' 2>&1 >/dev/null | %FileCheck -check-prefix VERBOSE %s
 

--- a/test/remote-run/exit-code.test-sh
+++ b/test/remote-run/exit-code.test-sh
@@ -1,3 +1,5 @@
+REQUIRES: shell
+
 RUN: not %debug-remote-run false >%t.txt 2>%t.errs.txt
 RUN: test -f %t.txt -a ! -s %t.txt
 RUN: test -f %t.errs.txt -a ! -s %t.errs.txt

--- a/test/remote-run/identity.test-sh
+++ b/test/remote-run/identity.test-sh
@@ -1,4 +1,4 @@
-RUN: %utils/remote-run -n --remote-dir /xyz-REMOTE -i spiderman --output-prefix %t some_user@some_host:12345 cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck %s
+RUN: %remote-run -n --remote-dir /xyz-REMOTE -i spiderman --output-prefix %/t some_user@some_host:12345 cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck %s
 
 CHECK: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
@@ -32,7 +32,7 @@ CHECK-DAG: -get '/xyz-REMOTE/output/nested/output' '{{.+}}/nested/output'
 CHECK-DAG: -get '/xyz-REMOTE/output/nested/input' '{{.+}}/nested/input'
 
 # Make sure things work without a port.
-RUN: %utils/remote-run -n --remote-dir /xyz-REMOTE -i spiderman --output-prefix %t some_user@some_host cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-PORTLESS %s
+RUN: %remote-run -n --remote-dir /xyz-REMOTE -i spiderman --output-prefix %/t some_user@some_host cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-PORTLESS %s
 
 CHECK-PORTLESS: /usr/bin/sftp
 CHECK-PORTLESS-SAME: -i spiderman

--- a/test/remote-run/lit.local.cfg
+++ b/test/remote-run/lit.local.cfg
@@ -2,4 +2,6 @@
 config.substitutions = list(config.substitutions)
 
 config.substitutions.insert(0, ('%debug-remote-run',
-  '%utils/remote-run --debug-as-local %sftp-server --remote-dir %t-REMOTE') )
+                                r'%r %%utils/remote-run --debug-as-local %%sftp-server --remote-dir %%t-REMOTE' % (sys.executable,)))
+config.substitutions.insert(0, ('%remote-run',
+                                r'%r %%utils/remote-run' % (sys.executable,)))

--- a/test/remote-run/port.test-sh
+++ b/test/remote-run/port.test-sh
@@ -1,4 +1,4 @@
-RUN: %utils/remote-run -n --remote-dir /xyz-REMOTE --output-prefix %t some_user@some_host:12345 cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck %s
+RUN: %remote-run -n --remote-dir /xyz-REMOTE --output-prefix %/t some_user@some_host:12345 cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck %s
 
 CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
 CHECK-NEXT: /usr/bin/sftp

--- a/test/remote-run/run-only.test-sh
+++ b/test/remote-run/run-only.test-sh
@@ -1,3 +1,5 @@
+REQUIRES: shell
+
 RUN: %debug-remote-run echo hello | %FileCheck %s
 RUN: %debug-remote-run -v echo hello 2>&1 >/dev/null | %FileCheck -check-prefix VERBOSE %s
 

--- a/test/remote-run/stderr.test-sh
+++ b/test/remote-run/stderr.test-sh
@@ -1,3 +1,5 @@
+REQUIRES: shell
+
 RUN: %debug-remote-run sh -c "echo hello; echo goodbye >&2" > %t.stdout.txt 2> %t.stderr.txt
 RUN: %FileCheck -check-prefix CHECK-STDOUT %s < %t.stdout.txt
 RUN: %FileCheck -check-prefix CHECK-STDERR %s < %t.stderr.txt

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -14,7 +14,8 @@
 from __future__ import print_function
 
 import argparse
-import os.path
+import os
+import posixpath
 import subprocess
 import sys
 
@@ -28,7 +29,7 @@ class CommandRunner(object):
 
     @staticmethod
     def _dirnames(files):
-        return sorted(set(os.path.dirname(f) for f in files))
+        return sorted(set(posixpath.dirname(f) for f in files))
 
     def popen(self, command, **kwargs):
         if self.verbose:
@@ -136,8 +137,8 @@ class LocalCommandRunner(CommandRunner):
         return ['/usr/bin/sftp', '-b', '-', '-q', '-D', self.sftp_server_path]
 
 def find_transfers(args, source_prefix, dest_prefix):
-    if source_prefix.endswith(os.path.sep):
-        source_prefix = source_prefix[:-len(os.path.sep)]
+    if source_prefix.endswith(posixpath.sep):
+        source_prefix = source_prefix[:-len(posixpath.sep)]
     return dict((arg, dest_prefix + arg[len(source_prefix):])
                 for arg in args if arg.startswith(source_prefix))
 
@@ -202,14 +203,14 @@ def main():
     remote_test_specific_dir = None
     if args.input_prefix:
         assert not args.remote_input_prefix.startswith("..")
-        remote_dir = os.path.join(args.remote_dir, args.remote_input_prefix)
+        remote_dir = posixpath.join(args.remote_dir, args.remote_input_prefix)
         input_files = find_transfers(args.command, args.input_prefix, 
                                      remote_dir)
         assert not any(upload_files.has_key(f) for f in input_files)
         upload_files.update(input_files)
     if args.output_prefix:
         assert not args.remote_output_prefix.startswith("..")
-        remote_dir = os.path.join(args.remote_dir, args.remote_output_prefix)
+        remote_dir = posixpath.join(args.remote_dir, args.remote_output_prefix)
         test_files = find_transfers(args.command, args.output_prefix, 
                                     remote_dir)
         assert not any(upload_files.has_key(f) for f in test_files)


### PR DESCRIPTION
Not all the tests are possible to run on Windows since they expect a
Unix-like shell environment.  However, the rest of the tests can be
accommodated.  This actually found an issue in the implementation.
Since the implementation assumes the target is POSIX/Unix-y, we should
use posixpath rather than os.path which uses the host's path style.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
