### PR TITLE
test: `#import` -> `#include`

### DIFF
--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -30,11 +30,11 @@ __attribute__((objc_root_class))
 
 #endif // __OBJC__
 
-#import <APINotesFrameworkTest/Classes.h>
-#import <APINotesFrameworkTest/Enums.h>
-#import <APINotesFrameworkTest/Globals.h>
-#import <APINotesFrameworkTest/ImportAsMember.h>
-#import <APINotesFrameworkTest/Properties.h>
-#import <APINotesFrameworkTest/Protocols.h>
-#import <APINotesFrameworkTest/Types.h>
-#import <APINotesFrameworkTest/SwiftWrapper.h>
+#include <APINotesFrameworkTest/Classes.h>
+#include <APINotesFrameworkTest/Enums.h>
+#include <APINotesFrameworkTest/Globals.h>
+#include <APINotesFrameworkTest/ImportAsMember.h>
+#include <APINotesFrameworkTest/Properties.h>
+#include <APINotesFrameworkTest/Protocols.h>
+#include <APINotesFrameworkTest/Types.h>
+#include <APINotesFrameworkTest/SwiftWrapper.h>

--- a/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h
+++ b/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h
@@ -1,4 +1,4 @@
-#import "app-bridging-header-to-pch.h"
+#include "app-bridging-header-to-pch.h"
 
 static inline int unit_test_function(int x) {
   return x + 28;


### PR DESCRIPTION
Replace `#import` with `#include` as `#import` is a Microsoft type
library inclusion feature on Windows.  This enables additional APINotes
tests to pass on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
