### PR TITLE
[AutoDiff] Work around duplicate diff task registration

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -985,9 +985,9 @@ public:
     assert(!lookUpDifferentiableAttr(original, indices));
     auto *attr =
         SILDifferentiableAttr::create(getModule(), indices,
-                                             /*primalName*/ StringRef(),
-                                             /*adjointName*/ StringRef(),
-                                             /*primitive*/ false);
+                                      /*primalName*/ StringRef(),
+                                      /*adjointName*/ StringRef(),
+                                      /*primitive*/ false);
     original->addDifferentiableAttr(attr);
     return attr;
   }
@@ -1022,6 +1022,8 @@ public:
                                    const SILAutoDiffIndices &indices) {
     auto supersetParamIndices = llvm::SmallBitVector();
     const auto &indexSet = indices.parameters;
+    if (auto *existingTask = lookUpDifferentiationTask(original, indices))
+      return existingTask;
     for (auto *rda : original->getDifferentiableAttrs()) {
       const auto &rdaIndexSet = rda->getIndices().parameters;
       // If all indices in indexSet are in rdaIndexSet, and it has fewer

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1821,8 +1821,10 @@ extension FloatingPoint {
   ///
   /// - Returns: The square root of the value.
   @_transparent
-  /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(reverse, wrt: (self), adjoint: _adjointSquareRoot)
+  // SWIFT_ENABLE_TENSORFLOW
+  // FIXME: This causes AD to register a differentiation task for this function
+  // twice.
+  // @differentiable(reverse, wrt: (self), adjoint: _adjointSquareRoot)
   public func squareRoot( ) -> Self {
     var lhs = self
     lhs.formSquareRoot( )


### PR DESCRIPTION
* In a build of stdlib with assertions enabled, `assert(!lookUpDifferentiationTask(original, indices))` fails in `ADContext:: registerDifferentiationTask`. This is only triggered by `FloatingPoint.squareRoot()`. This patch works around it by removing the `@differentiable` attribute. [SR-9401](https://bugs.swift.org/browse/SR-9401) is tracking the duplicate diff task registration bug.

* NFC: Make `lookUpMinimalDifferentiationTask` search existing differentiation tasks using the provided indices first for efficiency.