### PR TITLE
[5.0] build: assume a parallel tree layout for unified builds

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -226,7 +226,7 @@ macro(swift_common_unified_build_config product)
   set(PATH_TO_LLVM_BUILD "${CMAKE_BINARY_DIR}")
   set(${product}_PATH_TO_CLANG_BUILD "${CMAKE_BINARY_DIR}")
   set(PATH_TO_CLANG_BUILD "${CMAKE_BINARY_DIR}")
-  set(CLANG_MAIN_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/tools/clang/include")
+  set(CLANG_MAIN_INCLUDE_DIR "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include")
   set(CLANG_BUILD_INCLUDE_DIR "${CMAKE_BINARY_DIR}/tools/clang/include")
   set(${product}_NATIVE_LLVM_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
   set(${product}_NATIVE_CLANG_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
@@ -235,8 +235,8 @@ macro(swift_common_unified_build_config product)
 
   # If cmark was checked out into tools/cmark, expect to build it as
   # part of the unified build.
-  if(EXISTS "${CMAKE_SOURCE_DIR}/tools/cmark/")
-    set(${product}_PATH_TO_CMARK_SOURCE "${CMAKE_SOURCE_DIR}/tools/cmark")
+  if(EXISTS "${LLVM_EXTERNAL_CMARK_SOURCE_DIR}")
+    set(${product}_PATH_TO_CMARK_SOURCE "${LLVM_EXTERNAL_CMARK_SOURCE_DIR}")
     set(${product}_PATH_TO_CMARK_BUILD "${CMAKE_BINARY_DIR}/tools/cmark")
     set(${product}_CMARK_LIBRARY_DIR "${CMAKE_BINARY_DIR}/lib")
 


### PR DESCRIPTION
Attempt to repair the build for the unified swift build.  This allows us
to build a single unified toolchain with swift support.  In this layout
assume that cmark and clang are peers of LLVM rather than located in
`tools`.  Doing so allows a uniform layout of the tree and a simpler
build approach.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
