### PR TITLE
[5.0] Get the ModelAssistant source compatibility project building with the swift-5.0-branch

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -365,6 +365,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
   auto &tc = getTypeChecker();
   bool hasNonDependentMemberRelationalConstraints = false;
   bool hasDependentMemberRelationalConstraints = false;
+  bool sawNilLiteral = false;
   for (auto constraint : constraints) {
     switch (constraint->getKind()) {
     case ConstraintKind::Bind:
@@ -481,8 +482,10 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       // If there is a 'nil' literal constraint, we might need optional
       // supertype bindings.
       if (constraint->getProtocol()->isSpecificProtocol(
-              KnownProtocolKind::ExpressibleByNilLiteral))
+              KnownProtocolKind::ExpressibleByNilLiteral)) {
+        sawNilLiteral = true;
         addOptionalSupertypeBindings = true;
+      }
 
       // If there is a default literal type for this protocol, it's a
       // potential binding.
@@ -719,6 +722,32 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       result.FullyBound = true;
     else
       result.Bindings.clear();
+  }
+
+  // Revise any optional-of-function-types we may try to nil literals
+  // to be non-throwing so they don't inadvertantly result in rethrows
+  // diagnostics.
+  if (sawNilLiteral) {
+    for (auto &binding : result.Bindings) {
+      auto nested = binding.BindingType->lookThroughAllOptionalTypes();
+      if (!nested)
+        continue;
+
+      if (!nested->is<FunctionType>())
+        continue;
+
+      // Remove throws from the nested function type.
+      binding.BindingType =
+          binding.BindingType.transform([&](Type inner) -> Type {
+            auto *fnTy = dyn_cast<FunctionType>(inner.getPointer());
+            if (!fnTy)
+              return inner;
+
+            auto extInfo = fnTy->getExtInfo().withThrows(false);
+            return FunctionType::get(fnTy->getParams(), fnTy->getResult(),
+                                     extInfo);
+          });
+    }
   }
 
   return result;

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -146,6 +146,9 @@ public:
       // Look through closure capture lists.
       } else if (auto captureList = dyn_cast<CaptureListExpr>(fn)) {
         fn = captureList->getClosureBody();
+        // Look through optional evaluations.
+      } else if (auto optionalEval = dyn_cast<OptionalEvaluationExpr>(fn)) {
+        fn = optionalEval->getSubExpr()->getValueProvidingExpr();
       } else {
         break;
       }

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -713,7 +713,10 @@ private:
 
     // If it doesn't have function type, we must have invalid code.
     Type argType = fn.getType();
-    auto argFnType = (argType ? argType->getAs<AnyFunctionType>() : nullptr);
+    if (!argType) return Classification::forInvalidCode();
+
+    auto argFnType =
+        argType->lookThroughAllOptionalTypes()->getAs<AnyFunctionType>();
     if (!argFnType) return Classification::forInvalidCode();
 
     // If it doesn't throw, this argument does not cause the call to throw.

--- a/test/Constraints/sr9102.swift
+++ b/test/Constraints/sr9102.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+func test(_ a: [Int], _ f: ((Int) -> Bool)?) {
+  _ = a.filter(f!)
+}


### PR DESCRIPTION
Explanation: There were a couple issues with how rethrows diagnostics were dealing with optional function types, resulting in a verification issue in a new source compatibility suite project.

Issue: [SR-9102](https://bugs.swift.org/browse/SR-9102) / rdar://problem/45615204

Scope: Only affects code that has arguments with are optional throwing function types.

Risk: Low.

Testing: Added a new test for the case where we were failing verification.

Reviewed by: @rjmccall, @xedin 

Does not affect ABI.