### PR TITLE
[ParseableInterface] Don't serialize all SIL like a SIB file

### DIFF
--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -349,7 +349,6 @@ static bool buildSwiftModuleFromSwiftInterface(
     SerializationOptions SerializationOpts;
     std::string OutPathStr = OutPath;
     SerializationOpts.OutputPath = OutPathStr.c_str();
-    SerializationOpts.SerializeAllSIL = true;
     SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
     SmallVector<FileDependency, 16> Deps;
     if (collectDepsForSerialization(FS, SubInstance, InPath, ModuleCachePath,

--- a/test/ParseableInterface/ModuleCache/SerializedSIL.swiftinterface
+++ b/test/ParseableInterface/ModuleCache/SerializedSIL.swiftinterface
@@ -1,0 +1,54 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name SerializedSIL -enable-resilience
+
+// RUN: %empty-directory(%t)
+// RUN: echo 'import SerializedSIL' | %target-swift-frontend -typecheck -enable-parseable-module-interface -module-cache-path %t -I %S -
+// RUN: %target-sil-opt -disable-sil-linking %t/SerializedSIL-*.swiftmodule -module-name SerializedSIL > %t/SerializedSIL.sil
+// RUN: %FileCheck %s < %t/SerializedSIL.sil
+// RUN: %FileCheck -check-prefix NEGATIVE %s < %t/SerializedSIL.sil
+
+public class TestClass {
+    public init()
+    public func method()
+    public subscript(_: Int) -> Void { get set }
+    public var prop: Int { get set }
+    public var storedProp: Int
+    public static var staticProp: Int
+    deinit
+}
+
+public class TestEmptyClass {
+}
+
+public struct TestEmptyStruct {
+}
+
+public enum TestEnum {
+    case a
+    public init()
+    public func method()
+    public subscript(_: Int) -> Void { get set }
+    public var prop: Int { get set }
+    public static var staticProp: Int
+}
+
+public struct TestStruct {
+    public init()
+    public func method()
+    public subscript(_: Int) -> Void { get set }
+    public var prop: Int { get set }
+    public var storedProp: Int
+    public static var staticProp: Int
+}
+
+public let globalWithNoAccessors: Int
+public var readOnlyVar: Int { get }
+public var readWriteVar: Int { get set }
+public func verySimpleFunction()
+
+// CHECK: sil [serialized] [canonical] @$s13SerializedSIL9TestClassCACycfC : $@convention(method) (@thick TestClass.Type) -> @owned TestClass {
+
+// NEGATIVE-NOT: {{sil .*@.+storedProp}}
+
+// NEGATIVE-NOT: sil_vtable
+// NEGATIVE-NOT: sil_witness_table


### PR DESCRIPTION
This would break resilience, which makes a distinction between "SIL only inside the module, which is inside the resilience domain" and "SIL we're going to serialize, which is outside the resilience domain".

I'm pretty sure @graydon asked me about this when he was first putting it in and I kind of shrugged as if it wouldn't matter. It totally matters. My bad.