### PR TITLE
Perform ExistentialSpecializer when SoleConformingType is known

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
@@ -19,6 +19,7 @@
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILValue.h"
 #include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -77,6 +78,10 @@ public:
   /// Traverse ProtocolConformanceMapCache recursively to determine sole
   /// conforming concrete type. 
   NominalTypeDecl *findSoleConformingType(ProtocolDecl *Protocol);
+
+  // Wrapper function to findSoleConformingType that checks for additional
+  // constraints for classes using ClassHierarchyAnalysis.
+  bool getSoleConformingType(ProtocolDecl *Protocol, ClassHierarchyAnalysis *CHA, CanType &ConcreteType);
 
 private:
   /// Compute inheritance properties.

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -401,6 +401,8 @@ void ExistentialTransform::populateThunkBody() {
         break;
       }
       case ExistentialRepresentation::Class: {
+        /// If the operand is not object type, we would need an explicit load.
+        assert(OrigOperand->getType().isObject());
         archetypeValue =
             Builder.createOpenExistentialRef(Loc, OrigOperand, OpenedSILType);
         ApplyArgs.push_back(archetypeValue);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -654,21 +654,9 @@ SILCombiner::buildConcreteOpenedExistentialInfoFromSoleConformingType(
     return None;
 
   // Determine the sole conforming type.
-  auto *NTD = PCA->findSoleConformingType(PD);
-  if (!NTD)
+  CanType ConcreteType;
+  if (!PCA->getSoleConformingType(PD, CHA, ConcreteType))
     return None;
-
-  // Sole conforming class should not be open access or have any derived class.
-  ClassDecl *CD;
-  if ((CD = dyn_cast<ClassDecl>(NTD)) &&
-      (CD->getEffectiveAccess() == AccessLevel::Open ||
-       CHA->hasKnownDirectSubclasses(CD))) {
-    return None;
-  }
-
-  // Create SIL type for the concrete type.
-  auto ElementType = NTD->getDeclaredType();
-  auto ConcreteType = ElementType->getCanonicalType();
 
   // Determine OpenedArchetypeDef and SubstituionMap.
   ConcreteOpenedExistentialInfo COAI(ArgOperand, ConcreteType, PD);

--- a/test/SILOptimizer/existential_transform_soletype.swift
+++ b/test/SILOptimizer/existential_transform_soletype.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend -O -wmo -sil-existential-specializer -Xllvm -sil-disable-pass=GenericSpecializer -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=SILCombine -emit-sil -sil-verify-all %s | %FileCheck %s
+
+internal protocol SPP {
+  func bar()  -> Int32
+}
+internal class SCC: SPP {
+  @inline(never) func bar() -> Int32 {
+   return 5
+  }
+}
+
+@inline(never) internal func opt2(b:SPP) -> Int32{
+ return b.bar()
+}
+
+@inline(never) internal func opt1(b:SPP) -> Int32{
+ return opt2(b:b)
+}
+
+// CHECK-LABEL: sil hidden [noinline] @$s30existential_transform_soletype4opt11bs5Int32VAA3SPP_p_tF : $@convention(thin) (@in_guaranteed SPP) -> Int32 {
+// CHECK: bb0(%0 : $*SPP):
+// CHECK:   debug_value_addr
+// CHECK:   function_ref @$s30existential_transform_soletype4opt21bs5Int32VAA3SPP_p_tFTf4e_n : $@convention(thin) <τ_0_0 where τ_0_0 : SPP> (@in_guaranteed τ_0_0) -> Int32 // user: %4
+// CHECK:   open_existential_addr
+// CHECK:   apply
+// CHECK:   return
+// CHECK-LABEL: } // end sil function '$s30existential_transform_soletype4opt11bs5Int32VAA3SPP_p_tF'
+
+// CHECK-LABEL: sil shared [noinline] @$s30existential_transform_soletype4opt21bs5Int32VAA3SPP_p_tFTf4e_n : $@convention(thin) <τ_0_0 where τ_0_0 : SPP> (@in_guaranteed τ_0_0) -> Int32 {
+// CHECK: bb0(%0 : $*τ_0_0):
+// CHECK:   alloc_stack
+// CHECK:   init_existential_addr
+// CHECK:   copy_addr
+// CHECK:   debug_value_addr
+// CHECK:   open_existential_addr
+// CHECK:   witness_method 
+// CHECK:   apply
+// CHECK:   dealloc_stack
+// CHECK:   return
+// CHECK-LABEL: } // end sil function '$s30existential_transform_soletype4opt21bs5Int32VAA3SPP_p_tFTf4e_n'
+
+
+@_optimize(none) func foo(number:Int32)->Int32 {
+  var b:SPP
+  if number < 5 {
+    b = SCC()
+  } else {
+    b = SCC()
+  }
+  let x = opt1(b:b)
+  return x
+}


### PR DESCRIPTION
The criteria for ExistentialSpecializer is now based on  an argument having "findInitExistential or SoleConformingType".