### PR TITLE
build: rename SWIFT_INCLUDE_TOOLS to SWIFT_BUILD_TOOLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,8 @@ include(CheckSymbolExists)
 # This is primarily to support building smaller or faster project files.
 #
 
-option(SWIFT_INCLUDE_TOOLS
-    "Generate build targets for swift tools"
-    TRUE)
+option(SWIFT_BUILD_TOOLS
+  "Build the swift tools.  If OFF, just generate build targets."  TRUE)
 
 option(SWIFT_BUILD_REMOTE_MIRROR
     "Build the Swift Remote Mirror Library"
@@ -1025,7 +1024,7 @@ add_subdirectory(stdlib)
 
 add_subdirectory(include)
 
-if(SWIFT_INCLUDE_TOOLS)
+if(SWIFT_BUILD_TOOLS)
   add_subdirectory(lib)
   
   # Always include this after including stdlib/!

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -355,7 +355,7 @@ function(_compile_swift_files
   set(line_directive_tool "${SWIFT_SOURCE_DIR}/utils/line-directive")
   set(swift_compiler_tool "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")
   set(swift_compiler_tool_dep)
-  if(SWIFT_INCLUDE_TOOLS)
+  if(SWIFT_BUILD_TOOLS)
     # Depend on the binary itself, in addition to the symlink.
     set(swift_compiler_tool_dep "swift")
   endif()

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 # Build a specific version for the host with the host toolchain.  This is going
 # to be used by tools (e.g. lldb)
-if(SWIFT_INCLUDE_TOOLS)
+if(SWIFT_BUILD_TOOLS)
   if(NOT SWIFT_BUILD_STDLIB)
     add_custom_target(swiftReflection-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})
   endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,7 +101,10 @@ endif()
 # consecutive execution, which makes local builds fail faster.
 set(SWIFT_TEST_EXTRA_ARGS "--incremental")
 
-if(NOT SWIFT_INCLUDE_TOOLS)
+# TODO(compnerd) unconditionalise the options.  We can always build and not
+# install the tools.  Instead, we should check if we want to use an external set
+# of tools via the SWIFT_NATIVE_SWIFT_TOOLS_PATH variable.
+if(NOT SWIFT_BUILD_TOOLS)
   list(APPEND SWIFT_TEST_EXTRA_ARGS
        "--path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
        "--path=${SWIFT_NATIVE_CLANG_TOOLS_PATH}"

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,7 +1,9 @@
 
 include(AddSwiftUnittests)
 
-if(SWIFT_INCLUDE_TOOLS)
+# TODO(compnerd) unconditionalise the unit tests.  We can always build the tools
+# and not install them.
+if(SWIFT_BUILD_TOOLS)
   # We can't link C++ unit tests unless we build the tools.
 
   add_subdirectory(AST)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2246,7 +2246,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_NATIVE_LLVM_TOOLS_PATH:STRING="${native_llvm_tools_path}"
                     -DSWIFT_NATIVE_CLANG_TOOLS_PATH:STRING="${native_clang_tools_path}"
                     -DSWIFT_NATIVE_SWIFT_TOOLS_PATH:STRING="${native_swift_tools_path}"
-                    -DSWIFT_INCLUDE_TOOLS:BOOL=$(true_false "${BUILD_SWIFT_TOOLS}")
+                    -DSWIFT_BUILD_TOOLS:BOOL=$(true_false "${BUILD_SWIFT_TOOLS}")
                     -DSWIFT_BUILD_REMOTE_MIRROR:BOOL=$(true_false "${BUILD_SWIFT_REMOTE_MIRROR}")
                     -DSWIFT_STDLIB_SIL_DEBUGGING:BOOL=$(true_false "${BUILD_SIL_DEBUGGING_STDLIB}")
                     -DSWIFT_CHECK_INCREMENTAL_COMPILATION:BOOL=$(true_false "${CHECK_INCREMENTAL_COMPILATION}")


### PR DESCRIPTION
Minor naming change to bring us inline with the LLVM naming.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
