### PR TITLE
synthesize vjp

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3121,8 +3121,8 @@ public:
   /// Pass `selfUncurried = true` when the function type is for a method whose
   /// self parameter has been uncurried as in (A, B, C, Self) -> R.
   AnyFunctionType *getAutoDiffAssociatedFunctionType(
-      const AutoDiffParameterIndices &indices, unsigned differentiationOrder,
-      AutoDiffAssociatedFunctionKind kind,
+      const AutoDiffParameterIndices &indices, unsigned resultIndex,
+      unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,
       LookupConformanceFn lookupConformance, bool selfUncurried = false);
 
   AnyFunctionType *
@@ -4161,9 +4161,9 @@ public:
   /// Returns the type of a differentiation function that is associated with
   /// a function of this type.
   CanSILFunctionType getAutoDiffAssociatedFunctionType(
-      const SmallBitVector &parameterIndices, unsigned differentiationOrder,
-      AutoDiffAssociatedFunctionKind kind, SILModule &module,
-      LookupConformanceFn lookupConformance);
+      const SmallBitVector &parameterIndices, unsigned resultIndex,
+      unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,
+      SILModule &module, LookupConformanceFn lookupConformance);
 
   /// If this is a @convention(witness_method) function with a protocol
   /// constrained self parameter, return the protocol constraint for

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4156,9 +4156,9 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAdjointFunctionType(
 }
 
 AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
-    const AutoDiffParameterIndices &indices, unsigned differentiationOrder,
-    AutoDiffAssociatedFunctionKind kind, LookupConformanceFn lookupConformance,
-    bool selfUncurried) {
+    const AutoDiffParameterIndices &indices, unsigned resultIndex,
+    unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,
+    LookupConformanceFn lookupConformance, bool selfUncurried) {
   // JVP: (T...) -> ((R...),
   //                 (T.TangentVector...) -> (R.TangentVector...))
   // VJP: (T...) -> ((R...),
@@ -4192,8 +4192,21 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
                                DependentMemberType *dependentType) -> CanType {
     // Builtins are their own Tangent/Cotangent.
     if (type->is<BuiltinType>()) return type->getCanonicalType();
-    return dependentType->substBaseType(type, lookupConformance)
-        ->getCanonicalType();
+
+    // TODO: If this is a tuple, recursively get the associated types of its
+    // components.
+
+    auto assocTy = dependentType->substBaseType(type, lookupConformance);
+    if (assocTy && !assocTy->is<DependentMemberType>()) {
+      auto canAssocTy = assocTy->getCanonicalType();
+      if (!canAssocTy->is<DependentMemberType>())
+        return canAssocTy;
+    }
+
+    // When the type does not have an associated type, fallback to treating it
+    // as its own Tangent/Cotangent.
+    // TODO: We should eliminate all instances where this happens.
+    return type->getCanonicalType();
   };
 
   SmallVector<Type, 8> wrtParamTypes;
@@ -4219,13 +4232,15 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
           wrtParamType, tangentDependentType)));
 
     SmallVector<TupleTypeElt, 8> differentialResults;
-    if (auto *resultTuple = originalResult->getAs<TupleType>())
-      for (auto &resultTupleElt : resultTuple->getElements())
-        differentialResults.push_back(getAssociatedType(
-            resultTupleElt.getType(), tangentDependentType));
-    else
+    if (auto *resultTuple = originalResult->getAs<TupleType>()) {
+      auto resultTupleEltType = resultTuple->getElementType(resultIndex);
+      differentialResults.push_back(getAssociatedType(
+          resultTupleEltType, tangentDependentType));
+    } else {
+      assert(resultIndex == 0 && "resultIndex out of bounds");
       differentialResults.push_back(getAssociatedType(
           originalResult, tangentDependentType));
+    }
     Type differentialResult =
         differentialResults.size() > 1
             ? TupleType::get(differentialResults, ctx)
@@ -4238,13 +4253,15 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
     // closure is the VJP "pullback":
     //   (R.CotangentVector...) -> (T.CotangentVector...)
     SmallVector<AnyFunctionType::Param, 8> pullbackParams;
-    if (auto *resultTuple = originalResult->getAs<TupleType>())
-      for (auto &resultTupleElt : resultTuple->getElements())
-        pullbackParams.push_back(AnyFunctionType::Param(getAssociatedType(
-            resultTupleElt.getType(), cotangentDependentType)));
-    else
+    if (auto *resultTuple = originalResult->getAs<TupleType>()) {
+      auto resultTupleEltType = resultTuple->getElementType(resultIndex);
+      pullbackParams.push_back(AnyFunctionType::Param(getAssociatedType(
+          resultTupleEltType, cotangentDependentType)));
+    } else {
+      assert(resultIndex == 0 && "resultIndex out of bounds");
       pullbackParams.push_back(AnyFunctionType::Param(getAssociatedType(
           originalResult, cotangentDependentType)));
+    }
 
     SmallVector<TupleTypeElt, 8> pullbackResults;
     for (auto wrtParamType : wrtParamTypes)

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4196,12 +4196,11 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
     // TODO: If this is a tuple, recursively get the associated types of its
     // components.
 
+    // Try to get the associated type, and return it if found (if the result is
+    // non-null and non-`DependentMemberType`).
     auto assocTy = dependentType->substBaseType(type, lookupConformance);
-    if (assocTy && !assocTy->is<DependentMemberType>()) {
-      auto canAssocTy = assocTy->getCanonicalType();
-      if (!canAssocTy->is<DependentMemberType>())
-        return canAssocTy;
-    }
+    if (assocTy && !assocTy->is<DependentMemberType>())
+      return assocTy->getCanonicalType();
 
     // When the type does not have an associated type, fallback to treating it
     // as its own Tangent/Cotangent.

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -482,11 +482,11 @@ const TypeInfo *TypeConverter::convertFunctionType(SILFunctionType *T) {
     // TODO(rxwei): Use the parameter indices and diff order in the @autodiff
     // function type.
     auto jvpTy = origTy->getAutoDiffAssociatedFunctionType(
-        SmallBitVector(T->getNumParameters(), true),
+        SmallBitVector(T->getNumParameters(), true), /*resultIndex*/ 0,
         /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::JVP,
         IGM.getSILModule(), LookUpConformanceInModule(IGM.getSwiftModule()));
     auto vjpTy = origTy->getAutoDiffAssociatedFunctionType(
-        SmallBitVector(T->getNumParameters(), true),
+        SmallBitVector(T->getNumParameters(), true), /*resultIndex*/ 0,
         /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::VJP,
         IGM.getSILModule(), LookUpConformanceInModule(IGM.getSwiftModule()));
     return convertTupleType(TupleType::get({origTy, jvpTy, vjpTy}, IGM.Context)

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -250,12 +250,11 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
     // TODO: If this is a tuple, recursively get the associated types of its
     // components.
 
+    // Try to get the associated type, and return it if found (if the result is
+    // non-null and non-`DependentMemberType`).
     auto assocTy = dependentType->substBaseType(type, lookupConformance);
-    if (assocTy && !assocTy->is<DependentMemberType>()) {
-      auto canAssocTy = assocTy->getCanonicalType();
-      if (!canAssocTy->is<DependentMemberType>())
-        return canAssocTy;
-    }
+    if (assocTy && !assocTy->is<DependentMemberType>())
+      return assocTy->getCanonicalType();
 
     // When the type does not have an associated type, fallback to treating it
     // as its own Tangent/Cotangent.

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -210,7 +210,8 @@ CanSILFunctionType SILFunctionType::getWithDifferentiability(
 }
 
 CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
-    const SmallBitVector &parameterIndices, unsigned differentiationOrder,
+    const SmallBitVector &parameterIndices, unsigned resultIndex,
+    unsigned differentiationOrder,
     AutoDiffAssociatedFunctionKind kind, SILModule &module,
     LookupConformanceFn lookupConformance) {
   // JVP: (T...) -> ((R...),
@@ -245,8 +246,21 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
                                DependentMemberType *dependentType) -> CanType {
     // Builtins are their own Tangent/Cotangent.
     if (type->is<BuiltinType>()) return type->getCanonicalType();
-    return dependentType->substBaseType(type, lookupConformance)
-        ->getCanonicalType();
+
+    // TODO: If this is a tuple, recursively get the associated types of its
+    // components.
+
+    auto assocTy = dependentType->substBaseType(type, lookupConformance);
+    if (assocTy && !assocTy->is<DependentMemberType>()) {
+      auto canAssocTy = assocTy->getCanonicalType();
+      if (!canAssocTy->is<DependentMemberType>())
+        return canAssocTy;
+    }
+
+    // When the type does not have an associated type, fallback to treating it
+    // as its own Tangent/Cotangent.
+    // TODO: We should eliminate all instances where this happens.
+    return type->getCanonicalType();
   };
 
   // Given a type, returns its formal SIL parameter info.
@@ -293,11 +307,11 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
       });
     }
     SmallVector<SILResultInfo, 8> tangentResults;
-    for (auto &result : getResults())
-      tangentResults.push_back({
-        getAssociatedType(result.getType(), tangentDependentType),
-        result.getConvention()
-      });
+    auto &result = getResults()[resultIndex];
+    tangentResults.push_back({
+      getAssociatedType(result.getType(), tangentDependentType),
+      result.getConvention()
+    });
     auto differentialType = SILFunctionType::get(
         getGenericSignature(), ExtInfo(), SILCoroutineKind::None,
         ParameterConvention::Direct_Guaranteed, tangentParams, {},
@@ -312,10 +326,8 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
   }
   case AutoDiffAssociatedFunctionKind::VJP: {
     SmallVector<SILParameterInfo, 8> cotangentParams;
-    for (auto &result : getResults())
-      cotangentParams.push_back(
-          getFormalParameterInfo(
-              getAssociatedType(result.getType(), cotangentDependentType)));
+    cotangentParams.push_back(getFormalParameterInfo(getAssociatedType(
+        getResults()[resultIndex].getType(), cotangentDependentType)));
     SmallVector<SILResultInfo, 8> cotangentResults;
     if (hasSelfParam() && testParamIndex(numParamsWithoutSelf)) {
       auto &param = getParameters()[numParamsWithoutSelf];

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -693,13 +693,15 @@ getExtracteeType(SILValue function, Extractee extractee,
   case Extractee::JVP:
     resultFnTy = originalFnTy->getAutoDiffAssociatedFunctionType(
         SmallBitVector(originalFnTy->getNumParameters(), true),
-        differentiationOrder, AutoDiffAssociatedFunctionKind::JVP, module,
-         LookUpConformanceInModule(module.getSwiftModule()));
+        /*resultIndex*/ 0, differentiationOrder,
+        AutoDiffAssociatedFunctionKind::JVP, module,
+        LookUpConformanceInModule(module.getSwiftModule()));
     break;
   case Extractee::VJP:
     resultFnTy = originalFnTy->getAutoDiffAssociatedFunctionType(
         SmallBitVector(originalFnTy->getNumParameters(), true),
-        differentiationOrder, AutoDiffAssociatedFunctionKind::VJP, module,
+        /*resultIndex*/ 0, differentiationOrder,
+        AutoDiffAssociatedFunctionKind::VJP, module,
         LookUpConformanceInModule(module.getSwiftModule()));
     break;
   }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1270,7 +1270,7 @@ public:
         require(!jvpType->isDifferentiable(),
                 "The JVP function must not be @autodiff");
         auto expectedJVPType = origTy->getAutoDiffAssociatedFunctionType(
-            adfi->getParameterIndices(), order,
+            adfi->getParameterIndices(), /*resultIndex*/ 0, order,
             AutoDiffAssociatedFunctionKind::JVP, F.getModule(),
             LookUpConformanceInModule(F.getModule().getSwiftModule()));
         require(expectedJVPType == jvpType, "Unexpected JVP function type");
@@ -1279,7 +1279,7 @@ public:
         require(!vjpType->isDifferentiable(),
                 "The VJP function must not be @autodiff");
         auto expectedVJPType = origTy->getAutoDiffAssociatedFunctionType(
-            adfi->getParameterIndices(), order,
+            adfi->getParameterIndices(), /*resultIndex*/ 0, order,
             AutoDiffAssociatedFunctionKind::VJP, F.getModule(),
             LookUpConformanceInModule(F.getModule().getSwiftModule()));
         require(expectedVJPType == vjpType, "Unexpected VJP function type");

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3752,7 +3752,7 @@ void SILGenFunction::emitProtocolWitness(AbstractionPattern reqtOrigTy,
   CanAnyFunctionType witnessOrigTy = getConstantInfo(witness).LoweredType;
   if (autoDiffFuncId) {
     auto associated = witnessOrigTy->getAutoDiffAssociatedFunctionType(
-        *autoDiffFuncId->getParameterIndices(),
+        *autoDiffFuncId->getParameterIndices(), /*resultIndex*/ 0,
         autoDiffFuncId->getDifferentiationOrder(), autoDiffFuncId->getKind(),
         LookUpConformanceInModule(SGM.M.getSwiftModule()),
         /*selfUncurried*/ true);
@@ -3794,9 +3794,9 @@ void SILGenFunction::emitProtocolWitness(AbstractionPattern reqtOrigTy,
     auto loweredIndices = autoDiffFuncId->getParameterIndices()->getLowered(
         witnessSubstTy, /*selfUncurried*/ true);
     origWitnessFTy = origWitnessFTy->getAutoDiffAssociatedFunctionType(
-        loweredIndices, autoDiffFuncId->getDifferentiationOrder(),
-        autoDiffFuncId->getKind(), SGM.M,
-        LookUpConformanceInModule(SGM.M.getSwiftModule()));
+        loweredIndices, /*resultIndex*/ 0,
+        autoDiffFuncId->getDifferentiationOrder(), autoDiffFuncId->getKind(),
+        SGM.M, LookUpConformanceInModule(SGM.M.getSwiftModule()));
   }
   auto witnessFTy = origWitnessFTy;
   if (!witnessSubs.empty())

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -636,7 +636,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
   auto requirementLoweredType = Types.getConstantInfo(requirement).LoweredType;
   if (autoDiffFuncId) {
     auto associated = requirementLoweredType->getAutoDiffAssociatedFunctionType(
-        *autoDiffFuncId->getParameterIndices(),
+        *autoDiffFuncId->getParameterIndices(), /*resultIndex*/ 0,
         autoDiffFuncId->getDifferentiationOrder(), autoDiffFuncId->getKind(),
         LookUpConformanceInModule(M.getSwiftModule()), /*selfUncurried*/ true);
     requirementLoweredType = cast<AnyFunctionType>(associated->getCanonicalType());

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -4199,6 +4199,8 @@ void DifferentiationTask::createVJP() {
 
   SILOptFunctionBuilder fb(context.getTransform());
   auto linkage = original->getLinkage();
+  if (linkage == SILLinkage::Public)
+    linkage = SILLinkage::PublicNonABI;
   vjp = fb.createFunction(
       linkage, vjpName, vjpType, original->getGenericEnvironment(),
       original->getLocation(), original->isBare(), original->isTransparent(),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2514,7 +2514,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   if (attr->getJVP()) {
     AnyFunctionType *expectedJVPFnTy =
         originalFnTy->getAutoDiffAssociatedFunctionType(
-            *checkedWrtParamIndices, 1, AutoDiffAssociatedFunctionKind::JVP,
+            *checkedWrtParamIndices, /*resultIndex*/ 0,
+            /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::JVP,
             LookUpConformanceInModule(D->getDeclContext()->getParentModule()));
 
     auto isValidJVP = [&](FuncDecl *jvpCandidate) {
@@ -2540,7 +2541,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   if (attr->getVJP()) {
     AnyFunctionType *expectedVJPFnTy =
         originalFnTy->getAutoDiffAssociatedFunctionType(
-            *checkedWrtParamIndices, 1, AutoDiffAssociatedFunctionKind::VJP,
+            *checkedWrtParamIndices, /*resultIndex*/ 0,
+            /*differentiationOrder*/ 1, AutoDiffAssociatedFunctionKind::VJP,
             LookUpConformanceInModule(D->getDeclContext()->getParentModule()));
 
     auto isValidVJP = [&](FuncDecl *vjpCandidate) {

--- a/test/AutoDiff/builtin_math.sil
+++ b/test/AutoDiff/builtin_math.sil
@@ -1,4 +1,3 @@
-// RUN: %target-swift-frontend -emit-sil -O %s
 // RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
 
 import Builtin

--- a/test/AutoDiff/builtin_math.sil
+++ b/test/AutoDiff/builtin_math.sil
@@ -1,3 +1,4 @@
+// RUN: %target-swift-frontend -emit-sil -O %s
 // RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
 
 import Builtin
@@ -91,10 +92,10 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK:   @sil_stored var v_1: Builtin.FPIEEE32
 // CHECK: }
 
-// CHECK-LABEL: [differentiable source 0 wrt 0, 1 primal @AD__simple_mul__primal_src_0_wrt_0_1 adjoint @AD__simple_mul__adjoint_src_0_wrt_0_1] @simple_mul
-// CHECK-LABEL: [differentiable source 0 wrt 0, 1 primal @AD__chain_rule__primal_src_0_wrt_0_1 adjoint @AD__chain_rule__adjoint_src_0_wrt_0_1] @chain_rule
-// CHECK-LABEL: [differentiable source 0 wrt 0, 1 primal @AD__add_literals__primal_src_0_wrt_0_1 adjoint @AD__add_literals__adjoint_src_0_wrt_0_1] @add_literals
-// CHECK-LABEL [differentiable source 0 wrt 0, 1 primal @AD__fanout__primal_src_0_wrt_0_1 adjoint @AD__fanout__adjoint_src_0_wrt_0_1] @fanout
+// CHECK-LABEL: [differentiable source 0 wrt 0, 1 primal @AD__simple_mul__primal_src_0_wrt_0_1 adjoint @AD__simple_mul__adjoint_src_0_wrt_0_1 vjp @AD__simple_mul__vjp_src_0_wrt_0_1] @simple_mul
+// CHECK-LABEL: [differentiable source 0 wrt 0, 1 primal @AD__chain_rule__primal_src_0_wrt_0_1 adjoint @AD__chain_rule__adjoint_src_0_wrt_0_1 vjp @AD__chain_rule__vjp_src_0_wrt_0_1] @chain_rule
+// CHECK-LABEL: [differentiable source 0 wrt 0, 1 primal @AD__add_literals__primal_src_0_wrt_0_1 adjoint @AD__add_literals__adjoint_src_0_wrt_0_1 vjp @AD__add_literals__vjp_src_0_wrt_0_1] @add_literals
+// CHECK-LABEL [differentiable source 0 wrt 0, 1 primal @AD__fanout__primal_src_0_wrt_0_1 adjoint @AD__fanout__adjoint_src_0_wrt_0_1 vjp @AD__fanout__vjp_src_0_wrt_0_1] @fanout
 
 // CHECK-LABEL: @AD__simple_mul__primal_src_0_wrt_0_1
 // CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):
@@ -104,6 +105,36 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK:   return %4 : $(AD__simple_mul__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
 // CHECK: }
 
+// CHECK-LABEL: @AD__simple_mul__adjoint_src_0_wrt_0_1
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__simple_mul__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %6 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %7 = tuple (%5 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32)
+// CHECK:   return %7 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
+// CHECK: }
+
+// CHECK-LABEL: @AD__simple_mul__vjp_src_0_wrt_0_1
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):
+// CHECK:   %2 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // users: %5, %6, %3
+// CHECK:   %3 = struct $AD__simple_mul__Type__src_0_wrt_0_1 (%2 : $Builtin.FPIEEE32) // user: %5
+// CHECK:   // function_ref AD__simple_mul__adjoint_src_0_wrt_0_1
+// CHECK:   %4 = function_ref @AD__simple_mul__adjoint_src_0_wrt_0_1 : $@convention(thin) (Builtin.FPIEEE32, AD__simple_mul__Type__src_0_wrt_0_1, Builtin.FPIEEE32, Builtin.FPIEEE32, Builtin.FPIEEE32) -> (Builtin.FPIEEE32, Builtin.FPIEEE32) // user: %5
+// CHECK:   %5 = partial_apply [callee_guaranteed] %4(%3, %2, %0, %1) : $@convention(thin) (Builtin.FPIEEE32, AD__simple_mul__Type__src_0_wrt_0_1, Builtin.FPIEEE32, Builtin.FPIEEE32, Builtin.FPIEEE32) -> (Builtin.FPIEEE32, Builtin.FPIEEE32) // user: %6
+// CHECK:   %6 = tuple (%2 : $Builtin.FPIEEE32, %5 : $@callee_guaranteed (Builtin.FPIEEE32) -> (Builtin.FPIEEE32, Builtin.FPIEEE32)) // user: %7
+// CHECK:   return %6 : $(Builtin.FPIEEE32, @callee_guaranteed (Builtin.FPIEEE32) -> (Builtin.FPIEEE32, Builtin.FPIEEE32)) // id: %7
+// CHECK: } // end sil function 'AD__simple_mul__vjp_src_0_wrt_0_1'
+
+// CHECK-LABEL: @AD__simple_div__adjoint_src_0_wrt_0_1
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__simple_div__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = builtin "fdiv_FPIEEE32"(%0 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %6 = builtin "fneg_FPIEEE32"(%3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %7 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %8 = builtin "fdiv_FPIEEE32"(%6 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %9 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %8 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %10 = tuple (%5 : $Builtin.FPIEEE32, %9 : $Builtin.FPIEEE32)
+// CHECK:   return %10 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
+// CHECK: }
+
 // CHECK-LABEL: @AD__chain_rule__primal_src_0_wrt_0_1
 // CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):
 // CHECK:   %2 = builtin "fneg_FPIEEE32"(%0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
@@ -111,6 +142,16 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK:   %4 = struct $AD__chain_rule__Type__src_0_wrt_0_1 (%2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32)
 // CHECK:   %5 = tuple (%4 : $AD__chain_rule__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32)
 // CHECK:   return %5 : $(AD__chain_rule__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
+// CHECK: }
+
+// CHECK-LABEL: @AD__chain_rule__adjoint_src_0_wrt_0_1
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__chain_rule__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = struct_extract %1 : $AD__chain_rule__Type__src_0_wrt_0_1, #AD__chain_rule__Type__src_0_wrt_0_1.v_0
+// CHECK:   %6 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %7 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %8 = builtin "fneg_FPIEEE32"(%7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %9 = tuple (%8 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32)
+// CHECK:   return %9 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: @AD__add_literals__primal_src_0_wrt_0_1
@@ -124,44 +165,6 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK:   return %7 : $(AD__add_literals__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
 // CHECK: }
 
-// CHECK-LABEL: @AD__fanout__primal_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):
-// CHECK:   %2 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %3 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %4 = struct $AD__fanout__Type__src_0_wrt_0_1 (%2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32)
-// CHECK:   %5 = tuple (%4 : $AD__fanout__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32)
-// CHECK:   return %5 : $(AD__fanout__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
-// CHECK: }
-
-// CHECK-LABEL: @AD__simple_mul__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__simple_mul__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %6 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %7 = tuple (%5 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32)
-// CHECK:   return %7 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
-// CHECK: }
-
-// CHECK-LABEL: @AD__simple_div__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__simple_div__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = builtin "fdiv_FPIEEE32"(%0 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %6 = builtin "fneg_FPIEEE32"(%3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %7 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %8 = builtin "fdiv_FPIEEE32"(%6 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %9 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %8 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %10 = tuple (%5 : $Builtin.FPIEEE32, %9 : $Builtin.FPIEEE32)
-// CHECK:   return %10 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
-// CHECK: }
-
-// CHECK-LABEL: @AD__chain_rule__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__chain_rule__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = struct_extract %1 : $AD__chain_rule__Type__src_0_wrt_0_1, #AD__chain_rule__Type__src_0_wrt_0_1.v_0
-// CHECK:   %6 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %7 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %8 = builtin "fneg_FPIEEE32"(%7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %9 = tuple (%8 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32)
-// CHECK:   return %9 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
-// CHECK: }
-
 // CHECK-LABEL: @AD__add_literals__adjoint_src_0_wrt_0_1
 // CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $AD__add_literals__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
 // CHECK:   %5 = builtin "fneg_FPIEEE32"(%0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
@@ -171,6 +174,15 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK:   %9 = builtin "fneg_FPIEEE32"(%8 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %10 = tuple (%9 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32)
 // CHECK:   return %10 : $(Builtin.FPIEEE32, Builtin.FPIEEE32)
+// CHECK: }
+
+// CHECK-LABEL: @AD__fanout__primal_src_0_wrt_0_1
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):
+// CHECK:   %2 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %3 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// CHECK:   %4 = struct $AD__fanout__Type__src_0_wrt_0_1 (%2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32)
+// CHECK:   %5 = tuple (%4 : $AD__fanout__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32)
+// CHECK:   return %5 : $(AD__fanout__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: @AD__fanout__adjoint_src_0_wrt_0_1

--- a/test/AutoDiff/nested_calls.sil
+++ b/test/AutoDiff/nested_calls.sil
@@ -62,17 +62,17 @@ bb0(%0 : @trivial $Float):
 // CHECK:   return %3 : $Float
 // CHECK: }
 
-// CHECK-LABEL: [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
+// CHECK-LABEL: [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj vjp @AD__foo__vjp_src_0_wrt_0] @foo : $@convention(thin) (Float) -> Float {
 // CHECK: bb0(%0 : $Float):
 // CHECK:   return %0 : $Float
 // CHECK: }
 
-// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {
+// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 vjp @AD__nested_func_without_diffattr__vjp_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {
 // CHECK: bb0(%0 : $Float):
 // CHECK:   return %0 : $Float
 // CHECK: }
 
-// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__func_to_diff__primal_src_0_wrt_0 adjoint @AD__func_to_diff__adjoint_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float {
+// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__func_to_diff__primal_src_0_wrt_0 adjoint @AD__func_to_diff__adjoint_src_0_wrt_0 vjp @AD__func_to_diff__vjp_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float {
 // CHECK: bb0(%0 : $Float):
 // CHECK:   return %0 : $Float
 // CHECK: }
@@ -85,16 +85,16 @@ bb0(%0 : @trivial $Float):
 // CHECK:   return %3 : $(AD__func_to_diff__Type__src_0_wrt_0, Float)
 // CHECK: }
 
+// CHECK-LABEL: @AD__func_to_diff__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__func_to_diff__Type__src_0_wrt_0, Float, Float) -> Float {
+// CHECK: bb0(%0 : $Float, %1 : $AD__func_to_diff__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
+// CHECK:   return %3 : $Float
+// CHECK: }
+
 // CHECK-LABEL: @AD__nested_func_without_diffattr__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float) {
 // CHECK: bb0(%0 : $Float):
 // CHECK:   %1 = struct $AD__nested_func_without_diffattr__Type__src_0_wrt_0 (%0 : $Float, %0 : $Float)
 // CHECK:   %2 = tuple (%1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %0 : $Float)
 // CHECK:   return %2 : $(AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float)
-// CHECK: }
-
-// CHECK-LABEL: @AD__func_to_diff__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__func_to_diff__Type__src_0_wrt_0, Float, Float) -> Float {
-// CHECK: bb0(%0 : $Float, %1 : $AD__func_to_diff__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
-// CHECK:   return %3 : $Float
 // CHECK: }
 
 // CHECK-LABEL: @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float, Float) -> Float {


### PR DESCRIPTION
This PR synthesizes the VJP.

Importantly, I create the VJP immediately when the task is registered, so that PrimalGen will be able to reference the VJP. This required me to also create the empty primal and adjoint immediately when the task is registered, so that the VJP can reference the primal and adjoint. This means that we can no longer check if primal/adjoint needs to be synthesized by checking if `task.primal`/`task.adjoint` is `nullptr`, so I created a new piece of state `FunctionSynthesisState` to keep track of that.

The VJP synthesis itself, in `DifferentiationTask::createVJP` is a pretty straightforward imitation of the existing gradient synthesis code.

Miscellaneous changes required to make it all work:
* A lot of the tests differentiate functions with args/results that do not conform to `Differentiable`. This breaks `getAutoDiffAssociatedFunctionType()`, which `createVJP()` calls. So I added a quick workaround to make `getAutoDiffAssociatedFunctionType()` treat types as their own Tangent/Cotangent when they do not conform to `Differentiable`.
* `getAutoDiffAssociatedFunctionType()` needed a `resultIndex` to make some tests pass. I think we'll eventually want to allow multiple differentiated results? This single differentiated result makes it compatible with all the existing code, and we can add multiple results later.
* Rearranged the order of some sil functions in some tests because now they get generated in a different order.

I added on SIL test for the synthesized VJP. Once I make the PR that uses the VJP, I should be able to test it more thoroughly by actually executing it.