### PR TITLE
sourcekit: avoid evaluating pound conditions while perform syntactic parsing. rdar://46143404

### DIFF
--- a/test/SourceKit/SyntaxTree/pound_if.swift
+++ b/test/SourceKit/SyntaxTree/pound_if.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-syntax %s > %t.emit
+// RUN: %sourcekitd-test -req=syntax-tree %s > %t.sourcekit
+// RUN: diff %t.emit %t.sourcekit
+
+#if swift(<4)
+  print(1)
+#endif

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -689,6 +689,9 @@ public:
 
     Parser->getDiagnosticEngine().addConsumer(DiagConsumer);
 
+    // Collecting syntactic information shouldn't evaluate # conditions.
+    Parser->getParser().State->PerformConditionEvaluation = false;
+
     // If there is a syntax parsing cache, incremental syntax parsing is
     // performed and thus the generated AST may not be up-to-date.
     HasUpToDateAST = CompInv.getMainFileSyntaxParsingCache() == nullptr;


### PR DESCRIPTION
 rdar://46143404