### PR TITLE
[String] Comparison Speedups

### DIFF
--- a/stdlib/public/core/NormalizedCodeUnitIterator.swift
+++ b/stdlib/public/core/NormalizedCodeUnitIterator.swift
@@ -16,58 +16,6 @@ extension _Normalization {
   internal typealias _SegmentOutputBuffer = _FixedArray16<UInt16>
 }
 
-extension Unicode.Scalar {
-  // Normalization boundary - a place in a string where everything left of the
-  // boundary can be normalized independently from everything right of the
-  // boundary. The concatenation of each result is the same as if the entire
-  // string had been normalized as a whole.
-  //
-  // Normalization segment - a sequence of code units between two normalization
-  // boundaries (without any boundaries in the middle). Note that normalization
-  // segments can, as a process of normalization, expand, contract, and even
-  // produce new sub-segments.
-
-  // Whether this scalar value always has a normalization boundary before it.
-  internal var _hasNormalizationBoundaryBefore: Bool {
-    _internalInvariant(Int32(exactly: self.value) != nil, "top bit shouldn't be set")
-    let value = Int32(bitPattern: self.value)
-    return 0 != __swift_stdlib_unorm2_hasBoundaryBefore(
-      _Normalization._nfcNormalizer, value)
-  }
-  internal var _isNFCQCYes: Bool {
-    return __swift_stdlib_u_getIntPropertyValue(
-      Builtin.reinterpretCast(value), __swift_stdlib_UCHAR_NFC_QUICK_CHECK
-    ) == 1
-  }
-}
-
-internal func _tryNormalize(
-  _ input: UnsafeBufferPointer<UInt16>,
-  into outputBuffer:
-    UnsafeMutablePointer<_Normalization._SegmentOutputBuffer>
-) -> Int? {
-  return _tryNormalize(input, into: _castOutputBuffer(outputBuffer))
-}
-internal func _tryNormalize(
-  _ input: UnsafeBufferPointer<UInt16>,
-  into outputBuffer: UnsafeMutableBufferPointer<UInt16>
-) -> Int? {
-  var err = __swift_stdlib_U_ZERO_ERROR
-  let count = __swift_stdlib_unorm2_normalize(
-    _Normalization._nfcNormalizer,
-    input.baseAddress._unsafelyUnwrappedUnchecked,
-    numericCast(input.count),
-    outputBuffer.baseAddress._unsafelyUnwrappedUnchecked,
-    numericCast(outputBuffer.count),
-    &err
-  )
-  guard err.isSuccess else {
-    // The output buffer needs to grow
-    return nil
-  }
-  return numericCast(count)
-}
-
 //
 // Pointer casting helpers
 //

--- a/stdlib/public/core/NormalizedCodeUnitIterator.swift
+++ b/stdlib/public/core/NormalizedCodeUnitIterator.swift
@@ -131,8 +131,10 @@ extension UnsafeBufferPointer where Element == UInt8 {
     if index == 0 || index == count {
       return true
     }
-
     assert(!_isContinuation(self[_unchecked: index]))
+
+    // Sub-300 latiny fast-path
+    if self[_unchecked: index] < 0xCC { return true }
 
     let cu = _decodeScalar(self, startingAt: index).0
     return cu._hasNormalizationBoundaryBefore

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -12,153 +12,244 @@
 
 import SwiftShims
 
-
-@usableFromInline
+@inlinable @inline(__always) // top-level fastest-paths
 @_effects(readonly)
 internal func _stringCompare(
-  _ lhs: _StringGuts, _ rhs: _StringGuts,
-  expecting: _StringComparisonResult
+  _ lhs: _StringGuts, _ rhs: _StringGuts, expecting: _StringComparisonResult
 ) -> Bool {
-  _internalInvariant(expecting == .equal || expecting == .less)
-  if lhs.rawBits == rhs.rawBits {
-    return expecting == .equal
-  }
-  if _fastPath(lhs.isFastUTF8 && rhs.isFastUTF8) {
-    let isNFC = lhs.isNFC && rhs.isNFC
-    return lhs.withFastUTF8 { utf8Left in
-      return rhs.withFastUTF8 { utf8Right in
-        if isNFC {
-          let cmp = _binaryCompare(utf8Left, utf8Right)
-          if expecting == .equal {
-            return cmp == 0
-          }
-          _internalInvariant(expecting == .less)
-          return cmp < 0
-        }
-
-        return _stringCompare(utf8Left, utf8Right, expecting: expecting)
-      }
-    }
-  }
-  return _stringCompareSlow(
-    lhs, 0..<lhs.count, rhs, 0..<rhs.count, expecting: expecting)
+  if lhs.rawBits == rhs.rawBits { return expecting == .equal }
+  return _stringCompareInternal(lhs, rhs, expecting: expecting)
 }
 
 @usableFromInline
+@_effects(readonly)
+internal func _stringCompareInternal(
+  _ lhs: _StringGuts, _ rhs: _StringGuts, expecting: _StringComparisonResult
+) -> Bool {
+  guard _fastPath(lhs.isFastUTF8 && rhs.isFastUTF8) else {
+    return _stringCompareSlow(lhs, rhs, expecting: expecting)
+  }
+
+  let isNFC = lhs.isNFC && rhs.isNFC
+  return lhs.withFastUTF8 { lhsUTF8 in
+    return rhs.withFastUTF8 { rhsUTF8 in
+      return _stringCompareFastUTF8(
+        lhsUTF8, rhsUTF8, expecting: expecting, bothNFC: isNFC)
+    }
+  }
+}
+
+@inlinable @inline(__always) // top-level fastest-paths
 @_effects(readonly)
 internal func _stringCompare(
   _ lhs: _StringGuts, _ lhsRange: Range<Int>,
   _ rhs: _StringGuts, _ rhsRange: Range<Int>,
   expecting: _StringComparisonResult
 ) -> Bool {
-  _internalInvariant(expecting == .equal || expecting == .less)
   if lhs.rawBits == rhs.rawBits && lhsRange == rhsRange {
     return expecting == .equal
   }
-  if _fastPath(lhs.isFastUTF8 && rhs.isFastUTF8) {
-    let isNFC = lhs.isNFC && rhs.isNFC
-    return lhs.withFastUTF8(range: lhsRange) { utf8Left in
-      return rhs.withFastUTF8(range: rhsRange) { utf8Right in
-        if isNFC {
-          let cmp = _binaryCompare(utf8Left, utf8Right)
-          if expecting == .equal {
-            return cmp == 0
-          }
-          _internalInvariant(expecting == .less)
-          return cmp < 0
-        }
+  return _stringCompareInternal(
+    lhs, lhsRange, rhs, rhsRange, expecting: expecting)
+}
 
-        return _stringCompare(utf8Left, utf8Right, expecting: expecting)
-      }
+@usableFromInline
+@_effects(readonly)
+internal func _stringCompareInternal(
+  _ lhs: _StringGuts, _ lhsRange: Range<Int>,
+  _ rhs: _StringGuts, _ rhsRange: Range<Int>,
+  expecting: _StringComparisonResult
+) -> Bool {
+  guard _fastPath(lhs.isFastUTF8 && rhs.isFastUTF8) else {
+    return _stringCompareSlow(
+      lhs, lhsRange, rhs, rhsRange, expecting: expecting)
+  }
+
+  let isNFC = lhs.isNFC && rhs.isNFC
+  return lhs.withFastUTF8(range: lhsRange) { lhsUTF8 in
+    return rhs.withFastUTF8(range: rhsRange) { rhsUTF8 in
+      return _stringCompareFastUTF8(
+        lhsUTF8, rhsUTF8, expecting: expecting, bothNFC: isNFC)
     }
   }
-  return _stringCompareSlow(lhs, lhsRange, rhs, rhsRange, expecting: expecting)
 }
 
-@usableFromInline
 @_effects(readonly)
-internal func _stringCompareSlow(
-  _ lhs: _StringGuts, _ lhsRange: Range<Int>?,
-  _ rhs: _StringGuts, _ rhsRange: Range<Int>?,
-  expecting: _StringComparisonResult
+private func _stringCompareFastUTF8(
+  _ utf8Left: UnsafeBufferPointer<UInt8>,
+  _ utf8Right: UnsafeBufferPointer<UInt8>,
+  expecting: _StringComparisonResult,
+  bothNFC: Bool
 ) -> Bool {
-  return _StringGutsSlice(lhs, lhsRange ?? 0..<lhs.count).compare(
-    with: _StringGutsSlice(rhs, rhsRange ?? 0..<rhs.count),
-    expecting: expecting)
+  if _fastPath(bothNFC) {
+    let cmp = _binaryCompare(utf8Left, utf8Right)
+    return _lexicographicalCompare(cmp, 0, expecting: expecting)
+  }
+
+  return _stringCompareFastUTF8Abnormal(
+    utf8Left, utf8Right, expecting: expecting)
 }
 
-@usableFromInline
 @_effects(readonly)
-internal func _stringCompare(
-  _ left: UnsafeBufferPointer<UInt8>,
-  _ right: UnsafeBufferPointer<UInt8>,
+private func _stringCompareFastUTF8Abnormal(
+  _ utf8Left: UnsafeBufferPointer<UInt8>,
+  _ utf8Right: UnsafeBufferPointer<UInt8>,
   expecting: _StringComparisonResult
 ) -> Bool {
-  _internalInvariant(expecting == .equal || expecting == .less)
-
-  if _binaryCompare(left, right) == 0 {
-    return expecting == .equal
-  }
-
-  // Do a binary scan finding the point of divergence. From there, see if we can
-  // determine our answer right away, otherwise back up to the beginning of the
-  // current normalization segment and fall back to the slow path.
-  var idx = 0
-  let end = Swift.min(left.count, right.count)
-  let leftPtr = left.baseAddress._unsafelyUnwrappedUnchecked
-  let rightPtr = right.baseAddress._unsafelyUnwrappedUnchecked
-  while idx < end {
-    guard leftPtr[idx] == rightPtr[idx] else { break }
-    idx &+= 1
-  }
-  _internalInvariant(idx != left.count || idx != right.count,
-    "should of been cought by prior binary compare")
-  if idx == end {
+  // Do a binary-equality prefix scan, to skip over long common prefixes.
+  guard let diffIdx = _findDiffIdx(utf8Left, utf8Right) else {
     // We finished one of our inputs.
     //
     // TODO: This gives us a consistent and good ordering, but technically it
     // could differ from our stated ordering if combination with a prior scalar
     // did not produce a greater-value scalar. Consider checking normality.
-    return expecting == _lexicographicalCompare(left.count, right.count)
+    return _lexicographicalCompare(
+      utf8Left.count, utf8Right.count, expecting: expecting)
   }
 
-  // Back up to nearest scalar boundary and check if normal and end of segment.
-  // If so, we have our answer.
-  while _isContinuation(left[_unchecked: idx]) && idx > 0 { idx &-= 1 }
+  let scalarDiffIdx = _scalarAlign(utf8Left, diffIdx)
+  _internalInvariant(scalarDiffIdx == _scalarAlign(utf8Right, diffIdx))
 
-  // TODO: Refactor this into a function, handle these boundary condition as
-  // early returns...
-  if !_isContinuation(right[_unchecked: idx]) {
-    let (leftScalar, leftLen) = _decodeScalar(left, startingAt: idx)
-    let (rightScalar, rightLen) = _decodeScalar(right, startingAt: idx)
-    _internalInvariant(leftScalar != rightScalar)
+  let (leftScalar, leftLen) = _decodeScalar(utf8Left, startingAt: scalarDiffIdx)
+  let (rightScalar, rightLen) = _decodeScalar(
+    utf8Right, startingAt: scalarDiffIdx)
 
-    let nfcQC = leftScalar._isNFCQCYes && rightScalar._isNFCQCYes
-    let isSegmentEnd = left.hasNormalizationBoundary(before: idx + leftLen)
-                    && right.hasNormalizationBoundary(before: idx + rightLen)
-    let isSegmentStart = leftScalar._hasNormalizationBoundaryBefore
-                      && rightScalar._hasNormalizationBoundaryBefore
-    if _fastPath(nfcQC && isSegmentEnd && isSegmentStart) {
-      return expecting == _lexicographicalCompare(leftScalar, rightScalar)
+  // Very frequent fast-path: point of binary divergence is a NFC single-scalar
+  // segment. Check that we diverged at the start of a segment, and the next
+  // scalar is both NFC and its own segment.
+  if _fastPath(
+    leftScalar._isNFCStarter && rightScalar._isNFCStarter &&
+    utf8Left.hasNormalizationBoundary(before: scalarDiffIdx &+ leftLen) &&
+    utf8Right.hasNormalizationBoundary(before: scalarDiffIdx &+ rightLen)
+  ) {
+    guard expecting == .less else {
+      // We diverged
+      _internalInvariant(expecting == .equal)
+      return false
+    }
+    return _lexicographicalCompare(
+      leftScalar.value, rightScalar.value, expecting: .less)
+  }
+
+  // Back up to the nearest normalization boundary before doing a slow
+  // normalizing compare.
+  let boundaryIdx = Swift.min(
+    _findBoundary(utf8Left, before: diffIdx),
+    _findBoundary(utf8Right, before: diffIdx))
+  _internalInvariant(boundaryIdx <= diffIdx)
+
+  return _stringCompareSlow(
+    UnsafeBufferPointer(rebasing: utf8Left[boundaryIdx...]),
+    UnsafeBufferPointer(rebasing: utf8Right[boundaryIdx...]),
+    expecting: expecting)
+}
+
+@_effects(readonly)
+private func _stringCompareSlow(
+  _ lhs: _StringGuts, _ rhs: _StringGuts, expecting: _StringComparisonResult
+) -> Bool {
+  return _stringCompareSlow(
+    lhs, 0..<lhs.count, rhs, 0..<rhs.count, expecting: expecting)
+}
+
+@_effects(readonly)
+private func _stringCompareSlow(
+  _ lhs: _StringGuts, _ lhsRange: Range<Int>,
+  _ rhs: _StringGuts, _ rhsRange: Range<Int>,
+  expecting: _StringComparisonResult
+) -> Bool {
+  // TODO: Just call the normalizer directly with range
+
+  return _StringGutsSlice(lhs, lhsRange).compare(
+    with: _StringGutsSlice(rhs, rhsRange),
+    expecting: expecting)
+}
+
+@_effects(readonly)
+private func _stringCompareSlow(
+  _ leftUTF8: UnsafeBufferPointer<UInt8>,
+  _ rightUTF8: UnsafeBufferPointer<UInt8>,
+  expecting: _StringComparisonResult
+) -> Bool {
+  // TODO: Just call the normalizer directly
+
+  let left = _StringGutsSlice(_StringGuts(leftUTF8, isASCII: false))
+  let right = _StringGutsSlice(_StringGuts(rightUTF8, isASCII: false))
+  return left.compare(with: right, expecting: expecting)
+}
+
+// Return the point of binary divergence. If they have no binary difference
+// (even if one is longer), returns nil.
+@_effects(readonly)
+private func _findDiffIdx(
+  _ left: UnsafeBufferPointer<UInt8>, _ right: UnsafeBufferPointer<UInt8>
+) -> Int? {
+  var count = Swift.min(left.count, right.count)
+  for idx in 0..<count {
+    guard left[_unchecked: idx] == right[_unchecked: idx] else {
+      return idx
     }
   }
+  return nil
+}
 
-  // TODO: Back up to start of segment, and slow-path resume from there
+@_effects(readonly)
+@inline(__always)
+private func _lexicographicalCompare<I: FixedWidthInteger>(
+  _ lhs: I, _ rhs: I, expecting: _StringComparisonResult
+) -> Bool {
+  return expecting == .equal ? lhs == rhs : lhs < rhs
+}
 
-  return _StringGutsSlice(_StringGuts(left, isASCII: false)).compare(with:
-    _StringGutsSlice(_StringGuts(right, isASCII: false)), expecting: expecting)
+@_effects(readonly)
+private func _findBoundary(
+  _ utf8: UnsafeBufferPointer<UInt8>, before: Int
+) -> Int {
+  var idx = before
+  _internalInvariant(idx >= 0)
+
+  // End of string is a normalization boundary
+  guard idx < utf8.count else {
+    _internalInvariant(before == utf8.count)
+    return utf8.count
+  }
+
+  // Back up to scalar boundary
+  while _isContinuation(utf8[_unchecked: idx]) {
+    idx &-= 1
+  }
+
+  while true {
+    if idx == 0 { return 0 }
+
+    let scalar = _decodeScalar(utf8, startingAt: idx).0
+    if scalar._hasNormalizationBoundaryBefore { return idx }
+
+    idx &-= _utf8ScalarLength(utf8, endingAt: idx)
+  }
 }
 
 @_frozen
 @usableFromInline
 internal enum _StringComparisonResult {
-  case less
   case equal
-  case greater
+  case less
 
   @inlinable @inline(__always)
   internal init(signedNotation int: Int) {
-    self = int < 0 ? .less : int == 0 ? .equal : .greater
+    _internalInvariant(int <= 0)
+    self = int == 0 ? .equal : .less
+  }
+
+  @inlinable @inline(__always)
+  static func ==(
+    _ lhs: _StringComparisonResult, _ rhs: _StringComparisonResult
+  ) -> Bool {
+    switch (lhs, rhs) {
+      case (.equal, .equal): return true
+      case (.less, .less): return true
+      default: return false
+    }
   }
 }
 
@@ -194,7 +285,7 @@ extension _StringGutsSlice {
 
 // Perform a binary comparison of bytes in memory. Return value is negative if
 // less, 0 if equal, positive if greater.
-@inlinable @inline(__always) // Memcmp wrapper
+@_effects(readonly)
 internal func _binaryCompare<UInt8>(
   _ lhs: UnsafeBufferPointer<UInt8>, _ rhs: UnsafeBufferPointer<UInt8>
 ) -> Int {
@@ -211,26 +302,10 @@ internal func _binaryCompare<UInt8>(
 
 // Double dispatch functions
 extension _StringGutsSlice {
-  @usableFromInline
   @_effects(readonly)
   internal func compare(
     with other: _StringGutsSlice, expecting: _StringComparisonResult
   ) -> Bool {
-    if self._guts.rawBits == other._guts.rawBits
-    && self._offsetRange == other._offsetRange {
-      return expecting == .equal
-    }
-
-    if _fastPath(self.isNFCFastUTF8 && other.isNFCFastUTF8) {
-      Builtin.onFastPath() // aggressively inline / optimize
-      return self.withFastUTF8 { nfcSelf in
-        return other.withFastUTF8 { nfcOther in
-          return expecting == _StringComparisonResult(
-            signedNotation: _binaryCompare(nfcSelf, nfcOther))
-        }
-      }
-    }
-
     if _fastPath(self.isFastUTF8 && other.isFastUTF8) {
       Builtin.onFastPath() // aggressively inline / optimize
       let isEqual = self.withFastUTF8 { utf8Self in
@@ -241,35 +316,21 @@ extension _StringGutsSlice {
       if isEqual { return expecting == .equal }
     }
 
-    return expecting == _slowCompare(with: other)
+    return _slowCompare(with: other, expecting: expecting)
   }
 
   @inline(never) // opaque slow-path
   @_effects(readonly)
   internal func _slowCompare(
-    with other: _StringGutsSlice
-  ) -> _StringComparisonResult {
+    with other: _StringGutsSlice,
+    expecting: _StringComparisonResult
+  ) -> Bool {
     return self.withNFCCodeUnitsIterator_2 {
       var selfIter = $0
       return other.withNFCCodeUnitsIterator_2 {
         let otherIter = $0
-        return selfIter.compare(with: otherIter)
+        return selfIter.compare(with: otherIter, expecting: expecting)
       }
     }
   }
 }
-
-@inline(__always)
-internal func _lexicographicalCompare<I: FixedWidthInteger>(
-  _ lhs: I, _ rhs: I
-) -> _StringComparisonResult {
-  return lhs < rhs ? .less : (lhs > rhs ? .greater : .equal)
-}
-@inline(__always)
-internal func _lexicographicalCompare(
-  _ lhs: Unicode.Scalar, _ rhs: Unicode.Scalar
-) -> _StringComparisonResult {
-  return _lexicographicalCompare(lhs.value, rhs.value)
-}
-
-

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -184,11 +184,13 @@ private func _stringCompareSlow(
 private func _findDiffIdx(
   _ left: UnsafeBufferPointer<UInt8>, _ right: UnsafeBufferPointer<UInt8>
 ) -> Int? {
-  var count = Swift.min(left.count, right.count)
-  for idx in 0..<count {
+  let count = Swift.min(left.count, right.count)
+  var idx = 0
+  while idx < count {
     guard left[_unchecked: idx] == right[_unchecked: idx] else {
       return idx
     }
+    idx &+= 1
   }
   return nil
 }

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -153,18 +153,11 @@ extension _StringGuts {
 
   @inlinable @inline(__always)
   internal func withFastUTF8<R>(
-    range: Range<Int>?,
+    range: Range<Int>,
     _ f: (UnsafeBufferPointer<UInt8>) throws -> R
   ) rethrows -> R {
     return try self.withFastUTF8 { wholeUTF8 in
-      let slicedUTF8: UnsafeBufferPointer<UInt8>
-      if let r = range {
-        slicedUTF8 = UnsafeBufferPointer(rebasing: wholeUTF8[r])
-      } else {
-        slicedUTF8 = wholeUTF8
-      }
-
-      return try f(slicedUTF8)
+      return try f(UnsafeBufferPointer(rebasing: wholeUTF8[range]))
     }
   }
 

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -35,3 +35,70 @@ internal enum _Normalization {
   internal static let _maxNFCExpansionFactor = 3
 }
 
+extension Unicode.Scalar {
+  // Normalization boundary - a place in a string where everything left of the
+  // boundary can be normalized independently from everything right of the
+  // boundary. The concatenation of each result is the same as if the entire
+  // string had been normalized as a whole.
+  //
+  // Normalization segment - a sequence of code units between two normalization
+  // boundaries (without any boundaries in the middle). Note that normalization
+  // segments can, as a process of normalization, expand, contract, and even
+  // produce new sub-segments.
+
+  // Whether this scalar value always has a normalization boundary before it.
+  @inline(__always) // common fast-path
+  internal var _hasNormalizationBoundaryBefore: Bool {
+    // Fast-path: All scalars up through U+02FF are NFC and have boundaries
+    // before them
+    if self.value < 0x300 { return true }
+
+    _internalInvariant(Int32(exactly: self.value) != nil, "top bit shouldn't be set")
+    let value = Int32(bitPattern: self.value)
+    return 0 != __swift_stdlib_unorm2_hasBoundaryBefore(
+      _Normalization._nfcNormalizer, value)
+  }
+  @inline(__always) // common fast-path
+  internal var _isNFCQCYes: Bool {
+    // Fast-path: All scalars up through U+02FF are NFC and have boundaries
+    // before them
+    if self.value < 0x300 { return true }
+
+    return __swift_stdlib_u_getIntPropertyValue(
+      Builtin.reinterpretCast(value), __swift_stdlib_UCHAR_NFC_QUICK_CHECK
+    ) == 1
+  }
+
+  // Quick check if a scalar is NFC and a segment starter
+  internal var _isNFCStarter: Bool {
+    // Otherwise, consult the properties
+    return self._hasNormalizationBoundaryBefore && self._isNFCQCYes
+  }
+}
+
+internal func _tryNormalize(
+  _ input: UnsafeBufferPointer<UInt16>,
+  into outputBuffer:
+    UnsafeMutablePointer<_Normalization._SegmentOutputBuffer>
+) -> Int? {
+  return _tryNormalize(input, into: _castOutputBuffer(outputBuffer))
+}
+internal func _tryNormalize(
+  _ input: UnsafeBufferPointer<UInt16>,
+  into outputBuffer: UnsafeMutableBufferPointer<UInt16>
+) -> Int? {
+  var err = __swift_stdlib_U_ZERO_ERROR
+  let count = __swift_stdlib_unorm2_normalize(
+    _Normalization._nfcNormalizer,
+    input.baseAddress._unsafelyUnwrappedUnchecked,
+    numericCast(input.count),
+    outputBuffer.baseAddress._unsafelyUnwrappedUnchecked,
+    numericCast(outputBuffer.count),
+    &err
+  )
+  guard err.isSuccess else {
+    // The output buffer needs to grow
+    return nil
+  }
+  return numericCast(count)
+}

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -482,6 +482,16 @@ Protocol _NSEnumerator has been removed
 Protocol _NSFastEnumeration has been removed
 Protocol _ShadowProtocol has been removed
 
+EnumElement _StringComparisonResult.equal in a non-resilient type changes position from 1 to 0
+EnumElement _StringComparisonResult.greater has been removed
+EnumElement _StringComparisonResult.less in a non-resilient type changes position from 0 to 1
+Func _StringGuts.withFastUTF8(range:_:) has parameter 0 type change from Optional<Range<Int>> to Range<Int>
+Func _binaryCompare(_:_:) has been removed
+Func _stringCompare(_:_:expecting:) has been renamed to Func _stringCompareInternal(_:_:expecting:)
+Func _stringCompare(_:_:expecting:) has parameter 0 type change from UnsafeBufferPointer<UInt8> to _StringGuts
+Func _stringCompare(_:_:expecting:) has parameter 1 type change from UnsafeBufferPointer<UInt8> to _StringGuts
+Func _stringCompareSlow(_:_:_:_:expecting:) has been removed
+
 Constructor _StringGutsSlice.init(_:) has been removed
 Constructor _StringGutsSlice.init(_:_:) has been removed
 Func _StringGutsSlice._normalizedHash(into:) has been removed

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2043,10 +2043,24 @@ struct ComparisonTestCase {
       switch comparison {
       case .less:
         expectLT(pair.0, pair.1)
+        if !pair.0.isEmpty {
+          // Test mixed String/Substring
+          expectTrue(pair.0.dropLast() < pair.1)
+        }
       case .greater:
         expectGT(pair.0, pair.1)
+        if !pair.1.isEmpty {
+          // Test mixed String/Substring
+          expectTrue(pair.0 > pair.1.dropLast())
+        }
       case .equal:
         expectEqual(pair.0, pair.1)
+        if !pair.0.isEmpty {
+          // Test mixed String/Substring
+          expectTrue(pair.0.dropLast() == pair.1.dropLast())
+          expectFalse(pair.0.dropFirst() == pair.1)
+          expectFalse(pair.0 == pair.1.dropFirst())
+        }
       }
     }
   }
@@ -2077,11 +2091,10 @@ struct ComparisonTestCase {
       
       guard string1.count > 0 else { return }
       
-      let expectedResult: _Ordering = string1 < string2 ? .less : (string1 > string2 ? .greater : .equal)
-      let opaqueResult: _Ordering = opaqueString < string2 ? .less : (opaqueString > string2 ? .greater : .equal)
-      
       expectEqual(string1, opaqueString)
-      expectEqual(opaqueResult, expectedResult)
+      expectEqual(string1 < string2, opaqueString < string2)
+      expectEqual(string1 > string2, opaqueString > string2)
+      expectEqual(string1 == string2, opaqueString == string2)
     }
 #endif
   }
@@ -2156,10 +2169,14 @@ let comparisonTestCases = [
     "ae\u{301}ae\u{301}ae\u{301}ae\u{301}ae\u{301}ae\u{301}",
     "ae\u{301}ae\u{301}ae\u{301}ae\u{301}ae\u{301}ae\u{301}ae\u{301}",
     "ae\u{301}ae\u{301}ae\u{301}ae\u{301}ae\u{301}ae\u{301}ae\u{301}ae\u{301}",
+    "ae\u{301}\u{302}",
     "ae\u{302}",
     "ae\u{302}{303}",
     "ae\u{302}🧀",
     "ae\u{303}",
+    "x\u{0939}x",
+    "x\u{0939}\u{093a}x",
+    "x\u{0939}\u{093a}\u{093b}x",
     "\u{f90b}\u{f90c}\u{f90d}", // Normalizes to BMP scalars
     "\u{FFEE}", // half width CJK dot
     "🧀", // D83E DDC0 -- aka a really big scalar


### PR DESCRIPTION
<!-- What's in this pull request? -->

A number of improvements to constant-factor costs in String comparison.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Fixes https://bugs.swift.org/browse/SR-9212, and most of https://bugs.swift.org/browse/SR-9270 
