### PR TITLE
[SILOptimizer] Stop optimization after serialization if only emitting a module

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -70,6 +70,9 @@ public:
   /// Whether to dump verbose SIL with scope and location information.
   bool EmitVerboseSIL = false;
 
+  /// Whether to stop the optimization pipeline after serializing SIL.
+  bool StopOptimizationAfterSerialization = false;
+
   /// Optimization mode being used.
   OptimizationMode OptMode = OptimizationMode::NotSet;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -655,6 +655,11 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     }
   }
 
+  // If we're only emitting a module, stop optimizations once we've serialized
+  // the SIL for the module.
+  if (FEOpts.RequestedAction == FrontendOptions::ActionType::EmitModuleOnly)
+    Opts.StopOptimizationAfterSerialization = true;
+
   if (Args.hasArg(OPT_sil_merge_partial_modules))
     Opts.MergePartialModules = true;
 

--- a/test/SILOptimizer/stop_after_module.swift
+++ b/test/SILOptimizer/stop_after_module.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -c -o /dev/null -O -Xllvm -sil-print-after=inline %s 2>&1 | %FileCheck %s --check-prefix NOTSKIPPING
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -O -Xllvm -sil-print-after=inline %s 2>&1 | %FileCheck %s --check-prefix NOTSKIPPING
+// RUN: %target-swift-frontend -emit-module -o /dev/null -O -Xllvm -sil-print-after=inline %s 2>&1 | %FileCheck %s --check-prefix SKIPPING
+
+// This test ensures that we don't run the Perf Inliner after serializing a
+// module, if we're stopping optimizations after serializing. We want to also
+// make sure we _do_ still run the Perf Inliner when we're doing a full
+// compile or emitting SIL directly.
+
+@inline(never)
+func _blackHole(_ x: Int) {}
+
+@inlinable
+public func inlinableFunction(_ x: Int) -> Int {
+  return x + 1
+}
+
+public func caller() {
+  _blackHole(inlinableFunction(20))
+}
+
+// NOTSKIPPING: *** SIL function after {{.*}}, stage MidLevel, pass {{.*}}: PerfInliner (inline)
+// SKIPPING-NOT: *** SIL function after {{.*}}, stage MidLevel, pass {{.*}}: PerfInliner (inline)


### PR DESCRIPTION
This is an experiment to stop the compilation pipeline after we've serialized a SIL module. There are a bunch of optimizations that happen after serialization whose results are tossed completely.

There are some modest wins here for compiling the stdlib with `-emit-module -O` (measured on an iMac Pro)

| Config                                                                 | Time    |
|:-----------------------------------------------------------------------|:--------|
| Swift Standard Library                                                 | 53.411s |
| Swift Standard Library (from interface)                                | 42.264s |
| Swift Standard Library (Stopping Optimizations Early)                  | 41.129s |
| Swift Standard Library (Stopping Optimizations Early) (from interface) | 36.66s  |