### PR TITLE
test: explicitly use the interpreter for scripts

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -363,8 +363,8 @@ shutil.rmtree(completion_cache_path, ignore_errors=True)
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
 
-config.substitutions.append( ('%validate-incrparse', '%utils/incrparse/validate_parse.py --temp-dir %t --swift-syntax-test %swift-syntax-test') )
-config.substitutions.append( ('%incr-transfer-tree', '%utils/incrparse/incr_transfer_tree.py --temp-dir %t --swift-syntax-test %swift-syntax-test') )
+config.substitutions.append( ('%validate-incrparse', '%{python} %utils/incrparse/validate_parse.py --temp-dir %t --swift-syntax-test %swift-syntax-test') )
+config.substitutions.append( ('%incr-transfer-tree', '%{python} %utils/incrparse/incr_transfer_tree.py --temp-dir %t --swift-syntax-test %swift-syntax-test') )
 config.substitutions.append( ('%swift_obj_root', config.swift_obj_root) )
 config.substitutions.append( ('%swift_src_root', config.swift_src_root) )
 config.substitutions.append( ('%{python}', sys.executable) )


### PR DESCRIPTION
The python scripts need the interpreter specified for portability to
Windows.  This allows us to execute more tests on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
