### PR TITLE
[5.0][CodeCompletion] Propagate completion status of parseGenericArguments()

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -972,9 +972,9 @@ public:
   /// \brief Parse layout constraint.
   LayoutConstraint parseLayoutConstraint(Identifier LayoutConstraintID);
 
-  bool parseGenericArguments(SmallVectorImpl<TypeRepr*> &Args,
-                             SourceLoc &LAngleLoc,
-                             SourceLoc &RAngleLoc);
+  ParserStatus parseGenericArguments(SmallVectorImpl<TypeRepr *> &Args,
+                                     SourceLoc &LAngleLoc,
+                                     SourceLoc &RAngleLoc);
 
   ParserResult<TypeRepr> parseTypeIdentifier();
   ParserResult<TypeRepr> parseOldStyleProtocolComposition();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1207,9 +1207,9 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       if (canParseAsGenericArgumentList()) {
         SmallVector<TypeRepr *, 8> args;
         SourceLoc LAngleLoc, RAngleLoc;
-        if (parseGenericArguments(args, LAngleLoc, RAngleLoc)) {
+        auto argStat = parseGenericArguments(args, LAngleLoc, RAngleLoc);
+        if (argStat.isError())
           diagnose(LAngleLoc, diag::while_parsing_as_left_angle_bracket);
-        }
 
         SmallVector<TypeLoc, 8> locArgs;
         for (auto ty : args)
@@ -2259,9 +2259,9 @@ Expr *Parser::parseExprIdentifier() {
   if (canParseAsGenericArgumentList()) {
     SyntaxContext->createNodeInPlace(SyntaxKind::IdentifierExpr);
     SyntaxContext->setCreateSyntax(SyntaxKind::SpecializeExpr);
-    if (parseGenericArguments(args, LAngleLoc, RAngleLoc)) {
+    auto argStat = parseGenericArguments(args, LAngleLoc, RAngleLoc);
+    if (argStat.isError())
       diagnose(LAngleLoc, diag::while_parsing_as_left_angle_bracket);
-    }
     
     // The result can be empty in error cases.
     hasGenericArgumentList = !args.empty();

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -362,13 +362,13 @@
 // RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
 
 
-// FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_GENERIC_1 > %t.types.txt
-// FIXME: %FileCheck %s -check-prefix=TYPE_IDENTIFIER_GENERIC_1 < %t.types.txt
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_GENERIC_1 > %t.types.txt
+// RUN: %FileCheck %s -check-prefix=TYPE_IDENTIFIER_GENERIC_1 < %t.types.txt
 // RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
 // RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_GENERIC_2 > %t.types.txt
-// FIXME: %FileCheck %s -check-prefix=TYPE_IDENTIFIER_GENERIC_2 < %t.types.txt
+// RUN: %FileCheck %s -check-prefix=TYPE_IDENTIFIER_GENERIC_2 < %t.types.txt
 // RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
 // RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
 
@@ -385,6 +385,16 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TYPEALIAS_2 > %t.gentypealias.txt
 // RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.gentypealias.txt
 // RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.gentypealias.txt
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_TOPLEVEL_VAR | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_TOPLEVEL_PARAM | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_TOPLEVEL_RETURN | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_MEMBER_VAR | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_MEMBER_PARAM | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_MEMBER_RETURN | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_LOCAL_VAR | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_LOCAL_PARAM | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_LOCAL_RETURN | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
 
 //===--- Helper types that are used in this test
 
@@ -1003,9 +1013,8 @@ func testTypeIdentifierGeneric1<
     >(a: GenericFoo.#^TYPE_IDENTIFIER_GENERIC_1^#
 
 // TYPE_IDENTIFIER_GENERIC_1: Begin completions
-// TYPE_IDENTIFIER_GENERIC_1-NEXT: Decl[TypeAlias]/Super: FooTypeAlias1{{; name=.+$}}
+// TYPE_IDENTIFIER_GENERIC_1-NEXT: Decl[AssociatedType]/Super: FooTypeAlias1{{; name=.+$}}
 // TYPE_IDENTIFIER_GENERIC_1-NEXT: Keyword/None:          Type[#GenericFoo.Type#]
-// TYPE_IDENTIFIER_GENERIC_1-NEXT: Keyword/None:          self[#GenericFoo#]
 // TYPE_IDENTIFIER_GENERIC_1-NEXT: End completions
 
 func testTypeIdentifierGeneric2<
@@ -1013,10 +1022,9 @@ func testTypeIdentifierGeneric2<
     >(a: GenericFoo.#^TYPE_IDENTIFIER_GENERIC_2^#
 
 // TYPE_IDENTIFIER_GENERIC_2: Begin completions
-// TYPE_IDENTIFIER_GENERIC_2-NEXT: Decl[TypeAlias]/Super: BarTypeAlias1{{; name=.+$}}
-// TYPE_IDENTIFIER_GENERIC_2-NEXT: Decl[TypeAlias]/Super: FooTypeAlias1{{; name=.+$}}
+// TYPE_IDENTIFIER_GENERIC_2-NEXT: Decl[AssociatedType]/Super: BarTypeAlias1{{; name=.+$}}
+// TYPE_IDENTIFIER_GENERIC_2-NEXT: Decl[AssociatedType]/Super: FooTypeAlias1{{; name=.+$}}
 // TYPE_IDENTIFIER_GENERIC_2-NEXT: Keyword/None:          Type[#GenericFoo.Type#]
-// TYPE_IDENTIFIER_GENERIC_2-NEXT: Keyword/None:          self[#GenericFoo#]
 // TYPE_IDENTIFIER_GENERIC_2-NEXT: End completions
 
 func testTypeIdentifierGeneric3<
@@ -1057,4 +1065,20 @@ func testGenericTypealias1() {
 func testGenericTypealias2() {
   typealias MyPair<T> = (T, T)
   let x: MyPair<#^GENERIC_TYPEALIAS_2^#>
+}
+
+// In generic argument
+struct GenStruct<T> { }
+let a : GenStruct<#^GENERIC_ARGS_TOPLEVEL_VAR^#
+func foo1(x: GenStruct<#^GENERIC_ARGS_TOPLEVEL_PARAM^#
+func foo2() -> GenStruct<#^GENERIC_ARGS_TOPLEVEL_RETURN^#
+class _TestForGenericArg_ {
+  let a : GenStruct<#^GENERIC_ARGS_MEMBER_VAR^#
+  func foo1(x: GenStruct<#^GENERIC_ARGS_MEMBER_PARAM^#
+  func foo2() -> GenStruct<#^GENERIC_ARGS_MEMBER_RETURN^#
+}
+func _testForGenericArg_() {
+  let a : GenStruct<#^GENERIC_ARGS_LOCAL_VAR^#
+  func foo1(x: GenStruct<#^GENERIC_ARGS_LOCAL_PARAM^#
+  func foo2() -> GenStruct<#^GENERIC_ARGS_LOCAL_RETURN^#
 }


### PR DESCRIPTION
(Cherry-pick of #20960 for swift-5.0-branch. Not critical for convergence. Not ABI-affecting.)

Handle code-completion in generic argument list.

rdar://problem/39312854
