### PR TITLE
[Parse] Warn if the same argument is specified more than once in @available

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1349,6 +1349,8 @@ ERROR(attr_availability_unavailable_deprecated,none,
       "'%0' attribute cannot be both unconditionally 'unavailable' and "
       "'deprecated'", (StringRef))
 
+WARNING(attr_availability_invalid_duplicate,none,
+        "'%0' argument has already been specified", (StringRef))
 WARNING(attr_availability_unknown_platform,none,
       "unknown platform '%0' for attribute '%1'", (StringRef, StringRef))
 ERROR(attr_availability_invalid_renamed,none,

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1057,3 +1057,15 @@ func rdar46348825_message() {}
 @available(*, deprecated, renamed: "rdar46348825_message", renamed: "unavailable_func_with_message")
 // expected-warning@-1 {{'renamed' argument has already been specified}}
 func rdar46348825_renamed() {}
+
+@available(swift, introduced: 4.0, introduced: 4.0)
+// expected-warning@-1 {{'introduced' argument has already been specified}}
+func rdar46348825_introduced() {}
+
+@available(swift, deprecated: 4.0, deprecated: 4.0)
+// expected-warning@-1 {{'deprecated' argument has already been specified}}
+func rdar46348825_deprecated() {}
+
+@available(swift, obsoleted: 4.0, obsoleted: 4.0)
+// expected-warning@-1 {{'obsoleted' argument has already been specified}}
+func rdar46348825_obsoleted() {}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1049,3 +1049,11 @@ struct SR8634_Struct: Equatable {
   @available(*, deprecated, message: "I must not be raised in synthesized code", renamed: "x")
   let a: Int
 }
+
+@available(*, deprecated, message: "This is a message", message: "This is another message")
+// expected-warning@-1 {{'message' argument has already been specified}}
+func rdar46348825_message() {}
+
+@available(*, deprecated, renamed: "rdar46348825_message", renamed: "unavailable_func_with_message")
+// expected-warning@-1 {{'renamed' argument has already been specified}}
+func rdar46348825_renamed() {}


### PR DESCRIPTION
Previously, if an argument to an `@available` attribute was duplicated, the first value would be silently dropped. With this change, the compiler produces a warning instead. (We emit a warning instead of an error to preserve source compatibility.)

Resolves rdar://problem/46348825.
