### PR TITLE
[CSDiag] Verify that @autoclosure param has function type before casting

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3056,9 +3056,13 @@ typeCheckArgumentChildIndependently(Expr *argExpr, Type argType,
         // Look at each of the arguments assigned to this parameter.
         auto currentParamType = param.getOldType();
 
-        if (param.isAutoClosure())
-          currentParamType =
-              currentParamType->castTo<FunctionType>()->getResult();
+        // Since this is diagnostics, let's make sure that parameter
+        // marked as @autoclosure indeed has a function type, because
+        // it can also be an error type and possibly unresolved type.
+        if (param.isAutoClosure()) {
+          if (auto *funcType = currentParamType->getAs<FunctionType>())
+            currentParamType = funcType->getResult();
+        }
 
         for (auto inArgNo : paramBindings[paramIdx]) {
           // Determine the argument type.

--- a/test/Constraints/rdar46377919.swift
+++ b/test/Constraints/rdar46377919.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+class Foo {
+  init(lhs: @autoclosure () -> Int,
+       rhs: @autoclosure () -> Undefined) {
+     // expected-error@-1 {{use of undeclared type 'Undefined'}}
+  }
+}
+
+func foo() -> Foo {
+  return Foo(lhs: 2, rhs: 2)
+  // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '<<error type>>'}}
+}


### PR DESCRIPTION
When parameter refers to something undefined its type is going to
be `ErrorType`, so diagnostic path needs to make sure that parameter
has a valid function type before trying to extract result from it.

Resolves: rdar://problem/46377919
(cherry picked from commit 138105bd9824a628e33ed992cc293134b71e11d7)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
