### PR TITLE
Platform: add setjmp module for VisualC

### DIFF
--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -26,6 +26,11 @@ module visualc [system] {
     export *
   }
 
+  module setjmp {
+    header "setjmp.h"
+    export *
+  }
+
   module stdint {
     header "stdint.h"
     export *


### PR DESCRIPTION
Add the setjmp module which was missing.  The roughly equivalent
function is `_setjmp`.  Unfortunately, it is not marked as
`__attribute__((__returns_twice__))`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
