### PR TITLE
incrparse: use python to diff rather than `diff`

### DIFF
--- a/utils/incrparse/validate_parse.py
+++ b/utils/incrparse/validate_parse.py
@@ -4,11 +4,9 @@ from __future__ import print_function
 
 import argparse
 import os
-import subprocess
 import sys
 
-from test_util import TestFailedError, run_command, \
-    serializeIncrParseMarkupFile
+from test_util import TestFailedError, serializeIncrParseMarkupFile
 
 
 def main():
@@ -102,19 +100,18 @@ def main():
         sys.exit(1)
 
     # Check if the two syntax trees are the same
-    try:
-        run_command(
-            [
-                'diff', '-u',
-                incremental_serialized_file,
-                post_edit_serialized_file
-            ])
-    except subprocess.CalledProcessError as e:
+    import difflib
+    lines = difflib.unified_diff(open(incremental_serialized_file).readlines(),
+                                 open(post_edit_serialized_file).readlines(),
+                                 fromfile=incremental_serialized_file,
+                                 tofile=incremental_serialized_file)
+    diff = '\n'.join(line for line in lines)
+    if diff:
         print('Test case "%s" of %s FAILed' % (test_case, test_file),
               file=sys.stderr)
         print('Syntax tree of incremental parsing does not match '
               'from-scratch parsing of post-edit file:\n\n', file=sys.stderr)
-        print(e.output, file=sys.stderr)
+        print(diff, file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
Use the python library `difflib` which is part of a standard python
installation to generate the diff.  This allows us to run the tool on
Windows wihtout needing external tools installed.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
