### PR TITLE
Cache LLVM attributes for intrinsics

### DIFF
--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -107,7 +107,10 @@ public:
 };
 
 /// \brief The information identifying the llvm intrinsic - its id and types.
-struct IntrinsicInfo {
+class IntrinsicInfo {
+  mutable llvm::AttributeList Attrs =
+      llvm::DenseMapInfo<llvm::AttributeList>::getEmptyKey();
+public:
   llvm::Intrinsic::ID ID;
   SmallVector<Type, 4> Types;
   bool hasAttribute(llvm::Attribute::AttrKind Kind) const;

--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -80,9 +80,9 @@ StringRef getBuiltinBaseName(ASTContext &C, StringRef Name,
                              SmallVectorImpl<Type> &Types);
 
 /// Given an LLVM IR intrinsic name with argument types remove (e.g. like
-/// "bswap") return the LLVM IR IntrinsicID for the intrinsic or 0 if the
-/// intrinsic name doesn't match anything.
-unsigned getLLVMIntrinsicID(StringRef Name);
+/// "bswap") return the LLVM IR IntrinsicID for the intrinsic or not_intrinsic
+/// (0) if the intrinsic name doesn't match anything.
+llvm::Intrinsic::ID getLLVMIntrinsicID(StringRef Name);
 
 /// Get the LLVM intrinsic ID that corresponds to the given builtin with
 /// overflow.

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -45,10 +45,12 @@ bool BuiltinInfo::isReadNone() const {
 }
 
 bool IntrinsicInfo::hasAttribute(llvm::Attribute::AttrKind Kind) const {
-  // FIXME: We should not be relying on the global LLVM context.
-  llvm::AttributeList attrs =
-      llvm::Intrinsic::getAttributes(getGlobalLLVMContext(), ID);
-  return (attrs.hasAttribute(llvm::AttributeList::FunctionIndex, Kind));
+  using DenseMapInfo = llvm::DenseMapInfo<llvm::AttributeList>;
+  if (DenseMapInfo::isEqual(Attrs, DenseMapInfo::getEmptyKey())) {
+    // FIXME: We should not be relying on the global LLVM context.
+    Attrs = llvm::Intrinsic::getAttributes(getGlobalLLVMContext(), ID);
+  }
+  return Attrs.hasFnAttribute(Kind);
 }
 
 Type swift::getBuiltinType(ASTContext &Context, StringRef Name) {

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1322,7 +1322,7 @@ getSwiftFunctionTypeForIntrinsic(llvm::Intrinsic::ID ID,
                                  ArrayRef<Type> TypeArgs,
                                  ASTContext &Context,
                                  SmallVectorImpl<Type> &ArgElts,
-                                 Type &ResultTy, FunctionType::ExtInfo &Info) {
+                                 Type &ResultTy) {
   typedef llvm::Intrinsic::IITDescriptor IITDescriptor;
   SmallVector<IITDescriptor, 8> Table;
   getIntrinsicInfoTableEntries(ID, Table);
@@ -1344,7 +1344,6 @@ getSwiftFunctionTypeForIntrinsic(llvm::Intrinsic::ID ID,
   // Translate LLVM function attributes to Swift function attributes.
   llvm::AttributeList attrs =
       llvm::Intrinsic::getAttributes(getGlobalLLVMContext(), ID);
-  Info = FunctionType::ExtInfo();
   if (attrs.hasAttribute(llvm::AttributeList::FunctionIndex,
                          llvm::Attribute::NoReturn)) {
     ResultTy = Context.getNeverType();
@@ -1438,10 +1437,8 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
   if (llvm::Intrinsic::ID ID = getLLVMIntrinsicID(OperationName)) {
     SmallVector<Type, 8> ArgElts;
     Type ResultTy;
-    FunctionType::ExtInfo Info;
-    if (getSwiftFunctionTypeForIntrinsic(ID, Types, Context, ArgElts, ResultTy,
-                                         Info))
-      return getBuiltinFunction(Id, ArgElts, ResultTy, Info);
+    if (getSwiftFunctionTypeForIntrinsic(ID, Types, Context, ArgElts, ResultTy))
+      return getBuiltinFunction(Id, ArgElts, ResultTy);
   }
   
   // If this starts with fence, we have special suffixes to handle.

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1225,10 +1225,7 @@ static const char *const IntrinsicNameTable[] = {
 #include "llvm/IR/IntrinsicImpl.inc"
 #undef GET_INTRINSIC_TARGET_DATA
 
-/// getLLVMIntrinsicID - Given an LLVM IR intrinsic name with argument types
-/// removed (e.g. like "bswap") return the LLVM IR IntrinsicID for the intrinsic
-/// or 0 if the intrinsic name doesn't match anything.
-unsigned swift::getLLVMIntrinsicID(StringRef InName) {
+llvm::Intrinsic::ID swift::getLLVMIntrinsicID(StringRef InName) {
   using namespace llvm;
 
   // Swift intrinsic names start with int_.
@@ -1321,12 +1318,11 @@ static Type DecodeIntrinsicType(ArrayRef<llvm::Intrinsic::IITDescriptor> &Table,
 
 /// \returns true on success, false on failure.
 static bool
-getSwiftFunctionTypeForIntrinsic(unsigned iid, ArrayRef<Type> TypeArgs,
+getSwiftFunctionTypeForIntrinsic(llvm::Intrinsic::ID ID,
+                                 ArrayRef<Type> TypeArgs,
                                  ASTContext &Context,
                                  SmallVectorImpl<Type> &ArgElts,
                                  Type &ResultTy, FunctionType::ExtInfo &Info) {
-  llvm::Intrinsic::ID ID = (llvm::Intrinsic::ID)iid;
-  
   typedef llvm::Intrinsic::IITDescriptor IITDescriptor;
   SmallVector<IITDescriptor, 8> Table;
   getIntrinsicInfoTableEntries(ID, Table);
@@ -1439,7 +1435,7 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   // If this is the name of an LLVM intrinsic, cons up a swift function with a
   // type that matches the IR types.
-  if (unsigned ID = getLLVMIntrinsicID(OperationName)) {
+  if (llvm::Intrinsic::ID ID = getLLVMIntrinsicID(OperationName)) {
     SmallVector<Type, 8> ArgElts;
     Type ResultTy;
     FunctionType::ExtInfo Info;

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -275,7 +275,7 @@ const IntrinsicInfo &SILModule::getIntrinsicInfo(Identifier ID) {
 
   // Otherwise, lookup the ID and Type and store them in the map.
   StringRef NameRef = getBuiltinBaseName(getASTContext(), ID.str(), Info.Types);
-  Info.ID = (llvm::Intrinsic::ID)getLLVMIntrinsicID(NameRef);
+  Info.ID = getLLVMIntrinsicID(NameRef);
 
   return Info;
 }


### PR DESCRIPTION
Looking these up is slow because the attribute lists get rebuilt and reuniqued in the LLVM context each time. Saving them is a single pointer per IntrinsicInfo and IntrinsicInfos are already cached in each SILModule.

This shaves about 4s off optimizing the standard library (72s out of a 3:00+ build), and probably has much less effect anywhere else. That is, it's not *really* important after all, but it was an easy bit of the profile to hammer down.