### PR TITLE
[IRGen] Foreign metadata is lazy metadata, always.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1184,7 +1184,12 @@ void IRGenerator::noteUseOfTypeGlobals(NominalTypeDecl *type,
   // Try to create a new record of the fact that we used this type.
   auto insertResult = LazyTypeGlobals.try_emplace(type);
   auto &entry = insertResult.first->second;
-  
+
+  // Imported structs and enums types are known to be lazy.
+  if (insertResult.second) {
+    entry.IsLazy = requiresForeignTypeMetadata(type);
+  }
+
   bool metadataWasUsed = entry.IsMetadataUsed;
   bool descriptorWasUsed = entry.IsDescriptorUsed;
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1684,7 +1684,10 @@ void irgen::emitLazyTypeContextDescriptor(IRGenModule &IGM,
 void irgen::emitLazyTypeMetadata(IRGenModule &IGM, NominalTypeDecl *type) {
   eraseExistingTypeContextDescriptor(IGM, type);
 
-  if (auto sd = dyn_cast<StructDecl>(type)) {
+  if (requiresForeignTypeMetadata(type)) {
+    (void)IGM.getAddrOfForeignTypeMetadataCandidate(
+        type->getDeclaredInterfaceType()->getCanonicalType());
+  } else if (auto sd = dyn_cast<StructDecl>(type)) {
     return emitStructMetadata(IGM, sd);
   } else if (auto ed = dyn_cast<EnumDecl>(type)) {
     emitEnumMetadata(IGM, ed);
@@ -3887,7 +3890,8 @@ bool irgen::requiresForeignTypeMetadata(NominalTypeDecl *decl) {
     llvm_unreachable("bad foreign class kind");
   }
 
-  return isa<ClangModuleUnit>(decl->getModuleScopeContext());
+  return isa<ClangModuleUnit>(decl->getModuleScopeContext()) &&
+    !isa<ProtocolDecl>(decl);
 }
 
 llvm::Constant *

--- a/test/IRGen/extension_type_metadata_linking.swift
+++ b/test/IRGen/extension_type_metadata_linking.swift
@@ -21,6 +21,8 @@ import Foundation
 // CHECK-LABEL: @"$sSo8NSNumberC31extension_type_metadata_linkingE6StructVMn" = constant
 // CHECK-LABEL: @"$sSo8NSNumberC31extension_type_metadata_linkingE6StructVMf" = internal constant
 
+// CHECK-LABEL: "$sSo18NSComparisonResultVMn" = linkonce_odr hidden
+
 // CHECK-LABEL: @"$sSo8NSNumberC31extension_type_metadata_linkingE4BaseCN" = alias
 // CHECK-LABEL: @"$sSo8NSNumberC31extension_type_metadata_linkingE7DerivedCN" = alias
 // CHECK-LABEL: @"$sSo8NSNumberC31extension_type_metadata_linkingE6StructVN" = alias
@@ -47,3 +49,22 @@ extension NSNumber {
   public struct Struct {}
 }
 
+// SR-9397: not emitting metadata for NSComparisonResult
+protocol CommandTypes {
+    associatedtype Result
+    associatedtype Message
+}
+
+struct EnumCommand: CommandTypes {
+    typealias Result = ComparisonResult
+    typealias Message = String
+}
+
+struct Command<T: CommandTypes> {
+    var result: T.Result?
+    var message: T.Message?
+}
+
+func createCommandArray() -> Any {
+  return [Command<EnumCommand>]()
+}


### PR DESCRIPTION
Treat foreign metadata as lazy metadata, emitted when needed.
Fixes SR-9397 / rdar://problem/46423275.
