### PR TITLE
[Stdlib] Ensure key paths allocate space for the terminating NUL.

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2099,7 +2099,7 @@ internal func _appendingKeyPaths<
         rootKVCLength = Int(_swift_stdlib_strlen(rootPtr))
         leafKVCLength = Int(_swift_stdlib_strlen(leafPtr))
         // root + "." + leaf
-        appendedKVCLength = rootKVCLength + 1 + leafKVCLength
+        appendedKVCLength = rootKVCLength + 1 + leafKVCLength + 1
       } else {
         rootKVCLength = 0
         leafKVCLength = 0


### PR DESCRIPTION
rdar://problem/46457346 [SR-9404](https://bugs.swift.org/browse/SR-9404)