### PR TITLE
Future-proof the ARM64 ABI by not reserving the entire top byte.

### DIFF
--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -136,9 +136,10 @@
 /// Darwin reserves the low 4GB of address space.
 #define SWIFT_ABI_DARWIN_ARM64_LEAST_VALID_POINTER 0x100000000ULL
 
-// TBI guarantees the top byte of pointers is unused.
+// TBI guarantees the top byte of pointers is unused, but ARMv8.5-A
+// claims the bottom four bits of that for memory tagging.
 // Heap objects are eight-byte aligned.
-#define SWIFT_ABI_ARM64_SWIFT_SPARE_BITS_MASK 0xFF00000000000007ULL
+#define SWIFT_ABI_ARM64_SWIFT_SPARE_BITS_MASK 0xF000000000000007ULL
 
 // Objective-C reserves just the high bit for tagged pointers.
 #define SWIFT_ABI_ARM64_OBJC_RESERVED_BITS_MASK 0x8000000000000000ULL

--- a/test/IRGen/bridge_object_arm64.sil
+++ b/test/IRGen/bridge_object_arm64.sil
@@ -35,8 +35,8 @@ entry(%c : $C, %w : $Builtin.Word):
 // CHECK:         [[TAGGED_RESULT:%.*]] = bitcast [[BRIDGE]] %0 to [[C:%objc_object\*]]
 // CHECK:         br label %tagged-cont
 // CHECK:       not-tagged-pointer:
-// --                                                     0x00ff_ffff_ffff_fff8
-// CHECK:         [[MASKED_BITS:%.*]] = and i64 [[BOBITS]], 72057594037927928
+// --                                                     0x0fff_ffff_ffff_fff8
+// CHECK:         [[MASKED_BITS:%.*]] = and i64 [[BOBITS]], 1152921504606846968
 // CHECK:         [[MASKED_RESULT:%.*]] = inttoptr i64 [[MASKED_BITS]] to [[C]]
 // CHECK:         br label %tagged-cont
 // CHECK:      tagged-cont:


### PR DESCRIPTION
Targets that want to use armv8.5a memory tagging will need this.  Hopefully nobody comes up with a brilliant reason they need to use anything else.

This is ABI-affecting but is unlikely to cause serious convergence problems because it only affects a small set of code-emission situations.

rdar://46465903