### PR TITLE
[do not merge] Evaluate the hot/cold splitting pass

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -283,6 +283,10 @@ void swift::performLLVMOptimizations(IRGenOptions &Opts, llvm::Module *Module,
     }));
   }
 
+  // [do not merge] Evaluate the hot/cold splitting pass
+  if (Opts.shouldOptimize() && !Opts.DisableLLVMOptzns)
+    ModulePasses.add(createHotColdSplittingPass());
+
   if (Opts.Verify)
     ModulePasses.add(createVerifierPass());
 


### PR DESCRIPTION
This PR is a sanity-check for hot/cold splitting in the swift compiler. It's not meant to be merged. The goal is to get a rough idea of the effectiveness of the pass by gathering some basic performance numbers.

Caveats:
- Outlined cold code will not be relocated towards the end of the text segment, as we cannot test with a modified linker. Based on prior experiments we expect this to lower performance.
- No swift-specific heuristics for marking cold basic blocks are being evaluated (that might be an interesting follow-up).