### PR TITLE
[String] In-register comparison of small ASCII strings

### DIFF
--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -18,9 +18,31 @@ internal func _stringCompare(
   _ lhs: _StringGuts, _ rhs: _StringGuts, expecting: _StringComparisonResult
 ) -> Bool {
   if lhs.rawBits == rhs.rawBits { return expecting == .equal }
+  return _stringCompareWithSmolCheck(lhs, rhs, expecting: expecting)
+}
+
+@usableFromInline
+@_effects(readonly)
+internal func _stringCompareWithSmolCheck(
+  _ lhs: _StringGuts, _ rhs: _StringGuts, expecting: _StringComparisonResult
+) -> Bool {
+  // ASCII small-string fast-path:
+  if lhs.isSmallASCII && rhs.isSmallASCII {
+    let lhsRaw = lhs.asSmall._storage
+    let rhsRaw = rhs.asSmall._storage
+
+    if lhsRaw.0 != rhsRaw.0 {
+      return _lexicographicalCompare(
+        lhsRaw.0.byteSwapped, rhsRaw.0.byteSwapped, expecting: expecting)
+    }
+    return _lexicographicalCompare(
+      lhsRaw.1.byteSwapped, rhsRaw.1.byteSwapped, expecting: expecting)
+  }
+
   return _stringCompareInternal(lhs, rhs, expecting: expecting)
 }
 
+@inline(never) // Keep `_stringCompareWithSmolCheck` fast-path fast
 @usableFromInline
 @_effects(readonly)
 internal func _stringCompareInternal(

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -90,6 +90,10 @@ extension _StringGuts {
     @inline(__always) get { return _object.isSmall }
   }
 
+  internal var isSmallASCII: Bool {
+    @inline(__always) get { return _object.isSmall && _object.smallIsASCII }
+  }
+
   @inlinable
   internal var asSmall: _SmallString {
     @inline(__always) get { return _SmallString(_object) }


### PR DESCRIPTION
Adds a small-ASCII-string fast path to comparison that skips the spill to the stack. Adds it in inlinable code for a further speedup, but note that this might regress non-small-ASCII-strings. Still investigating.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
