### PR TITLE
IDE: preserve the environment in the triple

### DIFF
--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -227,6 +227,8 @@ static std::string adjustClangTriple(StringRef TripleStr) {
     break;
   }
   OS << '-' << Triple.getVendorName() << '-' << Triple.getOSName();
+  if (Triple.hasEnvironment())
+    OS << '-' << Triple.getEnvironmentName();
   OS.flush();
   return Result;
 }


### PR DESCRIPTION
Adjust the triple manipulation to preserve the environment in the case
of non-Darwin targets.  This is particularly important for android which
is an environment for Linux, and Windows, where we support specific
environments only.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
