### PR TITLE
[5.0] [ABI] Make swift::swift_conformsToSwiftProtocol overridable

### DIFF
--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -130,6 +130,13 @@ OVERRIDE_PROTOCOLCONFORMANCE(conformsToProtocol, const WitnessTable *, , swift::
                               const ProtocolDescriptor *protocol),
                              (type, protocol))
 
+OVERRIDE_PROTOCOLCONFORMANCE(conformsToSwiftProtocol,
+                             const ProtocolConformanceDescriptor *, , swift::,
+                             (const Metadata * const type,
+                              const ProtocolDescriptor *protocol,
+                              StringRef moduleName),
+                             (type, protocol, moduleName))
+
 OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , swift::,
                  (const void *pattern, const void *arguments),
                  (pattern, arguments))

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -510,9 +510,9 @@ public:
   /// Determine whether the given type conforms to the given Swift protocol,
   /// returning the appropriate protocol conformance descriptor when it does.
   const ProtocolConformanceDescriptor *
-  _conformsToSwiftProtocol(const Metadata * const type,
-                           const ProtocolDescriptor *protocol,
-                           StringRef module);
+  swift_conformsToSwiftProtocol(const Metadata * const type,
+                                const ProtocolDescriptor *protocol,
+                                StringRef module);
 
   /// Retrieve an associated type witness from the given witness table.
   ///

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -511,7 +511,8 @@ public:
   /// returning the appropriate protocol conformance descriptor when it does.
   const ProtocolConformanceDescriptor *
   _conformsToSwiftProtocol(const Metadata * const type,
-                           const ProtocolDescriptor *protocol);
+                           const ProtocolDescriptor *protocol,
+                           StringRef module);
 
   /// Retrieve an associated type witness from the given witness table.
   ///

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -532,10 +532,10 @@ namespace {
   };
 }
 
-const ProtocolConformanceDescriptor *
-swift::_conformsToSwiftProtocol(const Metadata * const type,
-                                const ProtocolDescriptor *protocol,
-                                StringRef module) {
+static const ProtocolConformanceDescriptor *
+swift_conformsToSwiftProtocolImpl(const Metadata * const type,
+                                  const ProtocolDescriptor *protocol,
+                                  StringRef module) {
   auto &C = Conformances.get();
 
   // See if we have a cached conformance. The ConcurrentMap data structure
@@ -601,7 +601,8 @@ swift::_conformsToSwiftProtocol(const Metadata * const type,
 static const WitnessTable *
 swift_conformsToProtocolImpl(const Metadata * const type,
                              const ProtocolDescriptor *protocol) {
-  auto description = _conformsToSwiftProtocol(type, protocol, StringRef());
+  auto description =
+    swift_conformsToSwiftProtocol(type, protocol, StringRef());
   if (!description)
     return nullptr;
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -534,7 +534,8 @@ namespace {
 
 const ProtocolConformanceDescriptor *
 swift::_conformsToSwiftProtocol(const Metadata * const type,
-                                const ProtocolDescriptor *protocol) {
+                                const ProtocolDescriptor *protocol,
+                                StringRef module) {
   auto &C = Conformances.get();
 
   // See if we have a cached conformance. The ConcurrentMap data structure
@@ -600,7 +601,7 @@ swift::_conformsToSwiftProtocol(const Metadata * const type,
 static const WitnessTable *
 swift_conformsToProtocolImpl(const Metadata * const type,
                              const ProtocolDescriptor *protocol) {
-  auto description = _conformsToSwiftProtocol(type, protocol);
+  auto description = _conformsToSwiftProtocol(type, protocol, StringRef());
   if (!description)
     return nullptr;
 

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -168,6 +168,11 @@ TEST_F(CompatibilityOverrideTest, test_swift_conformsToProtocol) {
   ASSERT_EQ(Result, nullptr);  
 }
 
+TEST_F(CompatibilityOverrideTest, test_swift_conformsToSwiftProtocol) {
+  auto Result = swift_conformsToSwiftProtocol(nullptr, nullptr, StringRef());
+  ASSERT_EQ(Result, nullptr);
+}
+
 TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledNode) {
   Demangler demangler;
   auto Result = swift_getTypeByMangledNode(demangler, nullptr, nullptr,


### PR DESCRIPTION
**ABI Addition**: Make the funnel point for looking up the protocol conformance
descriptor for a given conforming type + conformance overridable. It's an
internal entry point, so there are no clients of it outside of the runtime, making
this strictly ABI-additive (doesn't break existing binaries). It's an important
hook for backward-deployment, however.

This is a funnel point for looking up the protocol conformance descriptor
for a given conforming type + conformance. Make it overridable in case we
need to back-deploy changes or fixes.

Implements rdar://problem/46281660.