### PR TITLE
[stdlib]Add an opaque flavor of the normalization tests

### DIFF
--- a/validation-test/stdlib/StringNormalization.swift
+++ b/validation-test/stdlib/StringNormalization.swift
@@ -14,7 +14,6 @@
 // RUN: then \
 // RUN:   %target-clang -fobjc-arc %S/Inputs/NSSlowString/NSSlowString.m -c -o %t/NSSlowString.o && \
 // RUN:   %target-build-swift -I %S/Inputs/NSSlowString/ %t/NSSlowString.o %s -o %t/a.out; \
-// REQUIRES: objc_interop
 // RUN: else \
 // RUN:   %target-build-swift %s -o %t/a.out; \
 // RUN: fi
@@ -22,6 +21,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out %S/Inputs/NormalizationTest.txt
 // REQUIRES: executable_test
+// REQUIRES: objc_interop
 
 import Swift
 import StdlibUnittest


### PR DESCRIPTION
Run the normalization tests through the opaque path as well.