### PR TITLE
[Type checker] Make sure we wire up generic parameters of a context.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4159,30 +4159,6 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
     }
   }
 
-  // When requested, print the conformance access path used to find this
-  // conformance.
-  ASTContext &ctx = Proto->getASTContext();
-  if (ctx.LangOpts.DebugGenericSignatures &&
-      InExpression && T->is<ArchetypeType>() && lookupResult->isAbstract() &&
-      !T->castTo<ArchetypeType>()->isOpenedExistential() &&
-      !T->castTo<ArchetypeType>()->requiresClass() &&
-      T->castTo<ArchetypeType>()->getGenericEnvironment()
-        == DC->getGenericEnvironmentOfContext()) {
-    auto interfaceType = T->mapTypeOutOfContext();
-    if (interfaceType->isTypeParameter()) {
-      auto genericSig = DC->getGenericSignatureOfContext();
-      auto path = genericSig->getConformanceAccessPath(interfaceType, Proto);
-
-      // Debugging aid: display the conformance access path for archetype
-      // conformances.
-      llvm::errs() << "Conformance access path for ";
-      T.print(llvm::errs());
-      llvm::errs() << ": " << Proto->getName() << " is ";
-      path.print(llvm::errs());
-      llvm::errs() << "\n";
-    }
-  }
-
   return lookupResult;
 }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -304,15 +304,18 @@ static void prepareGenericParamList(GenericParamList *genericParams) {
 /// context have been configured.
 static void configureOuterGenericParams(const GenericContext *dc) {
   auto genericParams = dc->getGenericParams();
-  if (!genericParams) return;
 
-  if (genericParams->getOuterParameters()) return;
+  // If we already configured the outer parameters, we're done.
+  if (genericParams && genericParams->getOuterParameters())
+    return;
 
   DeclContext *outerDC = dc->getParent();
   while (!outerDC->isModuleScopeContext()) {
     if (auto outerDecl = outerDC->getAsDecl()) {
       if (auto outerGenericDC = outerDecl->getAsGenericContext()) {
-        genericParams->setOuterParameters(outerGenericDC->getGenericParams());
+        if (genericParams)
+          genericParams->setOuterParameters(outerGenericDC->getGenericParams());
+
         configureOuterGenericParams(outerGenericDC);
         return;
       }

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -1,6 +1,4 @@
 // RUN: %target-typecheck-verify-swift -typecheck -swift-version 4 %s -verify
-// RUN: %target-typecheck-verify-swift -typecheck -swift-version 4 -debug-generic-signatures %s > %t.dump 2>&1
-// RUN: %FileCheck %s < %t.dump
 
 protocol P0 { }
 protocol Q0: P0 { }
@@ -37,22 +35,16 @@ func acceptP3<T: P3>(_: T) { }
 
 
 func testPaths1<T: P2 & P4>(_ t: T) {
-	// CHECK: Conformance access path for T.AssocP2.AssocP1: P0 is τ_0_0: P2 -> τ_0_0.AssocP2: P1 -> τ_0_0.AssocP1: Q0 -> τ_0_0: P0
 	acceptP0(t.getAssocP2().getAssocP1())
-	// CHECK: Conformance access path for T.AssocP3: P0 is τ_0_0: P4 -> τ_0_0: P3 -> τ_0_0.AssocP3: P0
 	acceptP0(t.getAssocP3())
 }
 
 func testPaths2<U: P2 & P4>(_ t: U) where U.AssocP3 == U.AssocP2.AssocP1 {
-	// CHECK: Conformance access path for U.AssocP3: P0 is τ_0_0: P4 -> τ_0_0: P3 -> τ_0_0.AssocP3: P0
 	acceptP0(t.getAssocP2().getAssocP1())
 }
 
 func testPaths3<V: P5>(_ v: V) {
-	// CHECK: Conformance access path for V.AssocP3: P0 is τ_0_0: P5 -> τ_0_0.AssocP3: Q0 -> τ_0_0: P0
 	acceptP0(v.getAssocP3())
-
-	// CHECK: Conformance access path for V.AssocP3: Q0 is τ_0_0: P5 -> τ_0_0.AssocP3: Q0
 	acceptQ0(v.getAssocP3())
 }
 
@@ -68,6 +60,5 @@ protocol P5Unordered {
 }
 
 func testUnorderedP5_P6<W: P6Unordered>(_ w: W) {
-	// CHECK: Conformance access path for W.A: P0 is τ_0_0: P6Unordered -> τ_0_0: P5Unordered -> τ_0_0.A: P0
 	acceptP0(w.getA())
 }

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -192,3 +192,13 @@ struct A<T, U, V> {
 extension A.B.C where T == V, X == Z.Assoc2 {
   func f() { }
 }
+
+// Extensions of nested non-generics within generics.
+extension A.B {
+  struct D { }
+}
+
+extension A.B.D {
+  func g() { }
+}
+


### PR DESCRIPTION
The attempt to short-circuit wiring up generic parameters of a context
didn’t work when one of the inner types didn’t itself have generic
parameters. Make sure we still wire up generic parameters in this case.

Fixes a crasher encountered while investigating rdar://problem/43406595.