### PR TITLE
[5.0] [Type checker] Make sure we wire up generic parameters of a context. 

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -304,15 +304,18 @@ static void prepareGenericParamList(GenericParamList *genericParams) {
 /// context have been configured.
 static void configureOuterGenericParams(const GenericContext *dc) {
   auto genericParams = dc->getGenericParams();
-  if (!genericParams) return;
 
-  if (genericParams->getOuterParameters()) return;
+  // If we already configured the outer parameters, we're done.
+  if (genericParams && genericParams->getOuterParameters())
+    return;
 
   DeclContext *outerDC = dc->getParent();
   while (!outerDC->isModuleScopeContext()) {
     if (auto outerDecl = outerDC->getAsDecl()) {
       if (auto outerGenericDC = outerDecl->getAsGenericContext()) {
-        genericParams->setOuterParameters(outerGenericDC->getGenericParams());
+        if (genericParams)
+          genericParams->setOuterParameters(outerGenericDC->getGenericParams());
+
         configureOuterGenericParams(outerGenericDC);
         return;
       }

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -192,3 +192,13 @@ struct A<T, U, V> {
 extension A.B.C where T == V, X == Z.Assoc2 {
   func f() { }
 }
+
+// Extensions of nested non-generics within generics.
+extension A.B {
+  struct D { }
+}
+
+extension A.B.D {
+  func g() { }
+}
+


### PR DESCRIPTION
The attempt to short-circuit wiring up generic parameters of a context
didn’t work when one of the inner types didn’t itself have generic
parameters. Make sure we still wire up generic parameters in this case.

Fixes a crasher encountered while investigating rdar://problem/43406595.
