### PR TITLE
[AutoDiff] Make `autodiff_function_extract` able to extract the original function.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5503,17 +5503,18 @@ autodiff_function_extract
                       sil-autodiff-function-order
                       sil-value ':' sil-type
 
-  sil-autodiff-associated-function-kind ::= '[' sil-autodiff-associated-function-kind-name ']'
-  sil-autodiff-associated-function-kind-name ::= 'jvp' | 'vjp'
+  sil-autodiff-function-extractee ::= '[' sil-autodiff-function-extractee ']'
+  sil-autodiff-function-extractee-name ::= 'original' | 'jvp' | 'vjp'
   sil-autodiff-function-differentiation-order ::= '[' 'order' [0-9]+ ']'
 
 
+  autodiff_function_extract [original] %0 : $@autodiff (T) -> T
   autodiff_function_extract [jvp] [order 1] %0 : $@autodiff (T) -> T
   autodiff_function_extract [vjp] [order 1] %0 : $@autodiff (T) -> T
 
-Extracts an associated differentiation function from the given ``@autodiff``
-function at a specific differentiation order. It must be provided with an
-associated function kind: ``[jvp]`` or ``[vjp]``.
+Extracts the original function or an associated function from the given
+``@autodiff`` function at a specific differentiation order. It must be provided
+with an extractee: ``[original]``, ``[jvp]`` or ``[vjp]``.
 
 .. SWIFT_ENABLE_TENSORFLOW
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1512,6 +1512,8 @@ ERROR(sil_inst_autodiff_attr_expected_rsquare,PointsToFirstBadToken,
       "expected ']' to complete the %0", (StringRef))
 ERROR(sil_inst_autodiff_expected_order,PointsToFirstBadToken,
       "expected an unsigned integer indicating the differentiation order", ())
+ERROR(sil_inst_autodiff_expected_nonzero_order,PointsToFirstBadToken,
+      "expected a non-zero differentiation order", ())
 ERROR(sil_inst_autodiff_operand_list_expected_lbrace,PointsToFirstBadToken,
       "expected '{' to start an associated function list", ())
 ERROR(sil_inst_autodiff_operand_list_expected_comma,PointsToFirstBadToken,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -519,11 +519,11 @@ public:
   }
   
   AutoDiffFunctionExtractInst *createAutoDiffFunctionExtract(
-      SILLocation loc, AutoDiffAssociatedFunctionKind associatedFunctionKind,
+      SILLocation loc, AutoDiffFunctionExtractInst::Extractee extractee,
       unsigned differentiationOrder, SILValue theFunction) {
     return insert(new (getModule()) AutoDiffFunctionExtractInst(
-        getModule(), getSILDebugLocation(loc), associatedFunctionKind,
-        differentiationOrder, theFunction));
+        getModule(), getSILDebugLocation(loc), extractee, differentiationOrder,
+        theFunction));
   }
 
   BuiltinInst *createBuiltin(SILLocation Loc, Identifier Name, SILType ResultTy,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -941,7 +941,7 @@ visitAutoDiffFunctionExtractInst(AutoDiffFunctionExtractInst *Inst) {
   recordClonedInstruction(Inst,
       getBuilder().createAutoDiffFunctionExtract(
           getOpLocation(Inst->getLoc()),
-          Inst->getAssociatedFunctionKind(),
+          Inst->getExtractee(),
           Inst->getDifferentiationOrder(),
           getOpValue(Inst->getFunctionOperand())));
 }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1990,9 +1990,10 @@ void IRGenSILFunction::visitAutoDiffFunctionInst(AutoDiffFunctionInst *i) {
 
 void IRGenSILFunction::
 visitAutoDiffFunctionExtractInst(AutoDiffFunctionExtractInst *i) {
-  unsigned assocFnOffset = autodiff::getOffsetForAutoDiffAssociatedFunction(
+  unsigned structFieldOffset = 0;
+  if (i->getExtractee() != AutoDiffFunctionExtractee::Original)
+    structFieldOffset = 1 + autodiff::getOffsetForAutoDiffAssociatedFunction(
       i->getDifferentiationOrder(), i->getAssociatedFunctionKind());
-  unsigned structFieldOffset = assocFnOffset + 1;
   unsigned fieldSize = 1;
   auto fnRepr = i->getFunctionOperand()->getType().getFunctionRepresentation();
   if (fnRepr == SILFunctionTypeRepresentation::Thick) {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -666,31 +666,53 @@ getAssociatedFunction(unsigned differentiationOrder,
   return getAssociatedFunctions()[offset].get();
 }
 
+AutoDiffFunctionExtractInst::Extractee::Extractee(StringRef string) {
+  Optional<innerty> result =
+      llvm::StringSwitch<Optional<innerty>>(string)
+          .Case("original", Original)
+          .Case("jvp", JVP)
+          .Case("vjp", VJP);
+  assert(result && "Invalid string");
+  rawValue = *result;
+}
+
 SILType AutoDiffFunctionExtractInst::
-getAssociatedFunctionType(SILValue function,
-                          AutoDiffAssociatedFunctionKind kind,
-                          unsigned differentiationOrder,
-                          SILModule &module) {
+getExtracteeType(SILValue function, Extractee extractee,
+                 unsigned differentiationOrder, SILModule &module) {
   auto fnTy = function->getType().castTo<SILFunctionType>();
   assert(fnTy->getExtInfo().isDifferentiable());
   auto originalFnTy =
       fnTy->getWithExtInfo(fnTy->getExtInfo().withDifferentiability(
           FunctionTypeDifferentiability::None));
-  // FIXME: Get indices from the @autodiff function type.
-  auto assocFnTy = originalFnTy->getAutoDiffAssociatedFunctionType(
-      SmallBitVector(originalFnTy->getNumParameters(), true),
-      differentiationOrder, kind, module,
-      LookUpConformanceInModule(module.getSwiftModule()));
-  return SILType::getPrimitiveObjectType(assocFnTy);
+  CanSILFunctionType resultFnTy;
+  switch (extractee) {
+  case Extractee::Original:
+    assert(differentiationOrder == 0);
+    resultFnTy = originalFnTy;
+    break;
+  case Extractee::JVP:
+    resultFnTy = originalFnTy->getAutoDiffAssociatedFunctionType(
+        SmallBitVector(originalFnTy->getNumParameters(), true),
+        differentiationOrder, AutoDiffAssociatedFunctionKind::JVP, module,
+         LookUpConformanceInModule(module.getSwiftModule()));
+    break;
+  case Extractee::VJP:
+    resultFnTy = originalFnTy->getAutoDiffAssociatedFunctionType(
+        SmallBitVector(originalFnTy->getNumParameters(), true),
+        differentiationOrder, AutoDiffAssociatedFunctionKind::VJP, module,
+        LookUpConformanceInModule(module.getSwiftModule()));
+    break;
+  }
+  return SILType::getPrimitiveObjectType(resultFnTy);
 }
 
 AutoDiffFunctionExtractInst::AutoDiffFunctionExtractInst(
     SILModule &module, SILDebugLocation debugLoc,
-    AutoDiffAssociatedFunctionKind associatedFunctionKind,
-    unsigned differentiationOrder, SILValue theFunction)
-    : InstructionBase(debugLoc, getAssociatedFunctionType(
-          theFunction, associatedFunctionKind, differentiationOrder, module)),
-      associatedFunctionKind(associatedFunctionKind),
+    Extractee extractee, unsigned differentiationOrder, SILValue theFunction)
+    : InstructionBase(debugLoc,
+                      getExtracteeType(theFunction, extractee,
+                                       differentiationOrder, module)),
+      extractee(extractee),
       differentiationOrder(differentiationOrder),
       operands(this, theFunction) {
 }

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1174,16 +1174,22 @@ public:
 
   void visitAutoDiffFunctionExtractInst(AutoDiffFunctionExtractInst *adfei) {
     *this << '[';
-    switch (adfei->getAssociatedFunctionKind()) {
-    case swift::AutoDiffAssociatedFunctionKind::JVP:
+    switch (adfei->getExtractee()) {
+    case AutoDiffFunctionExtractee::Original:
+      *this << "original";
+      break;
+    case AutoDiffFunctionExtractee::JVP:
       *this << "jvp";
       break;
-    case swift::AutoDiffAssociatedFunctionKind::VJP:
+    case AutoDiffFunctionExtractee::VJP:
       *this << "vjp";
       break;
     }
-    *this << "] [order " << adfei->getDifferentiationOrder()
-          << "] " << getIDAndType(adfei->getFunctionOperand());
+    *this << "] ";
+    auto order = adfei->getDifferentiationOrder();
+    if (order > 0)
+      *this << "[order " << order << "] ";
+    *this << getIDAndType(adfei->getFunctionOperand());
   }
 
   void visitFunctionRefInst(FunctionRefInst *FRI) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1254,7 +1254,8 @@ public:
   }
 
   void checkAutoDiffFunctionInst(AutoDiffFunctionInst *adfi) {
-    // FIXME(rxwei): Complete verification.
+    require(adfi->getDifferentiationOrder() > 0,
+            "The differentiation order must be non-zero");
     auto origTy =
         adfi->getOriginalFunction()->getType().getAs<SILFunctionType>();
     require(origTy, "The original function must have a function type");
@@ -1287,7 +1288,14 @@ public:
   }
   
   void checkAutoDiffFunctionExtractInst(AutoDiffFunctionExtractInst *adfei) {
-    // FIXME(rxwei): Complete verification.
+    if (adfei->getExtractee() == AutoDiffFunctionExtractee::Original)
+      require(adfei->getDifferentiationOrder() == 0,
+              "Differentiation order should not have been set when the original"
+              " function is being extracted");
+    else
+      require(adfei->getDifferentiationOrder() > 0,
+              "Extraction of associated functions requires a differentiation "
+              "order");
     auto fnTy = adfei->getFunctionOperand()->getType().getAs<SILFunctionType>();
     require(fnTy, "The function operand must have a function type");
     require(fnTy->isDifferentiable(),

--- a/test/AutoDiff/autodiff_function_inst.sil
+++ b/test/AutoDiff/autodiff_function_inst.sil
@@ -39,6 +39,8 @@ bb0:
   %vjp = function_ref @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %diffFunc = autodiff_function [wrt 0] [order 1] %orig : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
   %extractedVJP = autodiff_function_extract [vjp] [order 1] %diffFunc : $@autodiff @convention(thin) (Float) -> Float
+  %extractedOriginal = autodiff_function_extract [original] %diffFunc : $@autodiff @convention(thin) (Float) -> Float
+  %copied = copy_value %extractedOriginal : $@convention(thin) (Float) -> Float
   return %undiffedFunc : $@autodiff @convention(thin) (Float) -> Float
 }
 
@@ -48,4 +50,6 @@ bb0:
 // CHECK:   [[FOO_VJP:%.*]] = function_ref @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // CHECK:   [[DIFFED_FOO:%.*]] = autodiff_function [wrt 0] [order 1] [[FOO]] : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), [[FOO_VJP]] : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
 // CHECK:   [[EXTRACTED_VJP:%.*]] = autodiff_function_extract [vjp] [order 1] [[DIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float
+// CHECK:   [[EXTRACTED_ORIG:%.*]] = autodiff_function_extract [original] [[DIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float
+// CHECK:   copy_value [[EXTRACTED_ORIG]] : $@convention(thin) (Float) -> Float
 // CHECK:   return [[UNDIFFED_FOO]] : $@autodiff @convention(thin) (Float) -> Float

--- a/test/AutoDiff/autodiff_function_inst_irgen.sil
+++ b/test/AutoDiff/autodiff_function_inst_irgen.sil
@@ -32,33 +32,34 @@ bb0(%0 : @trivial $Float):
   return %5 : $(Float, @callee_guaranteed (Float) -> Float)
 }
 
-sil @make_diff_func : $@convention(thin) () -> (@autodiff @convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) {
+sil @make_diff_func : $@convention(thin) () -> (@convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) {
 bb0:
   %orig = function_ref @foo : $@convention(thin) (Float) -> Float
   %vjp = function_ref @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %diffFunc = autodiff_function [wrt 0] [order 1] %orig : $@convention(thin) (Float) -> Float with {undef : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
+  %extractedOrig = autodiff_function_extract [original] %diffFunc : $@autodiff @convention(thin) (Float) -> Float
   %extractedVJP = autodiff_function_extract [vjp] [order 1] %diffFunc : $@autodiff @convention(thin) (Float) -> Float
-  %tuple = tuple (%diffFunc : $@autodiff @convention(thin) (Float) -> Float, %extractedVJP : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
-  return %tuple : $(@autodiff @convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
+  %tuple = tuple (%extractedOrig : $@convention(thin) (Float) -> Float, %extractedVJP : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
+  return %tuple : $(@convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
 }
 
 sil @caller : $@convention(thin) () -> () {
 bb0:
-  %f = function_ref @make_diff_func : $@convention(thin) () -> (@autodiff @convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
-  %tuple = apply %f() : $@convention(thin) () -> (@autodiff @convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
-  %vjp = tuple_extract %tuple : $(@autodiff @convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)), 1
+  %f = function_ref @make_diff_func : $@convention(thin) () -> (@convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
+  %tuple = apply %f() : $@convention(thin) () -> (@convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float))
+  %vjp = tuple_extract %tuple : $(@convention(thin) (Float) -> Float, @convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)), 1
   %res = apply %vjp(undef) : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %ret = tuple ()
   return %ret : $()
 }
 
-// CHECK-LABEL: swiftcc { i8*, i8*, i8*, i8* } @make_diff_func()
+// CHECK-LABEL: swiftcc { i8*, i8* } @make_diff_func()
 // CHECK-NEXT: entry:
-// CHECK-NEXT:   ret { i8*, i8*, i8*, i8* } { i8* bitcast (float (float)* @foo to i8*), i8* undef, i8* bitcast ({ float, i8*, %swift.refcounted* } (float)* @foo_vjp to i8*), i8* bitcast ({ float, i8*, %swift.refcounted* } (float)* @foo_vjp to i8*) }
+// CHECK-NEXT:   ret { i8*, i8* } { i8* bitcast (float (float)* @foo to i8*), i8* bitcast ({ float, i8*, %swift.refcounted* } (float)* @foo_vjp to i8*) }
 
 // CHECK-LABEL: swiftcc void @caller()
 // CHECK-NEXT: entry:
-// CHECK-NEXT:   [[RESULT_TUPLE:%.*]] = call swiftcc { i8*, i8*, i8*, i8* } @make_diff_func()
-// CHECK:   [[VJP:%.*]] = extractvalue { i8*, i8*, i8*, i8* } [[RESULT_TUPLE]], 3
+// CHECK-NEXT:   [[RESULT_TUPLE:%.*]] = call swiftcc { i8*, i8* } @make_diff_func()
+// CHECK:   [[VJP:%.*]] = extractvalue { i8*, i8* } [[RESULT_TUPLE]], 1
 // CHECK:   [[VJP_TYPED:%.*]] = bitcast i8* [[VJP]] to { float, i8*, %swift.refcounted* } (float)*
 // CHECK:   call swiftcc { float, i8*, %swift.refcounted* } [[VJP_TYPED]](float undef)


### PR DESCRIPTION
* Add `AutoDiffFunctionExtractee`, which corresponds to `[original]`, `[jvp]` and `[vjp]` in the `autodiff_function_extract` instruction.

* Make the SIL parser reject `[order 0]` in both `autodiff_function` and `autdiff_function_extract` instructions.

* Complete the verifier for `autodiff_function` and `autodiff_function_extract`.