### PR TITLE
test: use %empty-directory more aggressively

### DIFF
--- a/test/Driver/Dependencies/README.txt
+++ b/test/Driver/Dependencies/README.txt
@@ -8,7 +8,8 @@ a --> b         File 'b' privately depends on file 'a' (normal dependencies casc
 
 Because of the way the tests are set up, the dependency information is put into the .swift files; any such test needs to start by "building" everything to copy that information into .swiftdeps files. To avoid timestamp issues, most of these tests start with:
 
-    // RUN: rm -rf %t && cp -r %S/Inputs/<TEST_GRAPH>/ %t
+    // RUN: %empty-directory(%t)
+    // RUN: cp -r %S/Inputs/<TEST_GRAPH>/* %t
     // RUN: touch -t 201401240005 %t/*
 
 
@@ -21,6 +22,7 @@ In order to correctly run these tests, the "before" information is put into .swi
 
 Most of these tests start with:
 
-    // RUN: rm -rf %t && cp -r %S/Inputs/<TEST_GRAPH>/ %t
+    // RUN: %empty-directory(%t)
+    // RUN: cp -r %S/Inputs/<TEST_GRAPH>/* %t
     // RUN: touch -t 201401240005 %t/*.swift
     // RUN: touch -t 201401240006 %t/*.o

--- a/test/Driver/Dependencies/bindings-build-record-options.swift
+++ b/test/Driver/Dependencies/bindings-build-record-options.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/bindings-build-record/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/bindings-build-record/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-INITIAL

--- a/test/Driver/Dependencies/bindings-build-record.swift
+++ b/test/Driver/Dependencies/bindings-build-record.swift
@@ -1,5 +1,6 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/bindings-build-record/ %t
-// RUN: %S/Inputs/touch.py 443865900 %t/*
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/bindings-build-record/* %t
+// RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC
 

--- a/test/Driver/Dependencies/build-record-invalid.swift
+++ b/test/Driver/Dependencies/build-record-invalid.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/bindings-build-record/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/bindings-build-record/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s -check-prefix=CHECK-ALL-BUILT

--- a/test/Driver/Dependencies/chained-additional-kinds.swift
+++ b/test/Driver/Dependencies/chained-additional-kinds.swift
@@ -1,6 +1,7 @@
 // other ==> main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-additional-kinds/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-additional-kinds/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/chained-after.swift
+++ b/test/Driver/Dependencies/chained-after.swift
@@ -1,7 +1,8 @@
 /// other ==> main | yet-another
 /// other ==> main +==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/chained-private-after-multiple-nominal-members.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple-nominal-members.swift
@@ -1,7 +1,8 @@
 /// other --> main ==> yet-another
 /// other ==>+ main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-private-after-multiple-nominal-members/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-after-multiple-nominal-members/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/chained-private-after-multiple.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple.swift
@@ -1,7 +1,8 @@
 /// other --> main ==> yet-another
 /// other ==>+ main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-private-after-multiple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-after-multiple/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/chained-private-after.swift
+++ b/test/Driver/Dependencies/chained-private-after.swift
@@ -1,7 +1,8 @@
 /// other --> main ==> yet-another
 /// other ==>+ main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-private-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/chained-private.swift
+++ b/test/Driver/Dependencies/chained-private.swift
@@ -1,6 +1,7 @@
 /// other --> main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-private/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/chained.swift
+++ b/test/Driver/Dependencies/chained.swift
@@ -1,6 +1,7 @@
 // other ==> main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/crash-added.swift
+++ b/test/Driver/Dependencies/crash-added.swift
@@ -1,6 +1,7 @@
 /// crash ==> main | crash --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/crash-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
@@ -21,7 +22,8 @@
 // CHECK-RECORD-ADDED-DAG: "./other.swift": [
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/crash-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/crash-new.swift
+++ b/test/Driver/Dependencies/crash-new.swift
@@ -1,6 +1,7 @@
 /// crash ==> main | crash --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/crash-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies-bad.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/crash-simple.swift
+++ b/test/Driver/Dependencies/crash-simple.swift
@@ -1,6 +1,7 @@
 /// crash ==> main | crash --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/crash-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/dependencies-preservation.swift
+++ b/test/Driver/Dependencies/dependencies-preservation.swift
@@ -1,7 +1,8 @@
 // Verify that the top-level build record file from the last incremental
 // compilation is preserved with the same name, suffixed by a '~'.
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json

--- a/test/Driver/Dependencies/driver-show-incremental-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-arguments.swift
@@ -8,7 +8,8 @@
 // is disabled.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 

--- a/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
@@ -8,7 +8,8 @@
 // is disabled. If both are specified, the driver should only print one message.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 

--- a/test/Driver/Dependencies/driver-show-incremental-inputs.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-inputs.swift
@@ -8,7 +8,8 @@
 // is disabled.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 

--- a/test/Driver/Dependencies/driver-show-incremental-malformed.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-malformed.swift
@@ -7,7 +7,8 @@
 // is disabled.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/driver-show-incremental-mutual.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-mutual.swift
@@ -1,6 +1,7 @@
 /// main <==> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/mutual/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mutual/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
@@ -8,7 +8,8 @@
 // is disabled.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/embed-bitcode-parallel.swift
+++ b/test/Driver/Dependencies/embed-bitcode-parallel.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/fake-build-for-bitcode.py -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/fail-added.swift
+++ b/test/Driver/Dependencies/fail-added.swift
@@ -1,6 +1,7 @@
 /// bad ==> main | bad --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
@@ -21,7 +22,8 @@
 // CHECK-RECORD-ADDED-DAG: "./other.swift": [
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/fail-chained.swift
+++ b/test/Driver/Dependencies/fail-chained.swift
@@ -1,6 +1,7 @@
 /// a ==> bad ==> c ==> d | b --> bad --> e ==> f
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-chained/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -60,7 +61,8 @@
 // NEGATIVE-A2-NOT: Handled f.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-chained/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/fail-interface-hash.swift
+++ b/test/Driver/Dependencies/fail-interface-hash.swift
@@ -1,6 +1,7 @@
 /// main ==> depends-on-main | bad ==> depends-on-bad
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-interface-hash/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-interface-hash/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/fail-new.swift
+++ b/test/Driver/Dependencies/fail-new.swift
@@ -1,6 +1,7 @@
 /// bad ==> main | bad --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies-bad.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/fail-simple.swift
+++ b/test/Driver/Dependencies/fail-simple.swift
@@ -1,6 +1,7 @@
 /// bad ==> main | bad --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/fail-with-bad-deps.swift
+++ b/test/Driver/Dependencies/fail-with-bad-deps.swift
@@ -1,6 +1,7 @@
 /// main ==> depends-on-main | bad ==> depends-on-bad
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-with-bad-deps/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-with-bad-deps/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/file-added.swift
+++ b/test/Driver/Dependencies/file-added.swift
@@ -1,6 +1,7 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/independent-half-dirty.swift
+++ b/test/Driver/Dependencies/independent-half-dirty.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/independent-parseable.swift
+++ b/test/Driver/Dependencies/independent-parseable.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -28,7 +29,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s

--- a/test/Driver/Dependencies/independent.swift
+++ b/test/Driver/Dependencies/independent.swift
@@ -1,6 +1,7 @@
 // main | other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -20,7 +21,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
@@ -34,7 +36,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SINGLE %s

--- a/test/Driver/Dependencies/malformed-but-valid-yaml.swift
+++ b/test/Driver/Dependencies/malformed-but-valid-yaml.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/malformed-but-valid-yaml/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-but-valid-yaml/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -24,7 +25,8 @@
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
 
-// RUN: rm -rf %t && cp -r %S/Inputs/malformed-but-valid-yaml/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-but-valid-yaml/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/malformed.swift
+++ b/test/Driver/Dependencies/malformed.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/malformed-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -24,7 +25,8 @@
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
 
-// RUN: rm -rf %t && cp -r %S/Inputs/malformed-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/moduleonly.swift
+++ b/test/Driver/Dependencies/moduleonly.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/moduleonly/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/moduleonly/* %t
 // RUN: touch -t 201801230045 %t/*.swift
 
 // RUN: cd %t && %target-build-swift -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1 | %FileCheck -check-prefix=CHECK1 %s
@@ -48,7 +49,8 @@
 
 // '-c' (without '-emit-module') from clean environment.
 //
-// RUN: rm -rf %t && cp -r %S/Inputs/moduleonly/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/moduleonly/* %t
 // RUN: touch -t 201801230045 %t/*.swift
 // RUN: cd %t && %target-build-swift -c -g -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1
 // RUN: test ! -f %t/buildrecord.swiftdeps~moduleonly
@@ -57,7 +59,8 @@
 
 // '-emit-library -g' (without '-emit-module') from clean environment.
 //
-// RUN: rm -rf %t && cp -r %S/Inputs/moduleonly/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/moduleonly/* %t
 // RUN: touch -t 201801230045 %t/*.swift
 // RUN: cd %t && %target-build-swift -emit-library -g -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1
 // RUN: test ! -f %t/buildrecord.swiftdeps~moduleonly
@@ -68,12 +71,14 @@
 //
 // RUN: rm -f %t-moduleonly.swiftmodule
 // RUN: rm -f %t-moduleonly.swiftdoc
-// RUN: rm -rf %t && cp -r %S/Inputs/moduleonly/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/moduleonly/* %t
 // RUN: touch -t 201801230045 %t/*.swift
 // RUN: cd %t && %target-build-swift -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1
 // RUN: cp -f %t/testmodule.swiftmodule %t-moduleonly.swiftmodule
 // RUN: cp -f %t/testmodule.swiftdoc %t-moduleonly.swiftdoc
-// RUN: rm -rf %t && cp -r %S/Inputs/moduleonly/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/moduleonly/* %t
 // RUN: touch -t 201801230045 %t/*.swift
 // RUN: cd %t && %target-build-swift -c -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1
 // RUN: diff %t/testmodule.swiftmodule %t-moduleonly.swiftmodule

--- a/test/Driver/Dependencies/mutual-interface-hash.swift
+++ b/test/Driver/Dependencies/mutual-interface-hash.swift
@@ -1,6 +1,7 @@
 /// does-change <==> does-not-change
 
-// RUN: rm -rf %t && cp -r %S/Inputs/mutual-interface-hash/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mutual-interface-hash/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // Generate the build record...

--- a/test/Driver/Dependencies/mutual.swift
+++ b/test/Driver/Dependencies/mutual.swift
@@ -1,6 +1,7 @@
 /// main <==> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/mutual/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mutual/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/nominal-members.swift
+++ b/test/Driver/Dependencies/nominal-members.swift
@@ -1,6 +1,7 @@
 /// a ==> depends-on-a-ext, depends-on-a-foo | a-ext ==> depends-on-a-ext
 
-// RUN: rm -rf %t && cp -r %S/Inputs/nominal-members/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/nominal-members/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/one-way-depends-after.swift
+++ b/test/Driver/Dependencies/one-way-depends-after.swift
@@ -1,7 +1,8 @@
 /// other | main
 /// other ==>+ main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-depends-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -26,7 +27,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-depends-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/one-way-depends-before.swift
+++ b/test/Driver/Dependencies/one-way-depends-before.swift
@@ -1,7 +1,8 @@
 /// other ==>+ main
 /// other | main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-depends-before/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-before/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -29,7 +30,8 @@
 // CHECK-THIRD-NOT: Handled main.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-depends-before/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-before/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/one-way-external-delete.swift
+++ b/test/Driver/Dependencies/one-way-external-delete.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-external/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-external/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -22,7 +23,8 @@
 // CHECK-THIRD-DAG: Handled main.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-external/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-external/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-external.swift
+++ b/test/Driver/Dependencies/one-way-external.swift
@@ -4,7 +4,8 @@
 /// "./other1-external" ==> other
 /// "./other2-external" ==> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-external/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-external/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-merge-module.swift
+++ b/test/Driver/Dependencies/one-way-merge-module.swift
@@ -1,6 +1,7 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-parallel.swift
+++ b/test/Driver/Dependencies/one-way-parallel.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-parseable.swift
+++ b/test/Driver/Dependencies/one-way-parseable.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-provides-after.swift
+++ b/test/Driver/Dependencies/one-way-provides-after.swift
@@ -1,7 +1,8 @@
 /// other | main
 /// other +==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-provides-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -24,7 +25,8 @@
 // RUN: touch -t 201401240007 %t/other.swift
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-provides-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/one-way-provides-before.swift
+++ b/test/Driver/Dependencies/one-way-provides-before.swift
@@ -1,7 +1,8 @@
 /// other +==> main
 /// other | main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-provides-before/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-before/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -28,7 +29,8 @@
 // CHECK-THIRD: Handled other.swift
 // CHECK-THIRD-NOT: Handled main.swift
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-provides-before/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-before/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/one-way-while-editing.swift
+++ b/test/Driver/Dependencies/one-way-while-editing.swift
@@ -1,6 +1,7 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path %S/Inputs/modify-non-primary-files.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/one-way.swift
+++ b/test/Driver/Dependencies/one-way.swift
@@ -1,6 +1,7 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -37,7 +38,8 @@
 // CHECK-FIFTH-NOT: Handled main.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
@@ -49,7 +51,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s

--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -1,5 +1,7 @@
 // XFAIL: linux
-// RUN: rm -rf %t && cp -r %S/Inputs/only-skip-once/ %t
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/only-skip-once/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/private-after.swift
+++ b/test/Driver/Dependencies/private-after.swift
@@ -1,7 +1,8 @@
 /// a --> b ==> c | a ==> d |    e ==> b |       f ==> g
 /// a --> b ==> c | a ==> d +==> e +==> b, e --> f ==> g
 
-// RUN: rm -rf %t && cp -r %S/Inputs/private-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/private-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -29,7 +30,8 @@
 // CHECK-A-NEG-NOT: Handled g.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/private-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/private-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/private.swift
+++ b/test/Driver/Dependencies/private.swift
@@ -1,6 +1,7 @@
 // a ==> b --> c ==> d | e ==> c
 
-// RUN: rm -rf %t && cp -r %S/Inputs/private/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/private/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/whole-module-build-record.swift
+++ b/test/Driver/Dependencies/whole-module-build-record.swift
@@ -1,6 +1,7 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/fake-build-whole-module.py -output-file-map %t/output.json -whole-module-optimization ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s


### PR DESCRIPTION
The copy would fail on Windows even with the GNUWin32 tools.  Use
%empty-directory to clean up and create the structure for the test.
NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
