### PR TITLE
[test] Add missing "executable_test" requirements

### DIFF
--- a/test/Interpreter/dynamic_replacement_chaining.swift
+++ b/test/Interpreter/dynamic_replacement_chaining.swift
@@ -16,6 +16,7 @@
 // RUN: %target-codesign %t/main %t/libA.%target-dylib-extension %t/libB.%target-dylib-extension %t/libC.%target-dylib-extension
 // RUN: %target-run %t/main %t/libA.%target-dylib-extension %t/libB.%target-dylib-extension %t/libC.%target-dylib-extension
 
+// REQUIRES: executable_test
 
 import A
 

--- a/test/Parse/strange_interpolation.swift
+++ b/test/Parse/strange_interpolation.swift
@@ -1,5 +1,10 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4.2
-// RUN: %target-run-simple-swift -swift-version 4.2 %s | %FileCheck %s
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -swift-version 4.2 %s -o %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
 
  let x = 1
 


### PR DESCRIPTION
These keep the tests from failing when running for device targets with `--param swift_test_mode=only_non_executable`.