### PR TITLE
Fix devirt_specialized_conformance with Debug stdlib builds.

### DIFF
--- a/test/SILOptimizer/devirt_specialized_conformance.swift
+++ b/test/SILOptimizer/devirt_specialized_conformance.swift
@@ -57,11 +57,14 @@ extension ContiguousArray : ContiguousBytes {}
 func takesPointer(_ p: UnsafeRawBufferPointer) {}
 
 // In specialized testWithUnsafeBytes<A>(_:), the conditional case and call to withUnsafeBytes must be eliminated.
+// Normally, we expect Array.withUnsafeBytes to be inlined so we would see:
+//   [[TAKES_PTR:%.*]] = function_ref @$s30devirt_specialized_conformance12takesPointeryySWF : $@convention(thin) (UnsafeRawBufferPointer) -> ()
+//   apply [[TAKES_PTR]](%{{.*}}) : $@convention(thin) (UnsafeRawBufferPointer) -> ()
+// But the inlining isn't consistent across builds with and without debug info.
+//
 // CHECK-LABEL: sil shared [noinline] @$s30devirt_specialized_conformance19testWithUnsafeBytesyyxlFSayypG_Tg5 : $@convention(thin) (@guaranteed Array<Any>) -> () {
 // CHECK: bb0
 // CHECK-NOT: witness_method
-// CHECK: [[TAKES_PTR:%.*]] = function_ref @$s30devirt_specialized_conformance12takesPointeryySWF : $@convention(thin) (UnsafeRawBufferPointer) -> ()
-// CHECK: apply [[TAKES_PTR]](%{{.*}}) : $@convention(thin) (UnsafeRawBufferPointer) -> ()
 // CHECK-LABEL: } // end sil function '$s30devirt_specialized_conformance19testWithUnsafeBytesyyxlFSayypG_Tg5'
 @inline(never)
 func testWithUnsafeBytes<T>(_ t: T) {


### PR DESCRIPTION
Fixes <rdar://problem/46486308>
test/SILOptimizer/devirt_specialized_conformance.swift fails on
Debug+Asssert stdlib bot

Note: I haven't yet figured out why debug info changes obvious
inlining decisions.

