### PR TITLE
[Sema] Emit a deprecation warning if a Hashable type only implements hashValue

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4263,6 +4263,10 @@ WARNING(non_exhaustive_switch_warn,none, "switch must be exhaustive", ())
 WARNING(override_nsobject_hashvalue,none,
         "override of 'NSObject.hashValue' is deprecated; "
         "override 'NSObject.hash' to get consistent hashing behavior", ())
+WARNING(hashvalue_implementation,none,
+        "'Hashable.hashValue' is deprecated as a protocol requirement; "
+        "conform type %0 to 'Hashable' by implementing 'hash(into:)' instead",
+        (Type))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1175,7 +1175,7 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
       // The hashValue failure will produce a diagnostic elsewhere.
       return nullptr;
     }
-    if (hashValueDecl && hashValueDecl->isImplicit()) {
+    if (hashValueDecl->isImplicit()) {
       // Neither hashValue nor hash(into:) is explicitly defined; we need to do
       // a full Hashable derivation.
       
@@ -1209,8 +1209,11 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
         llvm_unreachable("Attempt to derive Hashable for a type other "
                          "than a struct or enum");      
     } else {
-      // We can always derive hash(into:) if hashValue has an explicit
-      // implementation.
+      // hashValue has an explicit implementation, but hash(into:) doesn't.
+      // Emit a deprecation warning, then derive hash(into:) in terms of
+      // hashValue.
+      TC.diagnose(hashValueDecl->getLoc(), diag::hashvalue_implementation,
+                  Nominal->getDeclaredType());
       return deriveHashable_hashInto(*this,
                                      &deriveBodyHashable_compat_hashInto);
     }

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -106,6 +106,9 @@ public protocol Hashable : Equatable {
   ///
   /// Hash values are not guaranteed to be equal across different executions of
   /// your program. Do not save hash values to use during a future execution.
+  ///
+  /// - Important: `hashValue` is deprecated as a Hashable requirement. To
+  ///   conform to `Hashable`, implement the `hash(into:)` requirement instead.
   var hashValue: Int { get }
 
   /// Hashes the essential components of this value by feeding them into the

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -107,7 +107,7 @@ public protocol Hashable : Equatable {
   /// Hash values are not guaranteed to be equal across different executions of
   /// your program. Do not save hash values to use during a future execution.
   ///
-  /// - Important: `hashValue` is deprecated as a Hashable requirement. To
+  /// - Important: `hashValue` is deprecated as a `Hashable` requirement. To
   ///   conform to `Hashable`, implement the `hash(into:)` requirement instead.
   var hashValue: Int { get }
 

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -261,6 +261,60 @@ protocol ImplierMain: Equatable {}
 struct ImpliedMain: ImplierMain {}
 extension ImpliedOther: ImplierMain {}
 
+
+// Hashable conformances that rely on a manual implementation of `hashValue`
+// should produce a deprecation warning.
+struct OldSchoolStruct: Hashable {
+  static func ==(left: OldSchoolStruct, right: OldSchoolStruct) -> Bool {
+    return true
+  }
+  var hashValue: Int { return 42 }
+  // expected-warning@-1{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'OldSchoolStruct' to 'Hashable' by implementing 'hash(into:)' instead}}
+}
+enum OldSchoolEnum: Hashable {
+  case foo
+  case bar
+
+  static func ==(left: OldSchoolEnum, right: OldSchoolEnum) -> Bool {
+    return true
+  }
+  var hashValue: Int { return 23 }
+  // expected-warning@-1{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'OldSchoolEnum' to 'Hashable' by implementing 'hash(into:)' instead}}
+}
+class OldSchoolClass: Hashable {
+  static func ==(left: OldSchoolClass, right: OldSchoolClass) -> Bool {
+    return true
+  }
+  var hashValue: Int { return -9000 }
+  // expected-warning@-1{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'OldSchoolClass' to 'Hashable' by implementing 'hash(into:)' instead}}
+}
+
+// However, it's okay to implement `hashValue` as long as `hash(into:)` is also
+// provided.
+struct MixedStruct: Hashable {
+  static func ==(left: MixedStruct, right: MixedStruct) -> Bool {
+    return true
+  }
+  func hash(into hasher: inout Hasher) {}
+  var hashValue: Int { return 42 }
+}
+enum MixedEnum: Hashable {
+  case foo
+  case bar
+  static func ==(left: MixedEnum, right: MixedEnum) -> Bool {
+    return true
+  }
+  func hash(into hasher: inout Hasher) {}
+  var hashValue: Int { return 23 }
+}
+class MixedClass: Hashable {
+  static func ==(left: MixedClass, right: MixedClass) -> Bool {
+    return true
+  }
+  func hash(into hasher: inout Hasher) {}
+  var hashValue: Int { return -9000 }
+}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'


### PR DESCRIPTION
SE-206 deprecated `hashValue` as a protocol requirement. We should gently encourage people to migrate to `hash(into:)`, for its more secure, easier and faster hashing.

Emit a compiler warning whenever `hashValue` has an explicit implementation, but `hash(into:)` doesn’t.

rdar://problem/39838478

(This was originally part of #20685)