### PR TITLE
Don't crash when modifying a global observed variable

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -675,10 +675,10 @@ void SILGenModule::visitFuncDecl(FuncDecl *fd) { emitFunction(fd); }
 /// Emit a function now, if it's externally usable or has been referenced in
 /// the current TU, or remember how to emit it later if not.
 template<typename /*void (SILFunction*)*/ Fn>
-void emitOrDelayFunction(SILGenModule &SGM,
-                         SILDeclRef constant,
-                         Fn &&emitter,
-                         bool forceEmission = false) {
+static void emitOrDelayFunction(SILGenModule &SGM,
+                                SILDeclRef constant,
+                                Fn &&emitter,
+                                bool forceEmission = false) {
   auto emitAfter = SGM.lastEmittedFunction;
 
   SILFunction *f = nullptr;
@@ -1312,7 +1312,8 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
       case AccessorKind::Read:
         return impl.getReadImpl() != ReadImplKind::Read;
       case AccessorKind::Set:
-        return impl.getWriteImpl() != WriteImplKind::Set;
+        return impl.getWriteImpl() != WriteImplKind::Set &&
+               impl.getWriteImpl() != WriteImplKind::StoredWithObservers;
       case AccessorKind::Modify:
         return impl.getReadWriteImpl() != ReadWriteImplKind::Modify;
 #define ACCESSOR(ID) \

--- a/test/SILGen/lazy_global_access.swift
+++ b/test/SILGen/lazy_global_access.swift
@@ -22,3 +22,16 @@ func useProps() -> (Int, Int) {
   return (globalProp, Fooo.staticProp)
 }
 
+// rdar://46472759
+// We used to crash tying to double-emit the setter.
+struct Bar {
+  mutating func mutate() {}
+}
+func useGlobalBar() -> Bar {
+  globalBar = Bar()
+  globalBar.mutate()
+  return globalBar
+}
+private var globalBar = Bar() {
+  willSet {}
+}


### PR DESCRIPTION
The terrible hack in SILGen here is to not visit opaque accessors of global variables if they were added to the decls list by the parser.  That needs to include the setter for an observed global variable, which we apparently did not have tests of.

rdar://46472759