### PR TITLE
Use VJP in differentiation

### DIFF
--- a/test/AutoDiff/autodiff_e2e_basic.swift
+++ b/test/AutoDiff/autodiff_e2e_basic.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -differentiation-use-vjp -emit-sil %s | %FileCheck %s
 
 @differentiable(reverse, adjoint: adjointId)
 func id(_ x: Float) -> Float {

--- a/test/AutoDiff/method.swift
+++ b/test/AutoDiff/method.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-use-vjp-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/nested_calls.sil
+++ b/test/AutoDiff/nested_calls.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -differentiation-use-vjp -emit-sil %s | %FileCheck %s
 
 import Builtin
 import Swift
@@ -13,7 +13,7 @@ bb0(%0 : @trivial $Float):
 
 sil @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float {
 bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float, %3 : @trivial $Float):
-  return %3 : $Float
+  return %0 : $Float
 }
 
 sil [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
@@ -34,21 +34,24 @@ sil [differentiable source 0 wrt 0] @func_to_diff : $@convention(thin) (Float) -
 bb0(%0 : @trivial $Float):
   %1 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
   %2 = apply %1(%0) : $@convention(thin) (Float) -> Float
+
+  // Note: This apply is not included in the result, so it doesn't get differentiated.
   %3 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
   %4 = apply %3(%2) : $@convention(thin) (Float) -> Float
+
   %5 = tuple (%2 : $Float, %2 : $Float)
   %6 = tuple_extract %5 : $(Float, Float), 0
   return %6 : $Float
 }
 
 // CHECK-LABEL: struct AD__func_to_diff__Type__src_0_wrt_0 {
-// CHECK-NEXT:   @sil_stored var pv_0: AD__nested_func_without_diffattr__Type__src_0_wrt_0
 // CHECK-NEXT:   @sil_stored var v_0: Float
+// CHECK-NEXT:   @sil_stored var pullback_0: (Float) -> Float
 // CHECK-NEXT: }
 
 // CHECK-LABEL: struct AD__nested_func_without_diffattr__Type__src_0_wrt_0 {
-// CHECK-NEXT:   @sil_stored var pv_0: Float
 // CHECK-NEXT:   @sil_stored var v_0: Float
+// CHECK-NEXT:   @sil_stored var pullback_0: (Float) -> Float
 // CHECK-NEXT: }
 
 // CHECK-LABEL: @foo_prim : $@convention(thin) (Float) -> (Float, Float) {
@@ -59,45 +62,71 @@ bb0(%0 : @trivial $Float):
 
 // CHECK-LABEL: @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float {
 // CHECK: bb0(%0 : $Float, %1 : $Float, %2 : $Float, %3 : $Float):
-// CHECK:   return %3 : $Float
-// CHECK: }
-
-// CHECK-LABEL: [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj vjp @AD__foo__vjp_src_0_wrt_0] @foo : $@convention(thin) (Float) -> Float {
-// CHECK: bb0(%0 : $Float):
 // CHECK:   return %0 : $Float
 // CHECK: }
 
-// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 vjp @AD__nested_func_without_diffattr__vjp_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {
-// CHECK: bb0(%0 : $Float):
-// CHECK:   return %0 : $Float
-// CHECK: }
+// CHECK-LABEL: [differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj vjp @AD__foo__vjp_src_0_wrt_0] @foo : $@convention(thin) (Float) -> Float
 
-// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__func_to_diff__primal_src_0_wrt_0 adjoint @AD__func_to_diff__adjoint_src_0_wrt_0 vjp @AD__func_to_diff__vjp_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float {
-// CHECK: bb0(%0 : $Float):
-// CHECK:   return %0 : $Float
-// CHECK: }
+// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 vjp @AD__nested_func_without_diffattr__vjp_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
+
+// CHECK-LABEL: [differentiable source 0 wrt 0 primal @AD__func_to_diff__primal_src_0_wrt_0 adjoint @AD__func_to_diff__adjoint_src_0_wrt_0 vjp @AD__func_to_diff__vjp_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float
 
 // CHECK-LABEL: @AD__func_to_diff__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__func_to_diff__Type__src_0_wrt_0, Float) {
 // CHECK: bb0(%0 : $Float):
-// CHECK:   %1 = struct $AD__nested_func_without_diffattr__Type__src_0_wrt_0 (%0 : $Float, %0 : $Float)
-// CHECK:   %2 = struct $AD__func_to_diff__Type__src_0_wrt_0 (%1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %0 : $Float)
-// CHECK:   %3 = tuple (%2 : $AD__func_to_diff__Type__src_0_wrt_0, %0 : $Float)
-// CHECK:   return %3 : $(AD__func_to_diff__Type__src_0_wrt_0, Float)
+// CHECK:   %1 = function_ref @AD__nested_func_without_diffattr__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:   %2 = apply %1(%0) : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:   %3 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 0
+// CHECK:   %4 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 1
+// CHECK:   %5 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
+// CHECK:   %6 = apply %5(%3) : $@convention(thin) (Float) -> Float
+// CHECK:   %7 = tuple (%3 : $Float, %3 : $Float)
+// CHECK:   %8 = tuple_extract %7 : $(Float, Float), 0
+// CHECK:   %9 = struct $AD__func_to_diff__Type__src_0_wrt_0 (%3 : $Float, %4 : $@callee_guaranteed (Float) -> Float)
+// CHECK:   %10 = tuple (%9 : $AD__func_to_diff__Type__src_0_wrt_0, %8 : $Float)
+// CHECK:   return %10 : $(AD__func_to_diff__Type__src_0_wrt_0, Float)
 // CHECK: }
 
 // CHECK-LABEL: @AD__func_to_diff__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__func_to_diff__Type__src_0_wrt_0, Float, Float) -> Float {
 // CHECK: bb0(%0 : $Float, %1 : $AD__func_to_diff__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
-// CHECK:   return %3 : $Float
+// CHECK:   %4 = struct_extract %1 : $AD__func_to_diff__Type__src_0_wrt_0, #AD__func_to_diff__Type__src_0_wrt_0.pullback_0
+// CHECK:   %5 = alloc_stack $Float
+// CHECK:   %6 = begin_access [init] [static] [no_nested_conflict] %5 : $*Float
+// CHECK:   %7 = begin_access [init] [static] [no_nested_conflict] %6 : $*Float
+// CHECK:   store %0 to %7 : $*Float
+// CHECK:   end_access %7 : $*Float
+// CHECK:   end_access %6 : $*Float
+// CHECK:   %11 = begin_access [read] [static] [no_nested_conflict] %5 : $*Float
+// CHECK:   %12 = load %11 : $*Float
+// CHECK:   end_access %11 : $*Float
+// CHECK:   %14 = apply %4(%12) : $@callee_guaranteed (Float) -> Float
+// CHECK:   dealloc_stack %5 : $*Float
+// CHECK:   return %14 : $Float
 // CHECK: }
 
 // CHECK-LABEL: @AD__nested_func_without_diffattr__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float) {
 // CHECK: bb0(%0 : $Float):
-// CHECK:   %1 = struct $AD__nested_func_without_diffattr__Type__src_0_wrt_0 (%0 : $Float, %0 : $Float)
-// CHECK:   %2 = tuple (%1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %0 : $Float)
-// CHECK:   return %2 : $(AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float)
+// CHECK:   %1 = function_ref @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:   %2 = apply %1(%0) : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:   %3 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 0
+// CHECK:   %4 = tuple_extract %2 : $(Float, @callee_guaranteed (Float) -> Float), 1
+// CHECK:   %5 = struct $AD__nested_func_without_diffattr__Type__src_0_wrt_0 (%3 : $Float, %4 : $@callee_guaranteed (Float) -> Float)
+// CHECK:   %6 = tuple (%5 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %3 : $Float)
+// CHECK:   return %6 : $(AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float)
 // CHECK: }
 
 // CHECK-LABEL: @AD__nested_func_without_diffattr__adjoint_src_0_wrt_0 : $@convention(thin) (Float, AD__nested_func_without_diffattr__Type__src_0_wrt_0, Float, Float) -> Float {
 // CHECK: bb0(%0 : $Float, %1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
-// CHECK:   return %3 : $Float
+// CHECK:   %4 = struct_extract %1 : $AD__nested_func_without_diffattr__Type__src_0_wrt_0, #AD__nested_func_without_diffattr__Type__src_0_wrt_0.pullback_0
+// CHECK:   %5 = alloc_stack $Float
+// CHECK:   %6 = begin_access [init] [static] [no_nested_conflict] %5 : $*Float
+// CHECK:   %7 = begin_access [init] [static] [no_nested_conflict] %6 : $*Float
+// CHECK:   store %0 to %7 : $*Float
+// CHECK:   end_access %7 : $*Float
+// CHECK:   end_access %6 : $*Float
+// CHECK:   %11 = begin_access [read] [static] [no_nested_conflict] %5 : $*Float
+// CHECK:   %12 = load %11 : $*Float
+// CHECK:   end_access %11 : $*Float
+// CHECK:   %14 = apply %4(%12) : $@callee_guaranteed (Float) -> Float
+// CHECK:   dealloc_stack %5 : $*Float
+// CHECK:   return %14 : $Float
 // CHECK: }

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -differentiation-use-vjp -emit-sil %s | %FileCheck %s
 
 public class NonTrivialStuff : Equatable {
   public init() {}
@@ -37,6 +37,8 @@ _ = #gradient(testOwnedVector)
 // CHECK-LABEL: struct {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0 {
 // CHECK-NEXT:   @sil_stored @usableFromInline
 // CHECK-NEXT:   var v_0: Vector
+// CHECK-NEXT:   @sil_stored @usableFromInline
+// CHECK-NEXT:   var pullback_0: (Vector) -> (Vector, Vector)
 // CHECK-NEXT: }
 
 // CHECK-LABEL: @{{.*}}testOwnedVector{{.*}}__grad_src_0_wrt_0_s_p
@@ -52,16 +54,20 @@ _ = #gradient(testOwnedVector)
 // The primal should not release primal values.
 //
 // CHECK-LABEL: @{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0 : $@convention(thin) (@guaranteed Vector) -> (@owned {{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, @owned Vector) {
-// CHECK:   [[ADD:%.*]] = function_ref @$s11refcounting6VectorV1poiyA2C_ACtFZ : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> @owned Vector
-// CHECK:   [[ADD_RESULT:%.*]] = apply [[ADD]]({{.*}}, {{.*}}, {{.*}}) : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> @owned Vector
-// CHECK-NOT: release_value [[ADD_RESULT]]
-// CHECK:   struct ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0 ([[ADD_RESULT]] : $Vector)
-// CHECK-NOT: release_value [[ADD_RESULT]]
+// CHECK:   [[ADD_VJP:%.*]] = function_ref @AD__$s11refcounting6VectorV1poiyA2C_ACtFZ__vjp_src_0_wrt_0_1 : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> (@owned Vector, @owned @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector))
+// CHECK:   [[ADD_VJP_RESULT:%.*]] = apply [[ADD_VJP]]({{.*}}, {{.*}}, {{.*}}) : $@convention(method) (@guaranteed Vector, @guaranteed Vector, @thin Vector.Type) -> (@owned Vector, @owned @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector))
+// CHECK:   [[ADD_ORIGINAL_RESULT:%.*]] = tuple_extract [[ADD_VJP_RESULT]] : $(Vector, @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector)), 0
+// CHECK:   [[ADD_PULLBACK:%.*]] = tuple_extract [[ADD_VJP_RESULT]] : $(Vector, @callee_guaranteed (@guaranteed Vector) -> (@owned Vector, @owned Vector)), 1
+// CHECK-NOT:   release_value [[ADD_VJP_RESULT]]
+// CHECK-NOT:   release_value [[ADD_ORIGINAL_RESULT]]
+// CHECK-NOT:   release_value [[ADD_PULLBACK]]
+// CHECK:   } // end sil function '{{.*}}testOwnedVector{{.*}}__primal_src_0_wrt_0'
 
 // The adjoint should not release primal values because they are passed in as @guaranteed.
 //
 // CHECK-LABEL: @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
 // CHECK: bb0({{%.*}} : $Vector, [[PRIMAL_VALUES:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, {{%.*}} : $Vector, {{%.*}} : $Vector):
-// CHECK:   [[PV0:%.*]] = struct_extract [[PRIMAL_VALUES]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0.v_0
-// CHECK-NOT:   release_value [[PV0]]
+// CHECK:   [[PULLBACK0:%.*]] = struct_extract [[PRIMAL_VALUES]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0.pullback_0
+// CHECK-NOT:   release_value [[PULLBACK0]]
 // CHECK-NOT:   release_value [[PRIMAL_VALUES]]
+// CHECK:   } // end sil function '{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0'

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-use-vjp-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/simple_model.swift
+++ b/test/AutoDiff/simple_model.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-run-use-vjp-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1143,6 +1143,12 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
+    config.target_run_swift_use_vjp = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -Xllvm -differentiation-use-vjp -o %%t/a.out -module-name main %s && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
 
     config.target_run_simple_opt_O_swift = (
         '%%empty-directory(%%t) && '
@@ -1282,6 +1288,7 @@ config.substitutions.append(('%target-run-simple-swift', config.target_run_simpl
 # SWIFT_ENABLE_TENSORFLOW
 config.substitutions.append(('%target-run-send-recv-handle-swift', config.target_run_simple_swift_send_recv_handle))
 config.substitutions.append(('%target-run-dynamic-compilation-swift', config.target_run_swift_dynamic_compilation))
+config.substitutions.append(('%target-run-use-vjp-swift', config.target_run_swift_use_vjp))
 config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))
 config.substitutions.append(('%target-run-simple-opt-Osize-swift', config.target_run_simple_opt_Osize_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb-swift3', config.target_run_stdlib_swiftgyb_swift3))


### PR DESCRIPTION
(This is on top of #21062. Ask GitHub to see the last commit to see the changes before I merge #21062).

This teaches the differentiation pass to use VJPs.

I put it under a flag because the TensorFlow autodiff tests are still failing. I will investigate those failures next.