### PR TITLE
[SIL Diagnostics] Create a mandatory pass to check correct usage of yields in generalized accessors: _read and _modify

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -358,6 +358,19 @@ WARNING(warning_int_to_fp_inexact, none,
   "'%1' is not exactly representable as %0; it becomes '%2'",
   (Type, StringRef, StringRef))
 
+
+// Yield usage errors
+ERROR(return_before_yield, none, "accessor must yield before returning",())
+
+ERROR(multiple_yields, none, "accessor must not yield more than once", ())
+
+NOTE(previous_yield, none, "previous yield was here", ())
+
+ERROR(possible_return_before_yield, none,
+      "accessor must yield on all paths before returning", ())
+
+NOTE(one_yield, none, "yield along one path is here", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -299,6 +299,8 @@ PASS(SimplifyUnreachableContainingBlocks, "simplify-unreachable-containing-block
      "Utility pass. Removes all non-term insts from blocks with unreachable terms")
 PASS(SerializeSILPass, "serialize-sil",
      "Utility pass. Serializes the current SILModule")
+PASS(YieldOnceCheck, "yield-once-check",
+    "Check correct usage of yields in yield-once coroutines")
 PASS(BugReducerTester, "bug-reducer-tester",
      "sil-bug-reducer Tool Testing by Asserting on a Sentinel Function")
 PASS_RANGE(AllPasses, AADumper, BugReducerTester)

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4496,7 +4496,7 @@ public:
   /// - accesses must be uniquely ended
   /// - flow-sensitive states must be equivalent on all paths into a block
   void verifyFlowSensitiveRules(SILFunction *F) {
-    // Do a breath-first search through the basic blocks.
+    // Do a traversal of the basic blocks.
     // Note that we intentionally don't verify these properties in blocks
     // that can't be reached from the entry block.
     llvm::DenseMap<SILBasicBlock*, VerifyFlowSensitiveRulesDetails::BBState> visitedBBs;

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -17,4 +17,5 @@ silopt_register_sources(
   SemanticARCOpts.cpp
   ClosureLifetimeFixup.cpp
   RawSILInstLowering.cpp
+  YieldOnceCheck.cpp
 )

--- a/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
+++ b/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
@@ -1,0 +1,325 @@
+//===------ YieldOnceCheck.cpp - Check usage of yields in accessors  ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This pass statically verifies that yield-once coroutines, such as the
+// generalized accessors `read` and `modify`, yield exactly once in every
+// invocation, and diagnoses any violation of this property. This pass uses a
+// linear-time, data-flow analysis to check that every path in the control-flow
+// graph of the coroutine has a yield instruction before a return instruction.
+
+#define DEBUG_TYPE "yield-once-check"
+#include "swift/AST/ASTWalker.h"
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/Stmt.h"
+#include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/Dominance.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/ADT/DenseSet.h"
+
+using namespace swift;
+
+namespace {
+
+class YieldOnceCheck : public SILFunctionTransform {
+
+  template <typename... T, typename... U>
+  static InFlightDiagnostic diagnose(ASTContext &Context, SourceLoc loc,
+                                     Diag<T...> diag, U &&... args) {
+    return Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+  }
+
+  /// Data-flow analysis state that is associated with basic blocks.
+  struct BBState {
+
+    /// Indicates whether a basic block is encountered before seeing a yield
+    /// (BeforeYield) or after seeing a yield (AfterYield), or in both states
+    /// (Conflict). This enum is a semi-lattice where Conflict is the top and
+    /// the merge of BeforeYield and AfterYield states is Conflict.
+    enum YieldState { BeforeYield, AfterYield, Conflict } yieldState;
+
+  private:
+    // The following state is maintained for emitting diagnostics.
+
+    /// For AfterYield and Conflict states, this field records the yield
+    /// instruction that was seen while propagating the state.
+    SILInstruction *yieldInst;
+
+    BBState(YieldState yState, SILInstruction *yieldI)
+        : yieldState(yState), yieldInst(yieldI) {}
+
+  public:
+    static BBState getInitialState() { return BBState(BeforeYield, nullptr); }
+
+    static BBState getAfterYieldState(SILInstruction *yieldI) {
+      assert(yieldI);
+      return BBState(AfterYield, yieldI);
+    }
+
+    static BBState getConflictState(SILInstruction *yieldI) {
+      assert(yieldI);
+      return BBState(Conflict, yieldI);
+    }
+
+    SILInstruction *getYieldInstruction() const {
+      assert(yieldState == AfterYield || yieldState == Conflict);
+      return yieldInst;
+    }
+  };
+
+  /// A structure that records an error found during the analysis along with
+  /// some context information that will be used by diagnostics.
+  struct YieldError {
+    /// The kind of error.
+    enum Kind { MultipleYield, ReturnBeforeYield, ReturnOnConflict } errorKind;
+    /// The termination instruction where the error should be reported.
+    SILInstruction *termInst;
+    /// The input state when the error is encountered.
+    BBState inState;
+
+  private:
+    YieldError(Kind kind, SILInstruction *term, BBState state)
+        : errorKind(kind), termInst(term), inState(state) {}
+
+  public:
+    static YieldError getMultipleYieldError(YieldInst *yield, BBState state) {
+      assert(state.yieldState != BBState::BeforeYield);
+      return YieldError(MultipleYield, yield, state);
+    }
+
+    static YieldError getReturnBeforeYieldError(ReturnInst *returnI,
+                                                BBState state) {
+      assert(state.yieldState == BBState::BeforeYield);
+      return YieldError(ReturnBeforeYield, returnI, state);
+    }
+
+    static YieldError getReturnOnConflict(ReturnInst *returnI, BBState state) {
+      assert(state.yieldState == BBState::Conflict);
+      return YieldError(ReturnOnConflict, returnI, state);
+    }
+  };
+
+  /// Transfer function of the data-flow analysis.
+  ///
+  /// \param bb Basic block that should be processed
+  /// \param inState BBState at the start of the basic block
+  /// \param error out parameter that will contain information about
+  /// an error that is detected.
+  /// \return the state at the exit of the basic block if it can be computed
+  /// and None otherwise.
+  static Optional<BBState>
+  transferStateThroughBasicBlock(SILBasicBlock *bb, BBState inState,
+                                 Optional<YieldError> &error) {
+    error = None;
+    auto *term = bb->getTerminator();
+
+    if (auto *returnInst = dyn_cast<ReturnInst>(term)) {
+      if (inState.yieldState == BBState::BeforeYield) {
+        error = YieldError::getReturnBeforeYieldError(returnInst, inState);
+        return None;
+      }
+
+      if (inState.yieldState == BBState::Conflict) {
+        error = YieldError::getReturnOnConflict(returnInst, inState);
+        return None;
+      }
+      return inState;
+    }
+
+    if (auto *yieldInst = dyn_cast<YieldInst>(term)) {
+      if (inState.yieldState != BBState::BeforeYield) {
+        error = YieldError::getMultipleYieldError(yieldInst, inState);
+        return None;
+      }
+
+      // If the current state is BeforeYield and if the basic block ends in a
+      // yield the new state is AfterYield.
+      return inState.getAfterYieldState(term);
+    }
+
+    // We cannot have throws within generalized accessors.
+    assert(!isa<ThrowInst>(term));
+
+    return inState;
+  }
+
+  /// Merge operation of the data-flow analysis.
+  ///
+  /// \param mergeBlock the basic block that is reached with two states
+  /// \param oldState the previous state at the entry of the basic block
+  /// \param newState the current state at the entry of the basic block
+  /// \return the new state obtained by merging the oldState with the newState
+  static BBState merge(SILBasicBlock *mergeBlock, BBState oldState,
+                       BBState newState) {
+    auto oldYieldState = oldState.yieldState;
+    auto newYieldState = newState.yieldState;
+
+    if (oldYieldState == BBState::Conflict) {
+      return oldState;
+    }
+
+    if (newYieldState == BBState::Conflict) {
+      return newState;
+    }
+
+    if (oldYieldState == newYieldState) {
+      return oldState;
+    }
+
+    // Here, one state is AfterYield and the other one is BeforeYield.
+    // Merging them will result in Conflict.
+    assert((newYieldState == BBState::AfterYield &&
+            oldYieldState == BBState::BeforeYield) ||
+           (newYieldState == BBState::BeforeYield &&
+            oldYieldState == BBState::AfterYield));
+
+    SILInstruction *yieldInst = (newYieldState == BBState::AfterYield)
+                                    ? newState.getYieldInstruction()
+                                    : oldState.getYieldInstruction();
+
+    return BBState::getConflictState(yieldInst);
+  }
+
+  /// Perform a data-flow analysis to check whether there is exactly one
+  /// yield before a return in every path in the control-flow graph.
+  /// Diagnostics are not reported for nodes unreachable from the entry of
+  /// the control-flow graph.
+  void diagnoseYieldOnceUsage(SILFunction &fun) {
+    llvm::DenseMap<SILBasicBlock *, BBState> bbToStateMap;
+    SmallVector<SILBasicBlock *, 16> worklist;
+
+    auto *entryBB = fun.getEntryBlock();
+    bbToStateMap.try_emplace(entryBB, BBState::getInitialState());
+    worklist.push_back(entryBB);
+
+    // ReturnBeforeYield errors, which denote that no paths yield before
+    // returning, are not diagnosed until the analysis completes, in order to
+    // distinguish them from ReturnOnConflict errors, which happen when some
+    // paths yield and some don't.
+    Optional<YieldError> returnBeforeYieldError = None;
+
+    // The algorithm uses a worklist to propagate the state through basic
+    // blocks until a fix point. Since the state lattice has height one, each
+    // basic block will be visited at most twice, and at most once if there are
+    // no conflicts (which are errors). The basic blocks are added to the
+    // worklist in a breadth-first fashion. The order of visiting basic blocks
+    // is not important for correctness, but it could change the errors
+    // diagnosed when there are multiple errors. Breadth-first order diagnoses
+    // errors along shorter paths to return.
+    while (!worklist.empty()) {
+      SILBasicBlock *bb = worklist.pop_back_val();
+      const BBState &state = bbToStateMap.find(bb)->getSecond();
+
+      Optional<YieldError> errorResult = None;
+      auto resultState = transferStateThroughBasicBlock(bb, state, errorResult);
+
+      if (!resultState.hasValue()) {
+        auto error = errorResult.getValue();
+
+        // ReturnBeforeYield errors will not be reported until the analysis
+        // completes. So record it and continue.
+        if (error.errorKind == YieldError::ReturnBeforeYield) {
+          if (!returnBeforeYieldError.hasValue()) {
+            returnBeforeYieldError = error;
+          }
+          continue;
+        }
+
+        emitDiagnostics(error, fun);
+        return;
+      }
+
+      auto nextState = resultState.getValue();
+
+      for (auto *succBB : bb->getSuccessorBlocks()) {
+        // Optimistically try to set the state of the successor as next state.
+        auto insertResult = bbToStateMap.try_emplace(succBB, nextState);
+
+        // If the insertion was successful, it means we are seeing the successor
+        // for the first time. Add the successor to the worklist.
+        if (insertResult.second) {
+          worklist.insert(worklist.begin(), succBB);
+          continue;
+        }
+
+        // Here the successor already has a state. Merge the current and
+        // previous states and propagate it if it is different from the
+        // old state.
+        const auto &oldState = insertResult.first->second;
+        auto mergedState = merge(succBB, oldState, nextState);
+
+        if (mergedState.yieldState == oldState.yieldState)
+          continue;
+
+        // Even though at this point there has to be an error since there is an
+        // inconsistency between states coming along two different paths,
+        // continue propagation of this conflict state to determine
+        // whether this results in multiple-yields error or return-on-conflict
+        // error.
+        insertResult.first->second = mergedState;
+        worklist.insert(worklist.begin(), succBB);
+      }
+    }
+
+    if (returnBeforeYieldError.hasValue()) {
+      emitDiagnostics(returnBeforeYieldError.getValue(), fun);
+    }
+  }
+
+  void emitDiagnostics(YieldError &error, SILFunction &fun) {
+    ASTContext &astCtx = fun.getModule().getASTContext();
+
+    switch (error.errorKind) {
+    case YieldError::ReturnBeforeYield: {
+      diagnose(astCtx, error.termInst->getLoc().getSourceLoc(),
+               diag::return_before_yield);
+      return;
+    }
+    case YieldError::MultipleYield: {
+      diagnose(astCtx, error.termInst->getLoc().getSourceLoc(),
+               diag::multiple_yields);
+
+      // Add a note that points to the previous yield.
+      diagnose(astCtx,
+               error.inState.getYieldInstruction()->getLoc().getSourceLoc(),
+               diag::previous_yield);
+      return;
+    }
+    case YieldError::ReturnOnConflict: {
+      // Emit an error on the return statement.
+      diagnose(astCtx, error.termInst->getLoc().getSourceLoc(),
+               diag::possible_return_before_yield);
+
+      // Add a note that points to the yield instruction found.
+      auto *yieldInst = error.inState.getYieldInstruction();
+      diagnose(astCtx, yieldInst->getLoc().getSourceLoc(), diag::one_yield);
+    }
+    }
+  }
+
+  /// The entry point to the transformation.
+  void run() override {
+    auto *fun = getFunction();
+
+    if (fun->getLoweredFunctionType()->getCoroutineKind() !=
+        SILCoroutineKind::YieldOnce)
+      return;
+
+    diagnoseYieldOnceUsage(*fun);
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createYieldOnceCheck() {
+  return new YieldOnceCheck();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -124,6 +124,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   P.addGuaranteedARCOpts();
   P.addDiagnoseUnreachable();
   P.addDiagnoseInfiniteRecursion();
+  P.addYieldOnceCheck();
   P.addEmitDFDiagnostics();
   // Canonical swift requires all non cond_br critical edges to be split.
   P.addSplitNonCondBrCriticalEdges();

--- a/test/SILOptimizer/generalized_accessors.sil
+++ b/test/SILOptimizer/generalized_accessors.sil
@@ -1,0 +1,107 @@
+// RUN: %target-sil-opt %s -yield-once-check -o /dev/null -verify
+//
+// SIL-level tests for yield-once diagnostics emitted for yield-once coroutines.
+// Note that the yield-once check runs on all functions with yield_once
+// qualifier in their type, regardless of whether or not they are
+// accessors of a property. In fact, currently it is not possible to parse
+// a property with _read and _modify accessors from a SIL source.
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+sil @testNoYield : $@yield_once @convention(thin) () -> @yields Int {
+bb0:
+%2 = tuple ()
+return %2 : $() // expected-error {{accessor must yield before returning}}
+}
+
+struct TestYield {
+  var flag : Builtin.Int1
+  var stored: Int64
+}
+
+sil @testMultipleYields : $@yield_once @convention(thin) (TestYield) -> @yields Int64 {
+bb0(%0 : $TestYield):
+%1 = struct_extract %0 : $TestYield, #TestYield.flag
+cond_br %1, bb1, bb3
+
+bb1:
+%5 = struct_extract %0 : $TestYield, #TestYield.stored
+yield %5 : $Int64, resume bb2, unwind bb6 // expected-note {{previous yield was here}}
+
+bb2:
+br bb4
+
+bb3:
+br bb4
+
+bb4:
+%9 = struct_extract %0 : $TestYield, #TestYield.stored
+yield %9 : $Int64, resume bb5, unwind bb7 // expected-error {{accessor must not yield more than once}}
+
+bb5:
+%11 = tuple ()
+return %11 : $()
+
+bb6:
+br bb8
+
+bb7:
+br bb8
+
+bb8:
+unwind
+}
+
+sil @testPartialReturnWithoutYield : $@yield_once @convention(thin) (TestYield) -> @yields Int64 {
+bb0(%0 : $TestYield):
+%1 = struct_extract %0 : $TestYield, #TestYield.flag
+cond_br %1, bb1, bb3
+
+bb1:
+%5 = struct_extract %0 : $TestYield, #TestYield.stored
+yield %5 : $Int64, resume bb2, unwind bb5   // expected-note {{yield along one path is here}}
+
+bb2:
+br bb4
+
+bb3:
+br bb4
+
+bb4:
+%21 = tuple ()
+return %21 : $()                          // expected-error {{accessor must yield on all paths before returning}}
+
+bb5:
+unwind
+}
+
+sil @testExplicitReturns : $@yield_once @convention(thin) (TestYield) -> @yields Int64 {
+bb0(%0 : $TestYield):
+%2 = struct_extract %0 : $TestYield, #TestYield.stored
+%3 = integer_literal $Builtin.Int64, 0
+%4 = struct_extract %2 : $Int64, #Int64._value
+%5 = builtin "cmp_slt_Int64"(%3 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int1
+%6 = struct $Bool (%5 : $Builtin.Int1)
+%7 = struct_extract %6 : $Bool, #Bool._value
+cond_br %7, bb1, bb2
+
+bb1:
+br bb4
+
+bb2:
+%10 = struct_extract %0 : $TestYield, #TestYield.stored
+yield %10 : $Int64, resume bb3, unwind bb5    // expected-note {{yield along one path is here}}
+
+bb3:
+br bb4
+
+bb4:
+%13 = tuple ()
+return %13 : $()                            // expected-error {{accessor must yield on all paths before returning}}
+
+bb5:
+unwind
+}

--- a/test/SILOptimizer/generalized_accessors.swift
+++ b/test/SILOptimizer/generalized_accessors.swift
@@ -1,0 +1,488 @@
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+//
+// Tests for yield-once diagnostics emitted for generalized accessors.
+
+struct TestNoYield {
+  var computed: Int {
+    _read {
+    } // expected-error {{accessor must yield before returning}}
+
+    _modify {
+    } // expected-error {{accessor must yield before returning}}
+  }
+}
+
+struct TestReturnPathWithoutYield {
+  var stored: Int
+  var flag: Bool
+
+  var computed: Int {
+    mutating _read {
+      if flag {
+        yield stored // expected-note {{yield along one path is here}}
+      }
+      flag = true
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      // Diagnostics should attach a note to the earliest conflicting branch.
+      if flag {
+        yield &stored // expected-note {{yield along one path is here}}
+      }
+
+      if !flag {
+        flag = true
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestIfElseWithoutYield {
+  var stored: Int
+  var flag: Bool
+
+  var computed: Int {
+    mutating _read {
+      if flag {
+        yield stored // expected-note {{yield along one path is here}}
+      } else {
+        flag = true
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      if flag {
+        flag = true
+      } else {
+        yield &stored // expected-note {{yield along one path is here}}
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+
+struct TestMultipleYields {
+  var stored: Int
+  var flag: Bool
+  var computed: Int {
+    _read {
+      if flag {
+        yield stored // expected-note {{previous yield was here}}
+      }
+      yield stored // expected-error {{accessor must not yield more than once}}
+    }
+
+    _modify {
+      yield &stored // expected-note {{previous yield was here}}
+      if flag {
+        yield &stored // expected-error {{accessor must not yield more than once}}
+      }
+    }
+  }
+}
+
+struct TestMultipleYields2 {
+  var stored: Int
+  var flag: Bool
+  var computed: Int {
+    _read {
+      if flag {
+        yield stored
+        return
+      }
+      yield stored
+    }
+
+    _modify {
+      if flag {
+        yield &stored
+      } else {
+        yield &stored
+      }
+    }
+  }
+}
+
+ struct TestConvolutedPaths {
+  var flag: Bool
+  var stored : Int
+
+  var computed: Int {
+    _read {
+      if flag {
+        yield stored // expected-note {{previous yield was here}}
+      }
+      if !flag {
+        yield stored // expected-error {{accessor must not yield more than once}}
+      }
+    }
+
+    _modify {
+      if flag {
+        yield &stored // expected-note {{previous yield was here}}
+      }
+      if !flag {
+        yield &stored // expected-error {{accessor must not yield more than once}}
+      }
+    }
+  }
+}
+
+struct TestYieldInLoops {
+  var stored: Int
+  var count: Int
+  var computed: Int {
+    _read {
+      for _ in 0..<count {
+        yield stored // expected-error {{accessor must not yield more than once}}
+                     // expected-note@-1 {{previous yield was here}}
+      }
+    }
+
+    _modify {
+      yield &stored // expected-note {{previous yield was here}}
+      for _ in 0..<count {
+        yield &stored // expected-error {{accessor must not yield more than once}}
+      }
+    }
+  }
+}
+
+enum CompassPoint {
+  case north
+  case south
+  case east
+  case west
+}
+
+struct TestYieldInSwitch {
+  var stored: Int
+  var cp: CompassPoint
+
+  var computed: Int {
+    get { return stored }
+    _modify {
+      switch cp {
+      case .north:
+        yield &stored // expected-note {{yield along one path is here}}
+      case .south:
+        stored = 10
+      case .east:
+        yield &stored
+      case .west:
+        stored = 12
+      }
+      cp = .north
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestYieldInSwitchWithFallThrough {
+  var stored: Int
+  var cp: CompassPoint
+
+  var computed: Int {
+    _read {
+      switch cp {
+      case .north:
+        fallthrough
+      case .south:
+        fallthrough
+      case .east:
+        fallthrough
+      case .west:
+        yield stored
+      }
+    }
+
+    _modify {
+      switch cp {
+      case .north:
+        fallthrough
+      case .south:
+        yield &stored // expected-note {{yield along one path is here}}
+      case .east:
+        fallthrough
+      case .west:
+        stored = 12
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestExplicitReturn {
+  var stored: Int
+  var flag: Bool
+
+  var computed: Int {
+    mutating _read {
+      if stored > 0 {
+        return
+      }
+      if flag {
+        yield stored // expected-note {{yield along one path is here}}
+      } else {
+        yield stored
+      }
+      flag = true
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      if stored > 0 {
+        return
+      }
+      if stored == 0 {
+        if flag {
+          yield &stored // expected-note {{yield along one path is here}}
+        } else {
+          yield &stored
+        }
+        return
+      }
+      flag = true
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+
+  var anotherProp: Int {
+    mutating _read {
+      if flag {
+        stored = 2
+      }
+      return // expected-error {{accessor must yield before returning}}
+
+      if !flag { // expected-warning {{code after 'return' will never be executed}}
+        stored = 3
+      }
+    }
+  }
+}
+
+struct TestYieldsInGuards {
+  var storedOpt: Int?
+  var defaultStorage: Int
+
+  var computed: Int {
+    _read {
+      guard let stored = storedOpt else {
+        yield defaultStorage
+        return
+      }
+      yield stored
+    }
+  }
+}
+
+struct TestYieldsInGuards2 {
+  var storedOpt: Int?
+  var defaultStorage: Int
+
+  var computed: Int {
+    _read {
+      guard let stored = storedOpt else {
+        return
+      }
+      yield stored // expected-note {{yield along one path is here}}
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      guard let stored = storedOpt else {
+        yield &defaultStorage // expected-note {{yield along one path is here}}
+        return
+      }
+      storedOpt = stored + 1
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+enum SoftError : Error {
+  case Ignorable
+}
+func aThrowingFunction() throws {
+  throw SoftError.Ignorable
+}
+
+struct TestYieldInDoCatch {
+  var stored: Int
+  var computed: Int {
+    _read {
+      do {
+        try aThrowingFunction()
+        yield stored
+      } catch {
+        yield stored
+      }
+    }
+  }
+}
+
+struct TestYieldInDoCatch2 {
+  var stored: Int
+  var computed: Int {
+    _read {
+      do {
+        try aThrowingFunction()
+        yield stored  // expected-note {{yield along one path is here}}
+      } catch {
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      do {
+        try aThrowingFunction()
+      }
+      catch {
+        yield &stored  // expected-note {{yield along one path is here}}
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+enum Binary {
+  case one
+  case two
+}
+
+struct TestMutipleTries {
+  var stored: Int
+  var computed: Int {
+    _read {
+      do {
+        try aThrowingFunction()
+        yield stored // expected-note {{previous yield was here}}
+
+        try aThrowingFunction()
+        yield stored // expected-error {{accessor must not yield more than once}}
+      } catch {
+      }
+    }
+
+    _modify {
+      do {
+        try aThrowingFunction()
+        yield &stored           // expected-note {{yield along one path is here}}
+
+        try aThrowingFunction()
+      }
+      catch {
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+
+  var flag: Bool
+  var bin: Binary
+
+  var computed2: Int {
+    _read {
+      do {
+        if flag {
+          try aThrowingFunction()
+        } else {
+          try aThrowingFunction()
+        }
+
+        yield stored // expected-note {{yield along one path is here}}
+      } catch {
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      do {
+        switch bin {
+        case .one:
+          try aThrowingFunction()
+          yield &stored // expected-note {{yield along one path is here}}
+
+        case .two:
+          try aThrowingFunction()
+          yield &stored
+        }
+      } catch {
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+
+  var computed3: Int {
+    _read {
+      do {
+        if flag {
+          try aThrowingFunction()
+        } else {
+          try aThrowingFunction()
+        }
+      } catch {
+        yield stored // expected-note {{yield along one path is here}}
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      do {
+        switch bin {
+        case .one:
+          try aThrowingFunction()
+        case .two:
+          try aThrowingFunction()
+        }
+      } catch {
+        yield &stored // expected-note {{yield along one path is here}}
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+struct TestMutipleCatches {
+  enum NumError: Error {
+    case One
+    case Two
+    case Three
+  }
+
+  var stored: Int
+  var computed: Int {
+    _read {
+      do {
+        try aThrowingFunction()
+        yield stored            // expected-note {{yield along one path is here}}
+      } catch NumError.One {
+        yield stored
+      } catch NumError.Two {
+        yield stored
+      } catch NumError.Three {
+      } catch {
+        yield stored
+      }
+    }  // expected-error {{accessor must yield on all paths before returning}}
+  }
+}
+
+// Test for labeled breaks.
+
+struct TestYieldWithLabeledBreaks {
+  var stored: Int
+  var flag: Bool
+  var bin: Binary
+
+  var computed: Int {
+    _read {
+      ifstmt: if flag {
+        switch bin {
+        case .one:
+          yield stored // expected-note {{yield along one path is here}}
+        case .two:
+          break ifstmt
+        }
+      }
+    } // expected-error {{accessor must yield on all paths before returning}}
+
+    _modify {
+      loop: while flag {
+        switch bin {
+        case .one:
+          yield &stored // expected-error {{accessor must not yield more than once}}
+                        // expected-note@-1 {{previous yield was here}}
+        case .two:
+          break loop
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pass is based on the existing SIL verifier checks but diagnoses only those errors that can be introduced by programmers.

<rdar://43578476>