### PR TITLE
[ome] Add an option sil-dump-before-ome-to-path to dump the current m…

### DIFF
--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -28,8 +28,14 @@
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace swift;
+
+// Utility command line argument to dump the module before we eliminate
+// ownership from it.
+static llvm::cl::opt<std::string>
+DumpBefore("sil-dump-before-ome-to-path", llvm::cl::Hidden);
 
 //===----------------------------------------------------------------------===//
 //                               Implementation
@@ -282,6 +288,10 @@ namespace {
 
 struct OwnershipModelEliminator : SILModuleTransform {
   void run() override {
+    if (DumpBefore.size()) {
+      getModule()->dump(DumpBefore.c_str());
+    }
+
     for (auto &F : *getModule()) {
       // Don't rerun early lowering on deserialized functions.
       if (F.wasDeserializedCanonical())


### PR DESCRIPTION
…odule to a path before stripping ownership.

This will simplify analyzing SIL as we move the ownership model eliminator back
through the pipeline.
