### PR TITLE
[String] String-from-whole-Substring fast-path.

### DIFF
--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -169,5 +169,16 @@ extension String {
   ) -> String {
     return String._fromCodeUnits(utf16, encoding: UTF16.self, repair: true)!.0
   }
+
+  @usableFromInline
+  internal static func _fromSubstring(
+    _ substring: __shared Substring
+  ) -> String {
+    if substring._offsetRange == substring._wholeString._offsetRange {
+      return substring._wholeString
+    }
+
+    return substring._withUTF8 { return String._uncheckedFromUTF8($0) }
+  }
 }
 

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -20,7 +20,7 @@ extension String {
   /// - Complexity: O(*n*), where *n* is the length of `substring`.
   @inlinable
   public init(_ substring: __shared Substring) {
-    self = substring._withUTF8 { return String._uncheckedFromUTF8($0) }
+    self = String._fromSubstring(substring)
   }
 }
 


### PR DESCRIPTION
Add in a fast-path for Strings created from Substring which covers the
entire String. Put String-from-Substring behind a non-inlinable
resilience barrier for future flexibility.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
