### PR TITLE
[5.0] Allow Error to conform to itself

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3975,6 +3975,9 @@ public:
              ->existentialConformsToSelfSlow();
   }
 
+  /// Does this protocol require a self-conformance witness table?
+  bool requiresSelfConformanceWitnessTable() const;
+
   /// Find direct Self references within the given requirement.
   ///
   /// \param allowCovariantParameters If true, 'Self' is assumed to be

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -385,6 +385,11 @@ public:
   Optional<ProtocolConformanceRef>
   lookupConformance(Type type, ProtocolDecl *protocol);
 
+  /// Look for the conformance of the given existential type to the given
+  /// protocol.
+  Optional<ProtocolConformanceRef>
+  lookupExistentialConformance(Type type, ProtocolDecl *protocol);
+
   /// Find a member named \p name in \p container that was declared in this
   /// module.
   ///

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3863,15 +3863,22 @@ bool ProtocolDecl::requiresClassSlow() {
   return Bits.ProtocolDecl.RequiresClass;
 }
 
+bool ProtocolDecl::requiresSelfConformanceWitnessTable() const {
+  return isSpecificProtocol(KnownProtocolKind::Error);
+}
+
 bool ProtocolDecl::existentialConformsToSelfSlow() {
   // Assume for now that the existential conforms to itself; this
   // prevents circularity issues.
   Bits.ProtocolDecl.ExistentialConformsToSelfValid = true;
   Bits.ProtocolDecl.ExistentialConformsToSelf = true;
 
+  // If it's not @objc, it conforms to itself only if it has a
+  // self-conformance witness table.
   if (!isObjC()) {
-    Bits.ProtocolDecl.ExistentialConformsToSelf = false;
-    return false;
+    bool hasSelfConformance = requiresSelfConformanceWitnessTable();
+    Bits.ProtocolDecl.ExistentialConformsToSelf = hasSelfConformance;
+    return hasSelfConformance;
   }
 
   // Check whether this protocol conforms to itself.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -571,6 +571,57 @@ void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results) const {
 }
 
 Optional<ProtocolConformanceRef>
+ModuleDecl::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
+  assert(type->isExistentialType());
+
+  // If the existential type cannot be represented or the protocol does not
+  // conform to itself, there's no point in looking further.
+  if (!protocol->existentialConformsToSelf())
+    return None;
+
+  auto layout = type->getExistentialLayout();
+
+  // Due to an IRGen limitation, witness tables cannot be passed from an
+  // existential to an archetype parameter, so for now we restrict this to
+  // @objc protocols.
+  if (!layout.isObjC()) {
+    return None;
+  }
+
+  // If the existential is class-constrained, the class might conform
+  // concretely.
+  if (auto superclass = layout.explicitSuperclass) {
+    if (auto result = lookupConformance(superclass, protocol))
+      return result;
+  }
+
+  // Otherwise, the existential might conform abstractly.
+  for (auto proto : layout.getProtocols()) {
+    auto *protoDecl = proto->getDecl();
+
+    // If we found the protocol we're looking for, return an abstract
+    // conformance to it.
+    if (protoDecl == protocol)
+      return ProtocolConformanceRef(protocol);
+
+    // If the protocol has a superclass constraint, we might conform
+    // concretely.
+    if (auto superclass = protoDecl->getSuperclass()) {
+      if (auto result = lookupConformance(superclass, protocol))
+        return result;
+    }
+
+    // Now check refined protocols.
+    if (protoDecl->inheritsFrom(protocol))
+      return ProtocolConformanceRef(protocol);
+  }
+
+  // We didn't find our protocol in the existential's list; it doesn't
+  // conform.
+  return None;
+}
+
+Optional<ProtocolConformanceRef>
 ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol) {
   ASTContext &ctx = getASTContext();
 
@@ -609,52 +660,8 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol) {
   // An existential conforms to a protocol if the protocol is listed in the
   // existential's list of conformances and the existential conforms to
   // itself.
-  if (type->isExistentialType()) {
-    // If the existential type cannot be represented or the protocol does not
-    // conform to itself, there's no point in looking further.
-    if (!protocol->existentialConformsToSelf())
-      return None;
-
-    auto layout = type->getExistentialLayout();
-
-    // Due to an IRGen limitation, witness tables cannot be passed from an
-    // existential to an archetype parameter, so for now we restrict this to
-    // @objc protocols.
-    if (!layout.isObjC())
-      return None;
-
-    // If the existential is class-constrained, the class might conform
-    // concretely.
-    if (auto superclass = layout.explicitSuperclass) {
-      if (auto result = lookupConformance(superclass, protocol))
-        return result;
-    }
-
-    // Otherwise, the existential might conform abstractly.
-    for (auto proto : layout.getProtocols()) {
-      auto *protoDecl = proto->getDecl();
-
-      // If we found the protocol we're looking for, return an abstract
-      // conformance to it.
-      if (protoDecl == protocol)
-        return ProtocolConformanceRef(protocol);
-
-      // If the protocol has a superclass constraint, we might conform
-      // concretely.
-      if (auto superclass = protoDecl->getSuperclass()) {
-        if (auto result = lookupConformance(superclass, protocol))
-          return result;
-      }
-
-      // Now check refined protocols.
-      if (protoDecl->inheritsFrom(protocol))
-        return ProtocolConformanceRef(protocol);
-    }
-
-    // We didn't find our protocol in the existential's list; it doesn't
-    // conform.
-    return None;
-  }
+  if (type->isExistentialType())
+    return lookupExistentialConformance(type, protocol);
 
   // Type variables have trivial conformances.
   if (type->isTypeVariableOrMember())

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1409,9 +1409,12 @@ DeclContext::getLocalConformances(
   if (!nominal)
     return result;
 
-  // Protocols don't have conformances.
-  if (isa<ProtocolDecl>(nominal))
+  // Protocols only have self-conformances.
+  if (auto protocol = dyn_cast<ProtocolDecl>(nominal)) {
+    if (protocol->requiresSelfConformanceWitnessTable())
+      return { protocol->getASTContext().getSelfConformance(protocol) };
     return { };
+  }
 
   // Update to record all potential conformances.
   nominal->prepareConformanceTable();

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -114,19 +114,21 @@ ProtocolConformanceRef::subst(Type origType,
 
   auto *proto = getRequirement();
 
+  // If the type is an existential, it must be self-conforming.
+  if (substType->isExistentialType()) {
+    auto optConformance =
+      proto->getModuleContext()->lookupExistentialConformance(substType, proto);
+    assert(optConformance && "existential type didn't self-conform");
+    return *optConformance;
+  }
+
   // Check the conformance map.
   if (auto result = conformances(origType->getCanonicalType(),
                                  substType, proto)) {
     return *result;
   }
 
-  // The only remaining case is that the type is an existential that
-  // self-conforms.
-  assert(substType->isExistentialType());
-  auto optConformance =
-    proto->getModuleContext()->lookupExistentialConformance(substType, proto);
-  assert(optConformance && "existential type didn't self-conform");
-  return *optConformance;
+  llvm_unreachable("Invalid conformance substitution");
 }
 
 Type

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -307,6 +307,9 @@ public:
   /// Emit the default witness table for a resilient protocol.
   void emitDefaultWitnessTable(ProtocolDecl *protocol);
 
+  /// Emit the self-conformance witness table for a protocol.
+  void emitSelfConformanceWitnessTable(ProtocolDecl *protocol);
+
   /// Emit the lazy initializer function for a global pattern binding
   /// declaration.
   SILFunction *emitLazyGlobalInitializer(StringRef funcName,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -651,7 +651,8 @@ public:
                            SubstitutionMap reqtSubs,
                            SILDeclRef witness,
                            SubstitutionMap witnessSubs,
-                           IsFreeFunctionWitness_t isFree);
+                           IsFreeFunctionWitness_t isFree,
+                           bool isSelfConformance);
   
   /// Convert a block to a native function with a thunk.
   ManagedValue emitBlockToFunc(SILLocation loc,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3575,15 +3575,23 @@ SILGenFunction::emitVTableThunk(SILDeclRef derived,
 enum class WitnessDispatchKind {
   Static,
   Dynamic,
-  Class
+  Class,
+  Witness
 };
 
-static WitnessDispatchKind getWitnessDispatchKind(SILDeclRef witness) {
+static WitnessDispatchKind getWitnessDispatchKind(SILDeclRef witness,
+                                                  bool isSelfConformance) {
   auto *decl = witness.getDecl();
 
+  if (isSelfConformance) {
+    assert(isa<ProtocolDecl>(decl->getDeclContext()));
+    return WitnessDispatchKind::Witness;
+  }
+
   ClassDecl *C = decl->getDeclContext()->getSelfClassDecl();
-  if (!C)
+  if (!C) {
     return WitnessDispatchKind::Static;
+  }
 
   // If the witness is dynamic, go through dynamic dispatch.
   if (decl->isObjCDynamic()) {
@@ -3630,6 +3638,7 @@ getWitnessFunctionType(SILGenModule &SGM,
   switch (witnessKind) {
   case WitnessDispatchKind::Static:
   case WitnessDispatchKind::Dynamic:
+  case WitnessDispatchKind::Witness:
     return SGM.Types.getConstantInfo(witness).SILFnType;
   case WitnessDispatchKind::Class:
     return SGM.Types.getConstantOverrideType(witness);
@@ -3638,11 +3647,21 @@ getWitnessFunctionType(SILGenModule &SGM,
   llvm_unreachable("Unhandled WitnessDispatchKind in switch.");
 }
 
+static std::pair<CanType, ProtocolConformanceRef>
+getSelfTypeAndConformanceForWitness(SILDeclRef witness, SubstitutionMap subs) {
+  auto protocol = cast<ProtocolDecl>(witness.getDecl()->getDeclContext());
+  auto selfParam = protocol->getProtocolSelfType()->getCanonicalType();
+  auto type = subs.getReplacementTypes()[0];
+  auto conf = *subs.lookupConformance(selfParam, protocol);
+  return {type->getCanonicalType(), conf};
+}
+
 static SILValue
 getWitnessFunctionRef(SILGenFunction &SGF,
                       SILDeclRef witness,
                       CanSILFunctionType witnessFTy,
                       WitnessDispatchKind witnessKind,
+                      SubstitutionMap witnessSubs,
                       SmallVectorImpl<ManagedValue> &witnessParams,
                       SILLocation loc) {
   switch (witnessKind) {
@@ -3650,6 +3669,14 @@ getWitnessFunctionRef(SILGenFunction &SGF,
     return SGF.emitGlobalFunctionRef(loc, witness);
   case WitnessDispatchKind::Dynamic:
     return SGF.emitDynamicMethodRef(loc, witness, witnessFTy).getValue();
+  case WitnessDispatchKind::Witness: {
+    auto typeAndConf =
+      getSelfTypeAndConformanceForWitness(witness, witnessSubs);
+    return SGF.B.createWitnessMethod(loc, typeAndConf.first,
+                                     typeAndConf.second,
+                                     witness,
+                            SILType::getPrimitiveObjectType(witnessFTy));
+  }
   case WitnessDispatchKind::Class: {
     SILValue selfPtr = witnessParams.back().getValue();
     return SGF.emitClassMethodRef(loc, selfPtr, witness, witnessFTy);
@@ -3659,13 +3686,32 @@ getWitnessFunctionRef(SILGenFunction &SGF,
   llvm_unreachable("Unhandled WitnessDispatchKind in switch.");
 }
 
+static ManagedValue
+emitOpenExistentialInSelfConformance(SILGenFunction &SGF, SILLocation loc,
+                                     SILDeclRef witness,
+                                     SubstitutionMap subs, ManagedValue value,
+                                     SILParameterInfo destParameter) {
+  auto typeAndConf = getSelfTypeAndConformanceForWitness(witness, subs);
+  auto archetype = typeAndConf.first->castTo<ArchetypeType>();
+  assert(archetype->isOpenedExistential());
+
+  auto openedTy = destParameter.getSILStorageType();
+  auto state = SGF.emitOpenExistential(loc, value, archetype, openedTy,
+                                       destParameter.isIndirectMutating()
+                                         ? AccessKind::ReadWrite
+                                         : AccessKind::Read);
+
+  return state.Value;
+}
+
 void SILGenFunction::emitProtocolWitness(AbstractionPattern reqtOrigTy,
                                          CanAnyFunctionType reqtSubstTy,
                                          SILDeclRef requirement,
                                          SubstitutionMap reqtSubs,
                                          SILDeclRef witness,
                                          SubstitutionMap witnessSubs,
-                                         IsFreeFunctionWitness_t isFree) {
+                                         IsFreeFunctionWitness_t isFree,
+                                         bool isSelfConformance) {
   // FIXME: Disable checks that the protocol witness carries debug info.
   // Should we carry debug info for witnesses?
   F.setBare(IsBare);
@@ -3679,7 +3725,7 @@ void SILGenFunction::emitProtocolWitness(AbstractionPattern reqtOrigTy,
   FullExpr scope(Cleanups, cleanupLoc);
   FormalEvaluationScope formalEvalScope(*this);
 
-  auto witnessKind = getWitnessDispatchKind(witness);
+  auto witnessKind = getWitnessDispatchKind(witness, isSelfConformance);
   auto thunkTy = F.getLoweredFunctionType();
 
   SmallVector<ManagedValue, 8> origParams;
@@ -3704,8 +3750,23 @@ void SILGenFunction::emitProtocolWitness(AbstractionPattern reqtOrigTy,
                                           ->getCanonicalType());
   }
 
+  // Get the lowered type of the witness.
+  auto origWitnessFTy = getWitnessFunctionType(SGM, witness, witnessKind);
+  auto witnessFTy = origWitnessFTy;
+  if (!witnessSubs.empty())
+    witnessFTy = origWitnessFTy->substGenericArgs(SGM.M, witnessSubs);
+
   auto reqtSubstParams = reqtSubstTy.getParams();
   auto witnessSubstParams = witnessSubstTy.getParams();
+
+  // For a self-conformance, open the self parameter.
+  if (isSelfConformance) {
+    assert(!isFree && "shouldn't have a free witness for a self-conformance");
+    origParams.back() =
+      emitOpenExistentialInSelfConformance(*this, loc, witness, witnessSubs,
+                                           origParams.back(),
+                                           witnessFTy->getSelfParameter());
+  }
 
   // For a free function witness, discard the 'self' parameter of the
   // requirement.
@@ -3716,11 +3777,6 @@ void SILGenFunction::emitProtocolWitness(AbstractionPattern reqtOrigTy,
 
   // Translate the argument values from the requirement abstraction level to
   // the substituted signature of the witness.
-  auto origWitnessFTy = getWitnessFunctionType(SGM, witness, witnessKind);
-  auto witnessFTy = origWitnessFTy;
-  if (!witnessSubs.empty())
-    witnessFTy = origWitnessFTy->substGenericArgs(SGM.M, witnessSubs);
-
   SmallVector<ManagedValue, 8> witnessParams;
   AbstractionPattern witnessOrigTy(witnessInfo.LoweredType);
   TranslateArguments(*this, loc,
@@ -3733,7 +3789,7 @@ void SILGenFunction::emitProtocolWitness(AbstractionPattern reqtOrigTy,
 
   SILValue witnessFnRef = getWitnessFunctionRef(*this, witness,
                                                 origWitnessFTy,
-                                                witnessKind,
+                                                witnessKind, witnessSubs,
                                                 witnessParams, loc);
 
   auto coroutineKind =

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -364,6 +364,11 @@ private:
   }
 };
 
+static IsSerialized_t isConformanceSerialized(RootProtocolConformance *conf) {
+  return SILWitnessTable::conformanceIsSerialized(conf)
+           ? IsSerialized : IsNotSerialized;
+}
+
 /// Emit a witness table for a protocol conformance.
 class SILGenConformance : public SILGenWitnessTable<SILGenConformance> {
   using super = SILGenWitnessTable<SILGenConformance>;
@@ -380,15 +385,10 @@ public:
     // We only need to emit witness tables for base NormalProtocolConformances.
     : SGM(SGM), Conformance(C->getRootNormalConformance()),
       Linkage(getLinkageForProtocolConformance(Conformance,
-                                               ForDefinition))
+                                               ForDefinition)),
+      Serialized(isConformanceSerialized(Conformance))
   {
     auto *proto = Conformance->getProtocol();
-
-    Serialized = IsNotSerialized;
-
-    // ... or if the conformance itself thinks it should be.
-    if (SILWitnessTable::conformanceIsSerialized(Conformance))
-      Serialized = IsSerialized;
 
     // Not all protocols use witness tables; in this case we just skip
     // all of emit() below completely.
@@ -627,18 +627,13 @@ SILFunction *SILGenModule::emitProtocolWitness(
     conformance = *reqtSubMap.lookupConformance(self, requirement);
   }
 
-  CanAnyFunctionType reqtSubstTy;
-  if (genericEnv) {
-    auto *genericSig = genericEnv->getGenericSignature();
-    reqtSubstTy = CanGenericFunctionType::get(
-        genericSig->getCanonicalSignature(),
-        substReqtTy->getParams(), substReqtTy.getResult(),
-        reqtOrigTy->getExtInfo());
-  } else {
-    reqtSubstTy = CanFunctionType::get(substReqtTy->getParams(),
-                                       substReqtTy.getResult(),
-                                       reqtOrigTy->getExtInfo());
-  }
+  CanAnyFunctionType reqtSubstTy =
+    CanAnyFunctionType::get(genericEnv ? genericEnv->getGenericSignature()
+                                                   ->getCanonicalSignature()
+                                       : nullptr,
+                            substReqtTy->getParams(),
+                            substReqtTy.getResult(),
+                            reqtOrigTy->getExtInfo());
 
   // Coroutine lowering requires us to provide these substitutions
   // in order to recreate the appropriate yield types for the accessor
@@ -701,9 +696,137 @@ SILFunction *SILGenModule::emitProtocolWitness(
 
   SGF.emitProtocolWitness(AbstractionPattern(reqtOrigTy), reqtSubstTy,
                           requirement, reqtSubMap, witnessRef,
-                          witnessSubs, isFree);
+                          witnessSubs, isFree, /*isSelfConformance*/ false);
 
   return f;
+}
+
+namespace {
+
+static SILFunction *emitSelfConformanceWitness(SILGenModule &SGM,
+                                           SelfProtocolConformance *conformance,
+                                               SILLinkage linkage,
+                                               SILDeclRef requirement) {
+  auto requirementInfo = SGM.Types.getConstantInfo(requirement);
+
+  // Work out the lowered function type of the SIL witness thunk.
+  auto reqtOrigTy = cast<GenericFunctionType>(requirementInfo.LoweredType);
+
+  // The transformations we do here don't work for generic requirements.
+  GenericEnvironment *genericEnv = nullptr;
+
+  // A mapping from the requirement's generic signature to the type parameters
+  // of the witness thunk (which is non-generic).
+  auto protocol = conformance->getProtocol();
+  auto protocolType = protocol->getDeclaredInterfaceType();
+  auto reqtSubs = SubstitutionMap::getProtocolSubstitutions(protocol,
+                                          protocolType,
+                                          ProtocolConformanceRef(protocol));
+
+  // Open the protocol type.
+  auto openedType = ArchetypeType::getOpened(protocolType);
+
+  // Form the substitutions for calling the witness.
+  auto witnessSubs = SubstitutionMap::getProtocolSubstitutions(protocol,
+                                          openedType,
+                                          ProtocolConformanceRef(protocol));
+
+  // Substitute to get the formal substituted type of the thunk.
+  auto reqtSubstTy =
+    cast<AnyFunctionType>(reqtOrigTy.subst(reqtSubs)->getCanonicalType());
+
+  // Substitute into the requirement type to get the type of the thunk.
+  auto witnessSILFnType =
+    requirementInfo.SILFnType->substGenericArgs(SGM.M, reqtSubs);
+
+  // Mangle the name of the witness thunk.
+  std::string name = [&] {
+    Mangle::ASTMangler mangler;
+    return mangler.mangleWitnessThunk(conformance, requirement.getDecl());
+  }();
+
+  SILGenFunctionBuilder builder(SGM);
+  auto *f = builder.createFunction(
+      linkage, name, witnessSILFnType, genericEnv,
+      SILLocation(requirement.getDecl()), IsNotBare, IsTransparent,
+      IsSerialized, IsNotDynamic, ProfileCounter(), IsThunk,
+      SubclassScope::NotApplicable, InlineDefault);
+
+  f->setDebugScope(new (SGM.M)
+                   SILDebugScope(RegularLocation(requirement.getDecl()), f));
+
+  PrettyStackTraceSILFunction trace("generating protocol witness thunk", f);
+
+  // Create the witness.
+  SILGenFunction SGF(SGM, *f, SGM.SwiftModule);
+
+  auto isFree = isFreeFunctionWitness(requirement.getDecl(),
+                                      requirement.getDecl());
+
+  SGF.emitProtocolWitness(AbstractionPattern(reqtOrigTy), reqtSubstTy,
+                          requirement, reqtSubs, requirement,
+                          witnessSubs, isFree, /*isSelfConformance*/ true);
+
+  return f;
+}
+
+/// Emit a witness table for a self-conformance.
+class SILGenSelfConformanceWitnessTable
+       : public SILWitnessVisitor<SILGenSelfConformanceWitnessTable> {
+  using super = SILWitnessVisitor<SILGenSelfConformanceWitnessTable>;
+
+  SILGenModule &SGM;
+  SelfProtocolConformance *conformance;
+  SILLinkage linkage;
+  IsSerialized_t serialized;
+
+  SmallVector<SILWitnessTable::Entry, 8> entries;
+public:
+  SILGenSelfConformanceWitnessTable(SILGenModule &SGM,
+                                    SelfProtocolConformance *conformance)
+    : SGM(SGM), conformance(conformance),
+      linkage(getLinkageForProtocolConformance(conformance, ForDefinition)),
+      serialized(isConformanceSerialized(conformance)) {
+  }
+
+  void emit() {
+    // Add entries for all the requirements.
+    visitProtocolDecl(conformance->getProtocol());
+
+    // Create the witness table.
+    (void) SILWitnessTable::create(SGM.M, linkage, serialized, conformance,
+                                   entries, /*conditional*/ {});
+  }
+
+  void addProtocolConformanceDescriptor() {}
+
+  void addOutOfLineBaseProtocol(ProtocolDecl *protocol) {
+    // This is an unnecessary restriction that's just not necessary for Error.
+    llvm_unreachable("base protocols not supported in self-conformance");
+  }
+
+  // These are real semantic restrictions.
+  void addAssociatedConformance(AssociatedConformance conformance) {
+    llvm_unreachable("associated conformances not supported in self-conformance");
+  }
+  void addAssociatedType(AssociatedType type) {
+    llvm_unreachable("associated types not supported in self-conformance");
+  }
+  void addPlaceholder(MissingMemberDecl *placeholder) {
+    llvm_unreachable("placeholders not supported in self-conformance");
+  }
+
+  void addMethod(SILDeclRef requirement) {
+    auto witness = emitSelfConformanceWitness(SGM, conformance, linkage,
+                                              requirement);
+    entries.push_back(SILWitnessTable::MethodWitness{requirement, witness});
+  }
+};
+}
+
+void SILGenModule::emitSelfConformanceWitnessTable(ProtocolDecl *protocol) {
+  auto conformance = getASTContext().getSelfConformance(protocol);
+  SILGenSelfConformanceWitnessTable(*this, conformance).emit();
 }
 
 namespace {
@@ -829,6 +952,9 @@ public:
         auto *SF = protocol->getParentSourceFile();
         if (!SF || SF->Kind != SourceFileKind::Interface)
           SGM.emitDefaultWitnessTable(protocol);
+      }
+      if (protocol->requiresSelfConformanceWitnessTable()) {
+        SGM.emitSelfConformanceWitnessTable(protocol);
       }
       return;
     }

--- a/test/IRGen/error_self_conformance.sil
+++ b/test/IRGen/error_self_conformance.sil
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+
+import Swift
+
+sil @take_any_error : $@convention(thin) <T: Error> (@in T) -> ()
+
+// CHECK-LABEL: swiftcc void @test(%swift.error**
+sil @test : $@convention(thin) (@in Error) -> () {
+entry(%0 : $*Error):
+  // CHECK:      [[VALUE:%.*]] = bitcast %swift.error** %0 to %swift.opaque*
+  // CHECK-NEXT: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$ss5Error_pMa"([[INT]] 0)
+  // CHECK-NEXT: [[ERROR_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+  // CHECK-NEXT: call swiftcc void @take_any_error(%swift.opaque* noalias nocapture [[VALUE]], %swift.type* [[ERROR_METADATA]], i8** @"$ss5ErrorWS")
+  // CHECK-NEXT: ret void
+  %take = function_ref @take_any_error : $@convention(thin) <T: Error> (@in T) -> ()
+  apply %take<Error>(%0) : $@convention(thin) <T: Error> (@in T) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}

--- a/test/Interpreter/error_self_conformance.swift
+++ b/test/Interpreter/error_self_conformance.swift
@@ -1,0 +1,75 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+struct BoxedError<T: Error> {
+  var contents: T
+}
+
+enum MyError: Error {
+  case nothingImportant
+  case reallyImportant(String)
+}
+
+// CHECK: start
+print("start")
+
+let value = MyError.reallyImportant("hello")
+
+// CHECK-NEXT: reallyImportant("hello")
+print(value)
+
+func takeBoxedError<T>(error: BoxedError<T>) -> Error {
+  return error.contents
+}
+
+func makeBoxedError<T: Error>(error: T) -> BoxedError<Error> {
+  return BoxedError(contents: error)
+}
+
+let unboxedValue = takeBoxedError(error: makeBoxedError(error: value))
+
+// CHECK-NEXT: reallyImportant("hello")
+print(unboxedValue)
+
+let errorValue: Error = MyError.reallyImportant("goodbye")
+
+func castValueToError<T>(error: T) -> Error? {
+  return error as? Error
+}
+
+// CHECK-NEXT: reallyImportant("goodbye")
+print(castValueToError(error: errorValue) ?? value)
+
+struct Carrier<T> {
+  var name: String
+}
+protocol ErrorCarrier {}
+extension Carrier: ErrorCarrier where T: Error {}
+
+func castValueToErrorCarrier<T>(_ value: T) -> ErrorCarrier? {
+  return value as? ErrorCarrier
+}
+
+// CHECK-NEXT: nil
+print(castValueToErrorCarrier(Carrier<Int>(name: "A carrier of numbers")))
+
+// CHECK-NEXT: A carrier of my errors
+print(castValueToErrorCarrier(Carrier<MyError>(name: "A carrier of my errors")))
+
+// CHECK-NEXT: A carrier of all errors
+print(castValueToErrorCarrier(Carrier<Error>(name: "A carrier of all errors")))
+
+// CHECK-NEXT: nil
+protocol ErrorRefinement : Error {}
+print(castValueToErrorCarrier(Carrier<ErrorRefinement>(name: "A carrier of refined errors")))
+
+// CHECK-NEXT: nil
+protocol OtherProtocol {}
+print(castValueToErrorCarrier(Carrier<Error & OtherProtocol>(name: "A carrier of composed errors")))
+
+// CHECK-NEXT: nil
+class C {}
+print(castValueToErrorCarrier(Carrier<Error & C>(name: "A carrier of classic composed errors")))
+
+// CHECK-NEXT: end
+print("end")

--- a/test/SILOptimizer/specialize_self_conforming_error.swift
+++ b/test/SILOptimizer/specialize_self_conforming_error.swift
@@ -1,0 +1,97 @@
+// RUN: %target-swift-frontend -module-name specialize_self_conforming -emit-sil -O -primary-file %s | %FileCheck %s
+
+// Test 1: apply the substitution
+//   [U:Error => Error:Error]
+// to the type argument map
+//   [T:Error => U:Error]
+// on the call to takesError.
+
+@_optimize(none)
+func takesError<T : Error>(_: T) {}
+
+@inline(__always)
+func callsTakesError<U : Error>(_ error: U) {
+  takesError(error)
+}
+
+// CHECK-LABEL: sil hidden @$s26specialize_self_conforming5test1yys5Error_pF : $@convention(thin) (@guaranteed Error) -> () {
+// CHECK: [[TEMP:%.*]] = alloc_stack $Error
+// CHECK: store %0 to [[TEMP]]
+// CHECK: [[FN:%.*]] = function_ref @$s26specialize_self_conforming10takesErroryyxs0E0RzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<Error>([[TEMP]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> ()
+// CHECK: dealloc_stack [[TEMP]]
+// CHECK: return
+
+func test1(_ error: Error) {
+  callsTakesError(error)
+}
+
+// Test 2: apply the substitution
+//   [U => Int]
+// to the type argument map
+//   [T:Error => Error:Error]
+// on the call to takesError.
+
+@inline(__always)
+func callsTakesErrorWithError<U>(_ error: Error, _ value : U) {
+  takesError(error)
+}
+
+// CHECK-LABEL: sil hidden @$s26specialize_self_conforming5test2yys5Error_pF : $@convention(thin) (@guaranteed Error) -> () {
+// CHECK: [[TEMP:%.*]] = alloc_stack $Error
+// CHECK: store %0 to [[TEMP]]
+// CHECK: [[FN:%.*]] = function_ref @$s26specialize_self_conforming10takesErroryyxs0E0RzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[FN]]<Error>([[TEMP]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> ()
+// CHECK: dealloc_stack [[TEMP]]
+// CHECK: return
+
+func test2(_ error: Error) {
+  callsTakesErrorWithError(error, 0)
+}
+
+// Test 3: apply the substitution
+//   [V => Int]
+// to the type argument map
+//   [T:Error => Error:Error, U => V]
+// on the call to takesErrorAndValue.
+
+@_optimize(none)
+func takesErrorAndValue<T : Error, U>(_: T, _: U) {}
+
+@inline(__always)
+func callsTakesErrorAndValueWithError<U>(_ error: Error, _ value : U) {
+  takesErrorAndValue(error, value)
+}
+
+// CHECK-LABEL: sil hidden @$s26specialize_self_conforming5test3yys5Error_pF : $@convention(thin) (@guaranteed Error) -> () {
+// CHECK: [[TEMP:%.*]] = alloc_stack $Error
+// CHECK: store %0 to [[TEMP]]
+// CHECK: [[FN:%.*]] = function_ref @$s26specialize_self_conforming18takesErrorAndValueyyx_q_ts0E0Rzr0_lF : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Error> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
+// CHECK: apply [[FN]]<Error, Int>([[TEMP]], {{%.*}}) :
+// CHECK: dealloc_stack [[TEMP]]
+// CHECK: return
+
+func test3(_ error: Error) {
+  callsTakesErrorAndValueWithError(error, 0)
+}
+
+// Test 4: just clone the type argument map
+//   [Self:P => opened:P, T:Error => Error:Error]
+// When the inliner is cloning a substitution map that includes an opened
+// archetype, it uses a substitution function that expects not to be called
+// on types it's not expecting.
+
+protocol P {}
+extension P {
+  @_optimize(none)
+  func exTakesError<T: Error>(_: T) {}
+}
+
+@inline(__always)
+func callsExTakesErrorWithError(_ p: P, _ error: Error) {
+  p.exTakesError(error)
+}
+
+func test4(_ p: P, _ error: Error) {
+  callsExTakesErrorWithError(p, error)
+}

--- a/test/decl/protocol/conforms/error_self_conformance.swift
+++ b/test/decl/protocol/conforms/error_self_conformance.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift
+
+func wantsError<T: Error>(_: T) {}
+
+func testSimple(error: Error) {
+  wantsError(error)
+}
+
+protocol ErrorRefinement : Error {}
+func testErrorRefinment(error: ErrorRefinement) {
+  wantsError(error) // expected-error {{protocol type 'ErrorRefinement' cannot conform to 'Error' because only concrete types can conform to protocols}}
+}
+
+protocol OtherProtocol {}
+func testErrorComposition(error: Error & OtherProtocol) {
+  wantsError(error) // expected-error {{protocol type 'Error & OtherProtocol' cannot conform to 'Error' because only concrete types can conform to protocols}}
+}
+
+class C {}
+func testErrorCompositionWithClass(error: Error & C) {
+  wantsError(error) // expected-error {{protocol type 'C & Error' cannot conform to 'Error' because only concrete types can conform to protocols}}
+}


### PR DESCRIPTION
5.0 version of https://github.com/apple/swift/pull/20629.  Includes the patches from #20658 and #20662.

ABI-additive: the stdlib exports some extra symbols.  Not specifically important for convergence, but eventually necessary in order to implement SE-0235 in Swift 5.0.