### PR TITLE
Teach the SIL cast optimizer to handle conditional conformance.

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -392,6 +392,12 @@ public:
   Optional<ProtocolConformanceRef>
   lookupExistentialConformance(Type type, ProtocolDecl *protocol);
 
+  /// Exposes TypeChecker functionality for querying protocol conformance.
+  /// Returns a valid ProtocolConformanceRef only if all conditional
+  /// requirements are successfully resolved.
+  Optional<ProtocolConformanceRef>
+  conformsToProtocol(Type sourceTy, ProtocolDecl *targetProtocol);
+
   /// Find a member named \p name in \p container that was declared in this
   /// module.
   ///

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -19,6 +19,7 @@
 #define SWIFT_SIL_DYNAMICCASTS_H
 
 #include "swift/Basic/ProfileCounter.h"
+#include "swift/SIL/SILValue.h"
 
 namespace swift {
 

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1391,68 +1391,68 @@ static bool optimizeStaticallyKnownProtocolConformance(
     auto *SM = Mod.getSwiftModule();
 
     auto Proto = dyn_cast<ProtocolDecl>(TargetType->getAnyNominal());
-    if (Proto) {
-      auto Conformance = SM->lookupConformance(SourceType, Proto);
-      if (Conformance.hasValue() &&
-          Conformance->getConditionalRequirements().empty()) {
-        // SourceType is a non-existential type with a non-conditional
-        // conformance to a protocol represented by the TargetType.
-        //
-        // Conditional conformances are complicated: they may depend on
-        // information not known until runtime. For instance, if `X: P` where `T
-        // == Int` in `func foo<T>(_: T) { ... X<T>() as? P ... }`, the cast
-        // will succeed for `foo(0)` but not for `foo("string")`. There are many
-        // cases where everything is completely static (`X<Int>() as? P`), but
-        // we don't try to handle that at the moment.
-        SILBuilder B(Inst);
-        SmallVector<ProtocolConformanceRef, 1> NewConformances;
-        NewConformances.push_back(Conformance.getValue());
-        ArrayRef<ProtocolConformanceRef> Conformances =
-            Ctx.AllocateCopy(NewConformances);
+    if (!Proto)
+      return false;
 
-        auto ExistentialRepr =
-            Dest->getType().getPreferredExistentialRepresentation(Mod,
-                                                                  SourceType);
+    // SourceType is a non-existential type with a non-conditional
+    // conformance to a protocol represented by the TargetType.
+    //
+    // TypeChecker::conformsToProtocol checks any conditional conformances. If
+    // they depend on information not known until runtime, the conformance
+    // will not be returned. For instance, if `X: P` where `T == Int` in `func
+    // foo<T>(_: T) { ... X<T>() as? P ... }`, the cast will succeed for
+    // `foo(0)` but not for `foo("string")`. There are many cases where
+    // everything is completely static (`X<Int>() as? P`), in which case a
+    // valid conformance will be returned.
+    auto Conformance = SM->conformsToProtocol(SourceType, Proto);
+    if (!Conformance)
+      return false;
 
-        switch (ExistentialRepr) {
-        default:
-          return false;
-        case ExistentialRepresentation::Opaque: {
-          auto ExistentialAddr = B.createInitExistentialAddr(
-              Loc, Dest, SourceType, Src->getType().getObjectType(),
-              Conformances);
-          B.createCopyAddr(Loc, Src, ExistentialAddr, IsTake_t::IsTake,
-                           IsInitialization_t::IsInitialization);
-          break;
-        }
-        case ExistentialRepresentation::Class: {
-          auto Value = B.createLoad(Loc, Src,
-                                    swift::LoadOwnershipQualifier::Unqualified);
-          auto Existential =
-              B.createInitExistentialRef(Loc, Dest->getType().getObjectType(),
-                                         SourceType, Value, Conformances);
-          B.createStore(Loc, Existential, Dest,
-                        swift::StoreOwnershipQualifier::Unqualified);
-          break;
-        }
-        case ExistentialRepresentation::Boxed: {
-          auto AllocBox = B.createAllocExistentialBox(Loc, Dest->getType(),
-                                                      SourceType, Conformances);
-          auto Projection =
-              B.createProjectExistentialBox(Loc, Src->getType(), AllocBox);
-          // This needs to be a copy_addr (for now) because we must handle
-          // address-only types.
-          B.createCopyAddr(Loc, Src, Projection, IsTake, IsInitialization);
-          B.createStore(Loc, AllocBox, Dest,
-                        swift::StoreOwnershipQualifier::Unqualified);
-          break;
-        }
-        };
+    SILBuilder B(Inst);
+    SmallVector<ProtocolConformanceRef, 1> NewConformances;
+    NewConformances.push_back(Conformance.getValue());
+    ArrayRef<ProtocolConformanceRef> Conformances =
+        Ctx.AllocateCopy(NewConformances);
 
-        return true;
-      }
+    auto ExistentialRepr =
+        Dest->getType().getPreferredExistentialRepresentation(Mod, SourceType);
+
+    switch (ExistentialRepr) {
+    default:
+      return false;
+    case ExistentialRepresentation::Opaque: {
+      auto ExistentialAddr = B.createInitExistentialAddr(
+          Loc, Dest, SourceType, Src->getType().getObjectType(), Conformances);
+      B.createCopyAddr(Loc, Src, ExistentialAddr, IsTake_t::IsTake,
+                       IsInitialization_t::IsInitialization);
+      break;
     }
+    case ExistentialRepresentation::Class: {
+      auto Value =
+          B.createLoad(Loc, Src, swift::LoadOwnershipQualifier::Unqualified);
+      auto Existential =
+          B.createInitExistentialRef(Loc, Dest->getType().getObjectType(),
+                                     SourceType, Value, Conformances);
+      B.createStore(Loc, Existential, Dest,
+                    swift::StoreOwnershipQualifier::Unqualified);
+      break;
+    }
+    case ExistentialRepresentation::Boxed: {
+      auto AllocBox = B.createAllocExistentialBox(Loc, Dest->getType(),
+                                                  SourceType, Conformances);
+      auto Projection =
+          B.createProjectExistentialBox(Loc, Src->getType(), AllocBox);
+      // This needs to be a copy_addr (for now) because we must handle
+      // address-only types.
+      B.createCopyAddr(Loc, Src, Projection, IsTake, IsInitialization);
+      B.createStore(Loc, AllocBox, Dest,
+                    swift::StoreOwnershipQualifier::Unqualified);
+      break;
+    }
+    };
+    return true;
   }
+  // Not a concrete -> existential cast.
   return false;
 }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4163,6 +4163,28 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
   return lookupResult;
 }
 
+// Exposes TypeChecker functionality for querying protocol conformance.
+//
+// Invoking TypeChecker::conformsToProtocol from the ModuleDecl bypasses
+// certain functionality that only applies to the diagnostic type checker:
+//
+// - ConformanceCheckFlags skips dependence checking.
+//
+// - Passing an invalid SourceLoc skips diagnostics.
+//
+// - Type::subst will be a nop, because 'source' type is already fully
+// substituted in SIL. Consequently, TypeChecker::LookUpConformance, which
+// is only valid during type checking, will never be invoked.
+//
+// - mapTypeIntoContext will be a nop.
+Optional<ProtocolConformanceRef>
+ModuleDecl::conformsToProtocol(Type sourceTy, ProtocolDecl *targetProtocol) {
+
+  auto flags = ConformanceCheckFlags::SuppressDependencyTracking;
+
+  return TypeChecker::conformsToProtocol(sourceTy, targetProtocol, this, flags);
+}
+
 void TypeChecker::markConformanceUsed(ProtocolConformanceRef conformance,
                                       DeclContext *dc) {
   if (conformance.isAbstract()) return;

--- a/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
+++ b/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
@@ -1,0 +1,366 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -assume-parsing-unqualified-ownership-sil -wmo -performance-constant-propagation -simplify-cfg -sil-combine -jumpthread-simplify-cfg -sil-combine -devirtualizer -generic-specializer %s | %FileCheck %s
+//
+// <rdar://problem/46322928> Failure to devirtualize a protocol method applied to an opened existential blocks implemention of
+// DataProtocol.
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public protocol HasFoo {
+  func foo()
+}
+
+@inline(never) func testHasFoo<T>(_ t: T)
+
+struct S1<T> {
+  init(_: T)
+}
+
+extension S1 : HasFoo where T == UInt8 {
+  func foo()
+}
+
+// ConstantPropagation converts checked_cast_addr to unconditional_checked_cast_addr.
+// SimplifyCFG removes the trivial branch.
+// SILCombine replaces the unconditional_checked_cast_addr with init_existential_addr + copy_addr
+//            and simplifies the switch condition.
+// JumpThreadSimplifyCFG eliminates the dead switch condition.
+// SILCombine specializes the witness_method instruction to S1<UInt8>.
+// Devirtualization replaces the witness invocation with a direct call.
+//
+// CHECK-LABEL: sil shared [noinline] @testSpecializedS1 : $@convention(thin) (S1<UInt8>) -> () {
+// CHECK: bb0(%0 : $S1<UInt8>):
+// CHECK: [[EXIS:%.*]] = alloc_stack $HasFoo
+// CHECK: [[S1:%.*]] = alloc_stack $S1<UInt8>
+// CHECK: store %0 to [[S1]] : $*S1<UInt8>
+// CHECK: [[OPT:%.*]] = alloc_stack $Optional<HasFoo>
+// CHECK: [[INIT_DATA:%.*]] = init_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[INIT_DATA]] : $*HasFoo, $S1<UInt8>
+// CHECK: copy_addr [take] [[S1]] to [initialization] [[EXIS_ADDR]] : $*S1<UInt8>
+// CHECK: inject_enum_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: copy_addr [take] [[DATA]] to [initialization] [[EXIS]] : $*HasFoo
+// CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*HasFoo to $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
+// CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") HasFoo to $*S1<UInt8>
+// CHECK: [[F:%.*]] = function_ref @witnessS1 : $@convention(witness_method: HasFoo) (@in_guaranteed S1<UInt8>) -> ()
+// CHECK: apply [[F]]([[OPEN_ADDR]]) : $@convention(witness_method: HasFoo) (@in_guaranteed S1<UInt8>) -> ()
+// CHECK-LABEL: } // end sil function 'testSpecializedS1'
+sil shared [noinline] @testSpecializedS1 : $@convention(thin) (S1<UInt8>) -> () {
+bb0(%0 : $S1<UInt8>):
+  debug_value %0 : $S1<UInt8>, let, name "t", argno 1
+  debug_value %0 : $S1<UInt8>, let, name "t", argno 1
+  %3 = alloc_stack $HasFoo
+  %4 = alloc_stack $S1<UInt8>
+  store %0 to %4 : $*S1<UInt8>
+  %6 = alloc_stack $Optional<HasFoo>
+  %7 = init_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  checked_cast_addr_br take_always S1<UInt8> in %4 : $*S1<UInt8> to HasFoo in %7 : $*HasFoo, bb1, bb2
+
+bb1:
+  inject_enum_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  br bb3
+
+bb2:
+  inject_enum_addr %6 : $*Optional<HasFoo>, #Optional.none!enumelt
+  br bb3
+
+bb3:
+  switch_enum_addr %6 : $*Optional<HasFoo>, case #Optional.some!enumelt.1: bb4, case #Optional.none!enumelt: bb5
+
+bb4:
+  %14 = unchecked_take_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  copy_addr [take] %14 to [initialization] %3 : $*HasFoo
+  dealloc_stack %6 : $*Optional<HasFoo>
+  dealloc_stack %4 : $*S1<UInt8>
+  %18 = open_existential_addr immutable_access %3 : $*HasFoo to $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
+  %19 = witness_method $@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") HasFoo, #HasFoo.foo!1 : <Self where Self : HasFoo> (Self) -> () -> (), %18 : $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") HasFoo : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
+  %20 = apply %19<@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD") HasFoo>(%18) : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %3 : $*HasFoo
+  br bb6
+
+bb5:
+  destroy_addr %6 : $*Optional<HasFoo>
+  dealloc_stack %6 : $*Optional<HasFoo>
+  dealloc_stack %4 : $*S1<UInt8>
+  br bb6
+
+bb6:
+  dealloc_stack %3 : $*HasFoo
+  %28 = tuple ()
+  return %28 : $()
+}
+
+struct S2<T> {
+  init(_: T) {}
+}
+
+protocol P {}
+
+extension S2 : HasFoo where T : P {
+  func foo() {}
+}
+
+struct IsP : P {}
+
+// CHECK-LABEL: sil shared [noinline] @testSpecializedS2 : $@convention(thin) (S2<IsP>) -> () {
+// CHECK: bb0(%0 : $S2<IsP>):
+// CHECK: [[EXIS:%.*]] = alloc_stack $HasFoo
+// CHECK: [[S2:%.*]] = alloc_stack $S2<IsP>
+// CHECK: store %0 to [[S2]] : $*S2<IsP>
+// CHECK: [[OPT:%.*]] = alloc_stack $Optional<HasFoo>
+// CHECK: [[INIT_DATA:%.*]] = init_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[INIT_DATA]] : $*HasFoo, $S2<IsP>
+// CHECK: copy_addr [take] [[S2]] to [initialization] [[EXIS_ADDR]] : $*S2<IsP>
+// CHECK: inject_enum_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: copy_addr [take] [[DATA]] to [initialization] [[EXIS]] : $*HasFoo
+// CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*HasFoo to $*@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
+// CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD") HasFoo to $*S2<IsP>
+// CHECK: [[F:%.*]] = function_ref @$s9witnessS24main3IsPV_Tg5 : $@convention(witness_method: HasFoo) (S2<IsP>) -> ()
+// CHECK: [[ARG:%.*]] = load [[OPEN_ADDR]] : $*S2<IsP>
+// CHECK: apply [[F]]([[ARG]]) : $@convention(witness_method: HasFoo) (S2<IsP>) -> ()
+// CHECK-LABEL: } // end sil function 'testSpecializedS2'
+sil shared [noinline] @testSpecializedS2 : $@convention(thin) (S2<IsP>) -> () {
+bb0(%0 : $S2<IsP>):
+  debug_value %0 : $S2<IsP>, let, name "t", argno 1
+  debug_value %0 : $S2<IsP>, let, name "t", argno 1
+  %3 = alloc_stack $HasFoo
+  %4 = alloc_stack $S2<IsP>
+  store %0 to %4 : $*S2<IsP>
+  %6 = alloc_stack $Optional<HasFoo>
+  %7 = init_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  checked_cast_addr_br take_always S2<IsP> in %4 : $*S2<IsP> to HasFoo in %7 : $*HasFoo, bb1, bb2
+
+bb1:
+  inject_enum_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  br bb3
+
+bb2:
+  inject_enum_addr %6 : $*Optional<HasFoo>, #Optional.none!enumelt
+  br bb3
+
+bb3:
+  switch_enum_addr %6 : $*Optional<HasFoo>, case #Optional.some!enumelt.1: bb4, case #Optional.none!enumelt: bb5
+
+bb4:
+  %14 = unchecked_take_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  copy_addr [take] %14 to [initialization] %3 : $*HasFoo
+  dealloc_stack %6 : $*Optional<HasFoo>
+  dealloc_stack %4 : $*S2<IsP>
+  %18 = open_existential_addr immutable_access %3 : $*HasFoo to $*@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
+  %19 = witness_method $@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD") HasFoo, #HasFoo.foo!1 : <Self where Self : HasFoo> (Self) -> () -> (), %18 : $*@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD") HasFoo : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
+  %20 = apply %19<@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD") HasFoo>(%18) : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %3 : $*HasFoo
+  br bb6
+
+bb5:
+  destroy_addr %6 : $*Optional<HasFoo>
+  dealloc_stack %6 : $*Optional<HasFoo>
+  dealloc_stack %4 : $*S2<IsP>
+  br bb6
+
+bb6:
+  dealloc_stack %3 : $*HasFoo
+  %28 = tuple ()
+  return %28 : $()
+}
+
+class C {
+  init() {}
+}
+
+struct S3<T> {
+  init(_: T) {}
+}
+
+extension S3 : HasFoo where T : AnyObject {
+  func foo() {}
+}
+
+// CHECK-LABEL: sil shared [noinline] @testSpecializedS3 : $@convention(thin) (S3<C>) -> () {
+// CHECK: bb0(%0 : $S3<C>):
+// CHECK: [[EXIS:%.*]] = alloc_stack $HasFoo
+// CHECK: [[S3:%.*]] = alloc_stack $S3<C>
+// CHECK: store %0 to [[S3]] : $*S3<C>
+// CHECK: [[OPT:%.*]] = alloc_stack $Optional<HasFoo>
+// CHECK: [[INIT_DATA:%.*]] = init_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[INIT_DATA]] : $*HasFoo, $S3<C>
+// CHECK: copy_addr [take] [[S3]] to [initialization] [[EXIS_ADDR]] : $*S3<C>
+// CHECK: inject_enum_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: copy_addr [take] [[DATA]] to [initialization] [[EXIS]] : $*HasFoo
+// CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*HasFoo to $*@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
+// CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD") HasFoo to $*S3<C>
+// CHECK: [[F:%.*]] = function_ref @$s9witnessS34main1CC_Tg5 : $@convention(witness_method: HasFoo) (S3<C>) -> ()
+// CHECK: [[ARG:%.*]] = load [[OPEN_ADDR]] : $*S3<C>
+// CHECK: apply [[F]]([[ARG]]) : $@convention(witness_method: HasFoo) (S3<C>) -> ()
+// CHECK-LABEL: } // end sil function 'testSpecializedS3'
+sil shared [noinline] @testSpecializedS3 : $@convention(thin) (S3<C>) -> () {
+bb0(%0 : $S3<C>):
+  debug_value %0 : $S3<C>, let, name "t", argno 1
+  debug_value %0 : $S3<C>, let, name "t", argno 1
+  %3 = alloc_stack $HasFoo
+  %4 = alloc_stack $S3<C>
+  store %0 to %4 : $*S3<C>
+  %6 = alloc_stack $Optional<HasFoo>
+  %7 = init_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  checked_cast_addr_br take_always S3<C> in %4 : $*S3<C> to HasFoo in %7 : $*HasFoo, bb1, bb2
+
+bb1:
+  inject_enum_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  br bb3
+
+bb2:
+  inject_enum_addr %6 : $*Optional<HasFoo>, #Optional.none!enumelt
+  br bb3
+
+bb3:
+  switch_enum_addr %6 : $*Optional<HasFoo>, case #Optional.some!enumelt.1: bb4, case #Optional.none!enumelt: bb5
+
+bb4:
+  %14 = unchecked_take_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  copy_addr [take] %14 to [initialization] %3 : $*HasFoo
+  dealloc_stack %6 : $*Optional<HasFoo>
+  dealloc_stack %4 : $*S3<C>
+  %18 = open_existential_addr immutable_access %3 : $*HasFoo to $*@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
+  %19 = witness_method $@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD") HasFoo, #HasFoo.foo!1 : <Self where Self : HasFoo> (Self) -> () -> (), %18 : $*@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD") HasFoo : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
+  %20 = apply %19<@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD") HasFoo>(%18) : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %3 : $*HasFoo
+  br bb6
+
+bb5:
+  destroy_addr %6 : $*Optional<HasFoo>
+  dealloc_stack %6 : $*Optional<HasFoo>
+  dealloc_stack %4 : $*S3<C>
+  br bb6
+
+bb6:
+  dealloc_stack %3 : $*HasFoo
+  %28 = tuple ()
+  return %28 : $()
+}
+
+class SubC : C {}
+
+struct S4<T> {
+  init(_: T) {}
+}
+
+extension S4 : HasFoo where T : C {
+  func foo() {}
+}
+
+// CHECK-LABEL: sil shared [noinline] @testSpecializedS4 : $@convention(thin) (S4<SubC>) -> () {
+// CHECK: bb0(%0 : $S4<SubC>):
+// CHECK: [[EXIS:%.*]] = alloc_stack $HasFoo
+// CHECK: [[S3:%.*]] = alloc_stack $S4<SubC>
+// CHECK: store %0 to [[S3]] : $*S4<SubC>
+// CHECK: [[OPT:%.*]] = alloc_stack $Optional<HasFoo>
+// CHECK: [[INIT_DATA:%.*]] = init_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[INIT_DATA]] : $*HasFoo, $S4<SubC>
+// CHECK: copy_addr [take] [[S3]] to [initialization] [[EXIS_ADDR]] : $*S4<SubC>
+// CHECK: inject_enum_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<HasFoo>, #Optional.some!enumelt.1
+// CHECK: copy_addr [take] [[DATA]] to [initialization] [[EXIS]] : $*HasFoo
+// CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*HasFoo to $*@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
+// CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD") HasFoo to $*S4<SubC>
+// CHECK: [[F:%.*]] = function_ref @$s9witnessS44main4SubCC_Tg5 : $@convention(witness_method: HasFoo) (S4<SubC>) -> ()
+// CHECK: [[ARG:%.*]] = load [[OPEN_ADDR]] : $*S4<SubC>
+// CHECK: apply [[F]]([[ARG]]) : $@convention(witness_method: HasFoo) (S4<SubC>) -> ()
+// CHECK: } // end sil function 'testSpecializedS4'
+sil shared [noinline] @testSpecializedS4 : $@convention(thin) (S4<SubC>) -> () {
+bb0(%0 : $S4<SubC>):
+  debug_value %0 : $S4<SubC>, let, name "t", argno 1
+  debug_value %0 : $S4<SubC>, let, name "t", argno 1
+  %3 = alloc_stack $HasFoo
+  %4 = alloc_stack $S4<SubC>
+  store %0 to %4 : $*S4<SubC>
+  %6 = alloc_stack $Optional<HasFoo>
+  %7 = init_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  checked_cast_addr_br take_always S4<SubC> in %4 : $*S4<SubC> to HasFoo in %7 : $*HasFoo, bb1, bb2
+
+bb1:
+  inject_enum_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  br bb3
+
+bb2:
+  inject_enum_addr %6 : $*Optional<HasFoo>, #Optional.none!enumelt
+  br bb3
+
+bb3:
+  switch_enum_addr %6 : $*Optional<HasFoo>, case #Optional.some!enumelt.1: bb4, case #Optional.none!enumelt: bb5
+
+bb4:
+  %14 = unchecked_take_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt.1
+  copy_addr [take] %14 to [initialization] %3 : $*HasFoo
+  dealloc_stack %6 : $*Optional<HasFoo>
+  dealloc_stack %4 : $*S4<SubC>
+  %18 = open_existential_addr immutable_access %3 : $*HasFoo to $*@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD") HasFoo
+  %19 = witness_method $@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD") HasFoo, #HasFoo.foo!1 : <Self where Self : HasFoo> (Self) -> () -> (), %18 : $*@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD") HasFoo : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
+  %20 = apply %19<@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD") HasFoo>(%18) : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %3 : $*HasFoo
+  br bb6
+
+bb5:
+  destroy_addr %6 : $*Optional<HasFoo>
+  dealloc_stack %6 : $*Optional<HasFoo>
+  dealloc_stack %4 : $*S4<SubC>
+  br bb6
+
+bb6:
+  dealloc_stack %3 : $*HasFoo
+  %28 = tuple ()
+  return %28 : $()
+}
+
+
+sil private [transparent] [thunk] @witnessS1 : $@convention(witness_method: HasFoo) (@in_guaranteed S1<UInt8>) -> () {
+bb0(%0 : $*S1<UInt8>):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+
+sil private [transparent] [thunk] @witnessS2 : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : P> (@in_guaranteed S2<τ_0_0>) -> () {
+bb0(%0 : $*S2<τ_0_0>):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil private [transparent] [thunk] @witnessS3 : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : AnyObject> (@in_guaranteed S3<τ_0_0>) -> () {
+bb0(%0 : $*S3<τ_0_0>):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil private [transparent] [thunk] @witnessS4 : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : C> (@in_guaranteed S4<τ_0_0>) -> () {
+bb0(%0 : $*S4<τ_0_0>):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil_vtable C {}
+
+sil_vtable SubC {}
+
+sil_witness_table hidden <T where T == UInt8> S1<T>: HasFoo module tot {
+  method #HasFoo.foo!1: <Self where Self : HasFoo> (Self) -> () -> () : @witnessS1
+}
+
+sil_witness_table hidden <T where T : P> S2<T>: HasFoo module tot {
+  method #HasFoo.foo!1: <Self where Self : HasFoo> (Self) -> () -> () : @witnessS2
+  conditional_conformance (T: P): dependent
+}
+
+sil_witness_table hidden IsP: P module tot {
+}
+
+sil_witness_table hidden <T where T : AnyObject> S3<T>: HasFoo module tot {
+  method #HasFoo.foo!1: <Self where Self : HasFoo> (Self) -> () -> () : @witnessS3
+}
+
+sil_witness_table hidden <T where T : C> S4<T>: HasFoo module tot {
+  method #HasFoo.foo!1: <Self where Self : HasFoo> (Self) -> () -> () : @witnessS4
+}


### PR DESCRIPTION
Previously the cast optimizer bailed out on any conformance with
requirements.

We can now constant-propagate this:

```
protocol P {}
struct S<E> {
  var e: E
}

extension S : P where E == Int {}

func specializeMe<T>(_ t: T) {
  if let p = t as? P {
    // do fast things.
  }
}

specializeMe(S(e: 0))
```

This turns out to be as simple as calling the TypeChecker.

<rdar://problem/46375150> Inlining does not seem to handle
specialization properly for Data.
