### PR TITLE
build: repair the windows cross-compilation

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -55,8 +55,12 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(runtime)
   add_subdirectory(stubs)
   add_subdirectory(core)
-  add_subdirectory(SIMDOperators)
   add_subdirectory(SwiftOnoneSupport)
+
+  # NOTE(compnerd) this must come after the SwiftOnoneSupport as the current
+  # cross-compilation support has to hand roll the import library setup which
+  # requires that the target is setup prior to use.
+  add_subdirectory(SIMDOperators)
 endif()
 
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)


### PR DESCRIPTION
The SIMDOperators module was being added prior to SwiftOnoneSupport, which
resulted in the import library target for Windows not being setup prior to use.
As a result, we would link against the DLL rather than the import library which
is not supported (except as a MinGW hack in the binutils linker).  Re-order the
registration to ensure that the target is setup already.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
