### PR TITLE
[WIP][stdlib] Array & friends: Add more _read/_modify accessors

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -384,7 +384,7 @@ extension Array {
   }
 
   @_semantics("array.get_element")
-  @inlinable // FIXME(inline-always)
+  @inlinable
   @inline(__always)
   public // @testable
   func _getElement(
@@ -444,10 +444,10 @@ extension Array: _ArrayProtocol {
   @inlinable
   public // @testable
   var _owner: AnyObject? {
-    @inlinable // FIXME(inline-always)
+    @inlinable
     @inline(__always)
     get {
-      return _buffer.owner      
+      return _buffer.owner
     }
   }
 
@@ -1478,7 +1478,7 @@ extension Array {
   ///   method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_semantics("array.withUnsafeMutableBufferPointer")
-  @inlinable // FIXME(inline-always)
+  @inlinable
   @inline(__always) // Performance: This method should get inlined into the
   // caller such that we can combine the partial apply with the apply in this
   // function saving on allocating a closure context. This becomes unnecessary

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -712,8 +712,7 @@ extension Array: RandomAccessCollection, MutableCollection {
     _modify {
       _makeMutableAndUnique() // makes the array native, too
       _checkSubscript_native(index)
-      let address = _buffer.subscriptBaseAddress + index
-      yield &address.pointee
+      yield &_buffer[index]
     }
   }
 

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -535,8 +535,7 @@ extension ArraySlice: RandomAccessCollection, MutableCollection {
     _modify {
       _makeMutableAndUnique() // makes the array native, too
       _checkSubscript_native(index)
-      let address = _buffer.subscriptBaseAddress + index
-      yield &address.pointee
+      yield &_buffer[index]
     }
   }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -381,15 +381,14 @@ extension ContiguousArray: RandomAccessCollection, MutableCollection {
   ///   writing is O(*n*), where *n* is the length of the array.
   @inlinable
   public subscript(index: Int) -> Element {
-    get {
+    _read {
       _checkSubscript_native(index)
-      return _buffer.getElement(index)
+      yield _buffer[index]
     }
     _modify {
       _makeMutableAndUnique()
       _checkSubscript_native(index)
-      let address = _buffer.subscriptBaseAddress + index
-      yield &address.pointee
+      yield &_buffer[index]
     }
   }
 

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -319,28 +319,27 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   @inlinable
   @inline(__always)
   internal func getElement(_ i: Int) -> Element {
-    _internalInvariant(i >= 0 && i < count, "Array index out of range")
-    return firstElementAddress[i]
+    return getElementAddress(i).pointee
   }
 
-  /// Get or set the value of the ith element.
+  @inlinable
+  @inline(__always)
+  internal func getElementAddress(_ i: Int) -> UnsafeMutablePointer<Element> {
+    _internalInvariant(i >= 0 && i < count, "Array index out of range")
+    return firstElementAddress + i
+  }
+
+  /// Get or set the value of the ith element without index validation.
+  /// Mutations assume self is uniquely referenced.
   @inlinable
   internal subscript(i: Int) -> Element {
     @inline(__always)
-    get {
-      return getElement(i)
+    _read {
+      yield getElementAddress(i).pointee
     }
     @inline(__always)
-    nonmutating set {
-      _internalInvariant(i >= 0 && i < count, "Array index out of range")
-
-      // FIXME: Manually swap because it makes the ARC optimizer happy.  See
-      // <rdar://problem/16831852> check retain/release order
-      // firstElementAddress[i] = newValue
-      var nv = newValue
-      let tmp = nv
-      nv = firstElementAddress[i]
-      firstElementAddress[i] = tmp
+    nonmutating _modify {
+      yield &getElementAddress(i).pointee
     }
   }
 

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -304,9 +304,16 @@ internal struct _SliceBuffer<Element>
 
   @inlinable
   internal func getElement(_ i: Int) -> Element {
-    _internalInvariant(i >= startIndex, "slice index is out of range (before startIndex)")
+    return getElementAddress(i).pointee
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func getElementAddress(_ i: Int) -> UnsafeMutablePointer<Element> {
+    _internalInvariant(i >= startIndex,
+      "slice index is out of range (before startIndex)")
     _internalInvariant(i < endIndex, "slice index is out of range")
-    return subscriptBaseAddress[i]
+    return subscriptBaseAddress + i
   }
 
   /// Access the element at `position`.
@@ -314,14 +321,12 @@ internal struct _SliceBuffer<Element>
   /// - Precondition: `position` is a valid position in `self` and
   ///   `position != endIndex`.
   @inlinable
-  internal subscript(position: Int) -> Element {
-    get {
-      return getElement(position)
+  internal subscript(index: Int) -> Element {
+    _read {
+      yield getElementAddress(index).pointee
     }
-    nonmutating set {
-      _internalInvariant(position >= startIndex, "slice index is out of range (before startIndex)")
-      _internalInvariant(position < endIndex, "slice index is out of range")
-      subscriptBaseAddress[position] = newValue
+    _modify {
+      yield &getElementAddress(index).pointee
     }
   }
 

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -600,3 +600,6 @@ Var Dictionary.values has been removed
 Var FixedWidthInteger.allZeros has been removed (deprecated)
 Var String.Index._offset has been removed (deprecated)
 Var String.Index._utf16Index has been removed (deprecated)
+
+Func Array._getElementAddress(_:) has been renamed to Func Array._getElementAddress(_:matchingSubscriptCheck:)
+Func ArraySlice._getElementAddress(_:) has been renamed to Func ArraySlice._getElementAddress(_:matchingSubscriptCheck:)

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -53,7 +53,7 @@ ArrayTestSuite.test("${array_type}<${element_type}>/subscript(_: Int)/COW")
   var a: ${array_type}<${array_type}<${element_type}>> = [[
     ${element_type}(10), ${element_type}(20), ${element_type}(30),
     ${element_type}(40), ${element_type}(50), ${element_type}(60),
-    ${element_type}(70)
+    ${element_type}(70), ${element_type}(80)
   ]]
   let identityOuter = a._bufferID
   var identityInner = a[0]._bufferID
@@ -82,31 +82,32 @@ ArrayTestSuite.test("${array_type}<${element_type}>/subscript(_: Int)/COW")
 
   checkIdentity(SourceLocStack().withCurrentLoc())
 
-  withInoutT(&a) {
-    (x: inout ${array_type}<${array_type}<${element_type}>>) in
+  withInoutT(&a) { (x: inout ${array_type}<${array_type}<${element_type}>>) in
     x[0][2].value += 1000
   }
 
   checkIdentity(SourceLocStack().withCurrentLoc())
 
-  withInoutT(&a[0]) {
-    (x: inout ${array_type}<${element_type}>) in
+  withInoutT(&a[0]) { (x: inout ${array_type}<${element_type}>) in
     x[3].value += 1000
   }
 
   checkIdentity(SourceLocStack().withCurrentLoc())
 
   // This will reallocate storage unless Array uses addressors for subscript.
-  //withInoutT(&a[0][4]) {
-  //  (x: inout ${element_type}) in
-  //  x.value += 1000
-  //}
+  withInoutT(&a[0][4]) { (x: inout ${element_type}) in
+    x.value += 1000
+  }
 
-  // FIXME: both of these lines crash the compiler.
-  // <rdar://problem/18439579> Passing an expression based on addressors as
-  // 'inout' crashes SILGen
-  //withInoutT(&a[0][5].value, { $0 += 1000 })
-  //withInoutInt(&a[0][6].value, { $0 += 1000 })
+  checkIdentity(SourceLocStack().withCurrentLoc())
+
+  withInoutT(&a[0][5].value) { $0 += 1000 }
+
+  checkIdentity(SourceLocStack().withCurrentLoc())
+
+  withInoutInt(&a[0][6].value) { $0 += 1000 }
+
+  checkIdentity(SourceLocStack().withCurrentLoc())
 
   // Don't change the last element.
 
@@ -114,9 +115,10 @@ ArrayTestSuite.test("${array_type}<${element_type}>/subscript(_: Int)/COW")
   expectEqual(1020, a[0][1].value)
   expectEqual(1030, a[0][2].value)
   expectEqual(1040, a[0][3].value)
-  expectEqual(50, a[0][4].value)
-  expectEqual(60, a[0][5].value)
-  expectEqual(70, a[0][6].value)
+  expectEqual(1050, a[0][4].value)
+  expectEqual(1060, a[0][5].value)
+  expectEqual(1070, a[0][6].value)
+  expectEqual(80, a[0][7].value)
 }
 
 ArrayTestSuite.test("${array_type}<${element_type}>/subscript(_: Range<Int>)/COW")


### PR DESCRIPTION
Replace getters with _read accessors in `Array.subscript` & `ContiguousArray.subscript`.
Review array buffer subscripting and add _read/_modify where appropriate.