### PR TITLE
[android] Avoid linking twice with C++

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -430,6 +430,9 @@ function(_add_variant_link_flags)
     list(APPEND result "-Wl,-Bsymbolic")
   elseif("${LFLAGS_SDK}" STREQUAL "ANDROID")
     list(APPEND link_libraries "dl" "log" "atomic" "icudataswift" "icui18nswift" "icuucswift")
+    # We provide our own C++ below, so we ask the linker not to do it. However,
+    # we need to add the math library, which is linked implicitly by libc++.
+    list(APPEND result "-nostdlib++" "-lm")
     if("${LFLAGS_ARCH}" MATCHES armv7)
       list(APPEND result "${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so")
     elseif("${LFLAGS_ARCH}" MATCHES aarch64)


### PR DESCRIPTION
The Android targetted libraries already link (manually) with the Android
NDK C++ libraries. When using Clang and lld, an extra link to libc++ is
requested, which will fail because Android names it libc++_shared.so
instead. To avoid looking for the wrong name, and since the library is
referenced manually either way, request no linking with the standard C++
libraries (but add the math library in, which is implicitly linked when
C++ is linked, and it is needed for Glibc at least).