### PR TITLE
[5.0][Runtime] Allow casts from AnyHashable to a Hashable enum to succeed.

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2436,6 +2436,10 @@ static bool swift_dynamicCastImpl(OpaqueValue *dest, OpaqueValue *src,
                                           cast<StructMetadata>(srcType),
                                           cast<StructMetadata>(targetType),
                                           flags);
+      } else if (isAnyHashableType(srcType)) {
+        // AnyHashable casts for enums.
+        return _dynamicCastFromAnyHashable(dest, src, srcType, targetType,
+                                           flags);
       }
       break;
 

--- a/test/stdlib/AnyHashableCasts.swift.gyb
+++ b/test/stdlib/AnyHashableCasts.swift.gyb
@@ -79,9 +79,15 @@ testCases = [
   ("AnyHashable(5)", "Any", "Int", "5"),
   ("HashableStruct(value: 5)", "HashableStruct", "AnyHashable",
    "AnyHashable(HashableStruct(value: 5))"),
+  ("HashableStruct(value: 5)", "AnyHashable", "HashableStruct",
+   "AnyHashable(HashableStruct(value: 5))"),
   ("HashableClass(value: 5)", "HashableClass", "AnyHashable",
    "AnyHashable(HashableClass(value: 5))"),
+  ("HashableClass(value: 5)", "AnyHashable", "HashableClass",
+   "AnyHashable(HashableClass(value: 5))"),
   ("HashableEnum.value(5)", "HashableEnum", "AnyHashable",
+   "AnyHashable(HashableEnum.value(5))"),
+  ("HashableEnum.value(5)", "AnyHashable", "HashableEnum",
    "AnyHashable(HashableEnum.value(5))"),
 ]
 }%


### PR DESCRIPTION
Cherry-pick #21044 to swift-5.0-branch.

rdar://problem/46472361