### PR TITLE
[ConstraintSystem] Handle `InOut` base introduced by diagnostic re-ty…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1189,6 +1189,21 @@ ConstraintSystem::getTypeOfMemberReference(
     OpenedTypeMap *replacementsPtr) {
   // Figure out the instance type used for the base.
   Type baseObjTy = getFixedTypeRecursive(baseTy, /*wantRValue=*/true);
+
+  ParameterTypeFlags baseFlags;
+  // FIXME(diagnostics): `InOutType` could appear here as a result
+  // of successful re-typecheck of the one of the sub-expressions e.g.
+  // `let _: Int = { (s: inout S) in s.bar() }`. On the first
+  // attempt to type-check whole expression `s.bar()` - is going
+  // to have a base which points directly to declaration of `S`.
+  // But when diagnostics attempts to type-check `s.bar()` standalone
+  // its base would be tranformed into `InOutExpr -> DeclRefExr`,
+  // and `InOutType` is going to be recorded in constraint system.
+  if (auto objType = baseObjTy->getInOutObjectType()) {
+    baseObjTy = objType;
+    baseFlags = baseFlags.withInOut(true);
+  }
+
   bool isInstance = true;
   if (auto baseMeta = baseObjTy->getAs<AnyMetatypeType>()) {
     baseObjTy = baseMeta->getInstanceType();
@@ -1200,7 +1215,7 @@ ConstraintSystem::getTypeOfMemberReference(
     return getTypeOfReference(value, functionRefKind, locator, useDC, base);
   }
 
-  FunctionType::Param baseObjParam(baseObjTy);
+  FunctionType::Param baseObjParam(baseObjTy, Identifier(), baseFlags);
 
   // Don't open existentials when accessing typealias members of
   // protocols.

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -849,3 +849,12 @@ func rdar_45659733() {
     }
   }
 }
+
+func rdar45771997() {
+  struct S {
+    mutating func foo() {}
+  }
+
+  let _: Int = { (s: inout S) in s.foo() }
+  // expected-error@-1 {{cannot convert value of type '(inout S) -> ()' to specified type 'Int'}}
+}


### PR DESCRIPTION
…pecheck

While trying to lookup member reference on some base type, handle
base being an `InOutType`, which could be a result of previous
sub-expression re-typechecks made by diagnostics.

Resolves: rdar://problem/45771997

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
