### PR TITLE
[silgen] When performing existential erasure, be sure that we have a …

### DIFF
--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -210,6 +210,10 @@ ManagedValue ManagedValue::ensurePlusOne(SILGenFunction &SGF,
 }
 
 bool ManagedValue::isPlusOne(SILGenFunction &SGF) const {
+  // If this is an lvalue or in context, the value is not at plus one.
+  if (isLValue() || isInContext())
+    return false;
+
   // If this value is SILUndef, return true. SILUndef can always be passed to +1
   // APIs.
   if (isa<SILUndef>(getValue()))
@@ -229,6 +233,10 @@ bool ManagedValue::isPlusOne(SILGenFunction &SGF) const {
 }
 
 bool ManagedValue::isPlusZero() const {
+  // If this is an lvalue or in context, the value is not at plus one.
+  if (isLValue() || isInContext())
+    return false;
+
   // SILUndef can always be passed to +0 APIs.
   if (isa<SILUndef>(getValue()))
     return true;

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -241,7 +241,7 @@ static ManagedValue emitTransformExistential(SILGenFunction &SGF,
                    [&](SGFContext C) -> ManagedValue {
                      if (openedArchetype)
                        return SGF.manageOpaqueValue(state, loc, C);
-                     return input;
+                     return input.ensurePlusOne(SGF, loc);
                    });
   
   return input;

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -672,3 +672,24 @@ func dontCrash() {
   let userInfo = ["hello": "world"]
   let d = [AnyHashable: Any](uniqueKeysWithValues: userInfo.map { ($0.key, $0.value) })
 }
+
+@inline(never)
+func takesTwoGeneric<T>(_ fn: (T) -> (), _ a: T) -> T {
+  fn(a)
+  return a
+}
+
+@inline(never)
+func callback(_: __owned AnyObject, _: __owned AnyObject) {}
+
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$syXlyXlIegxx_19function_conversion5FeralCACIeggg_TR : $@convention(thin) (@guaranteed Feral, @guaranteed Feral, @guaranteed @callee_guaranteed (@owned AnyObject, @owned AnyObject) -> ()) -> () {
+// CHECK: bb0([[ARG0:%.*]] : @guaranteed $Feral, [[ARG1:%.*]] : @guaranteed $Feral, [[ARG2:%.*]] :
+// CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
+// CHECK:   [[ARG0_EXISTENTIAL:%.*]] = init_existential_ref [[ARG0_COPY]]
+// CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
+// CHECK:   [[ARG1_EXISTENTIAL:%.*]] = init_existential_ref [[ARG1_COPY]]
+// CHECK:   apply {{%.*}}([[ARG0_EXISTENTIAL]], [[ARG1_EXISTENTIAL]]) : $@callee_guaranteed (@owned AnyObject, @owned AnyObject) -> ()
+// CHECK: } // end sil function '$syXlyXlIegxx_19function_conversion5FeralCACIeggg_TR'
+func test() {
+  let z = takesTwoGeneric(callback, (Feral(), Feral()))
+}


### PR DESCRIPTION
…plus one value.

This both fixes the issue in SILGenPoly that exposed the problem and
additionally introduces a check in asserts builds to ensure that we catch this
problem in the future.

rdar://43398898
