### PR TITLE
[ownership] Enable ownership verification on all target-run-simple-swift* tests

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1154,21 +1154,21 @@ config.substitutions.append(('%sftp-server',
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift_parameterized =                               \
         (SubstituteCaptures('%%empty-directory(%%t) && '
-                            '%s %s %%s \\1 -o %%t/a.out -module-name main && '
+                            '%s %s %%s \\1 -o %%t/a.out -module-name main -Xfrontend -enable-sil-ownership && '
                             '%s %%t/a.out &&'
                             '%s %%t/a.out' % (config.target_build_swift,
                                               mcp_opt, config.target_codesign,
                                               config.target_run)))
     config.target_run_simple_swift = (
         '%%empty-directory(%%t) && '
-        '%s %s %%s -o %%t/a.out -module-name main && '
+        '%s %s %%s -o %%t/a.out -module-name main -Xfrontend -enable-sil-ownership && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
     config.target_run_stdlib_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main '
-        '-Xfrontend -disable-access-control && '
+        '-Xfrontend -disable-access-control -Xfrontend -enable-sil-ownership && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
@@ -1176,7 +1176,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
         '%%line-directive %%t/main.swift -- '
-        '%s %s %%t/main.swift -o %%t/a.out -module-name main && '
+        '%s %s %%t/main.swift -o %%t/a.out -module-name main -Xfrontend -enable-sil-ownership && '
         '%s %%t/a.out &&'
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
@@ -1186,7 +1186,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%%gyb %%s -o %%t/main.swift && '
         '%%line-directive %%t/main.swift -- '
         '%s %s %%t/main.swift -o %%t/a.out -module-name main '
-        '-Xfrontend -disable-access-control && '
+        '-Xfrontend -disable-access-control -Xfrontend -enable-sil-ownership && '
         '%s %%t/a.out &&'
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'


### PR DESCRIPTION
This includes both the stdlib test suite and interpreter. So this should massively increase our coverage with ownership sil.