### PR TITLE
Runtime: Provide ABI space for source location info in unconditional casts.

### DIFF
--- a/include/swift/Runtime/Casting.h
+++ b/include/swift/Runtime/Casting.h
@@ -62,12 +62,16 @@ swift_dynamicCastClass(const void *object, const ClassMetadata *targetType);
 /// \param object The object to cast.
 /// \param targetType The type to which we are casting, which is known to be
 /// a Swift class type.
+/// \param file The source filename from which to report failure. May be null.
+/// \param line The source line from which to report failure.
+/// \param column The source column from which to report failure.
 ///
 /// \returns the object.
 SWIFT_RUNTIME_EXPORT
 const void *
 swift_dynamicCastClassUnconditional(const void *object,
-                                    const ClassMetadata *targetType);
+                                    const ClassMetadata *targetType,
+                                    const char *file, unsigned line, unsigned column);
 
 #if SWIFT_OBJC_INTEROP
 /// Checked Objective-C-style dynamic cast to a class type.
@@ -103,25 +107,33 @@ swift_dynamicCastForeignClass(const void *object,
 /// \param object The object to cast, or nil.
 /// \param targetType The type to which we are casting, which is known to be
 /// a class type, but not necessarily valid type metadata.
+/// \param file The source filename from which to report failure. May be null.
+/// \param line The source line from which to report failure.
+/// \param column The source column from which to report failure.
 ///
 /// \returns the object.
 SWIFT_RUNTIME_EXPORT
 const void *
 swift_dynamicCastObjCClassUnconditional(const void *object,
-                                        const ClassMetadata *targetType);
+                                        const ClassMetadata *targetType,
+                                        const char *file, unsigned line, unsigned column);
 
 /// Unconditional, checked dynamic cast to a foreign class type.
 ///
 /// \param object The object to cast, or nil.
 /// \param targetType The type to which we are casting, which is known to be
 /// a foreign class type.
+/// \param file The source filename from which to report failure. May be null.
+/// \param line The source line from which to report failure.
+/// \param column The source column from which to report failure.
 ///
 /// \returns the object if the cast succeeds, or null otherwise.
 SWIFT_RUNTIME_EXPORT
 const void *
 swift_dynamicCastForeignClassUnconditional(
   const void *object,
-  const ForeignClassMetadata *targetType);
+  const ForeignClassMetadata *targetType,
+  const char *file, unsigned line, unsigned column);
 #endif
 
 /// Checked dynamic cast of a class instance pointer to the given type.
@@ -146,11 +158,16 @@ swift_dynamicCastUnknownClass(const void *object, const Metadata *targetType);
 /// \param targetType The type to which we are casting, which may be either a
 /// class type or a wrapped Objective-C class type.
 ///
+/// \param file The source filename from which to report failure. May be null.
+/// \param line The source line from which to report failure.
+/// \param column The source column from which to report failure.
+///
 /// \returns the object.
 SWIFT_RUNTIME_EXPORT
 const void *
 swift_dynamicCastUnknownClassUnconditional(const void *object,
-                                           const Metadata *targetType);
+                                           const Metadata *targetType,
+                                           const char *file, unsigned line, unsigned column);
 
 SWIFT_RUNTIME_EXPORT
 const Metadata *
@@ -159,7 +176,8 @@ swift_dynamicCastMetatype(const Metadata *sourceType,
 SWIFT_RUNTIME_EXPORT
 const Metadata *
 swift_dynamicCastMetatypeUnconditional(const Metadata *sourceType,
-                                       const Metadata *targetType);
+                                       const Metadata *targetType,
+                                       const char *file, unsigned line, unsigned column);
 #if SWIFT_OBJC_INTEROP
 SWIFT_RUNTIME_EXPORT
 const ClassMetadata *
@@ -168,7 +186,8 @@ swift_dynamicCastObjCClassMetatype(const ClassMetadata *sourceType,
 SWIFT_RUNTIME_EXPORT
 const ClassMetadata *
 swift_dynamicCastObjCClassMetatypeUnconditional(const ClassMetadata *sourceType,
-                                                const ClassMetadata *targetType);
+                                                const ClassMetadata *targetType,
+                                                const char *file, unsigned line, unsigned column);
 #endif
 
 SWIFT_RUNTIME_EXPORT
@@ -179,7 +198,8 @@ SWIFT_RUNTIME_EXPORT
 const ClassMetadata *
 swift_dynamicCastForeignClassMetatypeUnconditional(
   const ClassMetadata *sourceType,
-  const ClassMetadata *targetType);
+  const ClassMetadata *targetType,
+  const char *file, unsigned line, unsigned column);
 
 /// Return the dynamic type of an opaque value.
 ///

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -942,7 +942,7 @@ FUNCTION(DynamicCastClass, swift_dynamicCastClass, C_CC,
 FUNCTION(DynamicCastClassUnconditional, swift_dynamicCastClassUnconditional,
          C_CC,
          RETURNS(Int8PtrTy),
-         ARGS(Int8PtrTy, Int8PtrTy),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // void *swift_dynamicCastObjCClass(void*, void*);
@@ -955,7 +955,7 @@ FUNCTION(DynamicCastObjCClass, swift_dynamicCastObjCClass, C_CC,
 FUNCTION(DynamicCastObjCClassUnconditional,
          swift_dynamicCastObjCClassUnconditional, C_CC,
          RETURNS(Int8PtrTy),
-         ARGS(Int8PtrTy, Int8PtrTy),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // void *swift_dynamicCastUnknownClass(void*, void*);
@@ -968,7 +968,7 @@ FUNCTION(DynamicCastUnknownClass, swift_dynamicCastUnknownClass, C_CC,
 FUNCTION(DynamicCastUnknownClassUnconditional,
          swift_dynamicCastUnknownClassUnconditional, C_CC,
          RETURNS(Int8PtrTy),
-         ARGS(Int8PtrTy, Int8PtrTy),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // type *swift_dynamicCastMetatype(type*, type*);
@@ -981,7 +981,7 @@ FUNCTION(DynamicCastMetatype, swift_dynamicCastMetatype, C_CC,
 FUNCTION(DynamicCastMetatypeUnconditional,
          swift_dynamicCastMetatypeUnconditional, C_CC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(TypeMetadataPtrTy, TypeMetadataPtrTy),
+         ARGS(TypeMetadataPtrTy, TypeMetadataPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // objc_class *swift_dynamicCastObjCClassMetatype(objc_class*, objc_class*);
@@ -995,7 +995,7 @@ FUNCTION(DynamicCastObjCClassMetatype, swift_dynamicCastObjCClassMetatype,
 FUNCTION(DynamicCastObjCClassMetatypeUnconditional,
          swift_dynamicCastObjCClassMetatypeUnconditional, C_CC,
          RETURNS(ObjCClassPtrTy),
-         ARGS(ObjCClassPtrTy, ObjCClassPtrTy),
+         ARGS(ObjCClassPtrTy, ObjCClassPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // bool swift_dynamicCast(opaque*, opaque*, type*, type*, size_t);
@@ -1011,7 +1011,7 @@ FUNCTION(DynamicCast, swift_dynamicCast, C_CC,
 FUNCTION(DynamicCastTypeToObjCProtocolUnconditional,
          swift_dynamicCastTypeToObjCProtocolUnconditional, C_CC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy),
+         ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind))
 
 // type* swift_dynamicCastTypeToObjCProtocolConditional(type* object,
@@ -1029,7 +1029,7 @@ FUNCTION(DynamicCastTypeToObjCProtocolConditional,
 FUNCTION(DynamicCastObjCProtocolUnconditional,
          swift_dynamicCastObjCProtocolUnconditional, C_CC,
          RETURNS(ObjCPtrTy),
-         ARGS(ObjCPtrTy, SizeTy, Int8PtrPtrTy),
+         ARGS(ObjCPtrTy, SizeTy, Int8PtrPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind))
 
 // id swift_dynamicCastObjCProtocolConditional(id object,
@@ -1045,7 +1045,7 @@ FUNCTION(DynamicCastObjCProtocolConditional,
 FUNCTION(DynamicCastMetatypeToObjectUnconditional,
          swift_dynamicCastMetatypeToObjectUnconditional, C_CC,
          RETURNS(ObjCPtrTy),
-         ARGS(TypeMetadataPtrTy),
+         ARGS(TypeMetadataPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadNone))
 
 // id swift_dynamicCastMetatypeToObjectConditional(type *type);

--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -85,8 +85,9 @@ OVERRIDE_CASTING(dynamicCastClass, const void *, , swift::,
 
 OVERRIDE_CASTING(dynamicCastClassUnconditional, const void *, , swift::,
                  (const void *object,
-                  const ClassMetadata *targetType),
-                 (object, targetType))
+                  const ClassMetadata *targetType,
+                  const char *file, unsigned line, unsigned column),
+                 (object, targetType, file, line, column))
 
 
 
@@ -96,8 +97,9 @@ OVERRIDE_CASTING(dynamicCastUnknownClass, const void *, , swift::,
 
 
 OVERRIDE_CASTING(dynamicCastUnknownClassUnconditional, const void *, , swift::,
-                 (const void *object, const Metadata *targetType),
-                 (object, targetType))
+                 (const void *object, const Metadata *targetType,
+                  const char *file, unsigned line, unsigned column),
+                 (object, targetType, file, line, column))
 
 
 OVERRIDE_CASTING(dynamicCastMetatype, const Metadata *, , swift::,
@@ -108,8 +110,9 @@ OVERRIDE_CASTING(dynamicCastMetatype, const Metadata *, , swift::,
 
 OVERRIDE_CASTING(dynamicCastMetatypeUnconditional, const Metadata *, , swift::,
                  (const Metadata *sourceType,
-                  const Metadata *targetType),
-                 (sourceType, targetType))
+                  const Metadata *targetType,
+                  const char *file, unsigned line, unsigned column),
+                 (sourceType, targetType, file, line, column))
 
 
 OVERRIDE_FOREIGN(dynamicCastForeignClassMetatype, const ClassMetadata *, , swift::,
@@ -121,8 +124,9 @@ OVERRIDE_FOREIGN(dynamicCastForeignClassMetatype, const ClassMetadata *, , swift
 OVERRIDE_FOREIGN(dynamicCastForeignClassMetatypeUnconditional,
                  const ClassMetadata *, , swift::,
                  (const ClassMetadata *sourceType,
-                  const ClassMetadata *targetType),
-                 (sourceType, targetType))
+                  const ClassMetadata *targetType,
+                  const char *file, unsigned line, unsigned column),
+                 (sourceType, targetType, file, line, column))
 
 
 OVERRIDE_PROTOCOLCONFORMANCE(conformsToProtocol, const WitnessTable *, , swift::,
@@ -179,8 +183,9 @@ OVERRIDE_OBJC(dynamicCastObjCClass, const void *, , swift::,
 
 OVERRIDE_OBJC(dynamicCastObjCClassUnconditional, const void *, , swift::,
               (const void *object,
-               const ClassMetadata *targetType),
-              (object, targetType))
+               const ClassMetadata *targetType,
+               const char *file, unsigned line, unsigned column),
+              (object, targetType, file, line, column))
 
 OVERRIDE_OBJC(dynamicCastObjCClassMetatype, const ClassMetadata *, , swift::,
               (const ClassMetadata *sourceType,
@@ -189,8 +194,9 @@ OVERRIDE_OBJC(dynamicCastObjCClassMetatype, const ClassMetadata *, , swift::,
 
 
 OVERRIDE_OBJC(dynamicCastObjCClassMetatypeUnconditional, const ClassMetadata *, , swift::,
-              (const ClassMetadata *sourceType, const ClassMetadata *targetType),
-              (sourceType, targetType))
+              (const ClassMetadata *sourceType, const ClassMetadata *targetType,
+               const char *file, unsigned line, unsigned column),
+              (sourceType, targetType, file, line, column))
 
 
 OVERRIDE_FOREIGN(dynamicCastForeignClass, const void *, , swift::,
@@ -200,8 +206,9 @@ OVERRIDE_FOREIGN(dynamicCastForeignClass, const void *, , swift::,
 
 
 OVERRIDE_FOREIGN(dynamicCastForeignClassUnconditional, const void *, , swift::,
-                 (const void *object, const ForeignClassMetadata *targetType),
-                 (object, targetType))
+                 (const void *object, const ForeignClassMetadata *targetType,
+                  const char *file, unsigned line, unsigned column),
+                 (object, targetType, file, line, column))
 
 #endif
 

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1116,7 +1116,9 @@ swift_dynamicCastObjCClassImpl(const void *object,
 
 static const void *
 swift_dynamicCastObjCClassUnconditionalImpl(const void *object,
-                                            const ClassMetadata *targetType) {
+                                            const ClassMetadata *targetType,
+                                            const char *filename,
+                                            unsigned line, unsigned column) {
   // FIXME: We need to decide if this is really how we want to treat 'nil'.
   if (object == nullptr)
     return nullptr;
@@ -1140,7 +1142,9 @@ swift_dynamicCastForeignClassImpl(const void *object,
 static const void *
 swift_dynamicCastForeignClassUnconditionalImpl(
          const void *object,
-         const ForeignClassMetadata *targetType) {
+         const ForeignClassMetadata *targetType,
+         const char *filename,
+         unsigned line, unsigned column) {
   // FIXME: Actual compare CFTypeIDs, once they are available in the metadata.
   return object;
 }
@@ -1160,9 +1164,11 @@ bool swift::classConformsToObjCProtocol(const void *theClass,
 
 SWIFT_RUNTIME_EXPORT
 const Metadata *swift_dynamicCastTypeToObjCProtocolUnconditional(
-                                                 const Metadata *type,
-                                                 size_t numProtocols,
-                                                 Protocol * const *protocols) {
+                                               const Metadata *type,
+                                               size_t numProtocols,
+                                               Protocol * const *protocols,
+                                               const char *filename,
+                                               unsigned line, unsigned column) {
   Class classObject;
 
   switch (type->getKind()) {
@@ -1233,7 +1239,9 @@ const Metadata *swift_dynamicCastTypeToObjCProtocolConditional(
 SWIFT_RUNTIME_EXPORT
 id swift_dynamicCastObjCProtocolUnconditional(id object,
                                               size_t numProtocols,
-                                              Protocol * const *protocols) {
+                                              Protocol * const *protocols,
+                                              const char *filename,
+                                              unsigned line, unsigned column) {
   for (size_t i = 0; i < numProtocols; ++i) {
     if (![object conformsToProtocol:protocols[i]]) {
       Class sourceType = object_getClass(object);
@@ -1289,7 +1297,9 @@ swift_dynamicCastObjCClassMetatypeImpl(const ClassMetadata *source,
 
 static const ClassMetadata *
 swift_dynamicCastObjCClassMetatypeUnconditionalImpl(const ClassMetadata *source,
-                                                    const ClassMetadata *dest) {
+                                                    const ClassMetadata *dest,
+                                                    const char *filename,
+                                                    unsigned line, unsigned column) {
   if ([class_const_cast(source) isSubclassOfClass:class_const_cast(dest)])
     return source;
 
@@ -1309,7 +1319,9 @@ swift_dynamicCastForeignClassMetatypeImpl(const ClassMetadata *sourceType,
 static const ClassMetadata *
 swift_dynamicCastForeignClassMetatypeUnconditionalImpl(
   const ClassMetadata *sourceType,
-  const ClassMetadata *targetType)
+  const ClassMetadata *targetType,
+  const char *filename,
+  unsigned line, unsigned column)
 {
   // FIXME: Actually compare CFTypeIDs, once they arae available in
   // the metadata.

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -85,7 +85,7 @@ func downcast(a a: A) -> B {
   // CHECK: [[CLASS:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_B"
   // CHECK: [[T0:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[CLASS]])
   // CHECK: [[T1:%.*]] = bitcast %objc_class* [[T0]] to i8*
-  // CHECK: call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[A:%.*]], i8* [[T1]]) [[NOUNWIND:#[0-9]+]]
+  // CHECK: call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[A:%.*]], i8* [[T1]], {{.*}}) [[NOUNWIND:#[0-9]+]]
   return a as! B
 }
 

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -168,7 +168,7 @@ func class_bounded_archetype_cast<T : ClassBound>(_ x: T) -> ConcreteClass {
   // CHECK: [[T0R:%.*]] = call swiftcc %swift.metadata_response @"$s22class_bounded_generics13ConcreteClassCMa"([[INT]] 0)
   // CHECK: [[T0:%.*]] = extractvalue %swift.metadata_response [[T0R]], 0
   // CHECK: [[T1:%.*]] = bitcast %swift.type* [[T0]] to i8*
-  // CHECK: [[OUT_PTR:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[IN_PTR]], i8* [[T1]])
+  // CHECK: [[OUT_PTR:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[IN_PTR]], i8* [[T1]], {{.*}})
   // CHECK: [[OUT:%.*]] = bitcast i8* [[OUT_PTR]] to %T22class_bounded_generics13ConcreteClassC*
   // CHECK: ret %T22class_bounded_generics13ConcreteClassC* [[OUT]]
 }
@@ -180,7 +180,7 @@ func class_bounded_protocol_cast(_ x: ClassBound) -> ConcreteClass {
   // CHECK: [[T0R:%.*]] = call swiftcc %swift.metadata_response @"$s22class_bounded_generics13ConcreteClassCMa"([[INT]] 0)
   // CHECK: [[T0:%.*]] = extractvalue %swift.metadata_response [[T0R]], 0
   // CHECK: [[T1:%.*]] = bitcast %swift.type* [[T0]] to i8*
-  // CHECK: [[OUT_PTR:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[IN_PTR]], i8* [[T1]])
+  // CHECK: [[OUT_PTR:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[IN_PTR]], i8* [[T1]], {{.*}})
   // CHECK: [[OUT:%.*]] = bitcast i8* [[OUT_PTR]] to %T22class_bounded_generics13ConcreteClassC*
   // CHECK: ret %T22class_bounded_generics13ConcreteClassC* [[OUT]]
 }

--- a/test/IRGen/objc_casts.sil
+++ b/test/IRGen/objc_casts.sil
@@ -15,7 +15,7 @@ protocol ClassProto : class {}
 // CHECK-LABEL: define hidden swiftcc %TSo8NSObjectC* @checkedClassBoundCast(%swift.type*, %TSo8NSObjectC*, %swift.type* %T) #0 {
 // CHECK: [[OPAQUE_OBJ:%.+]] = bitcast %TSo8NSObjectC* %1 to i8*
 // CHECK: [[OPAQUE_CLASS:%.+]] = bitcast %swift.type* %T to i8*
-// CHECK: [[OPAQUE_RESULT:%.+]] = call i8* @swift_dynamicCastUnknownClassUnconditional(i8* [[OPAQUE_OBJ]], i8* [[OPAQUE_CLASS]])
+// CHECK: [[OPAQUE_RESULT:%.+]] = call i8* @swift_dynamicCastUnknownClassUnconditional(i8* [[OPAQUE_OBJ]], i8* [[OPAQUE_CLASS]], {{.*}})
 // CHECK: [[RESULT:%.+]] = bitcast i8* [[OPAQUE_RESULT]] to %TSo8NSObjectC*
 // CHECK: ret %TSo8NSObjectC* [[RESULT]]
 // CHECK: {{^}$}}
@@ -30,13 +30,13 @@ bb0(%unused : $@thick T.Type, %obj : $NSObject):
 
 // rdar://24924966
 // CHECK-LABEL: define hidden swiftcc void @metatype_to_objc_class(%swift.type*, %swift.type* %T)
-// CHECK:       [[T0:%.*]] = call %objc_object* @swift_dynamicCastMetatypeToObjectUnconditional(%swift.type* %0)
+// CHECK:       [[T0:%.*]] = call %objc_object* @swift_dynamicCastMetatypeToObjectUnconditional(%swift.type* %0, {{.*}})
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
 // CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_Foo"
 // CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
-// CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]])
+// CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]], {{.*}})
 sil hidden @metatype_to_objc_class : $@convention(thin) <T> (@thick T.Type) -> () {
 bb0(%metatype : $@thick T.Type):
   %result = unconditional_checked_cast %metatype : $@thick T.Type to $Foo
@@ -46,13 +46,13 @@ bb0(%metatype : $@thick T.Type):
 
 // CHECK-LABEL: define hidden swiftcc void @opt_metatype_to_objc_class({{(i32|i64)}}, %swift.type* %T)
 // CHECK:       [[ARG:%.*]] = inttoptr {{.*}} %0 to %swift.type*
-// CHECK:       [[T0:%.*]] = call %objc_object* @swift_dynamicCastMetatypeToObjectUnconditional(%swift.type* [[ARG]])
+// CHECK:       [[T0:%.*]] = call %objc_object* @swift_dynamicCastMetatypeToObjectUnconditional(%swift.type* [[ARG]], {{.*}})
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
 // CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_Foo"
 // CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
-// CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]])
+// CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]], {{.*}})
 sil hidden @opt_metatype_to_objc_class : $@convention(thin) <T> (Optional<@thick T.Type>) -> () {
 bb0(%metatype : $Optional<@thick T.Type>):
   %result = unconditional_checked_cast %metatype : $Optional<@thick T.Type> to $Foo

--- a/test/IRGen/protocol_with_superclass.sil
+++ b/test/IRGen/protocol_with_superclass.sil
@@ -104,7 +104,7 @@ bb0(%0 : @owned $Concrete, %1 : @owned $SuperProto, %2 : @owned $SuperProto & Co
   // CHECK-NEXT:        [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s24protocol_with_superclass7DerivedCMa"(i{{[0-9]+}} 0)
   // CHECK-NEXT:        [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
   // CHECK-NEXT:        [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
-  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]])
+  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]], {{.*}})
   // CHECK-NEXT:        [[REFERENCE:%.*]] = bitcast i8* [[RESULT]] to %T24protocol_with_superclass7DerivedC*
   %11 = unconditional_checked_cast %3 : $ProtoRefinesClass to $Derived
 
@@ -115,7 +115,7 @@ bb0(%0 : @owned $Concrete, %1 : @owned $SuperProto, %2 : @owned $SuperProto & Co
   // CHECK-NEXT:        [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s24protocol_with_superclass10SubDerivedCMa"(i{{[0-9]+}} 0)
   // CHECK-NEXT:        [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
   // CHECK-NEXT:        [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
-  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]])
+  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]], {{.*}})
   // CHECK-NEXT:        [[REFERENCE:%.*]] = bitcast i8* [[RESULT]] to %T24protocol_with_superclass10SubDerivedC*
   %12 = unconditional_checked_cast %3 : $ProtoRefinesClass to $SubDerived
 
@@ -150,7 +150,7 @@ bb0(%0 : @owned $Concrete, %1 : @owned $SuperProto, %2 : @owned $SuperProto & Co
   // CHECK-NEXT:        [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s24protocol_with_superclass11MoreDerivedCMa"(i{{[0-9]+}} 0)
   // CHECK-NEXT:        [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
   // CHECK-NEXT:        [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
-  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]])
+  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]], {{.*}})
   // CHECK-NEXT:        [[REFERENCE:%.*]] = bitcast i8* [[RESULT]] to %T24protocol_with_superclass11MoreDerivedC*
   %15 = unconditional_checked_cast %4 : $SubProto to $MoreDerived
 

--- a/test/IRGen/protocol_with_superclass_where_clause.sil
+++ b/test/IRGen/protocol_with_superclass_where_clause.sil
@@ -104,7 +104,7 @@ bb0(%0 : @owned $Concrete, %1 : @owned $SuperProto, %2 : @owned $SuperProto & Co
   // CHECK-NEXT:        [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s24protocol_with_superclass7DerivedCMa"(i{{[0-9]+}} 0)
   // CHECK-NEXT:        [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
   // CHECK-NEXT:        [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
-  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]])
+  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]], {{.*}})
   // CHECK-NEXT:        [[REFERENCE:%.*]] = bitcast i8* [[RESULT]] to %T24protocol_with_superclass7DerivedC*
   %11 = unconditional_checked_cast %3 : $ProtoRefinesClass to $Derived
 
@@ -115,7 +115,7 @@ bb0(%0 : @owned $Concrete, %1 : @owned $SuperProto, %2 : @owned $SuperProto & Co
   // CHECK-NEXT:        [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s24protocol_with_superclass10SubDerivedCMa"(i{{[0-9]+}} 0)
   // CHECK-NEXT:        [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
   // CHECK-NEXT:        [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
-  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]])
+  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]], {{.*}})
   // CHECK-NEXT:        [[REFERENCE:%.*]] = bitcast i8* [[RESULT]] to %T24protocol_with_superclass10SubDerivedC*
   %12 = unconditional_checked_cast %3 : $ProtoRefinesClass to $SubDerived
 
@@ -150,7 +150,7 @@ bb0(%0 : @owned $Concrete, %1 : @owned $SuperProto, %2 : @owned $SuperProto & Co
   // CHECK-NEXT:        [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s24protocol_with_superclass11MoreDerivedCMa"(i{{[0-9]+}} 0)
   // CHECK-NEXT:        [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
   // CHECK-NEXT:        [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
-  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]])
+  // CHECK-NEXT:        [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[OBJECT]], i8* [[METADATA_PTR]], {{.*}})
   // CHECK-NEXT:        [[REFERENCE:%.*]] = bitcast i8* [[RESULT]] to %T24protocol_with_superclass11MoreDerivedC*
   %15 = unconditional_checked_cast %4 : $SubProto to $MoreDerived
 

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -112,7 +112,7 @@ bb0(%0 : @owned $C, %1 : @owned $C & P):
 
 // CHECK-NEXT:  [[VALUE:%.*]] = bitcast %T21subclass_existentials1CC* %1 to i8*
 // CHECK-NEXT:  [[CLASS_ADDR:%.*]] = bitcast %swift.type* [[SUPERCLASS]] to i8*
-// CHECK-NEXT:  [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[VALUE]], i8* [[CLASS_ADDR]])
+// CHECK-NEXT:  [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[VALUE]], i8* [[CLASS_ADDR]], {{.*}})
 // CHECK-NEXT:  [[VALUE:%.*]] = bitcast i8* [[RESULT]] to %T21subclass_existentials1DC*
   %3 = unconditional_checked_cast %1 : $C & P to $D
 
@@ -193,7 +193,7 @@ bb0(%0 : @trivial $@thick C.Type, %1 : @trivial $@thick (C & P).Type):
 // CHECK-NEXT:  [[WTABLE:%.*]] = extractvalue { i8*, i8** } [[RESULT]], 1
   %2 = unconditional_checked_cast %0 : $@thick C.Type to $@thick (D & R).Type
 
-// CHECK-NEXT:  [[RESULT:%.*]] = call %swift.type* @swift_dynamicCastMetatypeUnconditional(%swift.type* %1, %swift.type* [[SUPERCLASS]])
+// CHECK-NEXT:  [[RESULT:%.*]] = call %swift.type* @swift_dynamicCastMetatypeUnconditional(%swift.type* %1, %swift.type* [[SUPERCLASS]], {{.*}})
   %3 = unconditional_checked_cast %1 : $@thick (C & P).Type to $@thick D.Type
 
 // CHECK-NEXT:  ret void

--- a/test/IRGen/unconditional_checked_cast.sil
+++ b/test/IRGen/unconditional_checked_cast.sil
@@ -17,7 +17,7 @@ sil_vtable D {}
 // CHECK-NEXT: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s26unconditional_checked_cast1DCMa"(i64 0)
 // CHECK-NEXT: [[T0:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK-NEXT: [[T1:%.*]] = bitcast %swift.type* [[T0]] to i8*
-// CHECK-NEXT: [[I8RESULTPTR:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[I8INPUTPTR]], i8* [[T1]])
+// CHECK-NEXT: [[I8RESULTPTR:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[I8INPUTPTR]], i8* [[T1]], {{.*}})
 // CHECK-NEXT: [[DOWNCASTINPUTPTR:%[0-9]+]] = bitcast i8* [[I8RESULTPTR]] to %T26unconditional_checked_cast1DC*
 // CHECK-NEXT: store %T26unconditional_checked_cast1DC* [[DOWNCASTINPUTPTR]], %T26unconditional_checked_cast1DC** {{%[0-9]+}}, align 8
 // CHECK-NEXT: ret void

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -98,7 +98,7 @@ TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastClass) {
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastClassUnconditional) {
-  auto Result = swift_dynamicCastClassUnconditional(nullptr, nullptr);
+  auto Result = swift_dynamicCastClassUnconditional(nullptr, nullptr, nullptr, 0, 0);
   ASSERT_EQ(Result, nullptr);
 }
 
@@ -108,7 +108,7 @@ TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastObjCClass) {
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastObjCClassUnconditional) {
-  auto Result = swift_dynamicCastObjCClassUnconditional(nullptr, nullptr);
+  auto Result = swift_dynamicCastObjCClassUnconditional(nullptr, nullptr, nullptr, 0, 0);
   ASSERT_EQ(Result, nullptr);
 }
 
@@ -118,7 +118,7 @@ TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastForeignClass) {
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastForeignClassUnconditional) {
-  auto Result = swift_dynamicCastForeignClassUnconditional(nullptr, nullptr);
+  auto Result = swift_dynamicCastForeignClassUnconditional(nullptr, nullptr, nullptr, 0, 0);
   ASSERT_EQ(Result, nullptr);
 }
 
@@ -128,7 +128,7 @@ TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastUnknownClass) {
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastUnknownClassUnconditional) {
-  auto Result = swift_dynamicCastUnknownClassUnconditional(nullptr, nullptr);
+  auto Result = swift_dynamicCastUnknownClassUnconditional(nullptr, nullptr, nullptr, 0, 0);
   ASSERT_EQ(Result, nullptr);
 }
 
@@ -138,7 +138,7 @@ TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastMetatype) {
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastMetatypeUnconditional) {
-  auto Result = swift_dynamicCastMetatypeUnconditional(nullptr, nullptr);
+  auto Result = swift_dynamicCastMetatypeUnconditional(nullptr, nullptr, nullptr, 0, 0);
   ASSERT_EQ(Result, nullptr);
 }
 
@@ -148,7 +148,7 @@ TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastObjCClassMetatype) {
 }
 
 TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastObjCClassMetatypeUnconditional) {
-  auto Result = swift_dynamicCastObjCClassMetatypeUnconditional(nullptr, nullptr);
+  auto Result = swift_dynamicCastObjCClassMetatypeUnconditional(nullptr, nullptr, nullptr, 0, 0);
   ASSERT_EQ(Result, nullptr);
 }
 
@@ -159,7 +159,7 @@ TEST_F(CompatibilityOverrideTest, test_swift_dynamicCastForeignClassMetatype) {
 
 TEST_F(CompatibilityOverrideTest,
        test_swift_dynamicCastForeignClassMetatypeUnconditional) {
-  auto Result = swift_dynamicCastForeignClassMetatypeUnconditional(nullptr, nullptr);
+  auto Result = swift_dynamicCastForeignClassMetatypeUnconditional(nullptr, nullptr, nullptr, 0, 0);
   ASSERT_EQ(Result, nullptr);
 }
 


### PR DESCRIPTION
Currently ignored, but this will allow future compilers to pass down source location information for cast
failure runtime errors without backward deployment constraints.
rdar://problem/46543048