### PR TITLE
fix VJP differentiation for TensorFlow autodiff tests

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2694,6 +2694,8 @@ bool TFGraphLowering::serializeGraphProtoBuf(ASTContext &ctx,
 ///   repl)
 std::string getTFCompatibleFuncName(SILFunction *fn) {
   auto fnName = fn->getName();
+  if (fnName.startswith("AD__"))
+    fnName = fnName.substr(4);
   if (fnName.startswith("$"))
     fnName = fnName.substr(1);
 

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -275,7 +275,10 @@ public extension Tensor where Scalar : Numeric {
 public func matmul<Scalar : Numeric>(
   _ left: Tensor<Scalar>, _ right: Tensor<Scalar>
 ) -> Tensor<Scalar> {
-  return Raw.matMul(left, right)
+  // Default arguments specified explicitly to avoid "external declarations of
+  // SILFunctions with shared visibility is not allowed" SILVerifier error in
+  // "tests/AutoDiff/tensor_autodiff_runtime.swift".
+  return Raw.matMul(left, right, transposeA: false, transposeB: false)
 }
 
 infix operator • : MultiplicationPrecedence

--- a/test/TensorFlow/tensor_autodiff.swift
+++ b/test/TensorFlow/tensor_autodiff.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -differentiation-use-vjp -O -emit-sil %s | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift %swift-tensorflow-test-run-extra-options
+// RUN: %target-run-use-vjp-swift %swift-tensorflow-test-run-extra-options
 //
 // TODO(SR-9110): Make this pass in dynamic compilation mode.
 // %target-run-dynamic-compilation-swift


### PR DESCRIPTION
Fixes/workarounds for some issues:
* make vjps noinline and nonspecializable to workaround a problem in deabstraction (more details in comment)
* remove the PublicNonABI linkage for vjps, because linking fails when noinline vjps are PublicNonABI
* make `getTFCompatibleFuncName` able to handle `AD__` functions
* I got a SILVerifier error when running TensorFlow/tensor_autodiff.swift in vjp mode. Adding the default arguments for matmul seems to fix it.

The SILVerifier error was:
```
SIL verification failed: external declarations of SILFunctions with shared visibility is not allowed: SingleFunction || !hasSharedVisibility(RefF->getLinkage()) || RefF->hasForeignBody()
Verifying instruction:
->   // function_ref default argument 2 of static Raw.matMul<A>(_:_:transposeA:transposeB:)
  %3 = function_ref @$s10TensorFlow3RawO6matMul__10transposeA0F1BAA0A0VyxGAI_AIS2btSjRzAA0aB6ScalarRzlFZfA1_ : $@convention(thin) <τ_0_0 where τ_0_0 : Numeric, τ_0_0 : TensorFlowScalar> () -> Bool // user: %4
     %4 = apply %3<Scalar>() : $@convention(thin) <τ_0_0 where τ_0_0 : Numeric, τ_0_0 : TensorFlowScalar> () -> Bool // user: %8
```

I believe that my PublicNonABI change will bring back https://bugs.swift.org/browse/SR-8723. I don't have swift set up on a macos right now (and I've only seen this failure happen on macos), so I'll run this PR through macos ci to see what happens. Maybe I can fix this by teaching TBDGen to generate symbols for autodiff associated functions?