### PR TITLE
 [IRGen] Don't emit relative references to Objective-C class references.

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -265,7 +265,7 @@ std::string LinkEntity::mangleAsString() const {
   case Kind::ObjCClassRef: {
     llvm::SmallString<64> tempBuffer;
     StringRef name = cast<ClassDecl>(getDecl())->getObjCRuntimeName(tempBuffer);
-    std::string Result("\01l_OBJC_CLASS_REF_$_");
+    std::string Result("OBJC_CLASS_REF_$_");
     Result.append(name.data(), name.size());
     return Result;
   }

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -92,7 +92,7 @@ public func testTopLevel() {
 }
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSo10PrivFooSubCMa{{.*}} {
-// CHECK: %objc_class** @"\01l_OBJC_CLASS_REF_$_PrivFooSub"
+// CHECK: %objc_class** @"OBJC_CLASS_REF_$_PrivFooSub"
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$sSo3BarC8__noArgsABSgyt_tcfcTO"

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -74,7 +74,7 @@ func propertyAccess(b b: B) {
    // CHECK: load i8*, i8** @"\01L_selector(setCounter:)"
    b.counter = b.counter + 1
 
-   // CHECK: load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_B"
+   // CHECK: load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_B"
    // CHECK: load i8*, i8** @"\01L_selector(sharedCounter)"
    // CHECK: load i8*, i8** @"\01L_selector(setSharedCounter:)"
    B.sharedCounter = B.sharedCounter + 1
@@ -82,7 +82,7 @@ func propertyAccess(b b: B) {
 
 // CHECK-LABEL: define hidden swiftcc %TSo1BC* @"$s7objc_ir8downcast1aSo1BCSo1AC_tF"(
 func downcast(a a: A) -> B {
-  // CHECK: [[CLASS:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_B"
+  // CHECK: [[CLASS:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_B"
   // CHECK: [[T0:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[CLASS]])
   // CHECK: [[T1:%.*]] = bitcast %objc_class* [[T0]] to i8*
   // CHECK: call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[A:%.*]], i8* [[T1]]) [[NOUNWIND:#[0-9]+]]

--- a/test/IRGen/COFF-objc-sections.swift
+++ b/test/IRGen/COFF-objc-sections.swift
@@ -21,7 +21,7 @@ class D {
 // CHECK-COFF-NOT: @"$s4main1CCMf" = {{.*}}, section "__DATA,__objc_data, regular"
 // CHECK-COFF: @"\01l_OBJC_LABEL_PROTOCOL_$_P" = {{.*}}, section ".objc_protolist$B"
 // CHECK-COFF: @"\01l_OBJC_PROTOCOL_REFERENCE_$_P" = {{.*}}, section ".objc_protorefs$B"
-// CHECK-COFF: @"\01l_OBJC_CLASS_REF_$_I" = {{.*}}, section ".objc_classrefs$B"
+// CHECK-COFF: @"OBJC_CLASS_REF_$_I" = {{.*}}, section ".objc_classrefs$B"
 // CHECK-COFF: @"\01L_selector(init)" = {{.*}}, section ".objc_selrefs$B"
 // CHECK-COFF: @objc_classes = {{.*}}, section ".objc_classlist$B"
 // CHECK-COFF: @objc_categories = {{.*}}, section ".objc_catlist$B"

--- a/test/IRGen/ELF-objc-sections.swift
+++ b/test/IRGen/ELF-objc-sections.swift
@@ -21,7 +21,7 @@ class D {
 // CHECK-ELF-NOT: @"$s4main1CCMf" = {{.*}}, section "__DATA,__objc_data, regular"
 // CHECK-ELF: @"\01l_OBJC_LABEL_PROTOCOL_$_P" = {{.*}}, section "objc_protolist"
 // CHECK-ELF: @"\01l_OBJC_PROTOCOL_REFERENCE_$_P" = {{.*}}, section "objc_protorefs", align 8
-// CHECK-ELF: @"\01l_OBJC_CLASS_REF_$_I" = {{.*}}, section "objc_classrefs", align 8
+// CHECK-ELF: @"OBJC_CLASS_REF_$_I" = {{.*}}, section "objc_classrefs", align 8
 // CHECK-ELF: @"\01L_selector(init)" = {{.*}}, section "objc_selrefs"
 // CHECK-ELF: @objc_classes = {{.*}}, section "objc_classlist"
 // CHECK-ELF: @objc_categories = {{.*}}, section "objc_catlist"

--- a/test/IRGen/MachO-objc-sections.swift
+++ b/test/IRGen/MachO-objc-sections.swift
@@ -21,7 +21,7 @@ class D {
 // CHECK-MACHO: @"$s4main1CCMf" = {{.*}}, section "__DATA,__objc_data, regular"
 // CHECK-MACHO: @"\01l_OBJC_LABEL_PROTOCOL_$_P" = {{.*}}, section "__DATA,__objc_protolist,coalesced,no_dead_strip"
 // CHECK-MACHO: @"\01l_OBJC_PROTOCOL_REFERENCE_$_P" = {{.*}}, section "__DATA,__objc_protorefs,coalesced,no_dead_strip"
-// CHECK-MACHO: @"\01l_OBJC_CLASS_REF_$_I" = {{.*}}, section "__DATA,__objc_classrefs,regular,no_dead_strip"
+// CHECK-MACHO: @"OBJC_CLASS_REF_$_I" = {{.*}}, section "__DATA,__objc_classrefs,regular,no_dead_strip"
 // CHECK-MACHO: @"\01L_selector(init)" = {{.*}}, section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip"
 // CHECK-MACHO: @objc_classes = {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip"
 // CHECK-MACHO: @objc_categories = {{.*}}, section "__DATA,__objc_catlist,regular,no_dead_strip"

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -2,7 +2,9 @@
 
 // CHECK-NOT: _TMnCSo
 
-// CHECK: @"$sSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @"\01l_OBJC_CLASS_REF_$_Thingy"
+// CHECK: @"$sSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @[[THINGY_NAME:[0-9]]]
+
+// CHECK: @[[THINGY_NAME]] = private constant [7 x i8] c"Thingy\00"
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/objc_casts.sil
+++ b/test/IRGen/objc_casts.sil
@@ -33,7 +33,7 @@ bb0(%unused : $@thick T.Type, %obj : $NSObject):
 // CHECK:       [[T0:%.*]] = call %objc_object* @swift_dynamicCastMetatypeToObjectUnconditional(%swift.type* %0)
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
-// CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_Foo"
+// CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Foo"
 // CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
 // CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]])
@@ -49,7 +49,7 @@ bb0(%metatype : $@thick T.Type):
 // CHECK:       [[T0:%.*]] = call %objc_object* @swift_dynamicCastMetatypeToObjectUnconditional(%swift.type* [[ARG]])
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
-// CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_Foo"
+// CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Foo"
 // CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
 // CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]])

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -39,7 +39,7 @@ entry:
   %b = metatype $@thick GenericClass<NSObject>.Type
   apply %z<GenericClass<NSObject>>(%b) : $@convention(thin) <T> (@thick T.Type) -> ()
 
-  // CHECK: [[T0:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_GenericClass",
+  // CHECK: [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_GenericClass",
   // CHECK: [[OBJC_CLASS:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T0]])
   // CHECK: call swiftcc void @objc_class_sink(%objc_class* [[OBJC_CLASS]], %swift.type* [[METADATA]])
   %c = metatype $@objc_metatype GenericClass<NSString>.Type
@@ -79,7 +79,7 @@ entry(%0: @owned $Subclass, %1: @owned $NSDictionary):
 }
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSo12GenericClassCMa"(
-// CHECK:         [[T0:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_GenericClass",
+// CHECK:         [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_GenericClass",
 // CHECK:         call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T0]])
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sSaySo12GenericClassC_SitGMa"

--- a/test/IRGen/objc_properties_jit.swift
+++ b/test/IRGen/objc_properties_jit.swift
@@ -14,7 +14,7 @@ extension NSString {
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private void @runtime_registration
-// CHECK:         [[NSOBJECT_UNINIT:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_NSString"
+// CHECK:         [[NSOBJECT_UNINIT:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_NSString"
 // CHECK:         [[NSOBJECT:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[NSOBJECT_UNINIT]])
 // CHECK:         [[GET_CLASS_PROP:%.*]] = call i8* @sel_registerName({{.*}}(classProp)
 // CHECK:         call i8* @class_replaceMethod(%objc_class* @"OBJC_METACLASS_$_NSString", i8* [[GET_CLASS_PROP]]

--- a/test/IRGen/objc_runtime_visible_conformance.swift
+++ b/test/IRGen/objc_runtime_visible_conformance.swift
@@ -10,8 +10,8 @@ extension A : YourProtocol {}
 
 // CHECK-LABEL: @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACMc"
 // CHECK-SAME:    @"$s32objc_runtime_visible_conformance10MyProtocolMp"
-// CHECK-SAME:    [2 x i8]* [[STRING_A:@[0-9]+]]
+// CHECK-SAME:    [[STRING_A:@[0-9]+]]
 // CHECK-SAME:    @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACWP"
 //   DirectObjCClassName
 // CHECK-SAME:    i32 16
-// CHECK:       [[STRING_A]] = private unnamed_addr constant [2 x i8] c"A\00"
+// CHECK:       [[STRING_A]] = private constant [22 x i8] c"MyRuntimeVisibleClass\00"

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -29,16 +29,18 @@ extension NSRect: Runcible {
 // CHECK-LABEL:         @"$sSo5GizmoC33protocol_conformance_records_objc8RuncibleACMc" = constant %swift.protocol_conformance_descriptor {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
-// -- class object reference
-// CHECK-SAME:           @"\01l_OBJC_CLASS_REF_$_Gizmo"
+// -- class name reference
+// CHECK-SAME:           @[[GIZMO_NAME:[0-9]+]]
 // -- witness table
 // CHECK-SAME:           @"$sSo5GizmoC33protocol_conformance_records_objc8RuncibleACWP"
 // -- flags
-// CHECK-SAME:           i32 24
+// CHECK-SAME:           i32 16
 // CHECK-SAME:         }
 extension Gizmo: Runcible {
   public func runce() {}
 }
+
+// CHECK: @[[GIZMO_NAME]] = private constant [6 x i8] c"Gizmo\00"
 
 // CHECK-LABEL: @"\01l_protocol_conformances" = private constant [
 // CHECK-SAME: @"$sSo6NSRectV33protocol_conformance_records_objc8RuncibleACMc"


### PR DESCRIPTION
Objective-C class references (which show up in the __objc_classrefs
section) are always coalesced by the linker. When we relatively
address them (which occurs in protocol conformance records), the
linker may compute the relative offset *before* coalescing, leading to
an incorrect result. The net effect is a protocol conformance record
that applies to the wrong Objective-C class, causing all sorts of
runtime mayhem.

Switch relatively-addressed Objective-C classes over to using the
Objective-C runtime name of the class. It's a less efficient encoding
(since we need to go through objc_lookUpClass), but it avoids the
linker bug.

Fixes rdar://problem/46428085 by working around the linker bug.