### PR TITLE
Extend @available to support PackageDescription

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -616,6 +616,10 @@ enum class PlatformAgnosticAvailabilityKind {
   /// The declaration is available in some but not all versions
   /// of Swift, as specified by the VersionTuple members.
   SwiftVersionSpecific,
+  /// The declaration is available in some but not all versions
+  /// of SwiftPM's PackageDescription library, as specified by
+  /// the VersionTuple members.
+  PackageDescriptionVersionSpecific,
   /// The declaration is unavailable for other reasons.
   Unavailable,
 };
@@ -686,6 +690,9 @@ public:
   /// Whether this is a language-version-specific entity.
   bool isLanguageVersionSpecific() const;
 
+  /// Whether this is a PackageDescription version specific entity.
+  bool isPackageDescriptionVersionSpecific() const;
+
   /// Whether this is an unconditionally unavailable entity.
   bool isUnconditionallyUnavailable() const;
 
@@ -721,6 +728,12 @@ public:
 
   /// Returns true if this attribute is active given the current platform.
   bool isActivePlatform(const ASTContext &ctx) const;
+
+  /// Returns the active version from the AST context corresponding to
+  /// the available kind. For example, this will return the effective language
+  /// version for swift version-specific availability kind, PackageDescription
+  /// version for PackageDescription version-specific availability.
+  llvm::VersionTuple getActiveVersion(const ASTContext &ctx) const;
 
   /// Compare this attribute's version information against the platform or
   /// language version (assuming the this attribute pertains to the active

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1367,15 +1367,15 @@ ERROR(attr_availability_expected_equal,none,
 ERROR(attr_availability_expected_version,none,
       "expected version number in '%0' attribute", (StringRef))
 
-WARNING(attr_availability_swift_expected_option,none,
+WARNING(attr_availability_platform_agnostic_expected_option,none,
       "expected 'introduced', 'deprecated', or 'obsoleted' in '%0' attribute "
-      "for platform 'swift'", (StringRef))
-WARNING(attr_availability_swift_expected_deprecated_version,none,
+      "for platform '%1'", (StringRef, StringRef))
+WARNING(attr_availability_platform_agnostic_expected_deprecated_version,none,
       "expected version number with 'deprecated' in '%0' attribute for "
-      "platform 'swift'", (StringRef))
-WARNING(attr_availability_swift_infeasible_option,none,
-      "'%0' cannot be used in '%1' attribute for platform 'swift'",
-      (StringRef, StringRef))
+      "platform '%1'", (StringRef, StringRef))
+WARNING(attr_availability_platform_agnostic_infeasible_option,none,
+      "'%0' cannot be used in '%1' attribute for platform '%2'",
+      (StringRef, StringRef, StringRef))
 
 WARNING(attr_availability_nonspecific_platform_unexpected_version,none,
       "unexpected version number in '%0' attribute for non-specific platform "
@@ -1610,11 +1610,14 @@ ERROR(avail_query_version_comparison_not_needed,
 ERROR(availability_query_wildcard_required, none,
       "must handle potential future platforms with '*'", ())
 
-ERROR(availability_swift_must_occur_alone, none,
-      "'swift' version-availability must be specified alone", ())
+ERROR(availability_must_occur_alone, none,
+      "'%0' version-availability must be specified alone", (StringRef))
 
 ERROR(pound_available_swift_not_allowed, none,
       "Swift language version checks not allowed in #available(...)", ())
+
+ERROR(pound_available_package_description_not_allowed, none,
+      "PackageDescription version checks not allowed in #available(...)", ())
 
 ERROR(availability_query_repeated_platform, none,
       "version for '%0' already specified", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3981,9 +3981,9 @@ NOTE(availability_marked_unavailable, none,
      "%select{getter for |setter for |}0%1 has been explicitly marked "
      "unavailable here", (unsigned, DeclName))
 
-NOTE(availability_introduced_in_swift, none,
-     "%select{getter for |setter for |}0%1 was introduced in Swift %2",
-     (unsigned, DeclName, llvm::VersionTuple))
+NOTE(availability_introduced_in_version, none,
+     "%select{getter for |setter for |}0%1 was introduced in %2 %3",
+     (unsigned, DeclName, StringRef, llvm::VersionTuple))
 
 NOTE(availability_obsoleted, none,
      "%select{getter for |setter for |}0%1 was obsoleted in %2 %3",

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -82,6 +82,9 @@ namespace swift {
     /// User-overridable language version to compile for.
     version::Version EffectiveLanguageVersion = version::Version::getCurrentLanguageVersion();
 
+    /// PackageDescription version to compile for.
+    version::Version PackageDescriptionVersion;
+
     /// Disable API availability checking.
     bool DisableAvailabilityChecking = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -172,6 +172,11 @@ def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption, Par
   HelpText<"Interpret input according to a specific Swift language version number">,
   MetaVarName<"<vers>">;
 
+def package_description_version: Separate<["-"], "package-description-version">,
+  Flags<[FrontendOption, HelpHidden, ParseableInterfaceOption]>,
+  HelpText<"The version number to be applied on the input for the PackageDescription availability kind">,
+  MetaVarName<"<vers>">;
+
 def tools_directory : Separate<["-"], "tools-directory">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
          ArgumentIsPath]>,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1414,8 +1414,8 @@ public:
   ParserResult<AvailabilitySpec> parseAvailabilitySpec();
   ParserResult<PlatformVersionConstraintAvailabilitySpec>
   parsePlatformVersionConstraintSpec();
-  ParserResult<LanguageVersionConstraintAvailabilitySpec>
-  parseLanguageVersionConstraintSpec();
+  ParserResult<PlatformAgnosticVersionConstraintAvailabilitySpec>
+  parsePlatformAgnosticVersionConstraintSpec();
 
   bool canDelayMemberDeclParsing();
 };

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 470; // Last change: Remove @trivial
+const uint16_t SWIFTMODULE_VERSION_MINOR = 471; // Last change: Add @available(_PackageDescription..)
 
 using DeclIDField = BCFixed<31>;
 
@@ -1547,6 +1547,7 @@ namespace decls_block {
     BCFixed<1>, // implicit flag
     BCFixed<1>, // is unconditionally unavailable?
     BCFixed<1>, // is unconditionally deprecated?
+    BCFixed<1>, // is this PackageDescription version-specific kind?
     BC_AVAIL_TUPLE, // Introduced
     BC_AVAIL_TUPLE, // Deprecated
     BC_AVAIL_TUPLE, // Obsoleted

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1437,7 +1437,8 @@ public:
           cast<PlatformVersionConstraintAvailabilitySpec>(Query)->print(OS, Indent + 2);
           break;
         case AvailabilitySpecKind::LanguageVersionConstraint:
-          cast<LanguageVersionConstraintAvailabilitySpec>(Query)->print(OS, Indent + 2);
+        case AvailabilitySpecKind::PackageDescriptionVersionConstraint:
+          cast<PlatformVersionConstraintAvailabilitySpec>(Query)->print(OS, Indent + 2);
           break;
         case AvailabilitySpecKind::OtherPlatform:
           cast<OtherPlatformAvailabilitySpec>(Query)->print(OS, Indent + 2);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -142,7 +142,8 @@ const AvailableAttr *DeclAttributes::getUnavailable(
 
       // If this attribute doesn't apply to the active platform, we're done.
       if (!AvAttr->isActivePlatform(ctx) &&
-          !AvAttr->isLanguageVersionSpecific())
+          !AvAttr->isLanguageVersionSpecific() &&
+          !AvAttr->isPackageDescriptionVersionSpecific())
         continue;
 
       // Unconditional unavailable.
@@ -172,7 +173,8 @@ DeclAttributes::getDeprecated(const ASTContext &ctx) const {
         continue;
 
       if (!AvAttr->isActivePlatform(ctx) &&
-          !AvAttr->isLanguageVersionSpecific())
+          !AvAttr->isLanguageVersionSpecific() &&
+          !AvAttr->isPackageDescriptionVersionSpecific())
         continue;
 
       // Unconditional deprecated.
@@ -183,10 +185,7 @@ DeclAttributes::getDeprecated(const ASTContext &ctx) const {
       if (!DeprecatedVersion.hasValue())
         continue;
 
-      llvm::VersionTuple MinVersion =
-        AvAttr->isLanguageVersionSpecific() ?
-        ctx.LangOpts.EffectiveLanguageVersion :
-        ctx.LangOpts.getMinPlatformVersion();
+      llvm::VersionTuple MinVersion = AvAttr->getActiveVersion(ctx);
 
       // We treat the declaration as deprecated if it is deprecated on
       // all deployment targets.
@@ -240,6 +239,7 @@ static bool isShortAvailable(const DeclAttribute *DA) {
     return false;
   case PlatformAgnosticAvailabilityKind::None:
   case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
+  case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
     return true;
   }
 
@@ -261,10 +261,16 @@ static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
   Printer << "@available(";
   auto FirstAvail = cast<AvailableAttr>(Attrs.front());
   if (Attrs.size() == 1 &&
-      FirstAvail->isLanguageVersionSpecific()) {
+      FirstAvail->getPlatformAgnosticAvailability() !=
+      PlatformAgnosticAvailabilityKind::None) {
     assert(FirstAvail->Introduced.hasValue());
-    Printer << "swift "
-            << FirstAvail->Introduced.getValue().getAsString()
+    if (FirstAvail->isLanguageVersionSpecific()) {
+      Printer << "swift ";
+    } else {
+      assert(FirstAvail->isPackageDescriptionVersionSpecific());
+      Printer << "_PackageDescription ";
+    }
+    Printer << FirstAvail->Introduced.getValue().getAsString()
             << ")";
   } else {
     for (auto *DA : Attrs) {
@@ -290,6 +296,7 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
   // Process attributes in passes.
   AttributeVector shortAvailableAttributes;
   const DeclAttribute *swiftVersionAvailableAttribute = nullptr;
+  const DeclAttribute *packageDescriptionVersionAvailableAttribute = nullptr;
   AttributeVector longAttributes;
   AttributeVector attributes;
   AttributeVector modifiers;
@@ -311,6 +318,11 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
         swiftVersionAvailableAttribute = availableAttr;
         continue;
       }
+      if (availableAttr->isPackageDescriptionVersionSpecific() &&
+          isShortAvailable(availableAttr)) {
+        packageDescriptionVersionAvailableAttribute = availableAttr;
+        continue;
+      }
     }
 
     AttributeVector &which = DA->isDeclModifier() ? modifiers :
@@ -322,6 +334,8 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
 
   if (swiftVersionAvailableAttribute)
     printShortFormAvailable(swiftVersionAvailableAttribute, Printer, Options);
+  if (packageDescriptionVersionAvailableAttribute)
+    printShortFormAvailable(packageDescriptionVersionAvailableAttribute, Printer, Options);
   if (!shortAvailableAttributes.empty())
     printShortFormAvailable(shortAvailableAttributes, Printer, Options);
 
@@ -424,6 +438,8 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     auto Attr = cast<AvailableAttr>(this);
     if (Attr->isLanguageVersionSpecific())
       Printer << "swift";
+    else if (Attr->isPackageDescriptionVersionSpecific())
+      Printer << "_PackageDescription";
     else
       Printer << Attr->platformString();
 
@@ -890,11 +906,25 @@ bool AvailableAttr::isLanguageVersionSpecific() const {
   return false;
 }
 
+bool AvailableAttr::isPackageDescriptionVersionSpecific() const {
+  if (PlatformAgnostic ==
+      PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific)
+    {
+      assert(Platform == PlatformKind::none &&
+             (Introduced.hasValue() ||
+              Deprecated.hasValue() ||
+              Obsoleted.hasValue()));
+      return true;
+    }
+  return false;
+}
+
 bool AvailableAttr::isUnconditionallyUnavailable() const {
   switch (PlatformAgnostic) {
   case PlatformAgnosticAvailabilityKind::None:
   case PlatformAgnosticAvailabilityKind::Deprecated:
   case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
+  case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
     return false;
 
   case PlatformAgnosticAvailabilityKind::Unavailable:
@@ -911,6 +941,7 @@ bool AvailableAttr::isUnconditionallyDeprecated() const {
   case PlatformAgnosticAvailabilityKind::Unavailable:
   case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
   case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
+  case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
     return false;
 
   case PlatformAgnosticAvailabilityKind::Deprecated:
@@ -920,6 +951,16 @@ bool AvailableAttr::isUnconditionallyDeprecated() const {
   llvm_unreachable("Unhandled PlatformAgnosticAvailabilityKind in switch.");
 }
 
+llvm::VersionTuple AvailableAttr::getActiveVersion(const ASTContext &ctx) const {
+  if (isLanguageVersionSpecific()) {
+    return ctx.LangOpts.EffectiveLanguageVersion;
+  } else if (isPackageDescriptionVersionSpecific()) {
+    return ctx.LangOpts.PackageDescriptionVersion;
+  } else {
+    return ctx.LangOpts.getMinPlatformVersion();
+  }
+}
+
 AvailableVersionComparison AvailableAttr::getVersionAvailability(
   const ASTContext &ctx) const {
 
@@ -927,10 +968,7 @@ AvailableVersionComparison AvailableAttr::getVersionAvailability(
   if (isUnconditionallyUnavailable())
     return AvailableVersionComparison::Unavailable;
 
-  llvm::VersionTuple queryVersion =
-    isLanguageVersionSpecific() ?
-    ctx.LangOpts.EffectiveLanguageVersion :
-    ctx.LangOpts.getMinPlatformVersion();
+  llvm::VersionTuple queryVersion = getActiveVersion(ctx);
 
   // If this entity was obsoleted before or at the query platform version,
   // consider it obsolete.
@@ -943,7 +981,7 @@ AvailableVersionComparison AvailableAttr::getVersionAvailability(
   // static requirement, so we treat "introduced later" as just plain
   // unavailable.
   if (Introduced && *Introduced > queryVersion) {
-    if (isLanguageVersionSpecific())
+    if (isLanguageVersionSpecific() || isPackageDescriptionVersionSpecific())
       return AvailableVersionComparison::Unavailable;
     else
       return AvailableVersionComparison::PotentiallyUnavailable;

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -134,7 +134,8 @@ AvailabilityInference::annotatedAvailableRange(const Decl *D, ASTContext &Ctx) {
     auto *AvailAttr = dyn_cast<AvailableAttr>(Attr);
     if (AvailAttr == nullptr || !AvailAttr->Introduced.hasValue() ||
         !AvailAttr->isActivePlatform(Ctx) ||
-        AvailAttr->isLanguageVersionSpecific()) {
+        AvailAttr->isLanguageVersionSpecific() ||
+        AvailAttr->isPackageDescriptionVersionSpecific()) {
       continue;
     }
 

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -26,7 +26,8 @@ SourceRange AvailabilitySpec::getSourceRange() const {
     return cast<PlatformVersionConstraintAvailabilitySpec>(this)->getSourceRange();
 
  case AvailabilitySpecKind::LanguageVersionConstraint:
-   return cast<LanguageVersionConstraintAvailabilitySpec>(this)->getSourceRange();
+ case AvailabilitySpecKind::PackageDescriptionVersionConstraint:
+   return cast<PlatformAgnosticVersionConstraintAvailabilitySpec>(this)->getSourceRange();
 
   case AvailabilitySpecKind::OtherPlatform:
     return cast<OtherPlatformAvailabilitySpec>(this)->getSourceRange();
@@ -54,13 +55,18 @@ void PlatformVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
                     << ')';
 }
 
-SourceRange LanguageVersionConstraintAvailabilitySpec::getSourceRange() const {
-  return SourceRange(SwiftLoc, VersionSrcRange.End);
+SourceRange PlatformAgnosticVersionConstraintAvailabilitySpec::getSourceRange() const {
+  return SourceRange(PlatformAgnosticNameLoc, VersionSrcRange.End);
 }
 
-void LanguageVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
+void PlatformAgnosticVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
                                                       unsigned Indent) const {
-  OS.indent(Indent) << '(' << "language_version_constraint_availability_spec"
+  OS.indent(Indent) << '('
+                    << "platform_agnostic_version_constraint_availability_spec"
+                    << " kind='"
+                    << (isLanguageVersionSpecific() ?
+                         "swift" : "package_description")
+                    << "'"
                     << " version='" << getVersion() << "'"
                     << ')';
 }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -221,6 +221,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_AssumeSingleThreaded);
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_dependencies);
+  inputArgs.AddLastArg(arguments, options::OPT_package_description_version);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -199,6 +199,16 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       diagnoseSwiftVersion(vers, A, Args, Diags);
   }
 
+  if (auto A = Args.getLastArg(OPT_package_description_version)) {
+    auto vers = version::Version::parseVersionString(
+      A->getValue(), SourceLoc(), &Diags);
+    if (vers.hasValue()) {
+      Opts.PackageDescriptionVersion = vers.getValue();
+    } else {
+      return true;
+    }
+  }
+
   Opts.AttachCommentsToDecls |= Args.hasArg(OPT_dump_api_path);
 
   Opts.UseMalloc |= Args.hasArg(OPT_use_malloc);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -535,28 +535,32 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   bool SomeVersion = (!Introduced.empty() ||
                       !Deprecated.empty() ||
                       !Obsoleted.empty());
-  if (!PlatformKind.hasValue() && Platform == "swift") {
+  if (!PlatformKind.hasValue() &&
+      (Platform == "swift" || Platform == "_PackageDescription")) {
+
     if (PlatformAgnostic == PlatformAgnosticAvailabilityKind::Deprecated) {
       diagnose(AttrLoc,
-               diag::attr_availability_swift_expected_deprecated_version,
-               AttrName);
+               diag::attr_availability_platform_agnostic_expected_deprecated_version,
+               AttrName, Platform);
       return nullptr;
     }
     if (PlatformAgnostic == PlatformAgnosticAvailabilityKind::Unavailable) {
-      diagnose(AttrLoc, diag::attr_availability_swift_infeasible_option,
-               "unavailable", AttrName);
+      diagnose(AttrLoc, diag::attr_availability_platform_agnostic_infeasible_option,
+               "unavailable", AttrName, Platform);
       return nullptr;
     }
     assert(PlatformAgnostic == PlatformAgnosticAvailabilityKind::None);
 
     if (!SomeVersion) {
-      diagnose(AttrLoc, diag::attr_availability_swift_expected_option,
-               AttrName);
+      diagnose(AttrLoc, diag::attr_availability_platform_agnostic_expected_option,
+               AttrName, Platform);
       return nullptr;
     }
 
     PlatformKind = PlatformKind::none;
-    PlatformAgnostic = PlatformAgnosticAvailabilityKind::SwiftVersionSpecific;
+    PlatformAgnostic = (Platform == "swift") ?
+                         PlatformAgnosticAvailabilityKind::SwiftVersionSpecific :
+                         PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific;
   }
 
 
@@ -1335,12 +1339,17 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       //  @available(iOS, introduced: 8.0)
       //  @available(OSX, introduced: 10.10)
       //
-      // Similarly if we have a language version spec in the spec
-      // list, create an implicit AvailableAttr with the specified
-      // version as the introduced argument. For example, if we have
+      // Similarly if we have a language version spec or PackageDescription
+      // version in the spec list, create an implicit AvailableAttr
+      // with the specified version as the introduced argument. 
+      // For example, if we have
       //   @available(swift 3.1)
       // we will synthesize
       //   @available(swift, introduced: 3.1)
+      // or, if we have
+      //   @available(_PackageDescription 4.2)
+      // we will synthesize
+      //   @available(_PackageDescription, introduced: 4.2)
 
       for (auto *Spec : Specs) {
         PlatformKind Platform;
@@ -1355,13 +1364,14 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
           VersionRange = PlatformVersionSpec->getVersionSrcRange();
           PlatformAgnostic = PlatformAgnosticAvailabilityKind::None;
 
-        } else if (auto *LanguageVersionSpec =
-                   dyn_cast<LanguageVersionConstraintAvailabilitySpec>(Spec)) {
+        } else if (auto *PlatformAgnosticVersionSpec =
+                   dyn_cast<PlatformAgnosticVersionConstraintAvailabilitySpec>(Spec)) {
           Platform = PlatformKind::none;
-          Version = LanguageVersionSpec->getVersion();
-          VersionRange = LanguageVersionSpec->getVersionSrcRange();
-          PlatformAgnostic =
-            PlatformAgnosticAvailabilityKind::SwiftVersionSpecific;
+          Version = PlatformAgnosticVersionSpec->getVersion();
+          VersionRange = PlatformAgnosticVersionSpec->getVersionSrcRange();
+          PlatformAgnostic = PlatformAgnosticVersionSpec->isLanguageVersionSpecific() ?
+                               PlatformAgnosticAvailabilityKind::SwiftVersionSpecific :
+                               PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific;
 
         } else {
           continue;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1188,9 +1188,10 @@ static void validateAvailabilitySpecList(Parser &P,
   bool HasOtherPlatformSpec = false;
 
   if (Specs.size() == 1 &&
-      isa<LanguageVersionConstraintAvailabilitySpec>(Specs[0])) {
-    // @available(swift N) is allowed only in isolation; it cannot
-    // be combined with other availability specs in a single list.
+      isa<PlatformAgnosticVersionConstraintAvailabilitySpec>(Specs[0])) {
+    // @available(swift N) and @available(_PackageDescription N) are allowed 
+    // only in isolation; they cannot be combined with other availability specs
+    // in a single list.
     return;
   }
 
@@ -1200,10 +1201,11 @@ static void validateAvailabilitySpecList(Parser &P,
       continue;
     }
 
-    if (auto *LangSpec =
-        dyn_cast<LanguageVersionConstraintAvailabilitySpec>(Spec)) {
-      P.diagnose(LangSpec->getSwiftLoc(),
-                 diag::availability_swift_must_occur_alone);
+    if (auto *PlatformAgnosticSpec =
+        dyn_cast<PlatformAgnosticVersionConstraintAvailabilitySpec>(Spec)) {
+      P.diagnose(PlatformAgnosticSpec->getPlatformAgnosticNameLoc(),
+                 diag::availability_must_occur_alone,
+                 PlatformAgnosticSpec->isLanguageVersionSpecific() ? "swift" : "_PackageDescription");
       continue;
     }
 
@@ -1250,10 +1252,12 @@ ParserResult<PoundAvailableInfo> Parser::parseStmtConditionPoundAvailable() {
   ParserStatus Status = parseAvailabilitySpecList(Specs);
 
   for (auto *Spec : Specs) {
-    if (auto *Lang =
-        dyn_cast<LanguageVersionConstraintAvailabilitySpec>(Spec)) {
-      diagnose(Lang->getSwiftLoc(),
-               diag::pound_available_swift_not_allowed);
+    if (auto *PlatformAgnostic =
+        dyn_cast<PlatformAgnosticVersionConstraintAvailabilitySpec>(Spec)) {
+        diagnose(PlatformAgnostic->getPlatformAgnosticNameLoc(),
+                 PlatformAgnostic->isLanguageVersionSpecific() ?
+                   diag::pound_available_swift_not_allowed :
+                   diag::pound_available_package_description_not_allowed);
       Status.setIsParseError();
     }
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2452,6 +2452,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
         bool isImplicit;
         bool isUnavailable;
         bool isDeprecated;
+        bool isPackageDescriptionVersionSpecific;
         DEF_VER_TUPLE_PIECES(Introduced);
         DEF_VER_TUPLE_PIECES(Deprecated);
         DEF_VER_TUPLE_PIECES(Obsoleted);
@@ -2459,6 +2460,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
         // Decode the record, pulling the version tuple information.
         serialization::decls_block::AvailableDeclAttrLayout::readRecord(
             scratch, isImplicit, isUnavailable, isDeprecated,
+            isPackageDescriptionVersionSpecific,
             LIST_VER_TUPLE_PIECES(Introduced),
             LIST_VER_TUPLE_PIECES(Deprecated),
             LIST_VER_TUPLE_PIECES(Obsoleted),
@@ -2481,7 +2483,8 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
                  (!Introduced.empty() ||
                   !Deprecated.empty() ||
                   !Obsoleted.empty()))
-          platformAgnostic =
+          platformAgnostic = isPackageDescriptionVersionSpecific ?
+            PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
             PlatformAgnosticAvailabilityKind::SwiftVersionSpecific;
         else
           platformAgnostic = PlatformAgnosticAvailabilityKind::None;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2307,6 +2307,7 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
         theAttr->isImplicit(),
         theAttr->isUnconditionallyUnavailable(),
         theAttr->isUnconditionallyDeprecated(),
+        theAttr->isPackageDescriptionVersionSpecific(),
         LIST_VER_TUPLE_PIECES(Introduced),
         LIST_VER_TUPLE_PIECES(Deprecated),
         LIST_VER_TUPLE_PIECES(Obsoleted),

--- a/test/attr/Inputs/PackageDescription.swift
+++ b/test/attr/Inputs/PackageDescription.swift
@@ -1,0 +1,54 @@
+public enum SwiftVersion {
+    // CHECK: @available(_PackageDescription, introduced: 3.0, deprecated: 4.2, obsoleted: 5.0)
+    @available(_PackageDescription, introduced: 3.0, deprecated: 4.2, obsoleted: 5.0)
+    case v3
+
+    case v4
+
+    // CHECK: @available(_PackageDescription 5.0)
+    // CHECK-NEXT: @available(OSX 10.1, *)
+    // CHECK-NEXT: v5
+    @available(_PackageDescription, introduced: 5.0)
+    @available(macOS, introduced: 10.1)
+    case v5
+}
+
+public class Package {
+
+    public var swiftVersion: [SwiftVersion]
+
+    @available(_PackageDescription 4.3)
+    public var buildSettings: [String: String] {
+        get {
+            return _buildSettings
+        }
+        set {
+            _buildSettings = newValue
+        }
+    }
+    private var _buildSettings: [String: String]
+
+    @available(_PackageDescription 5)
+    public init(
+        swiftVersion: [SwiftVersion] = [],
+        buildSettings: [String: String] = [:]
+    ) {
+        self._buildSettings = buildSettings
+        self.swiftVersion = swiftVersion
+    }
+
+    @available(_PackageDescription, introduced: 3.0, obsoleted: 5.0)
+    public init(
+        swiftVersion: [SwiftVersion] = []
+    ) {
+        self._buildSettings = [:]
+        self.swiftVersion = swiftVersion
+    }
+
+    public func serialize() {
+        for version in swiftVersion {
+            print(version)
+        }
+        print(_buildSettings)
+    }
+}

--- a/test/attr/attr_availability_swiftpm_deserialize.swift
+++ b/test/attr/attr_availability_swiftpm_deserialize.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PackageDescription.swiftmodule -module-name PackageDescription %S/Inputs/PackageDescription.swift 
+// RUN: not %target-swift-frontend -typecheck -I %t -package-description-version 4.2 %s 2>&1 | %FileCheck -check-prefix FOURTWO %s
+// RUN: not %target-swift-frontend -typecheck -I %t -package-description-version 5 %s 2>&1 | %FileCheck -check-prefix FIVE %s
+// RUN: %target-swift-ide-test -print-module -module-to-print PackageDescription -source-filename x -I %t | %FileCheck %S/Inputs/PackageDescription.swift
+
+import PackageDescription
+
+// FOURTWO: warning: 'v3' is deprecated
+// FOURTWO: error: 'v5' is unavailable
+// FOURTWO: note: 'v5' was introduced in PackageDescription 5.0
+// FIVE: error: 'v3' is unavailable
+// FIVE: note: 'v3' was obsoleted in PackageDescription 5.0
+let package = Package(
+    swiftVersion: [ .v3, .v4, .v5 ]
+)
+
+// FOURTWO: note: 'buildSettings' was introduced in PackageDescription 4.3
+package.buildSettings = ["Foo": "Bar"]

--- a/test/attr/attr_availability_swiftpm_v4.swift
+++ b/test/attr/attr_availability_swiftpm_v4.swift
@@ -1,0 +1,65 @@
+// RUN: %target-typecheck-verify-swift -package-description-version 4.0
+
+@available(_PackageDescription 3)
+func shortThree() {}
+
+@available(_PackageDescription, introduced: 3.0)
+func threePointOh() {}
+
+@available(_PackageDescription, introduced: 3.0, obsoleted: 4.0)
+func threePointOhOnly() {} // expected-note {{was obsoleted in PackageDescription 4.0}}
+
+@available(_PackageDescription, deprecated: 3.0)
+func deprecatedThreePointOh() {}
+
+@available(_PackageDescription, obsoleted: 3.0)
+func obsoletedThreePointOh() {} // expected-note {{was obsoleted in PackageDescription 3.0}}
+
+@available(_PackageDescription, introduced: 3.0, obsoleted: 4.0)
+class ThreePointOhOnly {} // expected-note {{was obsoleted in PackageDescription 4.0}}
+
+@available(_PackageDescription, introduced: 3, obsoleted: 4, message: "use abc")
+class ThreeOnlyWithMessage {} // expected-note {{was obsoleted in PackageDescription 4}}
+
+
+@available(_PackageDescription 4)
+func shortFour() {}
+
+@available(_PackageDescription 4.0)
+func shortFourPointOh() {}
+
+@available(_PackageDescription, introduced: 4)
+func four() {}
+
+@available(_PackageDescription, introduced: 4.0)
+func fourPointOh() {}
+
+@available(_PackageDescription 4)
+class ShortFour {}
+
+shortThree()
+threePointOh()
+threePointOhOnly() // expected-error {{is unavailable}}
+deprecatedThreePointOh() // expected-warning {{is deprecated}}
+obsoletedThreePointOh() // expected-error {{is unavailable}}
+let a : ThreePointOhOnly // expected-error {{is unavailable}}
+let b : ThreeOnlyWithMessage // expected-error {{is unavailable: use abc}}
+
+
+shortFour()
+shortFourPointOh()
+four()
+fourPointOh()
+let aa : ShortFour
+
+@available(_PackageDescription, introduced: 4.0)
+@available(*, deprecated, message: "test deprecated")
+func unconditionallyDeprecated() {}
+
+unconditionallyDeprecated() // expected-warning {{test deprecated}}
+
+@available(_PackageDescription 4.0, iOS 2.0, *) // expected-error {{'_PackageDescription' version-availability must be specified alone}}
+func shouldBeAlone() {} 
+
+@available(_PackageDescription 4.0, swift 2.0, *) // expected-error {{'_PackageDescription' version-availability must be specified alone}} // expected-error {{'swift' version-availability must be specified alone}}
+func shouldBeAlone2() {} 


### PR DESCRIPTION
This introduces a new private availability kind "_PackageDescription" to
allow availability testing by an arbitary version that can be passed
using a new command-line flag "-package-description-version". The semantics
are exactly same as Swift version specific availability. In longer term,
it maybe possible to remove this enhancement once there is
a language-level availability support for 3rd party libraries.

Motivation:

Swift packages are configured using a Package.swift manifest file. The
manifest file uses a library called PackageDescription, which contains
various settings that can be configured for a package. The new additions
in the PackageDescription APIs are gated behind a "tools version" that
every manifest must declare. This means, packages don't automatically
get access to the new APIs. They need to update their declared tools
version in order to use the new API. This is basically similar to the
minimum deployment target version we have for our OSes.

This gating is important for allowing packages to maintain backwards
compatibility. SwiftPM currently checks for API usages at runtime in
order to implement this gating. This works reasonably well but can lead
to a poor experience with features like code-completion and module
interface generation in IDEs and editors (that use sourcekit-lsp) as
SwiftPM has no control over these features.

<rdar://problem/46548531> Extend @available to support PackageDescription