### PR TITLE
[5.0] [IRGen] Don't emit relative references to Objective-C class references.

### DIFF
--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -2,7 +2,9 @@
 
 // CHECK-NOT: _TMnCSo
 
-// CHECK: @"$sSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @"\01l_OBJC_CLASS_REF_$_Thingy"
+// CHECK: @"$sSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @[[THINGY_NAME:[0-9]]]
+
+// CHECK: @[[THINGY_NAME]] = private constant [7 x i8] c"Thingy\00"
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/objc_runtime_visible_conformance.swift
+++ b/test/IRGen/objc_runtime_visible_conformance.swift
@@ -10,8 +10,8 @@ extension A : YourProtocol {}
 
 // CHECK-LABEL: @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACMc"
 // CHECK-SAME:    @"$s32objc_runtime_visible_conformance10MyProtocolMp"
-// CHECK-SAME:    [2 x i8]* [[STRING_A:@[0-9]+]]
+// CHECK-SAME:    [[STRING_A:@[0-9]+]]
 // CHECK-SAME:    @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACWP"
 //   DirectObjCClassName
 // CHECK-SAME:    i32 16
-// CHECK:       [[STRING_A]] = private unnamed_addr constant [2 x i8] c"A\00"
+// CHECK:       [[STRING_A]] = private constant [22 x i8] c"MyRuntimeVisibleClass\00"

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -29,16 +29,18 @@ extension NSRect: Runcible {
 // CHECK-LABEL:         @"$sSo5GizmoC33protocol_conformance_records_objc8RuncibleACMc" = constant %swift.protocol_conformance_descriptor {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
-// -- class object reference
-// CHECK-SAME:           @"\01l_OBJC_CLASS_REF_$_Gizmo"
+// -- class name reference
+// CHECK-SAME:           @[[GIZMO_NAME:[0-9]+]]
 // -- witness table
 // CHECK-SAME:           @"$sSo5GizmoC33protocol_conformance_records_objc8RuncibleACWP"
 // -- flags
-// CHECK-SAME:           i32 24
+// CHECK-SAME:           i32 16
 // CHECK-SAME:         }
 extension Gizmo: Runcible {
   public func runce() {}
 }
+
+// CHECK: @[[GIZMO_NAME]] = private constant [6 x i8] c"Gizmo\00"
 
 // CHECK-LABEL: @"\01l_protocol_conformances" = private constant [
 // CHECK-SAME: @"$sSo6NSRectV33protocol_conformance_records_objc8RuncibleACMc"


### PR DESCRIPTION
Objective-C class references (which show up in the __objc_classrefs
section) are always coalesced by the linker. When we relatively
address them (which occurs in protocol conformance records), the
linker may compute the relative offset *before* coalescing, leading to
an incorrect result. The net effect is a protocol conformance record
that applies to the wrong Objective-C class, causing all sorts of
runtime mayhem.

Switch relatively-addressed Objective-C classes over to using the
Objective-C runtime name of the class. It's a less efficient encoding
(since we need to go through objc_lookUpClass), but it avoids the
linker bug.

Fixes rdar://problem/46428085 by working around the linker bug.
