### PR TITLE
[runtime] Fix some bugs when the stable ABI's is-Swift bit is set.

### DIFF
--- a/include/swift/CMakeLists.txt
+++ b/include/swift/CMakeLists.txt
@@ -2,5 +2,6 @@ configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
                ESCAPE_QUOTES @ONLY)
 
 add_subdirectory(Option)
+add_subdirectory(Runtime)
 add_subdirectory(SwiftRemoteMirror)
 add_subdirectory(Syntax)

--- a/include/swift/Runtime/CMakeConfig.h.in
+++ b/include/swift/Runtime/CMakeConfig.h.in
@@ -1,0 +1,8 @@
+// This file is processed by CMake.
+// See https://cmake.org/cmake/help/v3.0/command/configure_file.html.
+
+#ifndef SWIFT_RUNTIME_CMAKECONFIG_H
+
+#cmakedefine01 SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
+
+#endif

--- a/include/swift/Runtime/CMakeLists.txt
+++ b/include/swift/Runtime/CMakeLists.txt
@@ -1,0 +1,2 @@
+configure_file(CMakeConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/CMakeConfig.h
+               ESCAPE_QUOTES @ONLY)

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_RUNTIME_CONFIG_H
 #define SWIFT_RUNTIME_CONFIG_H
 
+#include "swift/Runtime/CMakeConfig.h"
+
 /// \macro SWIFT_RUNTIME_GNUC_PREREQ
 /// Extend the default __GNUC_PREREQ even if glibc's features.h isn't
 /// available.

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -1,11 +1,6 @@
 set(swift_runtime_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
 set(swift_runtime_linker_flags ${SWIFT_RUNTIME_CORE_LINK_FLAGS})
 
-if(SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT)
-  list(APPEND swift_runtime_compile_flags
-      "-DSWIFT_DARWIN_ENABLE_STABLE_ABI_BIT=1")
-endif()
-
 if(SWIFT_RUNTIME_CLOBBER_FREED_OBJECTS)
   list(APPEND swift_runtime_compile_flags
       "-DSWIFT_RUNTIME_CLOBBER_FREED_OBJECTS=1")

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2246,7 +2246,7 @@ static uint32_t getLog2AlignmentFromMask(size_t alignMask) {
 }
 
 static inline ClassROData *getROData(ClassMetadata *theClass) {
-  return (ClassROData*) (theClass->Data & ~uintptr_t(1));
+  return (ClassROData*)(theClass->Data & ~uintptr_t(SWIFT_CLASS_IS_SWIFT_MASK));
 }
 
 static void initGenericClassObjCName(ClassMetadata *theClass) {

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -56,7 +56,7 @@
 // CHECK-SAME:   %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
 // CHECK-SAME:   %swift.opaque* @_objc_empty_cache,
 // CHECK-SAME:   %swift.opaque* null,
-// CHECK-SAME:   i64 add (i64 ptrtoint ({{.*}}* @_DATA__TtC17objc_class_export3Foo to i64), i64 1),
+// CHECK-SAME:   i64 add (i64 ptrtoint ({{.*}}* @_DATA__TtC17objc_class_export3Foo to i64), i64 {{1|2}}),
 // CHECK-SAME:   [[FOO]]* (%swift.type*)* @"$s17objc_class_export3FooC6createACyFZ",
 // CHECK-SAME:   void (double, double, double, double, [[FOO]]*)* @"$s17objc_class_export3FooC10drawInRect5dirtyySo6NSRectV_tF"
 // CHECK-SAME: }>, section "__DATA,__objc_data, regular"

--- a/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
+++ b/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
@@ -52,32 +52,39 @@ static int Errors;
 
 // Add methods to class SwiftObject that can be called by performSelector: et al
 
-#if SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
-// mangled Swift._SwiftObject
-#define SwiftObject _TtCs12_SwiftObject
-#define SwiftObjectDemangledName "Swift._SwiftObject"
-#else
-// Pre-stable ABI uses un-mangled name for SwiftObject.
-#define SwiftObjectDemangledName "SwiftObject"
-#endif
+static const char *SwiftObjectDemangledName;
 
-@interface SwiftObject /* trust me, I know what I'm doing */ @end
-@implementation SwiftObject (MethodsToPerform)
--(id) perform0 {
+static id Perform0(id self, SEL sel) {
     return self;
 }
 
--(id) perform1:(id)one {
+static id Perform1(id self, SEL sel, id one) {
   expectTrue ([one isEqual:@1]);
   return self;
 }
 
--(id) perform2:(id)one :(id)two {
+static id Perform2(id self, SEL sel, id one, id two) {
   expectTrue ([one isEqual:@1]);
   expectTrue ([two isEqual:@2]);
   return self;
 }
-@end
+
+static __attribute__((constructor))
+void HackSwiftObject()
+{
+    SwiftObjectDemangledName = "Swift._SwiftObject";
+    Class cls = objc_getClass(SwiftObjectDemangledName);
+    // FIXME: Remove this fallback after we enable
+    // SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT everywhere.
+    if (!cls) {
+        SwiftObjectDemangledName = "SwiftObject";
+        cls = objc_getClass(SwiftObjectDemangledName);
+    }
+
+    class_addMethod(cls, @selector(perform0), (IMP)Perform0, "@@:");
+    class_addMethod(cls, @selector(perform1:), (IMP)Perform1, "@@:@");
+    class_addMethod(cls, @selector(perform2::), (IMP)Perform2, "@@:@@");
+}
 
 void TestSwiftObjectNSObject(id c, id d)
 {
@@ -411,10 +418,10 @@ void TestSwiftObjectNSObject(id c, id d)
   expectTrue ([[c description] isEqual:@"SwiftObjectNSObject.C"]);
   expectTrue ([[D description] isEqual:@"SwiftObjectNSObject.D"]);
   expectTrue ([[C description] isEqual:@"SwiftObjectNSObject.C"]);
-  expectTrue ([[S description] isEqual:@ SwiftObjectDemangledName]);
+  expectTrue ([[S description] isEqual:@(SwiftObjectDemangledName)]);
   expectTrue ([[D_meta description] isEqual:@"SwiftObjectNSObject.D"]);
   expectTrue ([[C_meta description] isEqual:@"SwiftObjectNSObject.C"]);
-  expectTrue ([[S_meta description] isEqual:@ SwiftObjectDemangledName]);
+  expectTrue ([[S_meta description] isEqual:@(SwiftObjectDemangledName)]);
 
   // NSLog() calls -description and also some private methods.
   // This output is checked by FileCheck in SwiftObjectNSObject.swift.
@@ -429,10 +436,10 @@ void TestSwiftObjectNSObject(id c, id d)
   expectTrue ([[c debugDescription] isEqual:@"SwiftObjectNSObject.C"]);
   expectTrue ([[D debugDescription] isEqual:@"SwiftObjectNSObject.D"]);
   expectTrue ([[C debugDescription] isEqual:@"SwiftObjectNSObject.C"]);
-  expectTrue ([[S debugDescription] isEqual:@ SwiftObjectDemangledName]);
+  expectTrue ([[S debugDescription] isEqual:@(SwiftObjectDemangledName)]);
   expectTrue ([[D_meta debugDescription] isEqual:@"SwiftObjectNSObject.D"]);
   expectTrue ([[C_meta debugDescription] isEqual:@"SwiftObjectNSObject.C"]);
-  expectTrue ([[S_meta debugDescription] isEqual:@ SwiftObjectDemangledName]);
+  expectTrue ([[S_meta debugDescription] isEqual:@(SwiftObjectDemangledName)]);
 
 
   printf("NSObjectProtocol.performSelector\n");


### PR DESCRIPTION
* cmake: Propagate SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT to overlay builds.
* runtime: Clear the correct bit in getROData()
* test/IRGen/objc_class_export.swift: Allow either is-Swift bit.
* test/stdlib/SwiftObjectNSObject.swift: Allow either name for SwiftObject.